### PR TITLE
Prepare connectrpc 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,33 @@ increment the patch version.
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-03-XX
+## [0.2.1] - 2026-03-18
+
+### Fixed
+
+- **`BidiStream` half-duplex deadlock on `SharedHttp2Connection`** ([#2], [#4]).
+  `call_bidi_stream` stored the transport's `send()` future unpolled, so for
+  transports where that future contains the connect/handshake/stream work
+  (i.e. not hyper's pooled client), the HTTP request never initiated until
+  the first `message()` call. The half-duplex pattern (send all, close,
+  then read) would buffer into the 32-deep `ChannelBody` mpsc with nobody
+  draining it and deadlock on the 33rd send. The send future is now
+  spawned so the request streams immediately.
+- **TLS connections to IPv6 literal URIs failed** ([#1], [#3]). `Uri::host()`
+  returns `[::1]` with brackets, which `rustls_pki_types::ServerName`
+  rejected as an invalid DNS name. Brackets are now stripped so the
+  address parses as `ServerName::IpAddress`.
+- **README required-dependencies example showed `buffa = "0.1"`** instead
+  of `"0.2"`. The `connectrpc` crate bakes the workspace README via
+  `readme = "../README.md"`, so the crates.io page for 0.2.0 shows the
+  stale version; this release updates it.
+
+[#1]: https://github.com/anthropics/connect-rust/issues/1
+[#2]: https://github.com/anthropics/connect-rust/issues/2
+[#3]: https://github.com/anthropics/connect-rust/pull/3
+[#4]: https://github.com/anthropics/connect-rust/pull/4
+
+## [0.2.0] - 2026-03-17
 
 First release from the [anthropics/connect-rust](https://github.com/anthropics/connect-rust)
 repository. This is a complete from-scratch implementation — not a continuation

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Changes

- `connectrpc/Cargo.toml`: `0.2.0` -> `0.2.1`
- `CHANGELOG.md`: new 0.2.1 section, 0.2.0 date backfilled

`connectrpc-codegen` and `connectrpc-build` stay at 0.2.0 (neither was touched by the three changes going into 0.2.1). The idempotent publish workflow skips already-published versions.

## Readiness check

Full pre-release check ran on `f585a52` (290 tests, 3600 conformance, clippy, fmt, rustdoc, `cargo package --list`). All green.

**Out-of-scope findings noted for follow-up** (all need `connectrpc-codegen@0.2.1`, separate release):
- Stale generated code in unpublished crates (4166 lines of additive buffa-0.2 codegen drift; compiles fine)
- `connectrpc-codegen/buf.plugin.yaml` has wrong feature names (`serde` vs `json`) and wrong versions - already shipped in 0.2.0 but not user-visible until BSR integration lands
- `connectrpc-codegen/Dockerfile` uses Rust 1.84 but edition 2024 needs 1.85

## Release sequence after merge

1. `workflow_dispatch` on publish-crates.yml with `dry_run=false` - publishes `connectrpc@0.2.1`, other two skip
2. Tag `v0.2.1` - triggers release.yml for the signed binary