### PR TITLE
Add streaming-tour and middleware examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  # Ubuntu's apt protobuf-compiler is too old (v21.x) to recognize the
+  # `edition = "2023"` proto syntax used by some examples. Pull a recent
+  # protoc directly from the GitHub release.
+  PROTOC_VERSION: "33.5"
 
 jobs:
   check:
@@ -19,7 +23,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local
+          protoc --version
       - run: cargo check --workspace --all-features --all-targets
 
   msrv-check:
@@ -32,7 +40,11 @@ jobs:
         with:
           toolchain: '1.88'
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local
+          protoc --version
       - run: cargo check --workspace --all-features --all-targets
 
   test:
@@ -43,7 +55,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local
+          protoc --version
       - run: cargo test --workspace --all-features
 
   clippy:
@@ -56,7 +72,11 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local
+          protoc --version
       - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
   fmt:
@@ -80,7 +100,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local
+          protoc --version
       - run: cargo doc --workspace --all-features --no-deps
 
   # Integration test: start server, run client, verify RPCs work end-to-end
@@ -92,7 +116,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local
+          protoc --version
       - run: ./examples/multiservice/test.sh
 
   # Conformance tests: validate protocol compliance.
@@ -137,7 +165,11 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local
+          protoc --version
       - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: cargo check -p connectrpc --no-default-features --target wasm32-unknown-unknown
       - run: cargo check -p connectrpc --no-default-features --features gzip --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["connectrpc", "connectrpc-codegen", "connectrpc-build", "conformance", "examples/eliza", "examples/multiservice", "examples/wasm-client", "tests/streaming", "benches/rpc", "benches/rpc-tonic"]
+members = ["connectrpc", "connectrpc-codegen", "connectrpc-build", "conformance", "examples/eliza", "examples/middleware", "examples/multiservice", "examples/streaming-tour", "examples/wasm-client", "tests/streaming", "benches/rpc", "benches/rpc-tonic"]
 resolver = "2"
 
 [workspace.package]

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1112,7 +1112,7 @@ fn generate_client_method(
     );
     let doc_opts = format!(
         " Call the {method_name} RPC with explicit per-call options. \
-         Options override [`connectrpc::client::ClientConfig`] defaults."
+         Options override [`ClientConfig`](::connectrpc::client::ClientConfig) defaults."
     );
 
     // Return type is protocol-specific. Compute once.

--- a/examples/middleware/Cargo.toml
+++ b/examples/middleware/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "middleware-example"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[[bin]]
+name = "middleware-server"
+path = "src/server.rs"
+
+[[bin]]
+name = "middleware-client"
+path = "src/client.rs"
+
+[dependencies]
+connectrpc = { path = "../../connectrpc", features = ["axum", "client", "server"] }
+
+# Protobuf
+buffa = { workspace = true }
+buffa-types = { workspace = true }
+
+# Serialization (for generated message types)
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# HTTP types (for generated client bounds + custom layer)
+http-body = { workspace = true }
+http-body-util = { workspace = true }
+http = { workspace = true }
+bytes = { workspace = true }
+
+# Async
+tokio = { workspace = true, features = ["full"] }
+futures = { workspace = true }
+
+# Web framework + tower middleware
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["trace", "timeout"] }
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[build-dependencies]
+connectrpc-build = { path = "../../connectrpc-build" }
+
+[lints]
+workspace = true

--- a/examples/middleware/README.md
+++ b/examples/middleware/README.md
@@ -1,0 +1,109 @@
+# Middleware example
+
+Demonstrates how data flows from a middleware layer into a connectrpc
+handler via `Context::extensions`. The server stack composes a
+bearer-token auth check (written as an `axum::middleware::from_fn`),
+tower-http's `TraceLayer` for request logging, and `TimeoutLayer` for
+a per-request deadline.
+
+The handler reads the caller identity from `Context::extensions()` and
+writes a `x-served-by` response trailer via `Context::set_trailer()`.
+
+## Run it
+
+```bash
+# Terminal 1: server with INFO-level tracing
+RUST_LOG=info,tower_http=debug \
+    cargo run -p middleware-example --bin middleware-server
+
+# Terminal 2: client (sends auth header via ClientConfig::default_header)
+cargo run -p middleware-example --bin middleware-client
+
+# Or with curl:
+curl -X POST http://127.0.0.1:8080/anthropic.connectrpc.middleware_demo.v1.SecretService/GetSecret \
+  -H 'authorization: Bearer demo-token-alice' \
+  -H 'content-type: application/json' \
+  -d '{"name": "shared"}'
+```
+
+Expected client output:
+
+```
+shared      -> the value of teamwork
+  trailer x-served-by: alice
+alice-only  -> alice's diary entry
+```
+
+Set `MIDDLEWARE_TOKEN` to `demo-token-bob` to see the permission-denied
+path on `alice-only`. Set `MIDDLEWARE_URL` to point at a different
+address.
+
+## What to look at
+
+### Server side (`src/server.rs`)
+
+- **`auth_middleware`** - an async function written in axum's
+  `from_fn` style. Validates a `Bearer <token>` header against a
+  static map. On success, stamps a `UserId` into the request
+  extensions and calls `next.run(req)`. On failure, returns a 401
+  directly with a Connect-protocol JSON error body. Mounted via
+  `axum::middleware::from_fn_with_state(tokens, auth_middleware)`,
+  which is the idiomatic axum pattern for stateful auth.
+
+  A hand-rolled `tower::Layer` + `tower::Service` pair would reach the
+  same `Context::extensions` endpoint but requires more boilerplate.
+  The connectrpc dispatcher only cares that something earlier in the
+  stack inserted the value; how it got there is up to you.
+
+- **Tower stack composition** - `ServiceBuilder` applies layers
+  top-to-bottom (outermost first). Wrapped in axum's `Router::layer()`
+  so axum handles the body conversion from `ConnectRpcBody` to
+  `axum::body::Body` automatically:
+
+  ```rust
+  let tokens = Arc::new(token_table());
+  axum::Router::new()
+      .fallback_service(connect_router.into_axum_service())
+      .layer(
+          ServiceBuilder::new()
+              .layer(TraceLayer::new_for_http())   // outermost
+              .layer(axum::middleware::from_fn_with_state(tokens, auth_middleware))
+              .layer(TimeoutLayer::with_status_code(...)),  // innermost
+      );
+  ```
+
+- **Handler reading from `Context`** - the dispatch path moves the
+  request's `http::Extensions` into `Context::extensions`. The handler
+  reads `UserId` via `ctx.extensions.get::<UserId>()`, performs its own
+  permission check against the secret store, and writes the
+  `x-served-by` response trailer via `ctx.set_trailer(...)`.
+
+### Client side (`src/client.rs`)
+
+- **`ClientConfig::default_header`** - sets the auth header once on
+  the client config; every RPC call picks it up automatically.
+- **`ClientConfig::default_timeout`** - default deadline for every
+  call.
+- **`CallOptions::with_timeout`** - per-call deadline override.
+  `_with_options` variants let any RPC method take per-call options.
+- **`resp.trailers()`** - unary responses surface trailers alongside
+  the body (and headers via `resp.headers()`).
+
+## Integration test
+
+`tests/e2e.rs` spins up the server with the same `from_fn` middleware
+stack and exercises four paths: authorized success (verifies the
+trailer arrives), missing auth header (expects `Unauthenticated`),
+invalid token (expects `Unauthenticated`), and permission denied at
+the handler level (expects `PermissionDenied`).
+
+```bash
+cargo test -p middleware-example
+```
+
+## Where to go next
+
+- See [`examples/streaming-tour`](../streaming-tour) for handler
+  signatures across all four RPC types.
+- See [`examples/eliza`](../eliza) for tower-http CORS layered onto a
+  streaming service plus TLS/mTLS support.

