### PR TITLE
error: box ConnectError header maps to fix result_large_err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,18 @@ increment the patch version.
   `connectrpc_build`. `connectrpc_build::Config` keeps its existing
   builder methods as thin shims and gains `.buffa_config(cfg)` for
   wholesale replacement. `generate_views = true` is still enforced.
+- **`ConnectError` shrunk from 248 to 72 bytes** ([#61]). The
+  `response_headers` and `trailers` fields are now
+  `Option<Box<http::HeaderMap>>` (was `http::HeaderMap`), so
+  `Result<_, ConnectError>` no longer trips
+  `clippy::result_large_err`. New accessors hide the boxing:
+  `response_headers()` / `trailers()` (borrow, empty map if `None`),
+  `response_headers_mut()` / `trailers_mut()`, and
+  `set_response_headers()` / `set_trailers()`. The `with_headers()` /
+  `with_trailers()` builders are unchanged.
 
 [#34]: https://github.com/anthropics/connect-rust/issues/34
+[#61]: https://github.com/anthropics/connect-rust/issues/61
 
 ## [0.3.3] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,18 @@ increment the patch version.
   builder methods as thin shims and gains `.buffa_config(cfg)` for
   wholesale replacement. `generate_views = true` is still enforced.
 - **`ConnectError` shrunk from 248 to 72 bytes** ([#61]). The
-  `response_headers` and `trailers` fields are now
-  `Option<Box<http::HeaderMap>>` (was `http::HeaderMap`), so
+  `response_headers` and `trailers` fields are now crate-private
+  `Option<Box<http::HeaderMap>>` (was `pub http::HeaderMap`), so
   `Result<_, ConnectError>` no longer trips
-  `clippy::result_large_err`. New accessors hide the boxing:
-  `response_headers()` / `trailers()` (borrow, empty map if `None`),
-  `response_headers_mut()` / `trailers_mut()`, and
+  `clippy::result_large_err`. New accessors replace direct field
+  access: `response_headers()` / `trailers()` (borrow, empty map if
+  unset), `response_headers_mut()` / `trailers_mut()`, and
   `set_response_headers()` / `set_trailers()`. The `with_headers()` /
-  `with_trailers()` builders are unchanged.
+  `with_trailers()` builders keep their signatures. Behaviour notes:
+  `with_headers` / `with_trailers` / `set_*` now normalize an empty
+  `HeaderMap` to "unset" (observationally identical via the
+  accessors), and the `Debug` output for an unset map now shows
+  `None` instead of `{}`.
 
 [#34]: https://github.com/anthropics/connect-rust/issues/34
 [#61]: https://github.com/anthropics/connect-rust/issues/61

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,3 @@ unused_lifetimes = "warn"
 [workspace.lints.clippy]
 dbg_macro = "warn"
 uninlined_format_args = "warn"
-# ConnectError carries HeaderMaps for response metadata which makes it large.
-# Error handling is not on the hot path; carrying metadata in errors is worth the size.
-result_large_err = "allow"

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -1538,8 +1538,8 @@ fn headers_to_conformance(headers: &http::HeaderMap) -> Vec<Header> {
 /// Convert a ConnectError to a conformance ClientResponseResult.
 fn connect_error_to_result(err: &ConnectError) -> ClientResponseResult {
     // Extract headers/trailers from the error
-    let response_headers = headers_to_conformance(&err.response_headers);
-    let response_trailers = headers_to_conformance(&err.trailers);
+    let response_headers = headers_to_conformance(err.response_headers());
+    let response_trailers = headers_to_conformance(err.trailers());
 
     ClientResponseResult {
         response_headers,

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1240,8 +1240,8 @@ where
         let body = collect_body_bounded(response.into_body(), max_err_body_size)
             .await
             .map_err(|mut e| {
-                e.response_headers = headers.clone();
-                e.trailers = trailers.clone();
+                e.set_response_headers(headers.clone());
+                e.set_trailers(trailers.clone());
                 e
             })?;
 
@@ -1263,8 +1263,8 @@ where
                             http_status_to_error_code(status),
                             format!("HTTP error {}", status.as_u16()),
                         );
-                        err.response_headers = headers;
-                        err.trailers = trailers;
+                        err.set_response_headers(headers);
+                        err.set_trailers(trailers);
                         return Err(err);
                     }
                 }
@@ -1280,8 +1280,8 @@ where
                 .unwrap_or_else(|| http_status_to_error_code(status));
             let mut err = ConnectError::new(code, error.message.unwrap_or_default());
             err.details = error.details;
-            err.response_headers = headers;
-            err.trailers = trailers;
+            err.set_response_headers(headers);
+            err.set_trailers(trailers);
             return Err(err);
         }
 
@@ -1294,8 +1294,8 @@ where
                 String::from_utf8_lossy(&body)
             ),
         );
-        err.response_headers = headers;
-        err.trailers = trailers;
+        err.set_response_headers(headers);
+        err.set_trailers(trailers);
         return Err(err);
     }
 
@@ -1397,7 +1397,7 @@ where
     if !status.is_success() {
         let code = http_status_to_error_code(status);
         let mut err = ConnectError::new(code, format!("HTTP error {}", status.as_u16()));
-        err.response_headers = resp_headers;
+        err.set_response_headers(resp_headers);
         return Err(err);
     }
 
@@ -1409,7 +1409,7 @@ where
                 ErrorCode::Unknown,
                 format!("unexpected content-type: {ct_str}"),
             );
-            err.response_headers = resp_headers;
+            err.set_response_headers(resp_headers);
             return Err(err);
         }
     }
@@ -1425,7 +1425,7 @@ where
         && !config.compression.supports(enc)
     {
         let mut err = ConnectError::internal(format!("unsupported response compression: {enc}"));
-        err.response_headers = resp_headers;
+        err.set_response_headers(resp_headers);
         return Err(err);
     }
 
@@ -1542,14 +1542,14 @@ where
     };
 
     if let Some(mut err) = parse_grpc_error_from_trailers(effective_trailers) {
-        err.response_headers = resp_headers;
+        err.set_response_headers(resp_headers);
         return Err(err);
     }
 
     // Validate message count for unary/client-stream (expect exactly 1)
     if message_count > 1 {
         let mut err = ConnectError::unimplemented("received multiple messages for unary response");
-        err.response_headers = resp_headers;
+        err.set_response_headers(resp_headers);
         return Err(err);
     }
 
