### PR TITLE
Pin MSRV to Rust 1.88 and verify in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,19 @@ jobs:
       - run: sudo apt-get install -y protobuf-compiler
       - run: cargo check --workspace --all-features --all-targets
 
+  msrv-check:
+    name: MSRV (1.88)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: '1.88'
+      - uses: Swatinem/rust-cache@v2
+      - run: sudo apt-get install -y protobuf-compiler
+      - run: cargo check --workspace --all-features --all-targets
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.88"
 license = "Apache-2.0"
 repository = "https://github.com/anthropics/connect-rust"
 keywords = ["connectrpc", "grpc", "rpc", "protobuf", "tower"]

--- a/benches/rpc-tonic/Cargo.toml
+++ b/benches/rpc-tonic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rpc-bench-tonic"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 

--- a/benches/rpc/Cargo.toml
+++ b/benches/rpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rpc-bench"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -2,6 +2,7 @@
 name = "connectrpc-conformance"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "ConnectRPC conformance test harness for the connectrpc crate"

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -2,6 +2,7 @@
 name = "connectrpc-build"
 version = "0.3.2"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Build-time integration for connectrpc (use in build.rs)"

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "connectrpc-codegen"
 version = "0.3.2"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Library for generating ConnectRPC Rust service bindings from proto descriptors"

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "connectrpc"
 version = "0.3.2"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "A Tower-based Rust implementation of the ConnectRPC protocol"

--- a/examples/eliza/Cargo.toml
+++ b/examples/eliza/Cargo.toml
@@ -2,6 +2,7 @@
 name = "eliza-example"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 

--- a/examples/multiservice/Cargo.toml
+++ b/examples/multiservice/Cargo.toml
@@ -2,6 +2,7 @@
 name = "multiservice-example"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 

--- a/examples/wasm-client/Cargo.toml
+++ b/examples/wasm-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-client-example"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 

--- a/tests/streaming/Cargo.toml
+++ b/tests/streaming/Cargo.toml
@@ -2,6 +2,7 @@
 name = "streaming-test"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 


### PR DESCRIPTION
Closes #43

The workspace had no declared MSRV. The codebase actually uses let-chains (\`if let Some(x) = y && condition\`) in 20+ places across the published crates, and let-chains were stabilized in Rust 1.88, so 1.88 is the real minimum.

## Changes

- \`rust-version = \"1.88\"\` added to \`[workspace.package]\` in the root \`Cargo.toml\`
- \`rust-version.workspace = true\` propagated to all 10 member crates
- New \`msrv-check\` CI job that runs \`cargo check --workspace --all-features --all-targets\` on Rust 1.88 to keep the floor honest going forward

## Verification

- \`cargo +1.88 check --workspace --all-features --all-targets\` passes locally
- \`cargo +1.88 test --workspace --all-features\` passes locally (310+ tests, 0 failures)
- Stable clippy + nightly fmt unaffected

## Notes

I initially tried 1.85 (matching the buffa workspace), but it fails for two compounding reasons:

1. Let-chains in \`connectrpc-codegen/src/codegen.rs:111\` and ~20 other call sites in the published crates - stabilized in 1.88
2. Transitive deps via dev-dependencies (\`rcgen\` → \`time\`) and bench dependencies (\`redis\` → \`url\` → \`idna\` → \`icu_*\`, \`pprof\` → \`home\`) require 1.86 - 1.88 themselves

Bumping to 1.88 reflects what the code already requires rather than refactoring the let-chains away.