### PR TITLE
Switch CLA action to Node 24 fork v2.7.1

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -17,7 +17,11 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        # Upstream contributor-assistant/github-action was archived 2026-03-23
+        # still on Node 20 (deprecated 2026-06-02). This fork bumps the
+        # runtime to Node 24 and fixes a false-failure where the check
+        # would go red after logging "All contributors have signed".
+        uses: iainmcgin/cla-github-action@eeb7f3ffa305b600c6e873578b9ea78ca11a5f3e  # v2.7.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Swaps the CLA workflow from the archived upstream `contributor-assistant/github-action@v2.6.1` to the forked `iainmcgin/cla-github-action` at v2.7.1. Brings connect-rust to parity with buffa (which adopted v2.7.0 in anthropics/buffa#10 and is bumping to v2.7.1 in anthropics/buffa#18).

## Why the fork

Upstream was archived 2026-03-23 while still declaring `using: "node20"`. GitHub force-upgrades Node 20 actions to Node 24 on 2026-06-02. No upstream fix is coming.

## What v2.7.1 fixes over upstream

1. **Node 24 runtime** (`action.yml`: `node20` → `node24`)
2. **False-failure bug**: `reRunLastWorkFlowIfRequired()` ran on every `pull_request_target` event, making 4-5 GitHub API calls after the "All contributors have signed ✅" message. Something in that chain could cause the step to exit non-zero without an error annotation — red check despite a clean log. v2.7.1 skips that logic on `pull_request_target` (it's only meaningful for `issue_comment` events) and isolates rerun errors so they never poison the CLA verdict. Also shaves ~9s off every PR-push check.

## Verification

`pull_request_target` runs from the base branch, so this PR's own CLA check still uses upstream v2.6.1. The fork is first exercised on the next PR after this merges.