@@ -1564,7 +1564,7 @@ where
         } else {
             ConnectError::internal("gRPC response missing grpc-status trailer")
         };
-        err.response_headers = resp_headers;
+        err.set_response_headers(resp_headers);
         return Err(err);
     }
 
@@ -1573,7 +1573,7 @@ where
         None => {
             // No message data — this is an error for unary/client-stream RPCs.
             let mut err = ConnectError::unimplemented("gRPC response contained no message data");
-            err.response_headers = resp_headers;
+            err.set_response_headers(resp_headers);
             return Err(err);
         }
     };
@@ -2076,7 +2076,7 @@ where
     if matches!(protocol, Protocol::Grpc | Protocol::GrpcWeb)
         && let Some(mut err) = parse_grpc_error_from_trailers(&response_headers)
     {
-        err.response_headers = response_headers;
+        err.set_response_headers(response_headers);
         return Err(err);
     }
 
@@ -2120,14 +2120,14 @@ where
                     .unwrap_or_else(|| http_status_to_error_code(status));
                 let mut err = ConnectError::new(code, error.message.unwrap_or_default());
                 err.details = error.details;
-                err.response_headers = response_headers;
+                err.set_response_headers(response_headers);
                 return Err(err);
             }
         }
 
         let code = http_status_to_error_code(status);
         let mut err = ConnectError::new(code, format!("HTTP error {}", status.as_u16()));
-        err.response_headers = response_headers;
+        err.set_response_headers(response_headers);
         return Err(err);
     }
 
@@ -2707,13 +2707,13 @@ where
                 .unwrap_or_else(|| http_status_to_error_code(status));
             let mut err = ConnectError::new(code, error.message.unwrap_or_default());
             err.details = error.details;
