### PR TITLE
Bump buffa to v0.3.0 and migrate to TypeRegistry API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ futures = "0.3"
 pin-project = "1"
 
 # Protobuf
-buffa = { version = "0.2", features = ["json"] }
-buffa-types = { version = "0.2", features = ["json"] }
-buffa-codegen = { version = "0.2" }
+buffa = { version = "0.3", features = ["json"] }
+buffa-types = { version = "0.3", features = ["json"] }
+buffa-codegen = { version = "0.3" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # connectrpc
 
+[![crates.io](https://img.shields.io/crates/v/connectrpc.svg)](https://crates.io/crates/connectrpc)
+[![docs.rs](https://img.shields.io/docsrs/connectrpc)](https://docs.rs/connectrpc)
+[![CI](https://github.com/anthropics/connect-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/anthropics/connect-rust/actions/workflows/ci.yml)
+[![deps.rs](https://deps.rs/repo/github/anthropics/connect-rust/status.svg)](https://deps.rs/repo/github/anthropics/connect-rust)
+[![License](https://img.shields.io/crates/l/connectrpc)](LICENSE)
+
 A [Tower](https://docs.rs/tower/latest/tower/)-based Rust implementation of the [ConnectRPC](https://connectrpc.com/) protocol, providing HTTP-based RPC with protobuf messages in either binary or JSON form.
 
 ## Overview

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -32,7 +32,7 @@ use connectrpc_conformance::HTTPVersion;
 use connectrpc_conformance::Header;
 use connectrpc_conformance::Protocol;
 use connectrpc_conformance::StreamType;
-use connectrpc_conformance::init_any_registry;
+use connectrpc_conformance::init_type_registry;
 use connectrpc_conformance::proto::connectrpc::conformance::v1::{
     BidiStreamResponseView, ClientStreamResponseView, IdempotentUnaryResponseView,
     ServerStreamResponseView, UnaryResponseView,
@@ -196,7 +196,7 @@ async fn main() -> Result<()> {
     tracing::info!("Conformance client starting");
 
     // Initialize the Any type registry for proper proto3 JSON serialization
-    init_any_registry();
+    init_type_registry();
 
     // Read requests from stdin until EOF
     loop {

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -40,7 +40,7 @@ use connectrpc_conformance::StreamResponseDefinition;
 use connectrpc_conformance::UnaryResponse;
 use connectrpc_conformance::UnaryResponseDefinition;
 use connectrpc_conformance::UnimplementedResponse;
-use connectrpc_conformance::init_any_registry;
+use connectrpc_conformance::init_type_registry;
 use connectrpc_conformance::proto::connectrpc::conformance::v1::{
     BidiStreamRequestView, ClientStreamRequestView, IdempotentUnaryRequestView,
     ServerStreamRequestView, UnaryRequestView, UnimplementedRequestView,
@@ -1179,7 +1179,7 @@ async fn main() -> Result<()> {
     // Initialize the Any type registry so that google.protobuf.Any fields
     // in conformance responses are serialized with inlined message fields
     // (proto3 canonical JSON) rather than a raw "value" base64 fallback.
-    init_any_registry();
+    init_type_registry();
 
     // Read the server configuration from stdin
     let request: ServerCompatRequest =

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -39,16 +39,16 @@ use std::io;
 use std::io::Read;
 use std::io::Write;
 
-/// Initialize the global `AnyRegistry` with conformance message types.
+/// Initialize the global `TypeRegistry` with conformance message types.
 ///
 /// Must be called before any JSON serialization/deserialization of messages
 /// containing `google.protobuf.Any` fields (e.g., `ConformancePayload.RequestInfo.requests`).
-pub fn init_any_registry() {
-    use buffa::any_registry::{AnyRegistry, AnyTypeEntry};
+pub fn init_type_registry() {
+    use buffa::type_registry::{JsonAnyEntry, TypeRegistry};
 
     macro_rules! register {
         ($registry:expr, $ty:ty) => {
-            $registry.register(AnyTypeEntry {
+            $registry.register_json_any(JsonAnyEntry {
                 type_url: <$ty>::TYPE_URL,
                 to_json: |bytes| {
                     let msg = <$ty>::decode_from_slice(bytes).map_err(|e| e.to_string())?;
@@ -63,7 +63,7 @@ pub fn init_any_registry() {
         };
     }
 
-    let mut registry = AnyRegistry::new();
+    let mut registry = TypeRegistry::new();
     buffa_types::register_wkt_types(&mut registry);
     register!(registry, UnaryRequest);
     register!(registry, ServerStreamRequest);
@@ -76,7 +76,7 @@ pub fn init_any_registry() {
     register!(registry, Header);
     register!(registry, RawHTTPRequest);
     register!(registry, RawHTTPResponse);
-    buffa::any_registry::set_any_registry(Box::new(registry));
+    buffa::type_registry::set_type_registry(registry);
 }
 
 /// Read a length-prefixed protobuf message from stdin.


### PR DESCRIPTION
Bumps the buffa workspace dependencies (`buffa`, `buffa-types`, `buffa-codegen`) from `0.2` to `0.3`.

buffa v0.3.0 renamed `AnyRegistry` → `TypeRegistry` and `AnyTypeEntry` → `JsonAnyEntry` (the old names remain as deprecated aliases for one release cycle). However, `buffa_types::register_wkt_types` now takes `&mut TypeRegistry` directly, so the conformance crate's registry initialization must use the new types.

Changes:
- `Cargo.toml`: workspace deps `0.2` → `0.3`
- `conformance/src/lib.rs`: migrate to `TypeRegistry`/`JsonAnyEntry`/`register_json_any`/`set_type_registry`; rename `init_any_registry` → `init_type_registry`
- `conformance/src/bin/{client,server}.rs`: update import and call site

`cargo test --workspace`: 294 passed, 0 failed.

Prerequisite for the connect-rust v0.3.0 release.

---

**Note (separate issue, not addressed here):** `cargo clippy --all-targets` reveals 3 pre-existing compile errors in `benches/rpc/benches/{rpc_bench,cross_impl_bench}.rs` that exist on `main` independently of this change — the bench callers are out of sync with the checked-in generated client stubs. CI doesn't build with `--all-targets` so this slipped through. Will address in a follow-up.