### PR TITLE
Expose mTLS peer credentials and remote address to handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ prettyplease = "0.2"
 
 # Dev dependencies
 tempfile = "3"
+rcgen = "0.13"
 
 [workspace.lints.rust]
 dead_code = "warn"

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -73,6 +73,7 @@ rustls-pki-types = { workspace = true, optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 tempfile = { workspace = true }
+rcgen = { workspace = true }
 buffa-types = { workspace = true }
 
 [features]

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -65,6 +65,14 @@ pub struct Context {
     /// policy. Set to `Some(false)` to disable compression for this response,
     /// or `Some(true)` to force it.
     pub compress_response: Option<bool>,
+    /// Request extensions carried from the underlying `http::Request`.
+    ///
+    /// This is the passthrough for connection-scoped metadata that a
+    /// tower layer in front of the service can attach — TLS peer
+    /// certificates, remote socket address, auth context, etc. The
+    /// dispatch path moves `parts.extensions` here verbatim; handlers
+    /// read it with `ctx.extensions.get::<T>()`.
+    pub extensions: http::Extensions,
 }
 
 impl Context {
@@ -76,6 +84,7 @@ impl Context {
             trailers: http::HeaderMap::new(),
             deadline: None,
             compress_response: None,
+            extensions: http::Extensions::new(),
         }
     }
 
@@ -86,6 +95,15 @@ impl Context {
     #[must_use]
     pub fn with_deadline(mut self, deadline: Option<std::time::Instant>) -> Self {
         self.deadline = deadline;
+        self
+    }
+
+    /// Attach request extensions captured from the underlying `http::Request`.
+    ///
+    /// Used by the server dispatch paths; see [`Context::extensions`].
+    #[must_use]
+    pub fn with_extensions(mut self, extensions: http::Extensions) -> Self {
+        self.extensions = extensions;
         self
     }
 
@@ -1401,5 +1419,20 @@ mod tests {
 
         let ctx = Context::new(http::HeaderMap::new()).with_deadline(None);
         assert_eq!(ctx.deadline, None);
+    }
+
+    #[test]
+    fn test_context_with_extensions() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct Peer(u32);
+
+        let mut ext = http::Extensions::new();
+        ext.insert(Peer(42));
+        let ctx = Context::new(http::HeaderMap::new()).with_extensions(ext);
+        assert_eq!(ctx.extensions.get::<Peer>(), Some(&Peer(42)));
+
+        // Default-constructed context has empty extensions.
+        let ctx = Context::default();
+        assert!(ctx.extensions.get::<Peer>().is_none());
     }
 }

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -258,6 +258,11 @@ pub use server::BoundServer;
 #[cfg(feature = "server")]
 pub use server::Server;
 
+#[cfg(feature = "server")]
+pub use server::PeerAddr;
+#[cfg(feature = "server-tls")]
+pub use server::PeerCerts;
+
 /// Re-export of `rustls` for TLS configuration.
 ///
 /// Use this to construct a [`rustls::ServerConfig`] for [`Server::with_tls`]

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -58,6 +58,53 @@ use crate::error::ErrorCode;
 use crate::router::Router;
 use crate::service::ConnectRpcService;
 
