### PR TITLE
Expose emit_register_fn option in codegen and build configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ increment the patch version.
 
 ## [Unreleased]
 
+### Added
+
+- **`emit_register_fn` option** on `connectrpc_codegen::codegen::Options` and
+  `connectrpc_build::Config`, plumbing through to
+  `buffa_codegen::CodeGenConfig::emit_register_fn`. Set to `false` to suppress
+  the per-file `register_types(&mut TypeRegistry)` aggregator when multiple
+  generated files are `include!`d into the same module (the identically-named
+  functions would otherwise collide). The protoc plugin accepts a matching
+  `no_register_fn` parameter for path-compat with the unified `connectrpc-build`
+  flow.
+
 ## [0.3.0] - 2026-04-02
 
 ### Changed

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -120,6 +120,18 @@ impl Config {
         self
     }
 
+    /// Emit the per-file `register_types(&mut TypeRegistry)` aggregator
+    /// (default: true).
+    ///
+    /// Set to `false` when the generated files are `include!`d into the
+    /// same module — the identically-named functions would otherwise
+    /// collide. See [`Options::emit_register_fn`].
+    #[must_use]
+    pub fn emit_register_fn(mut self, enabled: bool) -> Self {
+        self.options.emit_register_fn = enabled;
+        self
+    }
+
     /// Invoke `buf build` instead of `protoc`.
     ///
     /// Requires `buf` on PATH. Uses buf's dependency resolution (BSR modules)
@@ -528,11 +540,13 @@ mod tests {
             .includes(&["proto/"])
             .strict_utf8_mapping(true)
             .generate_json(false)
+            .emit_register_fn(false)
             .include_file("_inc.rs");
         assert_eq!(cfg.files.len(), 2);
         assert_eq!(cfg.includes.len(), 1);
         assert!(cfg.options.strict_utf8_mapping);
         assert!(!cfg.options.generate_json);
+        assert!(!cfg.options.emit_register_fn);
         assert_eq!(cfg.include_file.as_deref(), Some("_inc.rs"));
     }
 
@@ -541,6 +555,7 @@ mod tests {
         let cfg = Config::new();
         assert!(!cfg.options.strict_utf8_mapping);
         assert!(cfg.options.generate_json);
+        assert!(cfg.options.emit_register_fn);
         assert!(matches!(cfg.descriptor_source, DescriptorSource::Protoc));
     }
 

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -61,6 +61,15 @@ pub struct Options {
     /// stubs so they compile independently of co-generated message types.
     /// Unused by [`generate_files`] (the unified `super::`-relative path).
     pub extern_paths: Vec<(String, String)>,
+    /// Emit the per-file `register_types(&mut TypeRegistry)` function that
+    /// aggregates every message in the file. Default `true`. See
+    /// `buffa_codegen::CodeGenConfig::emit_register_fn`.
+    ///
+    /// Set to `false` when multiple generated files are `include!`d into
+    /// the same module — the identically-named `register_types` fns would
+    /// otherwise collide. The per-message `__*_JSON_ANY` consts are still
+    /// emitted; only the aggregating function is suppressed.
+    pub emit_register_fn: bool,
 }
 
 impl Default for Options {
@@ -69,6 +78,7 @@ impl Default for Options {
             strict_utf8_mapping: false,
             generate_json: true,
             extern_paths: Vec::new(),
+            emit_register_fn: true,
         }
     }
 }
@@ -80,6 +90,7 @@ impl Options {
         config.generate_json = self.generate_json;
         config.strict_utf8_mapping = self.strict_utf8_mapping;
         config.extern_paths.clone_from(&self.extern_paths);
+        config.emit_register_fn = self.emit_register_fn;
         config
     }
 }