-            err.response_headers = response_headers;
+            err.set_response_headers(response_headers);
             return Err(err);
         }
 
         let code = http_status_to_error_code(status);
         let mut err = ConnectError::new(code, format!("HTTP error {}", status.as_u16()));
-        err.response_headers = response_headers;
+        err.set_response_headers(response_headers);
         return Err(err);
     }
 
@@ -2785,8 +2785,8 @@ where
                     err.message.unwrap_or_default(),
                 );
                 connect_error.details = err.details;
-                connect_error.response_headers = resp_headers;
-                connect_error.trailers = trailers;
+                connect_error.set_response_headers(resp_headers);
+                connect_error.set_trailers(trailers);
                 return Err(connect_error);
             }
         } else {
@@ -3101,7 +3101,7 @@ fn parse_grpc_error_from_trailers(trailers: &http::HeaderMap) -> Option<ConnectE
     for (key, value) in trailers.iter() {
         let name = key.as_str();
         if name != "grpc-status" && name != "grpc-message" && name != "grpc-status-details-bin" {
-            err.trailers.append(key, value.clone());
+            err.trailers_mut().append(key, value.clone());
         }
     }
 
@@ -3507,7 +3507,7 @@ mod tests {
         let err = parse_grpc_error_from_trailers(&trailers).unwrap();
         assert_eq!(err.code, ErrorCode::Internal);
         assert_eq!(
-            err.trailers.get("x-custom").unwrap().to_str().unwrap(),
+            err.trailers().get("x-custom").unwrap().to_str().unwrap(),
             "value"
         );
     }

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -3098,10 +3098,11 @@ fn parse_grpc_error_from_trailers(trailers: &http::HeaderMap) -> Option<ConnectE
     }
 
     // Include other trailers as error metadata
+    let out = err.trailers_mut();
     for (key, value) in trailers.iter() {
         let name = key.as_str();
         if name != "grpc-status" && name != "grpc-message" && name != "grpc-status-details-bin" {
-            err.trailers_mut().append(key, value.clone());
+            out.append(key, value.clone());
         }
     }
 

--- a/connectrpc/src/error.rs
+++ b/connectrpc/src/error.rs
@@ -217,20 +217,15 @@ pub struct ConnectError {
     ///
     /// Boxed to keep `ConnectError` small enough to pass by value in
     /// `Result` without tripping `clippy::result_large_err`. `None` means
-    /// no extra headers. Prefer the [`ConnectError::response_headers`] /
-    /// [`ConnectError::response_headers_mut`] /
-    /// [`ConnectError::set_response_headers`] accessors over touching this
-    /// field directly.
+    /// no extra headers.
     #[serde(skip)]
-    pub response_headers: Option<Box<http::HeaderMap>>,
+    pub(crate) response_headers: Option<Box<http::HeaderMap>>,
     /// Response trailers to include in error response (not serialized).
     ///
     /// Boxed for the same reason as `response_headers`. `None` means no
-    /// extra trailers. Prefer the [`ConnectError::trailers`] /
-    /// [`ConnectError::trailers_mut`] / [`ConnectError::set_trailers`]
-    /// accessors.
+    /// extra trailers.
     #[serde(skip)]
-    pub trailers: Option<Box<http::HeaderMap>>,
+    pub(crate) trailers: Option<Box<http::HeaderMap>>,
 }
 
 /// Shared empty `HeaderMap` for the `None` arm of the read accessors, so