+/// Remote socket address of the connected peer.
+///
+/// Inserted into every request's extensions by the built-in server's accept
+/// loop. Handlers read it via `ctx.extensions.get::<PeerAddr>()`.
+///
+/// Callers using a different HTTP stack (axum, raw hyper) in front of
+/// [`ConnectRpcService`](crate::ConnectRpcService) can insert this same type
+/// from a tower layer so handlers stay agnostic to the transport.
+#[derive(Clone, Debug)]
+pub struct PeerAddr(pub SocketAddr);
+
+/// TLS client certificate chain presented by the peer (leaf first).
+///
+/// Inserted by the built-in server's TLS accept loop when the
+/// [`rustls::ServerConfig`] requests client authentication and the peer
+/// presents a valid chain. Absent on plaintext connections or when the
+/// client presents no certificate. Handlers read it via
+/// `ctx.extensions.get::<PeerCerts>()`.
+///
+/// The `Arc` makes per-request insertion cheap: all requests on a
+/// connection share one chain, so this is a refcount bump, not a copy.
+#[cfg(feature = "server-tls")]
+#[derive(Clone, Debug)]
+pub struct PeerCerts(pub Arc<[rustls::pki_types::CertificateDer<'static>]>);
+
+/// Connection-scoped peer info captured once per accepted stream and
+/// inserted into every request's extensions by [`PeerInfo::insert_into`].
+#[derive(Clone, Debug)]
+struct PeerInfo {
+    addr: SocketAddr,
+    #[cfg(feature = "server-tls")]
+    certs: Option<Arc<[rustls::pki_types::CertificateDer<'static>]>>,
+}
+
+impl PeerInfo {
+    /// Insert this connection's peer info as public extension types
+    /// ([`PeerAddr`], [`PeerCerts`]) so handlers can read them via
+    /// `ctx.extensions.get::<T>()`.
+    fn insert_into(&self, ext: &mut http::Extensions) {
+        ext.insert(PeerAddr(self.addr));
+        #[cfg(feature = "server-tls")]
+        if let Some(certs) = &self.certs {
+            ext.insert(PeerCerts(Arc::clone(certs)));
+        }
+    }
+}
+
 /// Default TLS handshake timeout.
 ///
 /// Bounds how long the server waits after TCP accept for a client to complete
@@ -380,18 +427,24 @@ type WrappedService<D> = tower_http::catch_panic::CatchPanic<
 ///
 /// Generic over the IO type so it works for both plain TCP and TLS streams.
 /// Logs connection outcome at trace level.
+///
+/// `peer` is inserted into every request's extensions so handlers can read
+/// the remote address (and TLS client cert chain, if any) via
+/// `ctx.extensions.get::<PeerAddr>()` / `get::<PeerCerts>()`.
 async fn serve_accepted_stream<D, S>(
     io: S,
-    remote_addr: SocketAddr,
+    peer: PeerInfo,
     service: Arc<WrappedService<D>>,
     http1_keep_alive: bool,
 ) where
     D: Dispatcher,
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
-    tracing::trace!(remote_addr = %remote_addr, "Accepted new connection");
+    tracing::trace!(remote_addr = %peer.addr, "Accepted new connection");
 
-    let svc = hyper::service::service_fn(move |req| {
+    let peer_for_requests = peer.clone();
+    let svc = hyper::service::service_fn(move |mut req| {
+        peer_for_requests.insert_into(req.extensions_mut());
         let mut service = (*service).clone();
         async move { service.call(req).await }
     });
@@ -401,11 +454,11 @@ async fn serve_accepted_stream<D, S>(
 
     match builder.serve_connection(TokioIo::new(io), svc).await {
         Ok(()) => {
-            tracing::trace!(remote_addr = %remote_addr, "Connection completed normally");
+            tracing::trace!(remote_addr = %peer.addr, "Connection completed normally");
         }
         Err(err) => {
             tracing::trace!(
-                remote_addr = %remote_addr,
+                remote_addr = %peer.addr,
                 error = %err,
                 "Connection ended with error",
             );
@@ -496,8 +549,21 @@ async fn serve_with_listener<D: Dispatcher>(
                 // indefinitely, holding a task and file descriptor per connection.
                 match tokio::time::timeout(tls_handshake_timeout, acceptor.accept(stream)).await {
                     Ok(Ok(tls_stream)) => {
-                        serve_accepted_stream(tls_stream, remote_addr, service, http1_keep_alive)
-                            .await;
+                        // Extract the client cert chain now — once hyper owns
+                        // the stream for I/O we can't borrow it again.
+                        // `into_owned()` detaches from the session's lifetime
+                        // so the Arc can outlive the TlsStream (which it must,
+                        // since we move the stream into hyper but need the certs
+                        // for every request on this connection).
+                        let (_, conn) = tls_stream.get_ref();
+                        let certs = conn.peer_certificates().map(|chain| -> Arc<[_]> {
+                            chain.iter().map(|c| c.clone().into_owned()).collect()
+                        });
+                        let peer = PeerInfo {
+                            addr: remote_addr,
+                            certs,
+                        };
+                        serve_accepted_stream(tls_stream, peer, service, http1_keep_alive).await;
                     }
                     Ok(Err(err)) => {
                         tracing::debug!(
@@ -517,7 +583,12 @@ async fn serve_with_listener<D: Dispatcher>(
             }
 
             // Plain TCP (no TLS or TLS not configured)
-            serve_accepted_stream(stream, remote_addr, service, http1_keep_alive).await;
+            let peer = PeerInfo {
+                addr: remote_addr,
+                #[cfg(feature = "server-tls")]
+                certs: None,
+            };
+            serve_accepted_stream(stream, peer, service, http1_keep_alive).await;
         });
     }
 
@@ -608,7 +679,23 @@ fn is_transient_accept_error(err: &std::io::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use std::time::Duration;
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+
+    /// Hand-crafted Connect unary request (`POST /svc/Echo`, empty proto
+    /// body, `Connection: close`). Used by the peer-info tests to probe the
+    /// server over raw TCP/TLS without pulling in an HTTP client dep.
+    const ECHO_REQ: &[u8] = concat!(
+        "POST /svc/Echo HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Content-Type: application/proto\r\n",
+        "Content-Length: 0\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+    )
+    .as_bytes();
 
     #[test]
     fn test_server_creation() {
@@ -719,5 +806,186 @@ mod tests {
             connect_result.is_err(),
             "expected connection refused after shutdown"
         );
+    }
+
+    // ========================================================================
+    // PeerAddr / PeerCerts extension plumbing
+    // ========================================================================
+
+    #[tokio::test]
+    async fn peer_addr_reaches_handler() {
+        // Handler stashes the PeerAddr it sees into a shared slot.
+        let captured: Arc<Mutex<Option<PeerAddr>>> = Arc::new(Mutex::new(None));
+        let handler_captured = Arc::clone(&captured);
+        let router = Router::new().route(
+            "svc",
+            "Echo",
+            crate::handler_fn(move |ctx: crate::Context, _req: buffa_types::Empty| {
+                let cap = Arc::clone(&handler_captured);
+                async move {
+                    *cap.lock().unwrap() = ctx.extensions.get::<PeerAddr>().cloned();
+                    Ok((buffa_types::Empty::default(), ctx))
+                }
+            }),
+        );
+
+        let bound = Server::bind("127.0.0.1:0").await.unwrap();
+        let addr = bound.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(router, async {
+                    rx.await.ok();
+                })
+                .await
+        });
+
+        // Hand-crafted Connect unary request over raw TCP (HTTP/1.1).
+        // Body is an empty-serialized `Empty` message (zero bytes).
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let client_local = stream.local_addr().unwrap();
+        stream.write_all(ECHO_REQ).await.unwrap();
+        // Drain the response so the server-side connection can complete.
+        let mut resp = Vec::new();
+        stream.read_to_end(&mut resp).await.unwrap();
+        // Sanity: 2xx status.
+        assert!(
+            resp.starts_with(b"HTTP/1.1 2"),
+            "expected 2xx, got: {}",
+            String::from_utf8_lossy(&resp[..resp.len().min(80)])
+        );
+
+        tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        let peer = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("handler should have captured PeerAddr");
+        // The server sees the client's local_addr() as the remote peer.
+        assert_eq!(peer.0, client_local);
+    }
+
+    /// End-to-end mTLS: client presents a cert; handler reads it from
+    /// `ctx.extensions.get::<PeerCerts>()` and the DER bytes round-trip.
+    #[cfg(feature = "server-tls")]
+    #[tokio::test]
+    async fn peer_certs_reach_handler() {
+        // Inline minimal mTLS PKI: one CA → one server leaf + one client leaf.
+        // Returns (server_config, client_config, client_cert_der).
+        fn pki() -> (
+            Arc<rustls::ServerConfig>,
+            Arc<rustls::ClientConfig>,
+            rustls::pki_types::CertificateDer<'static>,
+        ) {
+            use rcgen::CertificateParams;
+            use rcgen::KeyPair;
+            use rcgen::SanType;
+            use rustls::pki_types::CertificateDer;
+            use rustls::pki_types::PrivatePkcs8KeyDer;
+
+            // Idempotent; err = already installed (tests share process state).
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+            let ca_key = KeyPair::generate().unwrap();
+            let mut ca = CertificateParams::default();
+            ca.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+            let ca = ca.self_signed(&ca_key).unwrap();
+
+            let issue = |sans: &[SanType]| {
+                let k = KeyPair::generate().unwrap();
+                let mut p = CertificateParams::default();
+                p.subject_alt_names = sans.to_vec();
+                let c = p.signed_by(&k, &ca, &ca_key).unwrap();
+                (
+                    CertificateDer::from(c.der().to_vec()),
+                    PrivatePkcs8KeyDer::from(k.serialized_der().to_vec()).into(),
+                )
+            };
+
+            let (srv_cert, srv_key) = issue(&[SanType::DnsName("localhost".try_into().unwrap())]);
+            let (cli_cert, cli_key) = issue(&[]);
+            let mut roots = rustls::RootCertStore::empty();
+            roots.add(CertificateDer::from(ca.der().to_vec())).unwrap();
+            let roots = Arc::new(roots);
+
+            let cv = rustls::server::WebPkiClientVerifier::builder(Arc::clone(&roots))
+                .build()
+                .unwrap();
+            let server = rustls::ServerConfig::builder()
+                .with_client_cert_verifier(cv)
+                .with_single_cert(vec![srv_cert], srv_key)
+                .unwrap();
+            let client = rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_client_auth_cert(vec![cli_cert.clone()], cli_key)
+                .unwrap();
+            (Arc::new(server), Arc::new(client), cli_cert)
+        }
+
+        let (server_cfg, client_cfg, expected_client_der) = pki();
+
+        let captured: Arc<Mutex<Option<PeerCerts>>> = Arc::new(Mutex::new(None));
+        let handler_captured = Arc::clone(&captured);
+        let router = Router::new().route(
+            "svc",
+            "Echo",
+            crate::handler_fn(move |ctx: crate::Context, _req: buffa_types::Empty| {
+                let cap = Arc::clone(&handler_captured);
+                async move {
+                    *cap.lock().unwrap() = ctx.extensions.get::<PeerCerts>().cloned();
+                    Ok((buffa_types::Empty::default(), ctx))
+                }
+            }),
+        );
+
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_tls(server_cfg);
+        let addr = bound.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(router, async {
+                    rx.await.ok();
+                })
+                .await
+        });
+
+        // TLS-over-raw-TCP + hand-crafted HTTP/1.1 Connect unary request.
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let connector = tokio_rustls::TlsConnector::from(client_cfg);
+        let sni = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        let mut tls = connector.connect(sni, tcp).await.unwrap();
+        tls.write_all(ECHO_REQ).await.unwrap();
+        let mut resp = Vec::new();
+        tls.read_to_end(&mut resp).await.unwrap();
+        assert!(
+            resp.starts_with(b"HTTP/1.1 2"),
+            "expected 2xx, got: {}",
+            String::from_utf8_lossy(&resp[..resp.len().min(80)])
+        );
+
+        tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        let certs = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("handler should have captured PeerCerts");
+        // The exact DER bytes the client presented.
+        assert_eq!(certs.0.len(), 1);
+        assert_eq!(certs.0[0].as_ref(), expected_client_der.as_ref());
     }
 }

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -64,7 +64,7 @@ use crate::service::ConnectRpcService;
 /// loop. Handlers read it via `ctx.extensions.get::<PeerAddr>()`.
 ///
 /// Callers using a different HTTP stack (axum, raw hyper) in front of
-/// [`ConnectRpcService`](crate::ConnectRpcService) can insert this same type
+/// [`ConnectRpcService`] can insert this same type
 /// from a tower layer so handlers stay agnostic to the transport.
 #[derive(Clone, Debug)]
 pub struct PeerAddr(pub SocketAddr);

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -239,6 +239,24 @@ impl Server {
     ///   via IPv4-mapped addresses by default)
     /// - `"localhost:8080"` — resolves via DNS/hosts (may yield v4, v6, or both)
     ///
+    /// Wrap a pre-bound [`TcpListener`].
+    ///
+    /// Use this instead of [`Server::bind`] when you need to configure
+    /// socket options before binding — e.g. `IPV6_V6ONLY=false` for
+    /// dual-stack listening, `SO_REUSEPORT` for multi-process accept,
+    /// or binding to a listener inherited from a parent process.
+    #[must_use]
+    pub fn from_listener(listener: TcpListener) -> BoundServer {
+        BoundServer {
+            listener,
+            http1_keep_alive: true,
+            #[cfg(feature = "server-tls")]
+            tls_config: None,
+            #[cfg(feature = "server-tls")]
+            tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+        }
+    }
+
     /// When multiple addresses are returned (e.g. `localhost` resolving to
     /// both `::1` and `127.0.0.1`), the first that successfully binds is used.
     pub async fn bind(

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -1462,7 +1462,8 @@ where
     let metadata = RequestMetadata::from_headers(req.headers(), Protocol::Connect);
 
     // Split request to consume the body
-    let (_parts, body) = req.into_parts();
+    let (parts, body) = req.into_parts();
+    let extensions = parts.extensions;
 
     // IMPORTANT: Read the full request body BEFORE returning any errors.
     // For HTTP/1.1, returning an error without reading the body causes
@@ -1564,7 +1565,9 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers).with_deadline(deadline);
+    let ctx = Context::new(metadata.headers)
+        .with_deadline(deadline)
+        .with_extensions(extensions);
 
     // Call the handler with the appropriate codec format, applying timeout if specified
     let (response_body, ctx) = if let Some(timeout) = metadata.timeout {
@@ -1716,7 +1719,8 @@ where
 
     // Read the full body. collect_body_limited bounds allocation during the
     // read, so an oversized body is rejected before it is fully buffered.
-    let (_parts, body) = req.into_parts();
+    let (parts, body) = req.into_parts();
+    let extensions = parts.extensions;
     let post_body = match collect_body_limited(body, limits.max_request_body_size).await {
         Ok(bytes) => bytes,
         Err(err) => return grpc_unary_error(&err),
@@ -1773,7 +1777,9 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers).with_deadline(deadline);
+    let ctx = Context::new(metadata.headers)
+        .with_deadline(deadline)
+        .with_extensions(extensions);
 
     // Call the handler with timeout if configured
     let handler_result = if let Some(timeout) = metadata.timeout {
@@ -1927,7 +1933,8 @@ where
     let method_desc = dispatcher.lookup(&path);
 
     // Split request to consume the body
-    let (_parts, body) = req.into_parts();
+    let (parts, body) = req.into_parts();
+    let extensions = parts.extensions;
 
     // For bidi streaming, pass the raw body stream directly (no buffering)
     if matches!(method_desc, Some(d) if d.kind == MethodKind::BidiStreaming) {
@@ -1936,6 +1943,7 @@ where
             &path,
             metadata,
             body,
+            extensions,
             protocol,
             codec_format,
             limits,
@@ -1952,6 +1960,7 @@ where
             &path,
             metadata,
             body,
+            extensions,
             protocol,
             codec_format,
             limits,
@@ -2052,7 +2061,9 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers).with_deadline(deadline);
+    let ctx = Context::new(metadata.headers)
+        .with_deadline(deadline)
+        .with_extensions(extensions);
 
     // Call the handler with the appropriate codec format.
     // For gRPC unary handlers, we wrap the single response in a one-item stream.
@@ -2167,6 +2178,7 @@ async fn handle_client_streaming_request<D, B>(
     path: &str,
     metadata: RequestMetadata,
     body: B,
+    extensions: http::Extensions,
     protocol: Protocol,
     codec_format: CodecFormat,
     limits: Limits,
@@ -2188,7 +2200,9 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers).with_deadline(deadline);
+    let ctx = Context::new(metadata.headers)
+        .with_deadline(deadline)
+        .with_extensions(extensions);
 
     // Call the handler. On error paths, the reader task is left running
     // (detached) so it can finish draining the request body — aborting it
@@ -2406,6 +2420,7 @@ async fn handle_bidi_streaming_request<D, B>(
     path: &str,
     metadata: RequestMetadata,
     body: B,
+    extensions: http::Extensions,
     protocol: Protocol,
     codec_format: CodecFormat,
     limits: Limits,
@@ -2428,7 +2443,9 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers).with_deadline(deadline);
+    let ctx = Context::new(metadata.headers)
+        .with_deadline(deadline)
+        .with_extensions(extensions);
 
     // Call the handler with timeout if configured
     let handler_result = if let Some(timeout) = metadata.timeout {
@@ -3354,6 +3371,59 @@ mod tests {
         assert!(
             json.contains("turn it off and on again"),
             "debug content missing: {json}"
+        );
+    }
+
+    // ========================================================================
+    // Context.extensions passthrough
+    // ========================================================================
+
+    /// Prove that `http::Request` extensions survive the unary dispatch
+    /// path and reach the handler via `Context.extensions`. A tower layer
+    /// in front of `ConnectRpcService` inserts peer info this way.
+    #[tokio::test]
+    async fn extensions_flow_to_handler_context() {
+        use std::sync::Mutex;
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct PeerTag(&'static str);
+
+        let captured = Arc::new(Mutex::new(None::<PeerTag>));
+        let handler_captured = Arc::clone(&captured);
+        let router = Router::new().route(
+            "svc",
+            "Method",
+            crate::handler_fn(move |ctx: Context, _req: buffa_types::Empty| {
+                let cap = Arc::clone(&handler_captured);
+                async move {
+                    *cap.lock().unwrap() = ctx.extensions.get::<PeerTag>().cloned();
+                    Ok((buffa_types::Empty::default(), ctx))
+                }
+            }),
+        );
+
+        let mut req = Request::builder()
+            .method(Method::POST)
+            .uri("/svc/Method")
+            .header(header::CONTENT_TYPE, "application/proto")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        req.extensions_mut().insert(PeerTag("10.0.0.1:54321"));
+
+        handle_unary_request(
+            &router,
+            req,
+            Limits::default(),
+            Arc::new(CompressionRegistry::new()),
+            &CompressionPolicy::default(),
+        )
+        .await
+        .expect("dispatch should succeed");
+
+        assert_eq!(
+            captured.lock().unwrap().take(),
+            Some(PeerTag("10.0.0.1:54321")),
+            "extension inserted on the http::Request must reach Context.extensions"
         );
     }
 }


### PR DESCRIPTION
Headline feature for v0.3.0.

## Summary

Adds `Context::extensions: http::Extensions` as a passthrough for connection-scoped metadata, and has the built-in server populate it with:

- **`PeerAddr`** — the remote socket address, on every connection
- **`PeerCerts`** — the client certificate chain (leaf first), when the `rustls::ServerConfig` requests client authentication and the peer presents a valid chain

Handlers read these via `ctx.extensions.get::<PeerAddr>()` / `get::<PeerCerts>()`. Other HTTP stacks (axum, raw hyper) wrapping `ConnectRpcService` can insert the same types from a tower layer, so handlers stay transport-agnostic.

## Implementation

- `Context::extensions` field + `with_extensions()` builder (`handler.rs`)
- `PeerAddr`, `PeerCerts` public newtypes; private `PeerInfo` carrier captured once per accepted stream and inserted per-request via `Arc` refcount bump (`server.rs`)
- All four dispatch paths (Connect unary, gRPC unary, server-stream, client/bidi-stream) forward `http::Request` extensions into the handler `Context` (`service.rs`)
- Re-exports of `PeerAddr` / `PeerCerts` from the crate root (`lib.rs`)
- `rcgen` added as a dev-dependency for the end-to-end mTLS test

## Tests

- `handler::tests::test_context_with_extensions` — builder round-trip
- `service::tests::extensions_flow_to_handler_context` — request extensions reach the unary handler
- `server::tests::peer_addr_reaches_handler` — raw-TCP request, handler sees `PeerAddr` matching the client's `local_addr()`
- `server::tests::peer_certs_reach_handler` — full mTLS handshake (rcgen-issued CA + leaves), handler sees `PeerCerts` with the exact DER bytes the client presented

`cargo test --workspace --all-features`: all pass. `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean. Compiles with and without `server-tls`.