### PR TITLE
Add --all-targets to CI cargo check and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get install -y protobuf-compiler
-      - run: cargo check --workspace --all-features
+      - run: cargo check --workspace --all-features --all-targets
 
   test:
     name: Test
@@ -41,7 +41,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get install -y protobuf-compiler
-      - run: cargo clippy --workspace --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
   fmt:
     name: Format


### PR DESCRIPTION
Ensures benches, examples, and integration test targets are compile-checked in CI.

The rpc-bench breakage fixed by #17 went undetected because `cargo check`/`cargo clippy` without `--all-targets` only build lib and bin targets. This adds the flag to both invocations so that class of drift is caught at PR time.

2 lines changed in `.github/workflows/ci.yml`.