### PR TITLE
Prepare connectrpc 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,49 @@ increment the patch version.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-04-03
+
+### Fixed
+
+- **Generated service code now compiles when multiple services are
+  `include!`d into the same Rust module** ([#32]). The codegen previously
+  emitted top-level `use` statements that collided with E0252 when
+  buffa-packaging's flat-output strategy concatenated several service
+  files into one module. Bindings now use fully-qualified paths
+  throughout (`::connectrpc::Context`, `::buffa::view::OwnedView`,
+  `::http_body::Body`, etc.), so multiple service files can coexist in
+  the same `mod` block.
+
+### Changed
+
+- **Generated client methods reference the per-service `*_SERVICE_NAME`
+  const** ([#16]) instead of repeating the fully-qualified service name
+  as a string literal at every call site. Matches the server-side
+  router.
+- **Workspace `tokio` feature footprint narrowed** ([#19]). The published
+  `connectrpc` crate previously inherited the full workspace tokio
+  feature set (`macros`, `net`, `signal`, `rt-multi-thread`, ...) when
+  `workspace = true` was inlined at publish time. It now requests only
+  `rt`, `io-util`, `sync`, `time`, plus `net` when the `client` or
+  `server` feature is enabled. Downstream crates that use `tokio`
+  directly should declare their own features rather than relying on
+  transitive activation.
+- **Workspace dependency updates** ([#37]).
+
+### Added
+
+- **`wasm32-unknown-unknown` target compatibility** ([#19]) for the
+  `connectrpc` crate with default features off. A new
+  `examples/wasm-client` demonstrates a Fetch-based `ClientTransport`
+  implementation with browser-based integration tests via `wasm-pack`.
+  Currently exercises unary calls without deadlines; timeouts and
+  streaming require additional setup beyond the example.
+
+[#16]: https://github.com/anthropics/connect-rust/pull/16
+[#19]: https://github.com/anthropics/connect-rust/pull/19
+[#32]: https://github.com/anthropics/connect-rust/pull/32
+[#37]: https://github.com/anthropics/connect-rust/pull/37
+
 ## [0.3.1] - 2026-04-02
 
 ### Added

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-build"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-codegen"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Lockstep bump of all three crates to 0.3.2: `connectrpc`, `connectrpc-codegen`, `connectrpc-build`.

## Headline

#32 — generated service code no longer emits top-level `use` statements, so multiple service files can be `include!`d into the same Rust module without E0252 collisions. This was the proximate motivation for cutting 0.3.2 (it unblocks downstream consumers using buffa-packaging's flat output strategy).

## Other changes shipping in 0.3.2

- **#16** — generated client methods reference the per-service `*_SERVICE_NAME` const instead of repeating the fully-qualified service name as a string literal at every call site.
- **#19** — `wasm32-unknown-unknown` target compatibility for the `connectrpc` crate (default features off), plus a new `examples/wasm-client` demonstrating a Fetch-based `ClientTransport`. As a side effect of this PR, the workspace `tokio` feature footprint narrowed: published `connectrpc` previously inherited the full workspace tokio feature set when `workspace = true` was inlined at publish time, and now requests only `rt`, `io-util`, `sync`, `time` (plus `net` when the `client`/`server` feature is enabled). Downstream crates that use `tokio` directly should declare their own features rather than relying on transitive activation.
- **#37** — workspace dependency updates.

## Notes

- Path-dep version constraint (build → codegen) already uses caret `"0.3"`, so no change required there.
- README dependency snippets are caret `"0.3"`, unchanged.
- CHANGELOG gains a 0.3.2 section with the four entries above.