--- a/examples/middleware/build.rs
+++ b/examples/middleware/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    connectrpc_build::Config::new()
+        .files(&["proto/anthropic/connectrpc/middleware_demo/v1/secret.proto"])
+        .includes(&["proto/"])
+        .include_file("_connectrpc.rs")
+        .compile()
+        .unwrap();
+}

--- a/examples/middleware/proto/anthropic/connectrpc/middleware_demo/v1/secret.proto
+++ b/examples/middleware/proto/anthropic/connectrpc/middleware_demo/v1/secret.proto
@@ -1,0 +1,20 @@
+edition = "2023";
+
+package anthropic.connectrpc.middleware_demo.v1;
+
+// SecretService demonstrates server-side tower middleware composition:
+// trace logging, a custom auth layer that validates a bearer token and
+// stamps the caller's identity into the request extensions, and a
+// timeout layer. The handler reads the identity from Context::extensions()
+// and writes a response trailer via Context::set_trailer().
+service SecretService {
+  rpc GetSecret(GetSecretRequest) returns (GetSecretResponse);
+}
+
+message GetSecretRequest {
+  string name = 1;
+}
+
+message GetSecretResponse {
+  string value = 1;
+}

--- a/examples/middleware/src/client.rs
+++ b/examples/middleware/src/client.rs
@@ -1,0 +1,68 @@
+//! Middleware-example client: demonstrates `ClientConfig::default_header`
+//! for the per-call auth header and `CallOptions::with_timeout` for a
+//! per-call deadline.
+
+use std::time::Duration;
+
+use connectrpc::client::{CallOptions, ClientConfig, HttpClient};
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+}
+
+use proto::anthropic::connectrpc::middleware_demo::v1::*;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let url = std::env::var("MIDDLEWARE_URL").unwrap_or_else(|_| "http://127.0.0.1:8080".into());
+    let token = std::env::var("MIDDLEWARE_TOKEN").unwrap_or_else(|_| "demo-token-alice".into());
+
+    // Auth header lives on `ClientConfig` so every call picks it up
+    // automatically. Set per-call defaults here for anything you want
+    // applied to all RPCs (auth, tracing IDs, request budget).
+    let config = ClientConfig::new(url.parse()?)
+        .default_header("authorization", format!("Bearer {token}"))
+        .default_timeout(Duration::from_secs(10));
+
+    let http = HttpClient::plaintext();
+    let client = SecretServiceClient::new(http, config);
+
+    // No-options call: picks up the auth header + 10s timeout from config.
+    // Edition 2023 default presence is EXPLICIT, so string fields are
+    // Option<String> on the wire and Option<&str> on views.
+    let resp = client
+        .get_secret(GetSecretRequest {
+            name: Some("shared".into()),
+            ..Default::default()
+        })
+        .await?;
+    println!("{:<11} -> {}", "shared", resp.view().value.unwrap_or(""));
+    if let Some(server) = resp.trailers().get("x-served-by") {
+        println!("  trailer x-served-by: {}", server.to_str().unwrap_or("?"));
+    }
+
+    // Per-call override: tighter 2s deadline for this single RPC.
+    // Per-call options replace config defaults for fields they set
+    // (timeout here); other defaults (the auth header) still apply.
+    let resp = client
+        .get_secret_with_options(
+            GetSecretRequest {
+                name: Some("alice-only".into()),
+                ..Default::default()
+            },
+            CallOptions::default().with_timeout(Duration::from_secs(2)),
+        )
+        .await;
+    match resp {
+        Ok(r) => println!("{:<11} -> {}", "alice-only", r.view().value.unwrap_or("")),
+        Err(e) => println!(
+            "{:<11} -> error: {}",
+            "alice-only",
+            e.message.as_deref().unwrap_or("(no message)")
+        ),
+    }
+
+    Ok(())
+}

