### PR TITLE
Split conformance CI into parallel server/client matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,29 +76,36 @@ jobs:
       - run: sudo apt-get install -y protobuf-compiler
       - run: ./examples/multiservice/test.sh
 
-  # Conformance tests: validate protocol compliance
+  # Conformance tests: validate protocol compliance.
+  # Matrix runs server and client suites in parallel — the server suite
+  # (~20s) finishes in the shadow of the client suite (~90s), so the
+  # duplicated build is net-faster than running both serially.
   conformance:
-    name: Conformance
+    name: Conformance (${{ matrix.mode }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: server
+            config: conformance/config/connect-only.yaml
+            bin: conformance-server
+          - mode: client
+            config: conformance/config/client-connect-only.yaml
+            bin: conformance-client
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
       - name: Download conformance runner
         run: ./conformance/scripts/download-conformance.sh
-      - name: Build conformance binaries
-        run: cargo build --release -p connectrpc-conformance
-      - name: Server conformance (Connect)
+      - name: Build conformance binary
+        run: cargo build --release -p connectrpc-conformance --bin ${{ matrix.bin }}
+      - name: Run conformance suite
         run: |
-          ./conformance/bin/connectconformance --mode server \
-            --conf conformance/config/connect-only.yaml \
-            -- ./target/release/conformance-server
-      - name: Client conformance (Connect)
-        run: |
-          ./conformance/bin/connectconformance --mode client \
-            --conf conformance/config/client-connect-only.yaml \
-            -- ./target/release/conformance-client
+          ./conformance/bin/connectconformance --mode ${{ matrix.mode }} \
+            --conf ${{ matrix.config }} \
+            -- ./target/release/${{ matrix.bin }}
 
   # Test with minimal feature set
   minimal:


### PR DESCRIPTION
## Changes

1. **Drop `apt-get install protobuf-compiler`** (14s). `connectrpc-conformance` uses checked-in generated code - no `build.rs`, no `connectrpc-build` in its dep tree, nothing invokes protoc.

2. **Matrix server/client** so the suites run in parallel. Each entry also builds only its own binary via `--bin`.

## Timings (from run 23173511743)

| Step | Serial | Matrix |
|---|---:|---:|
| Setup + cache | 9s | 9s (each) |
| ~~apt-get protoc~~ | ~~14s~~ | - |
| Build | 50s | 50s (each, per-bin may be less) |
| Server conformance | 20s | 20s (concurrent) |
| Client conformance | 94s | 94s (concurrent) |
| Post | 6s | 6s (each) |
| **Wall-clock** | **~193s** | **~159s** |

The server suite finishes in the shadow of the client suite.

## Post-merge follow-up

The two matrix entries will surface as separate checks: `Conformance (server)` and `Conformance (client)`. Ruleset 13913375 currently requires `Conformance`; after merge, update its `required_status_checks` to replace that with the two new names (same GET/edit/PUT pattern as the case-sensitivity fix earlier).

## Separate open question

The 50s build with a warm Swatinem cache is surprisingly slow - a full hit should be 5-10s. Worth investigating separately (cache key invalidation? something uncacheable in the build?) since that would help every job, not just conformance.