### PR TITLE
connectrpc-build: skip rerun-if-changed for .files() in Precompiled mode

### DIFF
--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -274,12 +274,20 @@ impl Config {
             write_if_changed(&include_path, include_src.as_bytes())?;
         }
 
-        // 6. Cargo re-run triggers.
-        for f in &self.files {
-            println!("cargo:rerun-if-changed={}", f.display());
-        }
-        if let DescriptorSource::Precompiled(p) = &self.descriptor_source {
-            println!("cargo:rerun-if-changed={}", p.display());
+        // 6. Cargo re-run triggers. In Precompiled mode `self.files` holds
+        // proto-relative names (per the docs on `descriptor_set()`), not
+        // on-disk paths; emitting `rerun-if-changed` for them points cargo at
+        // missing files and forces a rebuild on every invocation. The `.pb`
+        // path is the only real input in that mode.
+        match &self.descriptor_source {
+            DescriptorSource::Precompiled(p) => {
+                println!("cargo:rerun-if-changed={}", p.display());
+            }
+            DescriptorSource::Protoc | DescriptorSource::Buf => {
+                for f in &self.files {
+                    println!("cargo:rerun-if-changed={}", f.display());
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
In Precompiled mode (`Config::descriptor_set(path)`), `.files()` entries are proto-relative names per the docs, not on-disk paths. Emitting `cargo:rerun-if-changed` for them points cargo at nonexistent files, which it treats as permanently stale — the consumer crate rebuilds on every `cargo build` invocation.

The `.pb` path is the only real input in Precompiled mode and already has its own `rerun-if-changed` line. Protoc/Buf modes are unchanged.

**Repro:** any crate using `.descriptor_set("foo.pb").files(&["pkg/foo.proto"])` where `pkg/foo.proto` doesn't exist relative to the crate dir — `CARGO_LOG=cargo::core::compiler::fingerprint=info cargo build` shows `StaleItem(MissingFile { ... })` on every run.

**Testing:** `cargo build/clippy/fmt/test -p connectrpc-build` clean. Verified against a local Precompiled-mode consumer: 4× consecutive `cargo build` are now no-ops (were full rebuilds before).