### PR TITLE
fix(build): skip rerun-if-changed for .files() in Buf mode

### DIFF
--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -337,7 +337,12 @@ impl Config {
             DescriptorSource::Precompiled(p) => {
                 println!("cargo:rerun-if-changed={}", p.display());
             }
-            DescriptorSource::Protoc | DescriptorSource::Buf => {
+            // Both Buf and Precompiled modes use proto-relative names (not
+            // filesystem paths) in `.files()`. Emitting `rerun-if-changed`
+            // for those would point cargo at non-existent files and force a
+            // rebuild every invocation.
+            DescriptorSource::Buf => {}
+            DescriptorSource::Protoc => {
                 for f in &self.files {
                     println!("cargo:rerun-if-changed={}", f.display());
                 }


### PR DESCRIPTION
## Summary

- Skip emitting `cargo:rerun-if-changed` for `.files()` entries when using `Config::use_buf()`, since those entries are proto-relative names (not filesystem paths)

## Problem

In Buf mode, `.files()` holds proto-relative names like `"my/service.proto"`, not filesystem paths. Emitting `cargo:rerun-if-changed=my/service.proto` points cargo at a non-existent file, which forces a rebuild on every invocation.

This is the same issue that was fixed for `Precompiled` mode in #56, but `Buf` mode was missed in that fix. The comment on `DescriptorSource::Precompiled` already explains the rationale:

> `self.files` holds proto-relative names (per the docs on `descriptor_set()`), not on-disk paths; emitting `rerun-if-changed` for them points cargo at missing files and forces a rebuild on every invocation.

The same applies to `Buf` mode — the docs on `Config::use_buf()` say:

> `Config::files()` must contain proto-relative names as they appear in the buf module (e.g. `"my/service.proto"`), not filesystem paths.

## Test plan

- [x] Existing tests pass (`cargo test -p connectrpc-build`)
- [x] The fix mirrors the approach already used for `Precompiled` mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)