### PR TITLE
Spawn bidi transport send so request initiates before first message()

### DIFF
--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2183,13 +2183,24 @@ impl Body for ChannelBody {
 
 /// State machine for the receive side of a [`BidiStream`].
 ///
-/// The response future is stored and awaited lazily on the first
-/// [`BidiStream::message`] call, so servers that wait for the first request
-/// message before sending response headers don't deadlock.
+/// The transport send is spawned so the HTTP request makes progress
+/// immediately (connect, handshake, start streaming the request body from
+/// [`ChannelBody`]) regardless of when the caller first calls
+/// [`BidiStream::message`]. Without the spawn, a transport whose `send()`
+/// future contains the actual connect/stream work (e.g.,
+/// [`SharedHttp2Connection`]) would not initiate the request until
+/// `message()` is called — so the half-duplex pattern (send all, then
+/// read) would buffer into the 32-deep mpsc with nobody draining it, and
+/// deadlock on the 33rd send.
+///
+/// The response HEADERS future (what the spawned task resolves to) is still
+/// awaited lazily on the first `message()` call, so servers that wait for
+/// the first request message before sending HEADERS don't deadlock either.
 enum RecvState<B, RespView> {
-    /// Response HEADERS not yet received. The boxed future resolves when
-    /// hyper reads the HEADERS frame.
-    Pending(BoxFuture<'static, Result<Response<B>, ConnectError>>),
+    /// Request initiated in a spawned task; response HEADERS not yet
+    /// received. Awaiting the handle yields the [`Response`] once hyper
+    /// reads the HEADERS frame.
+    Pending(tokio::task::JoinHandle<Result<Response<B>, ConnectError>>),
     /// HEADERS received; response-side decoding delegates to [`ServerStream`].
     Ready(Box<ServerStream<B, RespView>>),
     /// Transport error or make_server_stream error stored on self.construct_err.
@@ -2241,9 +2252,9 @@ pub struct BidiStream<B, Req, RespView> {
     _req: PhantomData<Req>,
 }
 
-// Manual impl: `RecvState` holds a `BoxFuture` (never `Debug`), and the body
-// type inside `ServerStream` typically isn't either. Print send-channel state,
-// recv-state discriminant, and any construction error for test diagnostics.
+// Manual impl: the body type inside `ServerStream` typically isn't `Debug`,
+// and the JoinHandle's inner type wouldn't format usefully anyway. Print
+// send-channel state, recv-state discriminant, and any construction error.
 impl<B, Req, RespView> std::fmt::Debug for BidiStream<B, Req, RespView> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let recv_state = match &self.recv {
@@ -2349,15 +2360,24 @@ where
 
         // Transition Pending -> Ready on first call.
         if matches!(self.recv, RecvState::Pending(_)) {
-            // Take the future out so we can await it (borrow check).
-            let RecvState::Pending(fut) = std::mem::replace(&mut self.recv, RecvState::Failed)
+            // Take the handle out so we can await it (borrow check).
+            let RecvState::Pending(handle) = std::mem::replace(&mut self.recv, RecvState::Failed)
             else {
                 unreachable!()
             };
 
             // Bound the response-HEADERS wait by the whole-call deadline.
             // A server that never sends headers shouldn't block forever.
-            match with_deadline(self.stream_config.deadline, fut).await {
+            // The spawned task either resolves or is cancelled: if we hit the
+            // deadline here and drop the handle, the task detaches — but the
+            // dropped tx (on BidiStream drop) will end the body stream, which
+            // ends the request, which completes the detached task naturally.
+            let awaited = async move {
+                handle.await.map_err(|e| {
+                    ConnectError::internal(format!("transport send task panicked: {e}"))
+                })?
+            };
+            match with_deadline(self.stream_config.deadline, awaited).await {
                 Ok(response) => {
                     let cfg = &self.stream_config;
                     match make_server_stream(
@@ -2505,22 +2525,22 @@ where
         .body(body)
         .map_err(|e| ConnectError::internal(format!("failed to build request: {e}")))?;
 
-    // Start the request but DON'T await it — the response future resolves
-    // when HEADERS arrive, which may not happen until after the first send().
-    // The future is awaited lazily in BidiStream::message().
+    // Spawn the transport send so the request initiates immediately and
+    // ChannelBody gets polled as sends happen, independent of when the
+    // caller first calls message(). See RecvState doc for the deadlock
+    // this avoids.
     let response_fut = transport.send(http_request);
-    let response_fut: BoxFuture<'static, Result<Response<T::ResponseBody>, ConnectError>> =
-        Box::pin(async move {
-            response_fut
-                .await
-                .map_err(|e| ConnectError::unavailable(format!("request failed: {e}")))
-        });
+    let response_task = tokio::spawn(async move {
+        response_fut
+            .await
+            .map_err(|e| ConnectError::unavailable(format!("request failed: {e}")))
+    });
 
     Ok(BidiStream {
         tx: Some(tx),
         encoder,
         codec_format: config.codec_format,
-        recv: RecvState::Pending(response_fut),
+        recv: RecvState::Pending(response_task),
         stream_config: StreamConfig {
             protocol: config.protocol,
             codec_format: config.codec_format,

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -554,6 +554,61 @@ mod tests {
         }
     }
 
+    /// Regression test for the half-duplex deadlock on `SharedHttp2Connection`.
+    ///
+    /// Before the fix, `call_bidi_stream` stored the transport's `send()`
+    /// future unpolled in `RecvState::Pending`, so the HTTP request never
+    /// initiated until the first `message()` call. `BidiStream::send()`
+    /// would buffer into the 32-deep mpsc with nobody draining it, and the
+    /// 33rd send would hang forever. After the fix, the send future is
+    /// spawned so the request streams immediately.
+    ///
+    /// Timeout-wrapped so a regression fails fast instead of hanging the
+    /// suite.
+    #[tokio::test]
+    async fn bidi_half_duplex_many_sends_before_first_read() {
+        use connectrpc::Protocol;
+        use connectrpc::client::Http2Connection;
+
+        let (addr, _server) = start_server_mono().await;
+        let uri: http::Uri = format!("http://{addr}").parse().unwrap();
+
+        let conn = Http2Connection::connect_plaintext(uri.clone())
+            .await
+            .unwrap()
+            .shared(64);
+        let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+        let client = EchoServiceClient::new(conn, config);
+
+        let test = async {
+            let mut stream = client.bidi_stream().await.unwrap();
+            // More than the 32-deep ChannelBody mpsc. Pre-fix, send #33 hangs
+            // here; post-fix, the spawned task drains as we go.
+            for i in 0..40 {
+                stream
+                    .send(EchoRequest {
+                        sequence: i,
+                        data: format!("half-duplex-{i}"),
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap();
+            }
+            stream.close_send();
+
+            let mut received = 0;
+            while let Some(resp) = stream.message().await.unwrap() {
+                assert_eq!(resp.data, format!("half-duplex-{}", resp.sequence));
+                received += 1;
+            }
+            assert_eq!(received, 40);
+        };
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), test)
+            .await
+            .expect("half-duplex bidi deadlocked (send #33 never completed?)");
+    }
+
     // ========================================================================
     // TLS integration tests — dogfood HttpClient::with_tls and
     // Http2Connection::connect_tls against our own Server::with_tls.


### PR DESCRIPTION
Fixes #2.

`call_bidi_stream` previously stored the `transport.send()` future unpolled in `RecvState::Pending`, awaiting it lazily on the first `message()` call. For `SharedHttp2Connection`, that future contains the actual poll_ready -> connect -> handshake -> stream-body work, so nothing happened until the caller started reading. The half-duplex pattern (send all, close_send, then read) would buffer into the 32-deep `ChannelBody` mpsc with nobody draining it and deadlock on the 33rd send.

## Changes

- `RecvState::Pending` holds `JoinHandle<Result<Response<B>, ConnectError>>` instead of `BoxFuture`
- `call_bidi_stream` spawns the send future instead of boxing it
- `message()` awaits the handle; JoinError (task panic) maps to `ConnectError::internal`
- Doc comments updated to explain the spawn and the deadline-drop-detach cleanup path
- Integration test in `tests/streaming`: 40 sends half-duplex over `SharedHttp2Connection`, timeout-wrapped so a regression fails fast rather than hanging the suite

## Preserved behaviour

- The lazy HEADERS await is unchanged - servers that wait for the first request message before sending HEADERS still work (the original reason for not awaiting eagerly)
- No API surface change; internal plumbing only

## Cleanup on drop

Dropping the BidiStream before `message()` detaches the spawned task. The dropped `tx` closes the body stream, which ends the request, which completes the task naturally - so no explicit abort is needed. If the task was mid-connect/handshake it completes that work before discovering an empty body; wasteful but not leaky.