### PR TITLE
Use write-if-changed pattern in connectrpc-build

### DIFF
--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -31,7 +31,6 @@
 //! call [`Config::use_buf`]. To avoid both, precompile a `FileDescriptorSet`
 //! once and ship it alongside your source via [`Config::descriptor_set`].
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -251,7 +250,7 @@ impl Config {
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::File::create(&path)?.write_all(file.content.as_bytes())?;
+            write_if_changed(&path, file.content.as_bytes())?;
             let pkg = name_to_package.get(&file.name).cloned().unwrap_or_default();
             entries.push((file.name.clone(), pkg));
         }
@@ -260,7 +259,7 @@ impl Config {
         if let Some(ref include_name) = self.include_file {
             let include_src = generate_include_file(&entries, relative_includes);
             let include_path = out_dir.join(include_name);
-            std::fs::File::create(&include_path)?.write_all(include_src.as_bytes())?;
+            write_if_changed(&include_path, include_src.as_bytes())?;
         }
 
         // 6. Cargo re-run triggers.
@@ -279,6 +278,19 @@ impl Default for Config {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Write `content` to `path` only if the file doesn't already exist with
+/// identical content. Cargo's rebuild decision for `include!`-ed files is
+/// mtime-based, so an unconditional write here would cascade into
+/// recompiling every downstream crate whenever any `.proto` is touched.
+fn write_if_changed(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    if let Ok(existing) = std::fs::read(path)
+        && existing == content
+    {
+        return Ok(());
+    }
+    std::fs::write(path, content)
 }
 
 /// Run `protoc` and return the serialized `FileDescriptorSet`.
@@ -677,5 +689,38 @@ mod tests {
             proto_relative_names(&files),
             vec!["my/pkg/svc.proto".to_string(), "top.proto".to_string()]
         );
+    }
+
+    #[test]
+    fn write_if_changed_creates_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new.rs");
+        write_if_changed(&path, b"hello").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn write_if_changed_skips_identical_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("same.rs");
+        std::fs::write(&path, b"content").unwrap();
+        let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        // Sleep briefly so a write would produce a distinguishable mtime.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        write_if_changed(&path, b"content").unwrap();
+        let mtime_after = std::fs::metadata(&path).unwrap().modified().unwrap();
+        assert_eq!(mtime_before, mtime_after);
+    }
+
+    #[test]
+    fn write_if_changed_overwrites_different_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("changed.rs");
+        std::fs::write(&path, b"old").unwrap();
+
+        write_if_changed(&path, b"new").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
     }
 }


### PR DESCRIPTION
Skip writing output files when their content is already identical to what's on disk, preserving mtime so Cargo doesn't spuriously recompile downstream crates.

## Why

Cargo's rebuild decision for `include!`-ed files is **mtime-based** — rustc's dep-info (`.d`) file lists every included path, and Cargo compares each one's mtime against the stored fingerprint timestamp. Verified empirically: `touch $OUT_DIR/gen.rs` (content unchanged) → `cargo build -v` reports `Dirty ...: the file 'gen.rs' has changed (mtime 1774896316s, 1m 14s after last build)` and recompiles.

Before this change, touching any single `.proto` file re-ran the build script (correct, per `cargo:rerun-if-changed`), which then unconditionally rewrote **every** output `.rs` file — bumping all their mtimes and cascading into a full downstream recompile even when N-1 of N generated files were byte-identical.

## Change

Two call sites in `Config::compile()` now go through `write_if_changed` (read-compare-conditionally-write). The now-unused `use std::io::Write` is removed. Three tests cover create/skip-identical/overwrite. Uses edition-2024 let-chain syntax for the nested condition.

## Prior art

- anthropics/buffa#17 — same pattern for `buffa-build`
- `prost-build` [`config.rs:1179`](https://github.com/tokio-rs/prost/blob/master/prost-build/src/config.rs) — `write_file_if_changed` with the identical implementation