@@ -197,6 +208,10 @@ pub fn generate_services(
 /// - `no_json` — disable `serde` derives on generated message types.
 ///   Ignored in this plugin (no message types emitted); accepted for
 ///   compatibility with the unified path.
+/// - `no_register_fn` — suppress the per-file
+///   `register_types(&mut TypeRegistry)` aggregator. See
+///   [`Options::emit_register_fn`]. Ignored in this plugin (no message
+///   types emitted); accepted for compatibility with the unified path.
 pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse> {
     let mut options = Options::default();
 
@@ -236,11 +251,12 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
                 match opt {
                     "strict_utf8_mapping" => options.strict_utf8_mapping = true,
                     "no_json" => options.generate_json = false,
+                    "no_register_fn" => options.emit_register_fn = false,
                     _ => {
                         return Err(anyhow::anyhow!(
                             "unknown plugin option: {opt:?}. Supported: \
                              buffa_module=<rust_path>, extern_path=<proto>=<rust>, \
-                             strict_utf8_mapping, no_json"
+                             strict_utf8_mapping, no_json, no_register_fn"
                         ));
                     }
                 }
@@ -1698,5 +1714,80 @@ mod tests {
         let file = minimal_file_with_methods("example.v1", &["GetFoo", "GetBar"]);
         let code = gen_service(std::slice::from_ref(&file), 0, &[], false).unwrap();
         syn::parse_str::<syn::File>(&code).expect("generated code parses");
+    }
+
+    #[test]
+    fn options_default_emits_register_fn() {
+        let opts = Options::default();
+        assert!(opts.emit_register_fn);
+        let cfg = opts.to_buffa_config();
+        assert!(cfg.emit_register_fn);
+    }
+
+    #[test]
+    fn options_emit_register_fn_false_disables_buffa_register_fn() {
+        let opts = Options {
+            emit_register_fn: false,
+            ..Options::default()
+        };
+        let cfg = opts.to_buffa_config();
+        assert!(!cfg.emit_register_fn);
+    }
+
+    #[test]
+    fn generate_files_emit_register_fn_false_suppresses_register_types() {
+        // Build a file with a single message so buffa would normally emit
+        // `pub fn register_types(&mut TypeRegistry)` aggregating it.
+        let file = FileDescriptorProto {
+            name: Some("ping.proto".into()),
+            package: Some("example.v1".into()),
+            message_type: vec![DescriptorProto {
+                name: Some("PingReq".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let with_fn = generate_files(
+            std::slice::from_ref(&file),
+            &["ping.proto".into()],
+            &Options::default(),
+        )
+        .unwrap();
+        assert_eq!(with_fn.len(), 1);
+        assert!(
+            with_fn[0].content.contains("fn register_types"),
+            "expected register_types in default output: {}",
+            with_fn[0].content
+        );
+
+        let without_fn = generate_files(
+            std::slice::from_ref(&file),
+            &["ping.proto".into()],
+            &Options {
+                emit_register_fn: false,
+                ..Options::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(without_fn.len(), 1);
+        assert!(
+            !without_fn[0].content.contains("fn register_types"),
+            "register_types should be suppressed: {}",
+            without_fn[0].content
+        );
+    }
+
+    #[test]
+    fn plugin_no_register_fn_parses() {
+        let request = CodeGeneratorRequest {
+            parameter: Some("buffa_module=crate::proto,no_register_fn".into()),
+            file_to_generate: vec![],
+            proto_file: vec![],
+            ..Default::default()
+        };
+        // Plugin path emits services only, so we can't observe the buffa
+        // config directly — just make sure the option parses without error.
+        generate(&request).expect("no_register_fn should be a recognized plugin option");
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `emit_register_fn` option to `connectrpc_codegen::codegen::Options` and a matching builder method on `connectrpc_build::Config`, plumbing through to `buffa_codegen::CodeGenConfig::emit_register_fn`. The protoc plugin (`protoc-gen-connect-rust`) accepts a matching `no_register_fn` parameter for path-compat with the unified `connectrpc-build` flow.

## Motivation

A downstream user reported that they need `emit_register_fn=false` because they `include!` multiple buffa-generated files into the same module — the identically-named per-file `register_types(&mut TypeRegistry)` functions collide. buffa-codegen has supported this knob since v0.3, but `connectrpc-codegen::Options` never plumbed it through. There was no way to set it short of dropping back to calling `buffa_codegen` directly.

## Changes

- `connectrpc-codegen/src/codegen.rs`: new `emit_register_fn: bool` field on `Options` (default `true`), copied into `CodeGenConfig` in `to_buffa_config()`. New `no_register_fn` plugin parameter token.
- `connectrpc-build/src/lib.rs`: new `Config::emit_register_fn(enabled)` builder method, matching the `strict_utf8_mapping` / `generate_json` shape.
- `CHANGELOG.md`: `[Unreleased]` entry under `Added`.

`Options` is `#[non_exhaustive]` so the field addition is non-breaking. Default of `true` preserves existing behavior.

## Test Plan

- Four new unit tests in `connectrpc-codegen`:
  - `options_default_emits_register_fn` — default is `true` and propagates to `CodeGenConfig`.
  - `options_emit_register_fn_false_disables_buffa_register_fn` — `false` propagates.
  - `generate_files_emit_register_fn_false_suppresses_register_types` — end-to-end through `generate_files`: default output contains `fn register_types`, opt-out output does not.
  - `plugin_no_register_fn_parses` — protoc plugin accepts `no_register_fn` as a parameter.
- Updated `config_builder_chain` and `config_default_options` in `connectrpc-build`.
- `task fmt`, `task clippy`, and `task test` all pass cleanly.

## Follow-up

Tracked under #34 for v0.4.0: rather than continuing to mirror buffa fields one-by-one, embed buffa's `CodeGenConfig` directly in `Options` so future buffa knobs are zero-touch on this side.