### PR TITLE
Bring graceful shutdown in line with Go's net/http.Server.Shutdown behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 # HTTP server/client
+h2 = "0.4"
 hyper = "1"
 hyper-util = "0"
 

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -102,7 +102,6 @@ server = [
     "dep:libc",
     "dep:tower-http",
     "tokio/net",
-    "tokio-util/rt",
 ]
 
 # HTTP client with connection pooling

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -76,6 +76,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"
 tempfile = { workspace = true }
 rcgen = { workspace = true }
 buffa-types = { workspace = true }
+h2 = { workspace = true }
 
 [features]
 default = ["gzip", "zstd", "streaming"]
@@ -91,6 +92,8 @@ server = [
     "hyper/http1",
     "hyper/http2",
     "hyper-util/server",
+    "hyper-util/server-auto",
+    "hyper-util/server-graceful",
     "hyper-util/tokio",
     "hyper-util/http1",
     "hyper-util/http2",

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -523,16 +523,12 @@ async fn serve_with_listener<D: Dispatcher>(
     #[cfg(not(feature = "server-tls"))]
     let _ = tls_acceptor; // always None; silence unused warning
 
-    // Track connection tasks so graceful shutdown can wait for them to drain.
-    // TaskTracker::spawn is equivalent to tokio::spawn but records the task;
-    // tracker.wait() resolves when all tracked tasks have completed AND
-    // tracker.close() has been called.
-    let tracker = tokio_util::task::TaskTracker::new();
-
     // Per-connection graceful-shutdown coordinator. Each accepted connection
-    // is wrapped via `graceful.watcher().watch(conn)`; on shutdown,
-    // `graceful.shutdown()` signals every wrapped connection to send GOAWAY
-    // (HTTP/2) or disable keep-alive (HTTP/1), then waits for them to drain.
+    // gets a `Watcher` (created in the accept loop, moved into the task) and
+    // is wrapped via `watcher.watch(conn)`. On shutdown, `graceful.shutdown()`
+    // signals every wrapped connection to send GOAWAY (HTTP/2) or disable
+    // keep-alive (HTTP/1), then waits for every `Watcher` to drop — which
+    // covers tasks still in TLS handshake as well as those serving traffic.
     let graceful = GracefulShutdown::new();
 
     // Pin the shutdown future so we can poll it in select!. If no shutdown
@@ -572,7 +568,7 @@ async fn serve_with_listener<D: Dispatcher>(
         #[cfg(feature = "server-tls")]
         let tls_acceptor = tls_acceptor.clone();
 
-        tracker.spawn(async move {
+        tokio::spawn(async move {
             #[cfg(feature = "server-tls")]
             if let Some(acceptor) = tls_acceptor {
                 // Apply a timeout to the TLS handshake to prevent connection
@@ -624,13 +620,9 @@ async fn serve_with_listener<D: Dispatcher>(
         });
     }
 
-    // Shutdown: drop the listener so the OS rejects new connections (RST),
-    // signal GOAWAY / keep-alive-disable to every live connection and wait for
-    // them to drain, then wait for any remaining task cleanup.
+    // Drop the listener (refuse new conns), then signal & drain existing ones.
     drop(listener);
-    tracker.close();
     graceful.shutdown().await;
-    tracker.wait().await;
     tracing::info!("All connections drained; shutdown complete");
 
     Ok(())
@@ -768,16 +760,19 @@ mod tests {
         // Spawn a server with a handler that blocks until released. Start a
         // request, fire shutdown, verify the server waits for that request to
         // complete (not just the connection to close).
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();
-        let release_rx = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+        let chans = Arc::new(Mutex::new(Some((entered_tx, release_rx))));
         let router = Router::new().route(
             "svc",
             "Slow",
             crate::handler_fn(move |ctx: crate::Context, _req: buffa_types::Empty| {
-                let release_rx = Arc::clone(&release_rx);
+                let chans = Arc::clone(&chans);
                 async move {
-                    if let Some(rx) = release_rx.lock().await.take() {
-                        rx.await.ok();
+                    let taken = chans.lock().unwrap().take();
+                    if let Some((entered_tx, release_rx)) = taken {
+                        entered_tx.send(()).ok();
+                        release_rx.await.ok();
                     }
                     Ok((buffa_types::Empty::default(), ctx))
                 }
@@ -807,8 +802,11 @@ mod tests {
             .unwrap();
         let (resp_fut, _) = send_request.send_request(req, true).unwrap();
         let mut resp_fut = tokio::spawn(resp_fut);
-        // Let the server accept and dispatch into the handler.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Wait until the handler has actually started before firing shutdown.
+        tokio::time::timeout(Duration::from_secs(5), entered_rx)
+            .await
+            .expect("handler never entered")
+            .unwrap();
 
         // Fire shutdown — the in-flight request must still be allowed to
         // complete.
@@ -898,8 +896,8 @@ mod tests {
         let h2_task = tokio::spawn(h2_conn);
 
         // Round-trip a request to prove the h2 connection is fully established
-        // on the server side before we fire the shutdown signal. (Router is
-        // empty so this 404s — that's fine, we just need any response.)
+        // on the server side before we fire the shutdown signal. The router is
+        // empty so this errors (415, no Content-Type), but any response will do.
         let req = http::Request::builder()
             .method(http::Method::POST)
             .uri(format!("http://{addr}/svc/Unknown"))
@@ -920,12 +918,11 @@ mod tests {
             .await
             .expect("server did not close idle h2 connection (no GOAWAY?)")
             .expect("h2 connection task panicked");
-        match conn_result {
-            Ok(()) => {} // clean close after GOAWAY
-            Err(e) => assert!(
+        if let Err(e) = conn_result {
+            assert!(
                 e.is_go_away(),
-                "h2 connection ended with non-GOAWAY error: {e:?}",
-            ),
+                "h2 connection ended with non-GOAWAY error: {e:?}"
+            );
         }
 
         // And the server itself should now drain promptly — the only open

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -46,6 +46,8 @@ use http_body_util::Full;
 use hyper_util::rt::TokioExecutor;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::conn::auto::Builder as AutoBuilder;
+use hyper_util::server::graceful::GracefulShutdown;
+use hyper_util::server::graceful::Watcher;
 use tokio::net::TcpListener;
 use tower::Service;
 use tower::ServiceBuilder;
@@ -336,17 +338,19 @@ impl BoundServer {
 
     /// Start serving requests, shutting down gracefully when `signal` resolves.
     ///
-    /// When the shutdown signal fires, the server drops the listener (new
-    /// connection attempts are refused with RST) and waits for all in-flight
-    /// connection tasks to complete before returning `Ok(())`.
+    /// When the shutdown signal fires, the server:
+    ///  1. drops the listener (new connection attempts are refused with RST),
+    ///  2. signals every open connection to wind down — HTTP/2 connections
+    ///     receive a GOAWAY (using the standard two-phase
+    ///     GOAWAY/PING/GOAWAY sequence so racing client streams are handled
+    ///     correctly); HTTP/1.1 connections have keep-alive disabled so they
+    ///     close after the in-flight request,
+    ///  3. waits for all in-flight requests to complete before returning
+    ///     `Ok(())`.
     ///
-    /// # Limitation
-    ///
-    /// This does not send HTTP/2 GOAWAY or otherwise signal existing
-    /// connections to stop accepting new requests. Long-lived HTTP/2
-    /// connections or HTTP/1.1 keep-alive connections will continue serving
-    /// until the client closes them. For bounded shutdown (e.g. Kubernetes
-    /// preStop hooks with a deadline), wrap this call in `tokio::time::timeout`:
+    /// In-flight requests are not cancelled; this method waits indefinitely
+    /// for them. For bounded shutdown (e.g. Kubernetes preStop hooks with a
+    /// deadline), wrap this call in `tokio::time::timeout`:
     ///
     /// ```rust,ignore
     /// tokio::time::timeout(
@@ -454,6 +458,7 @@ async fn serve_accepted_stream<D, S>(
     peer: PeerInfo,
     service: Arc<WrappedService<D>>,
     http1_keep_alive: bool,
+    watcher: Watcher,
 ) where
     D: Dispatcher,
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
@@ -470,7 +475,8 @@ async fn serve_accepted_stream<D, S>(
     let mut builder = AutoBuilder::new(TokioExecutor::new());
     builder.http1().keep_alive(http1_keep_alive);
 
-    match builder.serve_connection(TokioIo::new(io), svc).await {
+    let conn = builder.serve_connection(TokioIo::new(io), svc).into_owned();
+    match watcher.watch(conn).await {
         Ok(()) => {
             tracing::trace!(remote_addr = %peer.addr, "Connection completed normally");
         }
@@ -523,6 +529,12 @@ async fn serve_with_listener<D: Dispatcher>(
     // tracker.close() has been called.
     let tracker = tokio_util::task::TaskTracker::new();
 
+    // Per-connection graceful-shutdown coordinator. Each accepted connection
+    // is wrapped via `graceful.watcher().watch(conn)`; on shutdown,
+    // `graceful.shutdown()` signals every wrapped connection to send GOAWAY
+    // (HTTP/2) or disable keep-alive (HTTP/1), then waits for them to drain.
+    let graceful = GracefulShutdown::new();
+
     // Pin the shutdown future so we can poll it in select!. If no shutdown
     // signal was provided, use a never-resolving pending() future.
     let mut shutdown = shutdown.unwrap_or_else(|| Box::pin(std::future::pending()));
@@ -555,6 +567,7 @@ async fn serve_with_listener<D: Dispatcher>(
         }
 
         let service = Arc::clone(&service);
+        let watcher = graceful.watcher();
 
         #[cfg(feature = "server-tls")]
         let tls_acceptor = tls_acceptor.clone();
@@ -581,7 +594,8 @@ async fn serve_with_listener<D: Dispatcher>(
                             addr: remote_addr,
                             certs,
                         };
-                        serve_accepted_stream(tls_stream, peer, service, http1_keep_alive).await;
+                        serve_accepted_stream(tls_stream, peer, service, http1_keep_alive, watcher)
+                            .await;
                     }
                     Ok(Err(err)) => {
                         tracing::debug!(
@@ -606,14 +620,16 @@ async fn serve_with_listener<D: Dispatcher>(
                 #[cfg(feature = "server-tls")]
                 certs: None,
             };
-            serve_accepted_stream(stream, peer, service, http1_keep_alive).await;
+            serve_accepted_stream(stream, peer, service, http1_keep_alive, watcher).await;
         });
     }
 
-    // Shutdown: stop tracking new tasks and wait for in-flight connections.
-    // Drop the listener so the OS rejects new connections (RST) while we drain.
+    // Shutdown: drop the listener so the OS rejects new connections (RST),
+    // signal GOAWAY / keep-alive-disable to every live connection and wait for
+    // them to drain, then wait for any remaining task cleanup.
     drop(listener);
     tracker.close();
+    graceful.shutdown().await;
     tracker.wait().await;
     tracing::info!("All connections drained; shutdown complete");
 
@@ -748,44 +764,75 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_graceful_shutdown_with_inflight_connection() {
-        // Spawn a server, open a TCP connection (keep it alive), trigger
-        // shutdown, verify the server waits for the connection to drop.
+    async fn test_graceful_shutdown_drains_inflight_request() {
+        // Spawn a server with a handler that blocks until released. Start a
+        // request, fire shutdown, verify the server waits for that request to
+        // complete (not just the connection to close).
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let release_rx = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+        let router = Router::new().route(
+            "svc",
+            "Slow",
+            crate::handler_fn(move |ctx: crate::Context, _req: buffa_types::Empty| {
+                let release_rx = Arc::clone(&release_rx);
+                async move {
+                    if let Some(rx) = release_rx.lock().await.take() {
+                        rx.await.ok();
+                    }
+                    Ok((buffa_types::Empty::default(), ctx))
+                }
+            }),
+        );
+
         let bound = Server::bind("127.0.0.1:0").await.unwrap();
         let addr = bound.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel();
-
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let serve = tokio::spawn(async move {
             bound
-                .serve_with_graceful_shutdown(Router::new(), async {
-                    rx.await.ok();
+                .serve_with_graceful_shutdown(router, async {
+                    shutdown_rx.await.ok();
                 })
                 .await
         });
 
-        // Open a raw TCP connection and hold it open
-        let conn = tokio::net::TcpStream::connect(addr).await.unwrap();
-        // Give the server a moment to accept and spawn the connection task
+        // Start the slow request over h2 and leave it in flight.
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut send_request, h2_conn) = h2::client::handshake(tcp).await.unwrap();
+        tokio::spawn(h2_conn);
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("http://{addr}/svc/Slow"))
+            .header(header::CONTENT_TYPE, "application/proto")
+            .body(())
+            .unwrap();
+        let (resp_fut, _) = send_request.send_request(req, true).unwrap();
+        let mut resp_fut = tokio::spawn(resp_fut);
+        // Let the server accept and dispatch into the handler.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        // Fire the shutdown signal — server should now be waiting for our
-        // connection to finish
-        tx.send(()).unwrap();
-
-        // Server should NOT complete yet (our connection is still open).
-        // Give it a moment to process the shutdown signal, then check the task.
+        // Fire shutdown — the in-flight request must still be allowed to
+        // complete.
+        shutdown_tx.send(()).unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert!(
             !serve.is_finished(),
-            "server shut down before connection closed"
+            "server shut down before in-flight request completed"
         );
+        assert!(!resp_fut.is_finished(), "response arrived too early");
 
-        // Close the connection — server should now drain and complete
-        drop(conn);
+        // Release the handler; the response should arrive and the server
+        // should drain.
+        release_tx.send(()).unwrap();
+        let resp = tokio::time::timeout(Duration::from_secs(5), &mut resp_fut)
+            .await
+            .expect("response never arrived")
+            .expect("join error")
+            .expect("h2 request failed");
+        assert!(resp.status().is_success(), "got status {}", resp.status());
 
         let result = tokio::time::timeout(Duration::from_secs(5), serve)
             .await
-            .expect("server did not shut down after connection dropped")
+            .expect("server did not shut down after in-flight request drained")
             .expect("join error");
         assert!(result.is_ok(), "serve returned error: {result:?}");
     }
@@ -824,6 +871,74 @@ mod tests {
             connect_result.is_err(),
             "expected connection refused after shutdown"
         );
+    }
+
+    #[tokio::test]
+    async fn test_graceful_shutdown_sends_h2_goaway() {
+        // Regression: on graceful shutdown the server must send HTTP/2 GOAWAY
+        // to existing connections so clients learn to stop sending new streams
+        // and the server can drain promptly. Prior behaviour just dropped the
+        // listener and waited, leaving idle h2 connections open until the
+        // client hung up.
+        let bound = Server::bind("127.0.0.1:0").await.unwrap();
+        let addr = bound.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    rx.await.ok();
+                })
+                .await
+        });
+
+        // Establish a raw HTTP/2 connection (prior-knowledge, no TLS).
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut send_request, h2_conn) = h2::client::handshake(tcp).await.unwrap();
+        let h2_task = tokio::spawn(h2_conn);
+
+        // Round-trip a request to prove the h2 connection is fully established
+        // on the server side before we fire the shutdown signal. (Router is
+        // empty so this 404s — that's fine, we just need any response.)
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("http://{addr}/svc/Unknown"))
+            .body(())
+            .unwrap();
+        let (resp, _) = send_request.send_request(req, true).unwrap();
+        resp.await.unwrap();
+
+        // Fire shutdown.
+        tx.send(()).unwrap();
+
+        // Expectation: the server sends GOAWAY(NO_ERROR) on this connection.
+        // The h2 client surfaces that on the connection task and on subsequent
+        // SendRequest readiness. We assert on the connection task: it must
+        // complete (server closed cleanly after GOAWAY) within the timeout,
+        // without us dropping our end first.
+        let conn_result = tokio::time::timeout(Duration::from_secs(2), h2_task)
+            .await
+            .expect("server did not close idle h2 connection (no GOAWAY?)")
+            .expect("h2 connection task panicked");
+        match conn_result {
+            Ok(()) => {} // clean close after GOAWAY
+            Err(e) => assert!(
+                e.is_go_away(),
+                "h2 connection ended with non-GOAWAY error: {e:?}",
+            ),
+        }
+
+        // And the server itself should now drain promptly — the only open
+        // connection has been closed via GOAWAY.
+        let result = tokio::time::timeout(Duration::from_secs(2), serve)
+            .await
+            .expect("server did not shut down after GOAWAY drained the connection")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+
+        // Keep send_request alive until here so the client doesn't initiate
+        // close before the server gets a chance to GOAWAY.
+        drop(send_request);
     }
 
     // ========================================================================


### PR DESCRIPTION
connect-rust doesn't currently handle graceful shutdown very gracefully. I'm mostly familiar with Go, where the http stack has some useful conventions:
- stop accepting new tcp connections
- allow in-flight requests (or h2 streams) to complete

For h1 it tears the connection down as soon as it goes idle (and sets `Connection: close` on the in-flight response if there is one). For h2, since streams can overlap, it uses the GOAWAY frame — actually a kind of clever GOAWAY → ping → pong → GOAWAY(last_stream_id) sequence so streams that race the first GOAWAY are still handled.

hyper implements the same behaviors, so this PR is mostly just plugging that in. Mechanically: each accepted connection gets wrapped with `hyper_util::server::graceful::Watcher::watch(conn)`, and after the accept loop exits we call `graceful.shutdown().await` to signal + drain. This fully subsumes the old `TaskTracker` (the `Watcher` is created in the accept loop and moved into the per-conn task, so `shutdown()` waits for tasks still mid-TLS-handshake too), so that's removed along with the `tokio-util/rt` feature.

Tests: added an `h2` dev-dep and a regression test that opens a raw h2 connection and asserts the server actually GOAWAYs it on shutdown. Also rewrote the old `with_inflight_connection` test — it was asserting the previous "idle socket keeps the server alive" behavior, which is exactly what we're fixing — into `drains_inflight_request`, which checks that an actual in-flight request is allowed to finish.

The doc comment that previously called this out as a Limitation now describes the new shutdown sequence instead.