### PR TITLE
fix: do not require default features for axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ tokio-rustls = "0.26"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "tls12"] }
 
 # Framework integration
-axum = { version = "0.8", features = ["http2"] }
+axum = { version = "0.8", default-features = false, features = ["http2"] }
 
 # OS types
 libc = "0.2"

--- a/examples/eliza/Cargo.toml
+++ b/examples/eliza/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true, features = ["full"] }
 futures = { workspace = true }
 
 # Web framework
-axum = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1"] }
 
 # ELIZA bot dependencies
 rand = "0.10"

--- a/examples/middleware/Cargo.toml
+++ b/examples/middleware/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { workspace = true, features = ["full"] }
 futures = { workspace = true }
 
 # Web framework + tower middleware
-axum = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1"] }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace", "timeout"] }
 

--- a/examples/multiservice/Cargo.toml
+++ b/examples/multiservice/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true, features = ["full"] }
 futures = { workspace = true }
 
 # Web framework
-axum = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1"] }
 
 # Logging
 tracing = { workspace = true }

--- a/examples/streaming-tour/Cargo.toml
+++ b/examples/streaming-tour/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true, features = ["full"] }
 futures = { workspace = true }
 
 # Web framework
-axum = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1"] }
 
 [build-dependencies]
 connectrpc-build = { path = "../../connectrpc-build" }

--- a/tests/streaming/Cargo.toml
+++ b/tests/streaming/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1"
 futures = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1"] }
 
 [build-dependencies]
 connectrpc-build = { path = "../../connectrpc-build" }


### PR DESCRIPTION
Previously, the connectrpc crate required default features of the `axum` crate. This created a dependency chain of `axum/tokio` -> `tokio/net` -> `mio`. Since `mio` does not support WebAssembly (WASM), it was impossible to use this crate in environments like Cloudflare Workers.

Because `connectrpc` does not actually depend on any of the default features, this PR disables them. This change removes the incompatible dependencies and enables the crate to be used in WASM environments.

No changes are required to the current crate users.