### PR TITLE
codegen: embed buffa CodeGenConfig directly in Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ increment the patch version.
 
 ## [Unreleased]
 
+### Breaking
+
+- **`connectrpc-codegen`**: `Options` now embeds the buffa
+  `CodeGenConfig` directly as `Options::buffa` instead of mirroring
+  individual fields ([#34]). The previous per-field shims
+  (`strict_utf8_mapping`, `generate_json`, `extern_paths`,
+  `emit_register_fn`) are gone; set `options.buffa.<field>` instead.
+  `CodeGenConfig` is re-exported from `connectrpc_codegen::codegen` and
+  `connectrpc_build`. `connectrpc_build::Config` keeps its existing
+  builder methods as thin shims and gains `.buffa_config(cfg)` for
+  wholesale replacement. `generate_views = true` is still enforced.
+
+[#34]: https://github.com/anthropics/connect-rust/issues/34
+
 ## [0.3.3] - 2026-04-17
 
 ### Fixed

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -39,6 +39,8 @@ use buffa::Message;
 use buffa_codegen::generated::descriptor::FileDescriptorSet;
 use connectrpc_codegen::codegen::{self, Options};
 
+pub use connectrpc_codegen::codegen::CodeGenConfig;
+
 /// How to acquire a `FileDescriptorSet` from `.proto` files.
 #[derive(Debug, Clone, Default)]
 enum DescriptorSource {
@@ -103,20 +105,20 @@ impl Config {
     }
 
     /// Honor `features.utf8_validation = NONE` by emitting `Vec<u8>`/`&[u8]`
-    /// for such string fields. See [`Options::strict_utf8_mapping`].
+    /// for such string fields. See [`CodeGenConfig::strict_utf8_mapping`].
     #[must_use]
     pub fn strict_utf8_mapping(mut self, enabled: bool) -> Self {
-        self.options.strict_utf8_mapping = enabled;
+        self.options.buffa.strict_utf8_mapping = enabled;
         self
     }
 
     /// Emit `serde` derives and proto3 JSON helpers (default: true).
     ///
     /// Disable only for binary-only clients; the Connect protocol's JSON
-    /// codec requires this. See [`Options::generate_json`].
+    /// codec requires this. See [`CodeGenConfig::generate_json`].
     #[must_use]
     pub fn generate_json(mut self, enabled: bool) -> Self {
-        self.options.generate_json = enabled;
+        self.options.buffa.generate_json = enabled;
         self
     }
 
@@ -125,10 +127,22 @@ impl Config {
     ///
     /// Set to `false` when the generated files are `include!`d into the
     /// same module — the identically-named functions would otherwise
-    /// collide. See [`Options::emit_register_fn`].
+    /// collide. See [`CodeGenConfig::emit_register_fn`].
     #[must_use]
     pub fn emit_register_fn(mut self, enabled: bool) -> Self {
-        self.options.emit_register_fn = enabled;
+        self.options.buffa.emit_register_fn = enabled;
+        self
+    }
+
+    /// Replace the underlying buffa [`CodeGenConfig`] wholesale.
+    ///
+    /// Any buffa knob not surfaced as a builder method here can be set this
+    /// way. The convenience builders above remain available for the common
+    /// cases. `generate_views` is forced to `true` regardless (service
+    /// stubs require view types); see [`Options::buffa`].
+    #[must_use]
+    pub fn buffa_config(mut self, config: CodeGenConfig) -> Self {
+        self.options.buffa = config;
         self
     }
 
@@ -552,19 +566,27 @@ mod tests {
             .include_file("_inc.rs");
         assert_eq!(cfg.files.len(), 2);
         assert_eq!(cfg.includes.len(), 1);
-        assert!(cfg.options.strict_utf8_mapping);
-        assert!(!cfg.options.generate_json);
-        assert!(!cfg.options.emit_register_fn);
+        assert!(cfg.options.buffa.strict_utf8_mapping);
+        assert!(!cfg.options.buffa.generate_json);
+        assert!(!cfg.options.buffa.emit_register_fn);
         assert_eq!(cfg.include_file.as_deref(), Some("_inc.rs"));
     }
 
     #[test]
     fn config_default_options() {
         let cfg = Config::new();
-        assert!(!cfg.options.strict_utf8_mapping);
-        assert!(cfg.options.generate_json);
-        assert!(cfg.options.emit_register_fn);
+        assert!(!cfg.options.buffa.strict_utf8_mapping);
+        assert!(cfg.options.buffa.generate_json);
+        assert!(cfg.options.buffa.emit_register_fn);
         assert!(matches!(cfg.descriptor_source, DescriptorSource::Protoc));
+    }
+
+    #[test]
+    fn config_buffa_config_wholesale() {
+        let mut buffa = CodeGenConfig::default();
+        buffa.generate_text = true;
+        let cfg = Config::new().buffa_config(buffa);
+        assert!(cfg.options.buffa.generate_text);
     }
 
     #[test]

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -140,6 +140,10 @@ impl Config {
     /// way. The convenience builders above remain available for the common
     /// cases. `generate_views` is forced to `true` regardless (service
     /// stubs require view types); see [`Options::buffa`].
+    ///
+    /// Calls to the convenience builders above made *before* this method
+    /// are discarded; calls made *after* override individual fields in the
+    /// supplied config.
     #[must_use]
     pub fn buffa_config(mut self, config: CodeGenConfig) -> Self {
         self.options.buffa = config;

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -37,7 +37,9 @@ use crate::plugin::CodeGeneratorResponseFile;
 /// These control both the underlying buffa message generation and the
 /// ConnectRPC service binding generation.
 ///
-/// Construct via `Options { field: value, ..Options::default() }`.
+/// Construct via `Options::default()` then set fields on `buffa` directly
+/// (the struct is `#[non_exhaustive]`, so struct-update syntax is
+/// unavailable from outside this crate).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Options {

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -25,8 +25,8 @@ use buffa_codegen::generated::descriptor::method_options::IdempotencyLevel;
 use buffa_codegen::idents::make_field_ident;
 use buffa_codegen::idents::rust_path_to_tokens;
 
-pub use buffa_codegen::GeneratedFile;
 pub use buffa_codegen::generated::descriptor;
+pub use buffa_codegen::{CodeGenConfig, GeneratedFile};
 
 use crate::plugin::CodeGeneratorRequest;
 use crate::plugin::CodeGeneratorResponse;
@@ -41,56 +41,36 @@ use crate::plugin::CodeGeneratorResponseFile;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Options {
-    /// Emit `Vec<u8>`/`&[u8]` for proto string fields with
-    /// `utf8_validation = NONE` instead of `String`/`&str`. See
-    /// `buffa_codegen::CodeGenConfig::strict_utf8_mapping`.
-    pub strict_utf8_mapping: bool,
-    /// Emit `serde::Serialize` / `serde::Deserialize` derives and the proto3
-    /// JSON mapping helpers on generated message types. Required for the
-    /// Connect protocol's JSON codec; disable only if you're targeting
-    /// binary-only clients.
-    pub generate_json: bool,
-    /// Map protobuf package prefixes to Rust module paths for message types.
+    /// The underlying buffa-codegen configuration. Set any
+    /// [`CodeGenConfig`] field directly here; connectrpc passes it through
+    /// verbatim except for [`CodeGenConfig::generate_views`], which is
+    /// forced to `true` (service stubs require view types).
     ///
-    /// Each entry is `(proto_prefix, rust_path)`, e.g.
-    /// `(".", "crate::proto")` routes every type through `crate::proto::...`.
-    /// More-specific prefixes win via longest-prefix-match, and the WKT
-    /// mapping (`.google.protobuf` -> `::buffa_types::...`) is auto-injected.
+    /// [`Options::default()`] starts from buffa's defaults but enables
+    /// `generate_json` (the Connect protocol's JSON codec needs it; buffa's
+    /// own default is `false`).
     ///
-    /// Used by [`generate_services`] to bake absolute paths into service
-    /// stubs so they compile independently of co-generated message types.
-    /// Unused by [`generate_files`] (the unified `super::`-relative path).
-    pub extern_paths: Vec<(String, String)>,
-    /// Emit the per-file `register_types(&mut TypeRegistry)` function that
-    /// aggregates every message in the file. Default `true`. See
-    /// `buffa_codegen::CodeGenConfig::emit_register_fn`.
-    ///
-    /// Set to `false` when multiple generated files are `include!`d into
-    /// the same module — the identically-named `register_types` fns would
-    /// otherwise collide. The per-message `__*_JSON_ANY` consts are still
-    /// emitted; only the aggregating function is suppressed.
-    pub emit_register_fn: bool,
+    /// `buffa.extern_paths` is used by [`generate_services`] to bake
+    /// absolute paths into service stubs (set a `(".", "crate::proto")`
+    /// catch-all so every type resolves); it is ignored by
+    /// [`generate_files`] (the unified `super::`-relative path).
+    pub buffa: CodeGenConfig,
 }
 
 impl Default for Options {
     fn default() -> Self {
-        Self {
-            strict_utf8_mapping: false,
-            generate_json: true,
-            extern_paths: Vec::new(),
-            emit_register_fn: true,
-        }
+        let mut buffa = CodeGenConfig::default();
+        buffa.generate_json = true;
+        Self { buffa }
     }
 }
 
 impl Options {
-    fn to_buffa_config(&self) -> buffa_codegen::CodeGenConfig {
-        let mut config = buffa_codegen::CodeGenConfig::default();
+    /// Clone the embedded buffa config and apply connectrpc's invariants
+    /// (`generate_views = true` — service stubs reference view types).
+    fn to_buffa_config(&self) -> CodeGenConfig {
+        let mut config = self.buffa.clone();
         config.generate_views = true;
-        config.generate_json = self.generate_json;
-        config.strict_utf8_mapping = self.strict_utf8_mapping;
-        config.extern_paths.clone_from(&self.extern_paths);
-        config.emit_register_fn = self.emit_register_fn;
         config
     }
 }
@@ -131,7 +111,7 @@ fn emit_service_files(
 ///
 /// This is the **unified** path: service stubs reference message types via
 /// `super::`-relative paths, so both must live in the same module tree.
-/// [`Options::extern_paths`] is ignored.
+/// [`CodeGenConfig::extern_paths`] is ignored.
 ///
 /// # Errors
 ///
@@ -168,7 +148,7 @@ pub fn generate_files(
 /// declares at least one `service`. No message types, no `mod.rs`.
 ///
 /// This is the **split** path: service stubs reference message types via
-/// absolute Rust paths derived from [`Options::extern_paths`]. Callers must
+/// absolute Rust paths derived from [`CodeGenConfig::extern_paths`]. Callers must
 /// set at least a `.` catch-all entry (e.g. `(".", "crate::proto")`) so
 /// every type resolves; the auto-injected WKT mapping still takes priority
 /// via longest-prefix-match. The generated code compiles standalone as long
@@ -204,13 +184,13 @@ pub fn generate_services(
 ///   to a Rust module path. Repeatable; longest-prefix-match wins.
 ///   `extern_path=.=<path>` is the catch-all (equivalent to `buffa_module`).
 ///   At least one catch-all mapping is required so every type resolves.
-/// - `strict_utf8_mapping` — see [`Options::strict_utf8_mapping`].
+/// - `strict_utf8_mapping` — see [`CodeGenConfig::strict_utf8_mapping`].
 /// - `no_json` — disable `serde` derives on generated message types.
 ///   Ignored in this plugin (no message types emitted); accepted for
 ///   compatibility with the unified path.
 /// - `no_register_fn` — suppress the per-file
 ///   `register_types(&mut TypeRegistry)` aggregator. See
-///   [`Options::emit_register_fn`]. Ignored in this plugin (no message
+///   [`CodeGenConfig::emit_register_fn`]. Ignored in this plugin (no message
 ///   types emitted); accepted for compatibility with the unified path.
 pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse> {
     let mut options = Options::default();
@@ -225,7 +205,10 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
                          e.g. buffa_module=crate::proto"
                     );
                 }
-                options.extern_paths.push((".".into(), rust.to_string()));
+                options
+                    .buffa
+                    .extern_paths
+                    .push((".".into(), rust.to_string()));
             } else if let Some(value) = opt.strip_prefix("extern_path=") {
                 // value is "<proto_path>=<rust_path>"
                 let (proto, rust) = value.split_once('=').ok_or_else(|| {
@@ -246,12 +229,12 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
                 if !proto.starts_with('.') {
                     proto.insert(0, '.');
                 }
-                options.extern_paths.push((proto, rust.to_string()));
+                options.buffa.extern_paths.push((proto, rust.to_string()));
             } else {
                 match opt {
-                    "strict_utf8_mapping" => options.strict_utf8_mapping = true,
-                    "no_json" => options.generate_json = false,
-                    "no_register_fn" => options.emit_register_fn = false,
+                    "strict_utf8_mapping" => options.buffa.strict_utf8_mapping = true,
+                    "no_json" => options.buffa.generate_json = false,
+                    "no_register_fn" => options.buffa.emit_register_fn = false,
                     _ => {
                         return Err(anyhow::anyhow!(
                             "unknown plugin option: {opt:?}. Supported: \
@@ -1731,21 +1714,22 @@ mod tests {
     }
 
     #[test]
-    fn options_default_emits_register_fn() {
-        let opts = Options::default();
-        assert!(opts.emit_register_fn);
-        let cfg = opts.to_buffa_config();
+    fn options_default_buffa_config() {
+        let cfg = Options::default().to_buffa_config();
+        assert!(cfg.generate_json, "connectrpc enables JSON by default");
+        assert!(cfg.generate_views);
         assert!(cfg.emit_register_fn);
+        assert!(!cfg.strict_utf8_mapping);
     }
 
     #[test]
-    fn options_emit_register_fn_false_disables_buffa_register_fn() {
-        let opts = Options {
-            emit_register_fn: false,
-            ..Options::default()
-        };
+    fn options_buffa_passthrough_forces_views() {
+        let mut opts = Options::default();
+        opts.buffa.emit_register_fn = false;
+        opts.buffa.generate_views = false;
         let cfg = opts.to_buffa_config();
         assert!(!cfg.emit_register_fn);
+        assert!(cfg.generate_views, "generate_views must be forced on");
     }
 
     #[test]
@@ -1775,15 +1759,10 @@ mod tests {
             with_fn[0].content
         );
 
-        let without_fn = generate_files(
-            std::slice::from_ref(&file),
-            &["ping.proto".into()],
-            &Options {
-                emit_register_fn: false,
-                ..Options::default()
-            },
-        )
-        .unwrap();
+        let mut opts = Options::default();
+        opts.buffa.emit_register_fn = false;
+        let without_fn =
+            generate_files(std::slice::from_ref(&file), &["ping.proto".into()], &opts).unwrap();
         assert_eq!(without_fn.len(), 1);
         assert!(
             !without_fn[0].content.contains("fn register_types"),

--- a/connectrpc-codegen/src/lib.rs
+++ b/connectrpc-codegen/src/lib.rs
@@ -38,3 +38,5 @@
 
 pub mod codegen;
 pub mod plugin;
+
+pub use codegen::CodeGenConfig;

--- a/connectrpc-codegen/src/lib.rs
+++ b/connectrpc-codegen/src/lib.rs
@@ -18,8 +18,8 @@
 //! `super::`-relative type paths. Used by `connectrpc-build`.
 //!
 //! [`codegen::generate_services`] - **service stubs only**. Message types
-//! are referenced via absolute paths configured with
-//! [`codegen::Options::extern_paths`], so the output compiles standalone
+//! are referenced via absolute paths configured via
+//! [`codegen::CodeGenConfig::extern_paths`], so the output compiles standalone
 //! against a separately-generated buffa module or crate. Used by the
 //! `protoc-gen-connect-rust` plugin.
 //!
@@ -28,10 +28,8 @@
 //! ```rust,ignore
 //! use connectrpc_codegen::codegen::{generate_services, Options};
 //!
-//! let options = Options {
-//!     extern_paths: vec![(".".into(), "crate::proto".into())],
-//!     ..Options::default()
-//! };
+//! let mut options = Options::default();
+//! options.buffa.extern_paths.push((".".into(), "crate::proto".into()));
 //! let files = generate_services(&descriptors, &files_to_generate, &options)?;
 //! for f in files {
 //!     std::fs::write(out_dir.join(&f.name), f.content)?;


### PR DESCRIPTION
Fixes #34.

## Problem

`connectrpc_codegen::Options` mirrors a hand-picked subset of `buffa_codegen::CodeGenConfig` fields one-by-one. Every new buffa knob (`generate_text`, `generate_arbitrary`, `bytes_fields`, `preserve_unknown_fields`, `allow_message_set`, and the upcoming 0.4 attribute knobs) requires five touchpoints here: a new `Options` field, a `Default` line, a `to_buffa_config()` copy, a `connectrpc_build::Config` builder method, and a plugin parameter token. #35 was the most recent instance - a one-line buffa change that needed a five-touchpoint plumbing PR plus a patch release.

## Change

`Options` now embeds the buffa config directly:

```rust
// before
let opts = Options {
    strict_utf8_mapping: true,
    emit_register_fn: false,
    ..Options::default()
};

// after
let mut opts = Options::default();
opts.buffa.strict_utf8_mapping = true;
opts.buffa.emit_register_fn = false;
// ...and any other CodeGenConfig field, with zero connectrpc plumbing
```

`CodeGenConfig` is re-exported from both `connectrpc_codegen::codegen` and `connectrpc_build` so downstream crates don't need a direct `buffa-codegen` dependency.

`connectrpc_build::Config` keeps `.strict_utf8_mapping()` / `.generate_json()` / `.emit_register_fn()` as thin shims for the common cases, and gains `.buffa_config(cfg)` for wholesale replacement.

## Invariants preserved

- `generate_views = true` is forced after the user's config (service stubs require view types). Set it to `false` and it's silently overridden.
- `Options::default()` enables `generate_json` (the Connect JSON codec needs it; buffa's own default is `false`).
- The plugin's `buffa_module=` / `extern_path=` parameters write into `options.buffa.extern_paths` directly - same destination, same semantics.

## Breaking

The four mirrored `Options` fields are removed. `Options` was already `#[non_exhaustive]` so this only breaks code that read or wrote those fields by name; migrate to `options.buffa.<field>`. Targeted at v0.4.0 alongside the buffa 0.4 sync (#62).
