### PR TITLE
Prepare connectrpc 0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,20 @@ increment the patch version.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-02
+
 ### Added
 
-- **`emit_register_fn` option** on `connectrpc_codegen::codegen::Options` and
-  `connectrpc_build::Config`, plumbing through to
+- **`emit_register_fn` option** ([#35]) on `connectrpc_codegen::codegen::Options`
+  and `connectrpc_build::Config`, plumbing through to
   `buffa_codegen::CodeGenConfig::emit_register_fn`. Set to `false` to suppress
   the per-file `register_types(&mut TypeRegistry)` aggregator when multiple
   generated files are `include!`d into the same module (the identically-named
   functions would otherwise collide). The protoc plugin accepts a matching
   `no_register_fn` parameter for path-compat with the unified `connectrpc-build`
   flow.
+
+[#35]: https://github.com/anthropics/connect-rust/pull/35
 
 ## [0.3.0] - 2026-04-02
 

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-build"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-codegen"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

Lockstep bump of all three crates to 0.3.1: `connectrpc`, `connectrpc-codegen`, `connectrpc-build`.

## What changed this cycle

Only `connectrpc-codegen` and `connectrpc-build` have user-facing changes — the `emit_register_fn` plumbing in #35 (ConnectRPC's `Options` / `Config` now expose buffa's `emit_register_fn` knob, with a matching `no_register_fn` plugin parameter). The `connectrpc` runtime is unchanged.

## Why lockstep on a two-of-three patch

The first patch since the lockstep v0.3.0 release surfaced the "independent vs lockstep on patches" question that's been open since v0.2.1 (tracked on #10). Going lockstep again here for two reasons:

1. **Tag-every-release ergonomics.** Independent versioning leaves the `connectrpc` runtime at 0.3.0 while `codegen` and `build` jump to 0.3.1. Tagging `v0.3.1` then ships a runtime binary that's bit-identical to v0.3.0's — confusing in the release listing. Lockstep keeps every tag's binaries reflecting the tagged version.
2. **Implicit codegen → runtime coupling.** `connectrpc-codegen` emits source that calls into the `connectrpc` runtime crate. There's no `[dependencies]` declaration that captures this — Cargo's resolver can't enforce "codegen X needs runtime ≥Y". Lockstep makes the user-facing story trivially correct ("use 0.3.x for all three"). The risk is zero on this particular release (no new runtime API surface), but the policy choice is forward-looking.

The trade-off is one zero-diff publish (`connectrpc@0.3.1` is index cruft on crates.io). That's a small price for the simpler mental model.

When we adopt sampo for release management (mentioned by a contributor — supports a "fixed groups" config that gives exactly this lockstep property automatically), this stops being a per-release decision. I'll capture the lockstep choice in #10's runbook when we get to it.

## Files changed

- `connectrpc/Cargo.toml`: 0.3.0 → 0.3.1
- `connectrpc-codegen/Cargo.toml`: 0.3.0 → 0.3.1
- `connectrpc-build/Cargo.toml`: 0.3.0 → 0.3.1
- `CHANGELOG.md`: new `[0.3.1] - 2026-04-02` section with the `emit_register_fn` entry and #35 link reference

The path-dep constraint (`connectrpc-build` → `connectrpc-codegen`) already uses caret `"0.3"`, so no change required there. README dependency snippets are also caret `"0.3"`, unchanged.

## Test Plan

`cargo build --workspace` clean with the bumped versions. Tests, clippy, and fmt all green from #35; this PR is metadata-only on top of that.