--- a/examples/middleware/src/server.rs
+++ b/examples/middleware/src/server.rs
@@ -1,0 +1,237 @@
+//! Middleware-example server: demonstrates how data flows from a
+//! middleware layer into a connectrpc handler via `Context::extensions`.
+//! Three layers wrap the dispatcher:
+//!
+//! 1. `TraceLayer` - request/response logging via the `tracing` crate.
+//! 2. `auth_middleware` - validates a `Bearer <token>` header, stamps
+//!    the caller's identity into request extensions, and short-circuits
+//!    unauthorized requests with 401. Written as an axum `from_fn`
+//!    middleware (the idiomatic axum pattern for stateful auth).
+//! 3. `TimeoutLayer` - hard ceiling on per-request handler latency.
+//!
+//! The handler reads the identity from `Context::extensions()` and writes
+//! a `x-served-by` response trailer via `Context::set_trailer()`.
+//!
+//! Run with:
+//!
+//! ```sh
+//! RUST_LOG=info,tower_http=debug \
+//!     cargo run -p middleware-example --bin middleware-server
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+use buffa::view::OwnedView;
+use connectrpc::{ConnectError, Context, ErrorCode, Router};
+use http_body_util::BodyExt;
+use tower::ServiceBuilder;
+use tower_http::timeout::TimeoutLayer;
+use tower_http::trace::TraceLayer;
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+}
+
+use proto::anthropic::connectrpc::middleware_demo::v1::*;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+// ============================================================================
+// Domain types
+// ============================================================================
+
+/// Caller identity, attached to the request by `auth_middleware`.
+#[derive(Debug, Clone)]
+struct UserId(String);
+
+/// Static token → identity table. Real services would consult a
+/// database, JWT verifier, or upstream auth service here.
+fn token_table() -> HashMap<String, UserId> {
+    HashMap::from([
+        ("demo-token-alice".into(), UserId("alice".into())),
+        ("demo-token-bob".into(), UserId("bob".into())),
+    ])
+}
+
+/// Static secret store. Each secret declares which users may read it.
+fn secret_store() -> HashMap<String, (String, Vec<&'static str>)> {
+    HashMap::from([
+        (
+            "shared".into(),
+            ("the value of teamwork".into(), vec!["alice", "bob"]),
+        ),
+        (
+            "alice-only".into(),
+            ("alice's diary entry".into(), vec!["alice"]),
+        ),
+    ])
+}
+
+// ============================================================================
+// Auth middleware (axum from_fn pattern)
+// ============================================================================
+
+/// Validates a `Bearer <token>` header against the static token table
+/// and stamps the caller's identity into request extensions before
+/// forwarding. Unauthorized requests get a 401 directly - the inner
+/// service (the connect dispatcher) is never invoked.
+///
+/// `axum::middleware::from_fn_with_state` is the idiomatic axum pattern
+/// for stateful interceptors: write a plain async fn, mount it via
+/// `from_fn_with_state(state, fn)`, and the resulting Layer composes
+/// with any tower stack. Equivalent to a hand-rolled `tower::Layer` +
+/// `tower::Service` pair, but without the trait-boilerplate ceremony.
+async fn auth_middleware(
+    State(tokens): State<Arc<HashMap<String, UserId>>>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let Some(token) = req
+        .headers()
+        .get(http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+    else {
+        return unauthorized("missing Bearer token");
+    };
+    let Some(user) = tokens.get(token).cloned() else {
+        return unauthorized("invalid Bearer token");
+    };
+
+    // The connect dispatcher forwards req.extensions() into
+    // Context::extensions verbatim, so the handler reads the UserId via
+    // ctx.extensions.get::<UserId>().
+    req.extensions_mut().insert(user);
+    next.run(req).await
+}
+
+/// Build a 401 response in the Connect-protocol JSON error shape.
+/// Returning a structured Connect error keeps clients on the same
+/// error-handling path they use for handler-side `ConnectError`s.
+fn unauthorized(message: &'static str) -> Response {
+    let err = ConnectError::new(ErrorCode::Unauthenticated, message);
+    let body = http_body_util::Full::new(err.to_json())
+        .map_err(|never| match never {})
+        .boxed_unsync();
+    http::Response::builder()
+        .status(http::StatusCode::UNAUTHORIZED)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::new(body))
+        .unwrap()
+}
+
+// ============================================================================
+// Service handler
+// ============================================================================
+
+struct SecretServiceImpl {
+    store: HashMap<String, (String, Vec<&'static str>)>,
+}
+
+impl SecretService for SecretServiceImpl {
+    async fn get_secret(
+        &self,
+        mut ctx: Context,
+        request: OwnedView<GetSecretRequestView<'static>>,
+    ) -> Result<(GetSecretResponse, Context), ConnectError> {
+        // The auth layer stamped UserId into the http::Request extensions,
+        // which the connect dispatcher then forwarded into ctx.extensions.
+        let user = ctx
+            .extensions
+            .get::<UserId>()
+            .ok_or_else(|| {
+                ConnectError::new(
+                    ErrorCode::Internal,
+                    "auth layer did not attach UserId - middleware misconfigured",
+                )
+            })?
+            .clone();
+
+        // Edition 2023 default presence is EXPLICIT, so string fields
+        // are Option<String> on owned messages and Option<&str> on
+        // views. unwrap_or("") treats unset as empty, mirroring proto3.
+        let name = request.name.unwrap_or("").to_owned();
+        let (value, allowed) = self.store.get(&name).ok_or_else(|| {
+            ConnectError::new(ErrorCode::NotFound, format!("no secret named {name:?}"))
+        })?;
+
+        if !allowed.iter().any(|u| *u == user.0) {
+            return Err(ConnectError::new(
+                ErrorCode::PermissionDenied,
+                format!("user {:?} cannot read {name:?}", user.0),
+            ));
+        }
+
+        // Stamp the serving user into a response trailer so the client
+        // (or any tracing middleware downstream) can attribute the read.
+        ctx.set_trailer(
+            http::header::HeaderName::from_static("x-served-by"),
+            user.0.parse().unwrap(),
+        );
+
+        Ok((
+            GetSecretResponse {
+                value: Some(value.clone()),
+                ..Default::default()
+            },
+            ctx,
+        ))
+    }
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let addr: std::net::SocketAddr = "127.0.0.1:8080".parse()?;
+
+    let service = Arc::new(SecretServiceImpl {
+        store: secret_store(),
+    });
+    let connect_router = service.register(Router::new());
+
+    // Compose the tower stack. ServiceBuilder applies layers top-to-bottom:
+    // TraceLayer is outermost (wraps everything), TimeoutLayer is innermost
+    // (closest to the dispatcher). A request flows trace -> auth -> timeout
+    // -> connect dispatcher -> handler.
+    let tokens = Arc::new(token_table());
+    let app = axum::Router::new()
+        .fallback_service(connect_router.into_axum_service())
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(axum::middleware::from_fn_with_state(
+                    tokens,
+                    auth_middleware,
+                ))
+                .layer(TimeoutLayer::with_status_code(
+                    http::StatusCode::REQUEST_TIMEOUT,
+                    Duration::from_secs(5),
+                )),
+        );
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    println!("SecretService listening on http://{addr}");
+    println!(
+        "Try: curl -X POST http://{addr}/anthropic.connectrpc.middleware_demo.v1.SecretService/GetSecret \\"
+    );
+    println!("       -H 'authorization: Bearer demo-token-alice' \\");
+    println!("       -H 'content-type: application/json' \\");
+    println!("       -d '{{\"name\": \"shared\"}}'");
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/examples/middleware/tests/e2e.rs
+++ b/examples/middleware/tests/e2e.rs
@@ -1,0 +1,238 @@
+//! End-to-end test: spin up SecretService with the full middleware
+//! stack, exercise the auth layer + handler permission check, and
+//! verify response trailers.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+use buffa::view::OwnedView;
+use connectrpc::client::{ClientConfig, HttpClient};
+use connectrpc::{ConnectError, Context, ErrorCode, Router};
+use http_body_util::BodyExt;
+use tower::ServiceBuilder;
+use tower_http::timeout::TimeoutLayer;
+use tower_http::trace::TraceLayer;
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+}
+
+use proto::anthropic::connectrpc::middleware_demo::v1::*;
+
+// ============================================================================
+// Domain types (mirror src/server.rs)
+// ============================================================================
+
+#[derive(Debug, Clone)]
+struct UserId(String);
+
+fn token_table() -> HashMap<String, UserId> {
+    HashMap::from([
+        ("demo-token-alice".into(), UserId("alice".into())),
+        ("demo-token-bob".into(), UserId("bob".into())),
+    ])
+}
+
+fn secret_store() -> HashMap<String, (String, Vec<&'static str>)> {
+    HashMap::from([
+        (
+            "shared".into(),
+            ("the value of teamwork".into(), vec!["alice", "bob"]),
+        ),
+        (
+            "alice-only".into(),
+            ("alice's diary entry".into(), vec!["alice"]),
+        ),
+    ])
+}
+
+// ============================================================================
+// auth_middleware (mirror src/server.rs)
+// ============================================================================
+
+async fn auth_middleware(
+    State(tokens): State<Arc<HashMap<String, UserId>>>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let Some(token) = req
+        .headers()
+        .get(http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+    else {
+        return unauthorized("missing Bearer token");
+    };
+    let Some(user) = tokens.get(token).cloned() else {
+        return unauthorized("invalid Bearer token");
+    };
+    req.extensions_mut().insert(user);
+    next.run(req).await
+}
+
+fn unauthorized(message: &'static str) -> Response {
+    let err = ConnectError::new(ErrorCode::Unauthenticated, message);
+    let body = http_body_util::Full::new(err.to_json())
+        .map_err(|never| match never {})
+        .boxed_unsync();
+    http::Response::builder()
+        .status(http::StatusCode::UNAUTHORIZED)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::new(body))
+        .unwrap()
+}
+
+// ============================================================================
+// SecretService impl (mirror src/server.rs)
+// ============================================================================
+
+struct SecretServiceImpl {
+    store: HashMap<String, (String, Vec<&'static str>)>,
+}
+
+impl SecretService for SecretServiceImpl {
+    async fn get_secret(
+        &self,
+        mut ctx: Context,
+        request: OwnedView<GetSecretRequestView<'static>>,
+    ) -> Result<(GetSecretResponse, Context), ConnectError> {
+        let user = ctx
+            .extensions
+            .get::<UserId>()
+            .ok_or_else(|| ConnectError::new(ErrorCode::Internal, "auth layer misconfigured"))?
+            .clone();
+        let name = request.name.unwrap_or("").to_owned();
+        let (value, allowed) = self
+            .store
+            .get(&name)
+            .ok_or_else(|| ConnectError::new(ErrorCode::NotFound, format!("no {name:?}")))?;
+        if !allowed.iter().any(|u| *u == user.0) {
+            return Err(ConnectError::new(
+                ErrorCode::PermissionDenied,
+                format!("user {:?} cannot read {name:?}", user.0),
+            ));
+        }
+        ctx.set_trailer(
+            http::header::HeaderName::from_static("x-served-by"),
+            user.0.parse().unwrap(),
+        );
+        Ok((
+            GetSecretResponse {
+                value: Some(value.clone()),
+                ..Default::default()
+            },
+            ctx,
+        ))
+    }
+}
+
+// ============================================================================
+// Test scaffolding
+// ============================================================================
+
+async fn start_server() -> std::net::SocketAddr {
+    let service = Arc::new(SecretServiceImpl {
+        store: secret_store(),
+    });
+    let connect_router = service.register(Router::new());
+    let tokens = Arc::new(token_table());
+    let app = axum::Router::new()
+        .fallback_service(connect_router.into_axum_service())
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(axum::middleware::from_fn_with_state(
+                    tokens,
+                    auth_middleware,
+                ))
+                .layer(TimeoutLayer::with_status_code(
+                    http::StatusCode::REQUEST_TIMEOUT,
+                    Duration::from_secs(5),
+                )),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    addr
+}
+
+fn make_client(addr: std::net::SocketAddr, token: &str) -> SecretServiceClient<HttpClient> {
+    let config = ClientConfig::new(format!("http://{addr}").parse().unwrap())
+        .default_header("authorization", format!("Bearer {token}"));
+    SecretServiceClient::new(HttpClient::plaintext(), config)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[tokio::test]
+async fn authorized_call_returns_value_and_trailer() {
+    let addr = start_server().await;
+    let client = make_client(addr, "demo-token-alice");
+    let resp = client
+        .get_secret(GetSecretRequest {
+            name: Some("shared".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(resp.view().value, Some("the value of teamwork"));
+    let served_by = resp
+        .trailers()
+        .get("x-served-by")
+        .expect("trailer should be present")
+        .to_str()
+        .unwrap();
+    assert_eq!(served_by, "alice");
+}
+
+#[tokio::test]
+async fn missing_auth_returns_unauthenticated() {
+    let addr = start_server().await;
+    // Build a client with no auth header at all.
+    let config = ClientConfig::new(format!("http://{addr}").parse().unwrap());
+    let client = SecretServiceClient::new(HttpClient::plaintext(), config);
+    let err = client
+        .get_secret(GetSecretRequest {
+            name: Some("shared".into()),
+            ..Default::default()
+        })
+        .await
+        .expect_err("must reject unauthenticated request");
+    assert_eq!(err.code, ErrorCode::Unauthenticated);
+}
+
+#[tokio::test]
+async fn invalid_token_returns_unauthenticated() {
+    let addr = start_server().await;
+    let client = make_client(addr, "not-a-real-token");
+    let err = client
+        .get_secret(GetSecretRequest {
+            name: Some("shared".into()),
+            ..Default::default()
+        })
+        .await
+        .expect_err("must reject invalid token");
+    assert_eq!(err.code, ErrorCode::Unauthenticated);
+}
+
+#[tokio::test]
+async fn permission_denied_for_other_users_secret() {
+    let addr = start_server().await;
+    let client = make_client(addr, "demo-token-bob");
+    let err = client
+        .get_secret(GetSecretRequest {
+            name: Some("alice-only".into()),
+            ..Default::default()
+        })
+        .await
+        .expect_err("bob cannot read alice's secret");
+    assert_eq!(err.code, ErrorCode::PermissionDenied);
+}

--- a/examples/streaming-tour/Cargo.toml
+++ b/examples/streaming-tour/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "streaming-tour-example"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[[bin]]
+name = "streaming-tour-server"
+path = "src/server.rs"
+
+[[bin]]
+name = "streaming-tour-client"
+path = "src/client.rs"
+
+[dependencies]
+connectrpc = { path = "../../connectrpc", features = ["axum", "client", "server"] }
+
+# Protobuf
+buffa = { workspace = true }
+buffa-types = { workspace = true }
+
+# Serialization (for generated message types)
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# HTTP types (for generated client bounds)
+http-body = { workspace = true }
+http = { workspace = true }
+
+# Async
+tokio = { workspace = true, features = ["full"] }
+futures = { workspace = true }
+
+# Web framework
+axum = { workspace = true }
+
+[build-dependencies]
+connectrpc-build = { path = "../../connectrpc-build" }
+
+[lints]
+workspace = true

--- a/examples/streaming-tour/README.md
+++ b/examples/streaming-tour/README.md
@@ -1,0 +1,65 @@
+# Streaming tour example
+
+A minimal `NumberService` that demonstrates all four ConnectRPC RPC types
+in one place. The methods are deliberately trivial - the example exists
+to show the wire-protocol shapes (handler signatures, client invocation
+patterns), not to be useful.
+
+| RPC | Type | Semantics |
+|---|---|---|
+| `Square` | Unary | n -> n*n |
+| `Range` | Server streaming | emit `count` consecutive integers from `start` |
+| `Sum` | Client streaming | total all values, return when client closes its send side |
+| `RunningSum` | Bidirectional streaming | after each request, emit the running total |
+
+## Run it
+
+```bash
+# Terminal 1: server (listens on 127.0.0.1:8080)
+cargo run -p streaming-tour-example --bin streaming-tour-server
+
+# Terminal 2: client (calls each RPC, prints results)
+cargo run -p streaming-tour-example --bin streaming-tour-client
+```
+
+Expected client output:
+
+```
+Square(7) -> 49
+Range(start=10, count=5) -> [10, 11, 12, 13, 14]
+Sum([3, 5, 7, 9]) -> 24
+RunningSum([2, 4, 6, 8]) -> [2, 6, 12, 20]
+```
+
+The client connects to `http://127.0.0.1:8080` by default; set
+`TOUR_URL` to point at a different address.
+
+## Integration test
+
+`tests/e2e.rs` reuses the same handler implementation, spins up the
+server in-process on a random port, and exercises every RPC type:
+
+```bash
+cargo test -p streaming-tour-example
+```
+
+## What to look at
+
+- **`proto/anthropic/connectrpc/tour/v1/number.proto`** - service definition with
+  one example of each RPC type.
+- **`src/server.rs`** - handler signatures for each kind. Note how the
+  request type changes: unary takes `OwnedView<RequestView<'static>>`,
+  client/bidi take a `Pin<Box<dyn Stream<Item = Result<OwnedView<...>>>>>`.
+- **`src/client.rs`** - generated-client invocation patterns. The
+  client-streaming `Sum` takes a `Vec<SumRequest>`; the bidi
+  `RunningSum` returns a stream you `.send()` to and `.message()` from
+  interleaved.
+
+## Where to go next
+
+- See [`examples/eliza`](../eliza) for a real-feeling streaming app
+  (a port of the `connectrpc/examples-go` ELIZA demo, with TLS, mTLS,
+  CORS, and IPv6 support).
+- See [`examples/middleware`](../middleware) for tower middleware
+  composition (custom auth layer, request tracing, timeouts) on the
+  server side.

--- a/examples/streaming-tour/build.rs
+++ b/examples/streaming-tour/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    connectrpc_build::Config::new()
+        .files(&["proto/anthropic/connectrpc/tour/v1/number.proto"])
+        .includes(&["proto/"])
+        .include_file("_connectrpc.rs")
+        .compile()
+        .unwrap();
+}

--- a/examples/streaming-tour/proto/anthropic/connectrpc/tour/v1/number.proto
+++ b/examples/streaming-tour/proto/anthropic/connectrpc/tour/v1/number.proto
@@ -1,0 +1,59 @@
+edition = "2023";
+
+package anthropic.connectrpc.tour.v1;
+
+// NumberService demonstrates all four ConnectRPC RPC types over a small
+// numeric API. The methods are deliberately trivial — the example exists
+// to show the wire-protocol shapes, not to be useful.
+service NumberService {
+  // Unary: one request, one response.
+  rpc Square(SquareRequest) returns (SquareResponse);
+
+  // Server streaming: one request, stream of responses.
+  // Emits `count` consecutive integers starting from `start`.
+  rpc Range(RangeRequest) returns (stream RangeResponse);
+
+  // Client streaming: stream of requests, one response.
+  // Sums every value the client sends, returns the total once the
+  // client closes its send side.
+  rpc Sum(stream SumRequest) returns (SumResponse);
+
+  // Bidirectional streaming: stream of requests, stream of responses.
+  // After each request, emits the running total — letting the client
+  // observe the cumulative sum mid-stream rather than waiting for the
+  // end.
+  rpc RunningSum(stream RunningSumRequest) returns (stream RunningSumResponse);
+}
+
+message SquareRequest {
+  int32 value = 1;
+}
+
+message SquareResponse {
+  int64 squared = 1;
+}
+
+message RangeRequest {
+  int32 start = 1;
+  int32 count = 2;
+}
+
+message RangeResponse {
+  int32 value = 1;
+}
+
+message SumRequest {
+  int32 value = 1;
+}
+
+message SumResponse {
+  int64 total = 1;
+}
+
+message RunningSumRequest {
+  int32 value = 1;
+}
+
+message RunningSumResponse {
+  int64 total = 1;
+}

--- a/examples/streaming-tour/src/client.rs
+++ b/examples/streaming-tour/src/client.rs
@@ -1,0 +1,90 @@
+//! Streaming-tour client: calls each NumberService RPC and prints the
+//! result. Pair with `streaming-tour-server`.
+
+use connectrpc::client::{ClientConfig, HttpClient};
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+}
+
+use proto::anthropic::connectrpc::tour::v1::*;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let url = std::env::var("TOUR_URL").unwrap_or_else(|_| "http://127.0.0.1:8080".into());
+    let base_uri: http::Uri = url.parse()?;
+
+    let http = HttpClient::plaintext();
+    let config = ClientConfig::new(base_uri);
+    let client = NumberServiceClient::new(http, config);
+
+    // --- Unary ---
+    // Edition 2023 default presence is EXPLICIT, so scalar fields are
+    // Option<T>: wrap on the way in, unwrap_or_default() on the way out.
+    let resp = client
+        .square(SquareRequest {
+            value: Some(7),
+            ..Default::default()
+        })
+        .await?;
+    println!("Square(7) -> {}", resp.view().squared.unwrap_or_default());
+
+    // --- Server streaming ---
+    let mut range = client
+        .range(RangeRequest {
+            start: Some(10),
+            count: Some(5),
+            ..Default::default()
+        })
+        .await?;
+    print!("Range(start=10, count=5) -> [");
+    let mut first = true;
+    while let Some(msg) = range.message().await? {
+        if !first {
+            print!(", ");
+        }
+        print!("{}", msg.value.unwrap_or_default());
+        first = false;
+    }
+    println!("]");
+
+    // --- Client streaming ---
+    let inputs = [3, 5, 7, 9];
+    let messages: Vec<SumRequest> = inputs
+        .iter()
+        .map(|&v| SumRequest {
+            value: Some(v),
+            ..Default::default()
+        })
+        .collect();
+    let resp = client.sum(messages).await?;
+    println!(
+        "Sum({inputs:?}) -> {}",
+        resp.view().total.unwrap_or_default()
+    );
+
+    // --- Bidirectional streaming ---
+    let mut bidi = client.running_sum().await?;
+    print!("RunningSum([2, 4, 6, 8]) -> [");
+    let mut first = true;
+    for v in [2, 4, 6, 8] {
+        bidi.send(RunningSumRequest {
+            value: Some(v),
+            ..Default::default()
+        })
+        .await?;
+        if let Some(msg) = bidi.message().await? {
+            if !first {
+                print!(", ");
+            }
+            print!("{}", msg.total.unwrap_or_default());
+            first = false;
+        }
+    }
+    bidi.close_send();
+    println!("]");
+
+    Ok(())
+}

--- a/examples/streaming-tour/src/server.rs
+++ b/examples/streaming-tour/src/server.rs
@@ -1,0 +1,137 @@
+//! Streaming-tour server: NumberService implementation covering all four
+//! ConnectRPC RPC types (unary, server stream, client stream, bidi stream).
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run -p streaming-tour-example --bin streaming-tour-server
+//! ```
+//!
+//! Then in another terminal:
+//!
+//! ```sh
+//! cargo run -p streaming-tour-example --bin streaming-tour-client
+//! ```
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use buffa::view::OwnedView;
+use connectrpc::{ConnectError, Context, Router};
+use futures::{Stream, StreamExt};
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+}
+
+use proto::anthropic::connectrpc::tour::v1::*;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+// Local type aliases that flatten the streaming-handler signatures.
+// The verbose `Pin<Box<dyn Stream<...> + Send>>` form is what the
+// generated traits expect today; these aliases are pure sugar at the
+// call site (pending broader handler-trait ergonomics work).
+type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> + Send>>;
+type RequestStream<V> = Pin<Box<dyn Stream<Item = Result<OwnedView<V>, ConnectError>> + Send>>;
+
+/// Trivial NumberService implementation. Each method demonstrates one
+/// of the four RPC patterns.
+struct NumberServiceImpl;
+
+impl NumberService for NumberServiceImpl {
+    /// Unary: square the input value.
+    async fn square(
+        &self,
+        ctx: Context,
+        request: OwnedView<SquareRequestView<'static>>,
+    ) -> Result<(SquareResponse, Context), ConnectError> {
+        // Edition 2023 default presence is EXPLICIT, so scalar fields
+        // are Option<T>. unwrap_or(0) treats unset as zero, mirroring
+        // the proto3 implicit-presence semantics.
+        let v = request.value.unwrap_or(0) as i64;
+        Ok((
+            SquareResponse {
+                squared: Some(v * v),
+                ..Default::default()
+            },
+            ctx,
+        ))
+    }
+
+    /// Server streaming: emit `count` consecutive integers from `start`.
+    async fn range(
+        &self,
+        ctx: Context,
+        request: OwnedView<RangeRequestView<'static>>,
+    ) -> Result<(ResponseStream<RangeResponse>, Context), ConnectError> {
+        let start = request.start.unwrap_or(0);
+        let count = request.count.unwrap_or(0).max(0);
+        let stream = futures::stream::iter((0..count).map(move |i| {
+            Ok(RangeResponse {
+                value: Some(start + i),
+                ..Default::default()
+            })
+        }));
+        Ok((Box::pin(stream), ctx))
+    }
+
+    /// Client streaming: drain the request stream, return the total.
+    async fn sum(
+        &self,
+        ctx: Context,
+        mut requests: RequestStream<SumRequestView<'static>>,
+    ) -> Result<(SumResponse, Context), ConnectError> {
+        let mut total: i64 = 0;
+        while let Some(req) = requests.next().await {
+            total += req?.value.unwrap_or(0) as i64;
+        }
+        Ok((
+            SumResponse {
+                total: Some(total),
+                ..Default::default()
+            },
+            ctx,
+        ))
+    }
+
+    /// Bidirectional streaming: emit a running total after each request.
+    async fn running_sum(
+        &self,
+        ctx: Context,
+        requests: RequestStream<RunningSumRequestView<'static>>,
+    ) -> Result<(ResponseStream<RunningSumResponse>, Context), ConnectError> {
+        let response_stream =
+            futures::stream::unfold((requests, 0i64), |(mut requests, mut total)| async move {
+                match requests.next().await? {
+                    Ok(req) => {
+                        total += req.value.unwrap_or(0) as i64;
+                        Some((
+                            Ok(RunningSumResponse {
+                                total: Some(total),
+                                ..Default::default()
+                            }),
+                            (requests, total),
+                        ))
+                    }
+                    Err(e) => Some((Err(e), (requests, total))),
+                }
+            });
+        Ok((Box::pin(response_stream), ctx))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let addr: std::net::SocketAddr = "127.0.0.1:8080".parse()?;
+
+    let service = Arc::new(NumberServiceImpl);
+    let router = service.register(Router::new());
+    let app = router.into_axum_router();
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    println!("NumberService listening on http://{addr}");
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -1,0 +1,184 @@
+//! End-to-end test: spin up the NumberService in-process, exercise all
+//! four RPC types over a real TCP socket, assert expected results.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use buffa::view::OwnedView;
+use connectrpc::client::{ClientConfig, HttpClient};
+use connectrpc::{ConnectError, Context, Router};
+use futures::{Stream, StreamExt};
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+}
+
+use proto::anthropic::connectrpc::tour::v1::*;
+
+// Local type aliases that flatten the streaming-handler signatures.
+// See src/server.rs for the rationale.
+type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> + Send>>;
+type RequestStream<V> = Pin<Box<dyn Stream<Item = Result<OwnedView<V>, ConnectError>> + Send>>;
+
+struct NumberServiceImpl;
+
+impl NumberService for NumberServiceImpl {
+    async fn square(
+        &self,
+        ctx: Context,
+        request: OwnedView<SquareRequestView<'static>>,
+    ) -> Result<(SquareResponse, Context), ConnectError> {
+        let v = request.value.unwrap_or(0) as i64;
+        Ok((
+            SquareResponse {
+                squared: Some(v * v),
+                ..Default::default()
+            },
+            ctx,
+        ))
+    }
+
+    async fn range(
+        &self,
+        ctx: Context,
+        request: OwnedView<RangeRequestView<'static>>,
+    ) -> Result<(ResponseStream<RangeResponse>, Context), ConnectError> {
+        let start = request.start.unwrap_or(0);
+        let count = request.count.unwrap_or(0).max(0);
+        let stream = futures::stream::iter((0..count).map(move |i| {
+            Ok(RangeResponse {
+                value: Some(start + i),
+                ..Default::default()
+            })
+        }));
+        Ok((Box::pin(stream), ctx))
+    }
+
+    async fn sum(
+        &self,
+        ctx: Context,
+        mut requests: RequestStream<SumRequestView<'static>>,
+    ) -> Result<(SumResponse, Context), ConnectError> {
+        let mut total: i64 = 0;
+        while let Some(req) = requests.next().await {
+            total += req?.value.unwrap_or(0) as i64;
+        }
+        Ok((
+            SumResponse {
+                total: Some(total),
+                ..Default::default()
+            },
+            ctx,
+        ))
+    }
+
+    async fn running_sum(
+        &self,
+        ctx: Context,
+        requests: RequestStream<RunningSumRequestView<'static>>,
+    ) -> Result<(ResponseStream<RunningSumResponse>, Context), ConnectError> {
+        let response_stream =
+            futures::stream::unfold((requests, 0i64), |(mut requests, mut total)| async move {
+                match requests.next().await? {
+                    Ok(req) => {
+                        total += req.value.unwrap_or(0) as i64;
+                        Some((
+                            Ok(RunningSumResponse {
+                                total: Some(total),
+                                ..Default::default()
+                            }),
+                            (requests, total),
+                        ))
+                    }
+                    Err(e) => Some((Err(e), (requests, total))),
+                }
+            });
+        Ok((Box::pin(response_stream), ctx))
+    }
+}
+
+async fn start_server() -> std::net::SocketAddr {
+    let service = Arc::new(NumberServiceImpl);
+    let router = service.register(Router::new());
+    let app = router.into_axum_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    addr
+}
+
+fn make_client(addr: std::net::SocketAddr) -> NumberServiceClient<HttpClient> {
+    let config = ClientConfig::new(format!("http://{addr}").parse().unwrap());
+    NumberServiceClient::new(HttpClient::plaintext(), config)
+}
+
+#[tokio::test]
+async fn unary_square() {
+    let addr = start_server().await;
+    let client = make_client(addr);
+    let resp = client
+        .square(SquareRequest {
+            value: Some(7),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(resp.view().squared, Some(49));
+}
+
+#[tokio::test]
+async fn server_stream_range() {
+    let addr = start_server().await;
+    let client = make_client(addr);
+    let mut stream = client
+        .range(RangeRequest {
+            start: Some(10),
+            count: Some(5),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let mut got = Vec::new();
+    while let Some(msg) = stream.message().await.unwrap() {
+        got.push(msg.value.unwrap());
+    }
+    assert_eq!(got, vec![10, 11, 12, 13, 14]);
+}
+
+#[tokio::test]
+async fn client_stream_sum() {
+    let addr = start_server().await;
+    let client = make_client(addr);
+    let messages: Vec<SumRequest> = [3, 5, 7, 9]
+        .iter()
+        .map(|&v| SumRequest {
+            value: Some(v),
+            ..Default::default()
+        })
+        .collect();
+    let resp = client.sum(messages).await.unwrap();
+    assert_eq!(resp.view().total, Some(24));
+}
+
+#[tokio::test]
+async fn bidi_stream_running_sum() {
+    let addr = start_server().await;
+    let client = make_client(addr);
+    let mut bidi = client.running_sum().await.unwrap();
+    let mut got = Vec::new();
+    for v in [2, 4, 6, 8] {
+        bidi.send(RunningSumRequest {
+            value: Some(v),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let msg = bidi.message().await.unwrap().unwrap();
+        got.push(msg.total.unwrap());
+    }
+    bidi.close_send();
+    assert_eq!(got, vec![2, 6, 12, 20]);
+}


### PR DESCRIPTION
Closes #45

Adds two small focused example crates that close the most-asked-about gaps for new adopters: protocol-mechanics demonstration of all four RPC types, and server-side tower middleware composition.

## examples/streaming-tour

A trivial \`NumberService\` exercising every ConnectRPC RPC type:

| RPC | Type | Semantics |
|---|---|---|
| \`Square\` | Unary | n -> n*n |
| \`Range\` | Server streaming | emit \`count\` integers from \`start\` |
| \`Sum\` | Client streaming | total all values |
| \`RunningSum\` | Bidirectional streaming | emit running total after each request |

The methods are deliberately tiny - the example exists to show handler signatures and client invocation patterns side-by-side. Ships server + client binaries plus an integration test that spins up the server in-process and verifies every RPC.

## examples/middleware

Server-side tower middleware composition around the connect router:

- **\`AuthLayer\`** - hand-rolled \`tower::Layer\` that validates a \`Bearer <token>\` header against a static map. On success, stamps a \`UserId\` into the request extensions. On failure, short-circuits with a 401 in the Connect-protocol JSON error shape.
- **\`TraceLayer\`** - tower-http request/response logging.
- **\`TimeoutLayer\`** - per-request handler deadline.

Layers compose via \`ServiceBuilder\` mounted on \`axum::Router::layer()\`, so axum handles body conversion from \`ConnectRpcBody\` to \`axum::body::Body\`. The handler reads \`UserId\` from \`Context::extensions()\`, performs a per-secret permission check, and writes a \`x-served-by\` response trailer via \`Context::set_trailer()\`.

The client demonstrates \`ClientConfig::default_header\` for the auth header, \`ClientConfig::default_timeout\` for a default deadline, and \`CallOptions::with_timeout\` for a per-call override. Integration tests cover four paths: authorized success (verifying the trailer arrives), missing auth header, invalid token, and permission denied.

## Verification

- \`cargo build -p streaming-tour-example -p middleware-example\` clean
- \`cargo test -p streaming-tour-example -p middleware-example\` - 8/8 tests pass
- \`cargo clippy -p streaming-tour-example -p middleware-example --all-targets -- -D warnings\` clean
- \`cargo +nightly fmt --all -- --check\` clean
- \`cargo check --workspace --all-features --all-targets\` clean (workspace-wide)

## Branch order note

This branch is off main (pre-#44). When #44 lands, I'll rebase this branch onto main and add \`rust-version.workspace = true\` to the two new examples' \`Cargo.toml\` to match the rest of the workspace.