### PR TITLE
[benches] Update RPC benches for current client API

### DIFF
--- a/benches/rpc/benches/cross_impl_bench.rs
+++ b/benches/rpc/benches/cross_impl_bench.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use connectrpc::Protocol;
-use connectrpc::client::{CallOptions, ClientConfig, HttpClient};
+use connectrpc::client::{ClientConfig, HttpClient};
 use rpc_bench::*;
 
 const STREAM_MSG_COUNT: i32 = 10;
@@ -292,7 +292,7 @@ fn bench_client_stream_grpc(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(impl_name), |b| {
             b.to_async(&rt).iter(|| async {
                 client
-                    .client_stream(messages.clone(), CallOptions::default())
+                    .client_stream(messages.clone())
                     .await
                     .expect("client_stream failed")
             });

--- a/benches/rpc/benches/rpc_bench.rs
+++ b/benches/rpc/benches/rpc_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use pprof::criterion::{Output, PProfProfiler};
 
-use connectrpc::client::{CallOptions, HttpClient};
+use connectrpc::client::{HttpClient, full_body};
 use connectrpc::{CodecFormat, Protocol};
 use rpc_bench::*;
 
@@ -216,7 +216,7 @@ fn bench_client_stream(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(protocol), |b| {
             b.to_async(&rt).iter(|| async {
                 client
-                    .client_stream(messages.clone(), CallOptions::default())
+                    .client_stream(messages.clone())
                     .await
                     .expect("client_stream failed")
             });
@@ -264,7 +264,7 @@ fn bench_bidi_stream(c: &mut Criterion) {
                 .uri(uri.clone())
                 .header("content-type", "application/connect+proto")
                 .header("connect-protocol-version", "1")
-                .body(http_body_util::Full::new(body_bytes.clone()))
+                .body(full_body(body_bytes.clone()))
                 .expect("failed to build request");
 
             let response = http.send(request).await.expect("bidi request failed");


### PR DESCRIPTION
## Summary
This updates the RPC benchmark code to match the current connectrpc client API. The client-stream benchmarks now call `client_stream(messages)` without redundant default call options, the manual bidi benchmark request uses `connectrpc::client::full_body(...)`, and the stale `CallOptions` import was removed.

## Why
The benchmark code had drifted behind the current client API and helper usage.

## Impact
The RPC benchmark crate builds cleanly against the current API, keeping the benchmark suite aligned with the library surface.

## Root cause
The benchmark code still referenced an older client-stream call shape and body-construction path after the client helpers changed.

## Validation
- `cargo check --manifest-path benches/rpc/Cargo.toml --benches`