### PR TITLE
fix: disable default features for axum workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tokio-rustls = "0.26"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "tls12"] }
 
 # Framework integration
-axum = { version = "0.8", features = ["http2"] }
+axum = { version = "0.8", default-features = false, features = ["http2"] }
 
 # OS types
 libc = "0.2"


### PR DESCRIPTION
## Summary

- Add `default-features = false` to the `axum` workspace dependency in the root `Cargo.toml`

## Problem

The `axum` workspace dependency enables default features, which pulls in `axum/tokio` → `tokio/net` → `mio`. Since `mio` does not support WASM, this makes the crate unusable in environments like Cloudflare Workers.

The connectrpc crate only uses axum's `Router` integration and does not depend on any of the default features (tokio, macros, etc.). The `http2` feature is sufficient.

This is the workspace-level fix that complements PR #55 (which was going to fix it at the crate level). Since the workspace dependency is the source of truth, fixing it here ensures all workspace members inherit the correct configuration.

## Test plan

- [x] `cargo check -p connectrpc --features axum` succeeds
- [x] `cargo test -p connectrpc --features axum` — all 233 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)