### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ increment the patch version.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-04-17
+
+### Fixed
+
+- **`connectrpc-build` no longer emits invalid
+  `cargo:rerun-if-changed` directives in `Precompiled` input mode**
+  ([#56]). When a precompiled `FileDescriptorSet` was supplied instead
+  of `.proto` source files, `.files()` paths were still being passed
+  through to cargo, causing spurious rebuild triggers on paths that
+  don't exist in that mode.
+
+### Changed
+
+- **MSRV is now declared as Rust 1.88** on the workspace and verified
+  in CI ([#44]). The code has required 1.88 since v0.3.2 (let-chains);
+  this commit documents the requirement in `Cargo.toml` and adds an
+  explicit CI check.
+
+### Added
+
+- New `examples/streaming-tour` and `examples/middleware` crates,
+  plus a user guide under `docs/guide.md` ([#46], [#48]).
+
+[#44]: https://github.com/anthropics/connect-rust/pull/44
+[#46]: https://github.com/anthropics/connect-rust/pull/46
+[#48]: https://github.com/anthropics/connect-rust/pull/48
+[#56]: https://github.com/anthropics/connect-rust/pull/56
+
 ## [0.3.2] - 2026-04-03
 
 ### Fixed

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-build"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-codegen"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Lockstep bump of `connectrpc`, `connectrpc-build`, and `connectrpc-codegen` to **0.3.3**.

## Headline

- **#56** — `connectrpc-build` no longer emits `cargo:rerun-if-changed`
  directives for `.files()` when `Precompiled` input mode is used.
  Consumers that feed a precompiled `FileDescriptorSet` were getting
  spurious rebuild triggers on paths that don't apply in that mode.

## Also included since v0.3.2

- **#44** — workspace declares `rust-version = "1.88"` and CI verifies
  it. The code already required 1.88 (let-chains) in v0.3.2; this
  commit documents the requirement.
- **#46** — new `examples/streaming-tour` and `examples/middleware`
  crates. Not published.
- **#48** — user guide at `docs/guide.md`, linked from README. Not
  published.

No public API changes in `connectrpc`. `connectrpc-codegen` only gained
a one-line intra-doc-link tweak in a generated doc comment (#46).

## Checklist

- [x] All three crate versions bumped to 0.3.3 (lockstep).
- [x] Inter-crate dependencies remain `version = "0.3"` (compatible).
- [x] CHANGELOG.md updated with the 0.3.3 entry and PR refs.
- [x] CI green.
- [ ] Tag `v0.3.3` and run the publish workflow after merge.