@@ -530,6 +525,12 @@ mod tests {
         // Setting an empty map stays None.
         e.set_response_headers(http::HeaderMap::new());
         assert!(e.response_headers.is_none());
+        assert!(
+            ConnectError::new(ErrorCode::Internal, "x")
+                .with_headers(http::HeaderMap::new())
+                .response_headers
+                .is_none()
+        );
 
         e.trailers_mut()
             .insert("x-t", http::HeaderValue::from_static("v"));

--- a/connectrpc/src/error.rs
+++ b/connectrpc/src/error.rs
@@ -214,11 +214,36 @@ pub struct ConnectError {
     #[serde(skip)]
     http_status_override: Option<StatusCode>,
     /// Response headers to include in error response (not serialized).
+    ///
+    /// Boxed to keep `ConnectError` small enough to pass by value in
+    /// `Result` without tripping `clippy::result_large_err`. `None` means
+    /// no extra headers. Prefer the [`ConnectError::response_headers`] /
+    /// [`ConnectError::response_headers_mut`] /
+    /// [`ConnectError::set_response_headers`] accessors over touching this
+    /// field directly.
     #[serde(skip)]
-    pub response_headers: http::HeaderMap,
+    pub response_headers: Option<Box<http::HeaderMap>>,
     /// Response trailers to include in error response (not serialized).
+    ///
+    /// Boxed for the same reason as `response_headers`. `None` means no
+    /// extra trailers. Prefer the [`ConnectError::trailers`] /
+    /// [`ConnectError::trailers_mut`] / [`ConnectError::set_trailers`]
+    /// accessors.
     #[serde(skip)]
-    pub trailers: http::HeaderMap,
+    pub trailers: Option<Box<http::HeaderMap>>,
+}
+
+/// Shared empty `HeaderMap` for the `None` arm of the read accessors, so
+/// callers can iterate / `.get()` unconditionally.
+static EMPTY_HEADERS: std::sync::LazyLock<http::HeaderMap> =
+    std::sync::LazyLock::new(http::HeaderMap::new);
+
+fn box_headers(h: http::HeaderMap) -> Option<Box<http::HeaderMap>> {
+    if h.is_empty() {
+        None
+    } else {
+        Some(Box::new(h))
+    }
 }
 
 impl ConnectError {
@@ -229,23 +254,55 @@ impl ConnectError {
             message: Some(message.into()),
             details: Vec::new(),
             http_status_override: None,
-            response_headers: http::HeaderMap::new(),
-            trailers: http::HeaderMap::new(),
+            response_headers: None,
+            trailers: None,
         }
     }
 
     /// Add response headers to be included in the error response.
     #[must_use]
     pub fn with_headers(mut self, headers: http::HeaderMap) -> Self {
-        self.response_headers = headers;
+        self.response_headers = box_headers(headers);
         self
     }
 
     /// Add response trailers to be included in the error response.
     #[must_use]
     pub fn with_trailers(mut self, trailers: http::HeaderMap) -> Self {
-        self.trailers = trailers;
+        self.trailers = box_headers(trailers);
         self
+    }
+
+    /// Borrow the response headers. Returns an empty map if none were set.
+    pub fn response_headers(&self) -> &http::HeaderMap {
+        self.response_headers.as_deref().unwrap_or(&EMPTY_HEADERS)
+    }
+
+    /// Borrow the response trailers. Returns an empty map if none were set.
+    pub fn trailers(&self) -> &http::HeaderMap {
+        self.trailers.as_deref().unwrap_or(&EMPTY_HEADERS)
+    }
+
+    /// Mutably borrow the response headers, allocating an empty map if
+    /// none were set.
+    pub fn response_headers_mut(&mut self) -> &mut http::HeaderMap {
+        self.response_headers.get_or_insert_default()
+    }
+
+    /// Mutably borrow the response trailers, allocating an empty map if
+    /// none were set.
+    pub fn trailers_mut(&mut self) -> &mut http::HeaderMap {
+        self.trailers.get_or_insert_default()
+    }
+
+    /// Replace the response headers. An empty map is stored as `None`.
+    pub fn set_response_headers(&mut self, headers: http::HeaderMap) {
+        self.response_headers = box_headers(headers);
+    }
+
+    /// Replace the response trailers. An empty map is stored as `None`.
+    pub fn set_trailers(&mut self, trailers: http::HeaderMap) {
+        self.trailers = box_headers(trailers);
     }
 
     /// Set an HTTP status override for this error.
@@ -449,5 +506,38 @@ mod tests {
     fn test_from_grpc_code_unknown_returns_none() {
         assert_eq!(ErrorCode::from_grpc_code(17), None);
         assert_eq!(ErrorCode::from_grpc_code(999), None);
+    }
+
+    #[test]
+    fn connect_error_stays_under_result_large_err_threshold() {
+        // clippy::result_large_err fires at 128 bytes. Keep some headroom so
+        // adding a small field doesn't immediately re-trip the lint.
+        const THRESHOLD: usize = 96;
+        let size = std::mem::size_of::<ConnectError>();
+        assert!(
+            size <= THRESHOLD,
+            "ConnectError is {size} bytes (threshold {THRESHOLD}); \
+             box large fields to keep Result<_, ConnectError> cheap to move"
+        );
+    }
+
+    #[test]
+    fn header_accessors() {
+        let mut e = ConnectError::internal("x");
+        assert!(e.response_headers().is_empty());
+        assert!(e.trailers().is_empty());
+
+        // Setting an empty map stays None.
+        e.set_response_headers(http::HeaderMap::new());
+        assert!(e.response_headers.is_none());
+
+        e.trailers_mut()
+            .insert("x-t", http::HeaderValue::from_static("v"));
+        assert_eq!(e.trailers().get("x-t").unwrap(), "v");
+
+        let mut h = http::HeaderMap::new();
+        h.insert("x-h", http::HeaderValue::from_static("w"));
+        let e = e.with_headers(h);
+        assert_eq!(e.response_headers().get("x-h").unwrap(), "w");
     }
 }

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -532,10 +532,9 @@ impl EndStreamResponse {
     /// the metadata and the handler-context trailers are skipped to avoid
     /// duplication. Otherwise the handler's context trailers are used.
     fn error(err: &ConnectError, context_trailers: &http::HeaderMap) -> Self {
-        let trailers_source = if err.trailers.is_empty() {
-            context_trailers
-        } else {
-            &err.trailers
+        let trailers_source = match err.trailers.as_deref() {
+            Some(t) if !t.is_empty() => t,
+            _ => context_trailers,
         };
         let metadata = Self::metadata_from_trailers(trailers_source);
         Self {
@@ -592,7 +591,7 @@ fn connect_streaming_error_response(
 ) -> Response<StreamingResponseBody> {
     use futures::stream::StreamExt as _;
 
-    let end_stream = EndStreamResponse::error(err, &err.trailers);
+    let end_stream = EndStreamResponse::error(err, err.trailers());
     let mut encoder = crate::envelope::EnvelopeEncoder::uncompressed();
     let mut buf = bytes::BytesMut::new();
     // encode_end_stream is infallible for uncompressed data
@@ -616,7 +615,7 @@ fn connect_streaming_error_response(
         Protocol::Connect.response_content_type(codec_format, true),
     );
 
-    for (key, value) in err.response_headers.iter() {
+    for (key, value) in err.response_headers() {
         response = response.header(key, value);
     }
 
@@ -638,7 +637,7 @@ fn grpc_error_response(
     protocol: Protocol,
     codec_format: CodecFormat,
 ) -> Response<StreamingResponseBody> {
-    let grpc_trailers = build_grpc_trailers(Some(err), &err.trailers);
+    let grpc_trailers = build_grpc_trailers(Some(err), err.trailers());
 
     let body_stream: Pin<Box<dyn Stream<Item = Result<Frame<Bytes>, Infallible>> + Send>> =
         match protocol {
@@ -681,7 +680,7 @@ fn grpc_error_response(
         }
     }
 
-    for (key, value) in err.response_headers.iter() {
+    for (key, value) in err.response_headers() {
         response = response.header(key, value);
     }
 
@@ -1653,7 +1652,7 @@ where
 {
     // Helper to build a gRPC trailers-only error response using GrpcUnaryBody.
     let grpc_unary_error = |err: &ConnectError| -> Response<GrpcUnaryBody> {
-        let grpc_trailers = build_grpc_trailers(Some(err), &err.trailers);
+        let grpc_trailers = build_grpc_trailers(Some(err), err.trailers());
         let trailers = match protocol {
             Protocol::Grpc => GrpcUnaryTrailers::Http2(grpc_trailers),
             Protocol::GrpcWeb => {
@@ -1676,7 +1675,7 @@ where
                 response = response.header(&GRPC_MESSAGE, val);
             }
         }
-        for (key, value) in err.response_headers.iter() {
+        for (key, value) in err.response_headers() {
             response = response.header(key, value);
         }
         let body = GrpcUnaryBody {
@@ -2575,7 +2574,7 @@ fn build_grpc_trailers(
                 }
             }
             // Include error-level trailers
-            for (key, value) in err.trailers.iter() {
+            for (key, value) in err.trailers() {
                 trailers.append(key, value.clone());
             }
         }
@@ -2587,7 +2586,7 @@ fn build_grpc_trailers(
     // Include custom trailing metadata from the handler context.
     // If the error already carries its own trailers (via .with_trailers()),
     // skip adding context trailers to avoid duplication.
-    let error_has_own_trailers = error.is_some_and(|e| !e.trailers.is_empty());
+    let error_has_own_trailers = error.is_some_and(|e| !e.trailers().is_empty());
     if !error_has_own_trailers {
         for (key, value) in custom_trailers.iter() {
             trailers.append(key, value.clone());
@@ -2626,12 +2625,12 @@ fn error_response(err: ConnectError) -> Response<Full<Bytes>> {
         .header(header::CONTENT_TYPE, content_type::JSON);
 
     // Add response headers from the error
-    for (key, value) in err.response_headers.iter() {
+    for (key, value) in err.response_headers() {
         response = response.header(key, value);
     }
 
     // Add trailers as trailer- prefixed headers
-    let response = add_trailers(response, &err.trailers);
+    let response = add_trailers(response, err.trailers());
 
     response.body(Full::new(body)).unwrap_or_else(|_| {
         Response::builder()
@@ -3087,7 +3086,7 @@ mod tests {
     fn test_build_grpc_trailers_dedup_error_trailers() {
         // When error has its own trailers, context trailers should be skipped
         let mut err = ConnectError::internal("error");
-        err.trailers
+        err.trailers_mut()
             .insert("x-trailer", http::HeaderValue::from_static("from-error"));
         let mut custom = http::HeaderMap::new();
         custom.insert("x-trailer", http::HeaderValue::from_static("from-context"));

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -532,9 +532,10 @@ impl EndStreamResponse {
     /// the metadata and the handler-context trailers are skipped to avoid
     /// duplication. Otherwise the handler's context trailers are used.
     fn error(err: &ConnectError, context_trailers: &http::HeaderMap) -> Self {
-        let trailers_source = match err.trailers.as_deref() {
-            Some(t) if !t.is_empty() => t,
-            _ => context_trailers,
+        let trailers_source = if err.trailers().is_empty() {
+            context_trailers
+        } else {
+            err.trailers()
         };
         let metadata = Self::metadata_from_trailers(trailers_source);
         Self {


### PR DESCRIPTION
`ConnectError` is **248 bytes** on x86_64, which trips `clippy::result_large_err` (128B threshold) on every handler returning `Result<_, ConnectError>` - effectively every generated service impl. The workspace currently carries `result_large_err = "allow"` to suppress this, but downstream `-D warnings` builds still need their own crate-level allow.

The two inline `http::HeaderMap` fields (~96B each) account for ~77% of the struct and are empty for the vast majority of errors - they're only populated when a handler calls `.with_headers()` / `.with_trailers()`.

## Change

`response_headers` and `trailers` are now `Option<Box<http::HeaderMap>>`:

| | before | after |
|---|---:|---:|
| `size_of::<ConnectError>()` | 248 B | 72 B |
| `ConnectError::new()` heap allocs | 0 | 0 |

New accessors hide the boxing so most callers don't see `Option<Box<_>>`:

- `response_headers()` / `trailers()` - borrow as `&HeaderMap`; returns a shared empty map when `None`
- `response_headers_mut()` / `trailers_mut()` - `&mut HeaderMap`, lazily allocating
- `set_response_headers()` / `set_trailers()` - replace; an empty map is stored as `None`
- `with_headers()` / `with_trailers()` - unchanged signature, now box internally

Internal call sites in `service.rs`, `client/mod.rs`, and the conformance client are migrated to the accessors. The workspace `result_large_err = "allow"` is dropped, and a `size_of` regression test pins the struct at <=96B.

Breaking change to the public field types; targeted at the next minor.

Fixes #61.
