### PR TITLE
handler: split Context into RequestContext/Response<B>, add Encodable trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@ increment the patch version.
   the body plus optional response headers/trailers/compression hint.
   Unary and client-stream methods return
   `ServiceResult<impl Encodable<Out>>`; server-stream and bidi
-  return `ServiceResult<ServiceStream<Out>>`. The happy path is
-  `Ok(body.into())`; for streaming bodies use
+  return `ServiceResult<ServiceStream<Out>>`. `Response::ok(body)` is
+  the bare-body happy-path shorthand; for streaming bodies use
   `Ok(Response::stream(s))`. `Encodable<M>` is the new "encodes as
   M" bound on response bodies — only the owned `M` implements it
   today; a follow-up will add a view-body impl for borrowed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ increment the patch version.
   `HeaderMap` to "unset" (observationally identical via the
   accessors), and the `Debug` output for an unset map now shows
   `None` instead of `{}`.
+- **Handler signatures redesigned** ([#7]): the generated service
+  trait no longer threads a single `Context` in and out. Handlers
+  now receive a read-only `RequestContext` (headers, deadline,
+  extensions) and return `ServiceResult<B>` =
+  `Result<Response<B>, ConnectError>`, where `Response<B>` carries
+  the body plus optional response headers/trailers/compression hint.
+  Unary and client-stream methods return
+  `ServiceResult<impl Encodable<Out>>`; server-stream and bidi
+  return `ServiceResult<ServiceStream<Out>>`. The happy path is
+  `Ok(body.into())`; for streaming bodies use
+  `Ok(Response::stream(s))`. `Encodable<M>` is the new "encodes as
+  M" bound on response bodies — only the owned `M` implements it
+  today; a follow-up will add a view-body impl for borrowed
+  responses. The old `Context` type is removed.
 
 ### Added
 
@@ -56,6 +70,7 @@ increment the patch version.
   `build.rs` context (e.g. from a Bazel genrule or standalone host tool).
   Default remains `true`.
 
+[#7]: https://github.com/anthropics/connect-rust/issues/7
 [#34]: https://github.com/anthropics/connect-rust/issues/34
 [#61]: https://github.com/anthropics/connect-rust/issues/61
 [buffa#22]: https://github.com/anthropics/buffa/pull/22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,21 @@ increment the patch version.
   `ServiceResult<impl Encodable<Out>>`; server-stream and bidi
   return `ServiceResult<ServiceStream<Out>>`. `Response::ok(body)` is
   the bare-body happy-path shorthand; for streaming bodies use
-  `Ok(Response::stream(s))`. `Encodable<M>` is the new "encodes as
-  M" bound on response bodies — only the owned `M` implements it
-  today; a follow-up will add a view-body impl for borrowed
-  responses. The old `Context` type is removed.
+  `Response::stream_ok(s)`. `Encodable<M>` is the new "encodes as
+  M" bound on response bodies — the owned `M` and the
+  `MaybeBorrowed` view wrapper both implement it. The old
+  `Context` type is removed.
+
+  ```rust
+  // before
+  async fn say(&self, ctx: Context, req: ...) -> Result<(SayResponse, Context), ConnectError> {
+      Ok((SayResponse { ... }, ctx))
+  }
+  // after
+  async fn say(&self, _ctx: RequestContext, req: ...) -> ServiceResult<SayResponse> {
+      Response::ok(SayResponse { ... })
+  }
+  ```
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,9 @@ dead_code = "warn"
 explicit_outlives_requirements = "warn"
 unused_imports = "warn"
 unused_lifetimes = "warn"
+# Generated trait methods return `ServiceResult<impl Encodable<M>>`; impls
+# intentionally refine to a concrete body type (e.g. `ServiceResult<M>`).
+refining_impl_trait = { level = "allow", priority = -1 }
 
 [workspace.lints.clippy]
 dbg_macro = "warn"

--- a/benches/rpc/src/bin/echo_server.rs
+++ b/benches/rpc/src/bin/echo_server.rs
@@ -5,7 +5,7 @@
 //! the per-request cost of the connectrpc-rs request pipeline.
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectRpcService, RequestContext, ServiceResult};
+use connectrpc::{ConnectRpcService, RequestContext, Response, ServiceResult};
 use rpc_bench::connect::bench::v1::*;
 use rpc_bench::proto::bench::v1::__buffa::view::EchoRequestView;
 use rpc_bench::proto::bench::v1::*;
@@ -24,7 +24,7 @@ impl EchoService for EchoImpl {
             message: req.message.to_string(),
             ..Default::default()
         };
-        Ok(resp.into())
+        Response::ok(resp)
     }
 }
 

--- a/benches/rpc/src/bin/echo_server.rs
+++ b/benches/rpc/src/bin/echo_server.rs
@@ -20,11 +20,10 @@ impl EchoService for EchoImpl {
     ) -> ServiceResult<EchoResponse> {
         // One allocation to copy the borrowed &str into the owned response.
         // This is the minimal work a real echo server would do.
-        let resp = EchoResponse {
+        Response::ok(EchoResponse {
             message: req.message.to_string(),
             ..Default::default()
-        };
-        Response::ok(resp)
+        })
     }
 }
 

--- a/benches/rpc/src/bin/echo_server.rs
+++ b/benches/rpc/src/bin/echo_server.rs
@@ -5,7 +5,7 @@
 //! the per-request cost of the connectrpc-rs request pipeline.
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectError, ConnectRpcService, Context};
+use connectrpc::{ConnectRpcService, RequestContext, ServiceResult};
 use rpc_bench::connect::bench::v1::*;
 use rpc_bench::proto::bench::v1::__buffa::view::EchoRequestView;
 use rpc_bench::proto::bench::v1::*;
@@ -15,16 +15,16 @@ struct EchoImpl;
 impl EchoService for EchoImpl {
     async fn echo(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<EchoRequestView<'static>>,
-    ) -> Result<(EchoResponse, Context), ConnectError> {
+    ) -> ServiceResult<EchoResponse> {
         // One allocation to copy the borrowed &str into the owned response.
         // This is the minimal work a real echo server would do.
         let resp = EchoResponse {
             message: req.message.to_string(),
             ..Default::default()
         };
-        Ok((resp, ctx))
+        Ok(resp.into())
     }
 }
 

--- a/benches/rpc/src/bin/fortune_server.rs
+++ b/benches/rpc/src/bin/fortune_server.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use connectrpc::{ConnectError, ConnectRpcService, RequestContext, ServiceResult};
+use connectrpc::{ConnectError, ConnectRpcService, RequestContext, Response, ServiceResult};
 
 use rpc_bench::connect::fortune::v1::*;
 use rpc_bench::fortune;
@@ -37,7 +37,7 @@ impl FortuneService for FortuneServiceImpl {
                 .collect(),
             ..Default::default()
         };
-        Ok(response.into())
+        Response::ok(response)
     }
 }
 

--- a/benches/rpc/src/bin/fortune_server.rs
+++ b/benches/rpc/src/bin/fortune_server.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use connectrpc::{ConnectError, ConnectRpcService, Context};
+use connectrpc::{ConnectError, ConnectRpcService, RequestContext, ServiceResult};
 
 use rpc_bench::connect::fortune::v1::*;
 use rpc_bench::fortune;
@@ -18,9 +18,9 @@ struct FortuneServiceImpl {
 impl FortuneService for FortuneServiceImpl {
     async fn get_fortunes(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         _req: OwnedView<GetFortunesRequestView<'static>>,
-    ) -> Result<(GetFortunesResponse, Context), ConnectError> {
+    ) -> ServiceResult<GetFortunesResponse> {
         let mut conn = self.pool.get();
         let fortunes = fortune::query_fortunes(&mut conn)
             .await
@@ -37,7 +37,7 @@ impl FortuneService for FortuneServiceImpl {
                 .collect(),
             ..Default::default()
         };
-        Ok((response, ctx))
+        Ok(response.into())
     }
 }
 

--- a/benches/rpc/src/bin/log_server.rs
+++ b/benches/rpc/src/bin/log_server.rs
@@ -8,7 +8,7 @@
 //! struct: proto decode/encode cost dominates.
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectRpcService, RequestContext, ServiceResult};
+use connectrpc::{ConnectRpcService, RequestContext, Response, ServiceResult};
 use rpc_bench::connect::bench::v1::*;
 use rpc_bench::proto::bench::v1::__buffa::view::LogRequestView;
 use rpc_bench::proto::bench::v1::*;
@@ -68,14 +68,13 @@ impl LogIngestService for LogIngestImpl {
             }
         }
 
-        Ok(LogIngestResponse {
+        Response::ok(LogIngestResponse {
             count,
             total_message_bytes,
             total_label_bytes,
             max_severity,
             ..Default::default()
-        }
-        .into())
+        })
     }
 }
 

--- a/benches/rpc/src/bin/log_server.rs
+++ b/benches/rpc/src/bin/log_server.rs
@@ -8,7 +8,7 @@
 //! struct: proto decode/encode cost dominates.
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectError, ConnectRpcService, Context};
+use connectrpc::{ConnectRpcService, RequestContext, ServiceResult};
 use rpc_bench::connect::bench::v1::*;
 use rpc_bench::proto::bench::v1::__buffa::view::LogRequestView;
 use rpc_bench::proto::bench::v1::*;
@@ -18,9 +18,9 @@ struct LogIngestImpl;
 impl LogIngestService for LogIngestImpl {
     async fn ingest(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<LogRequestView<'static>>,
-    ) -> Result<(LogIngestResponse, Context), ConnectError> {
+    ) -> ServiceResult<LogIngestResponse> {
         let mut count = 0i32;
         let mut total_message_bytes = 0i64;
         let mut total_label_bytes = 0i64;
@@ -68,16 +68,14 @@ impl LogIngestService for LogIngestImpl {
             }
         }
 
-        Ok((
-            LogIngestResponse {
-                count,
-                total_message_bytes,
-                total_label_bytes,
-                max_severity,
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(LogIngestResponse {
+            count,
+            total_message_bytes,
+            total_label_bytes,
+            max_severity,
+            ..Default::default()
+        }
+        .into())
     }
 }
 

--- a/benches/rpc/src/bin/log_server_noutf8.rs
+++ b/benches/rpc/src/bin/log_server_noutf8.rs
@@ -9,7 +9,7 @@
 //! the actual recovery.
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectError, ConnectRpcService, Context};
+use connectrpc::{ConnectRpcService, RequestContext, ServiceResult};
 use rpc_bench::connect::bench::noutf8::v1::*;
 use rpc_bench::proto::bench::noutf8::v1::__buffa::view::LogRequestView;
 use rpc_bench::proto::bench::noutf8::v1::*;
@@ -19,9 +19,9 @@ struct LogIngestImpl;
 impl LogIngestService for LogIngestImpl {
     async fn ingest(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<LogRequestView<'static>>,
-    ) -> Result<(LogIngestResponse, Context), ConnectError> {
+    ) -> ServiceResult<LogIngestResponse> {
         let mut count = 0i32;
         let mut total_message_bytes = 0i64;
         let mut max_severity = 0i32;
@@ -61,16 +61,14 @@ impl LogIngestService for LogIngestImpl {
             }
         }
 
-        Ok((
-            LogIngestResponse {
-                count: Some(count),
-                total_message_bytes: Some(total_message_bytes),
-                total_label_bytes: Some(total_label_bytes),
-                max_severity: Some(max_severity),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(LogIngestResponse {
+            count: Some(count),
+            total_message_bytes: Some(total_message_bytes),
+            total_label_bytes: Some(total_label_bytes),
+            max_severity: Some(max_severity),
+            ..Default::default()
+        }
+        .into())
     }
 }
 

--- a/benches/rpc/src/bin/log_server_noutf8.rs
+++ b/benches/rpc/src/bin/log_server_noutf8.rs
@@ -9,7 +9,7 @@
 //! the actual recovery.
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectRpcService, RequestContext, ServiceResult};
+use connectrpc::{ConnectRpcService, RequestContext, Response, ServiceResult};
 use rpc_bench::connect::bench::noutf8::v1::*;
 use rpc_bench::proto::bench::noutf8::v1::__buffa::view::LogRequestView;
 use rpc_bench::proto::bench::noutf8::v1::*;
@@ -61,14 +61,13 @@ impl LogIngestService for LogIngestImpl {
             }
         }
 
-        Ok(LogIngestResponse {
+        Response::ok(LogIngestResponse {
             count: Some(count),
             total_message_bytes: Some(total_message_bytes),
             total_label_bytes: Some(total_label_bytes),
             max_severity: Some(max_severity),
             ..Default::default()
-        }
-        .into())
+        })
     }
 }
 

--- a/benches/rpc/src/generated/connect/bench.rs
+++ b/benches/rpc/src/generated/connect/bench.rs
@@ -17,125 +17,85 @@ pub trait BenchService: Send + Sync + 'static {
     /// Handle the Unary RPC.
     fn unary(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::v1::__buffa::view::BenchRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::v1::BenchResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::v1::BenchResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// Handle the ServerStream RPC.
     fn server_stream(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::v1::__buffa::view::BenchRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
-                ::std::pin::Pin<
-                    Box<
-                        dyn ::futures::Stream<
-                            Item = Result<
-                                crate::proto::bench::v1::BenchResponse,
-                                ::connectrpc::ConnectError,
-                            >,
-                        > + Send,
-                    >,
-                >,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            ::connectrpc::ServiceStream<crate::proto::bench::v1::BenchResponse>,
         >,
     > + Send;
     /// Handle the ClientStream RPC.
     fn client_stream(
         &self,
-        ctx: ::connectrpc::Context,
-        requests: ::std::pin::Pin<
-            Box<
-                dyn ::futures::Stream<
-                    Item = Result<
-                        ::buffa::view::OwnedView<
-                            crate::proto::bench::v1::__buffa::view::BenchRequestView<
-                                'static,
-                            >,
-                        >,
-                        ::connectrpc::ConnectError,
-                    >,
-                > + Send,
+        ctx: ::connectrpc::RequestContext,
+        requests: ::connectrpc::ServiceStream<
+            ::buffa::view::OwnedView<
+                crate::proto::bench::v1::__buffa::view::BenchRequestView<'static>,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::v1::BenchResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::v1::BenchResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// Handle the BidiStream RPC.
     fn bidi_stream(
         &self,
-        ctx: ::connectrpc::Context,
-        requests: ::std::pin::Pin<
-            Box<
-                dyn ::futures::Stream<
-                    Item = Result<
-                        ::buffa::view::OwnedView<
-                            crate::proto::bench::v1::__buffa::view::BenchRequestView<
-                                'static,
-                            >,
-                        >,
-                        ::connectrpc::ConnectError,
-                    >,
-                > + Send,
+        ctx: ::connectrpc::RequestContext,
+        requests: ::connectrpc::ServiceStream<
+            ::buffa::view::OwnedView<
+                crate::proto::bench::v1::__buffa::view::BenchRequestView<'static>,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
-                ::std::pin::Pin<
-                    Box<
-                        dyn ::futures::Stream<
-                            Item = Result<
-                                crate::proto::bench::v1::BenchResponse,
-                                ::connectrpc::ConnectError,
-                            >,
-                        > + Send,
-                    >,
-                >,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            ::connectrpc::ServiceStream<crate::proto::bench::v1::BenchResponse>,
         >,
     > + Send;
     /// Handle the LogUnary RPC.
     fn log_unary(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::v1::__buffa::view::LogRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::v1::LogResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::v1::LogResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// Handle the LogUnaryOwned RPC.
     fn log_unary_owned(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::v1::__buffa::view::LogRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::v1::LogResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::v1::LogResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -308,7 +268,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -323,12 +283,9 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::BenchRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.unary(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.unary(ctx, req)
+                        .await?
+                        .encode::<crate::proto::bench::v1::BenchResponse>(format)
                 })
             }
             "LogUnary" => {
@@ -337,12 +294,9 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::LogRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.log_unary(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.log_unary(ctx, req)
+                        .await?
+                        .encode::<crate::proto::bench::v1::LogResponse>(format)
                 })
             }
             "LogUnaryOwned" => {
@@ -351,12 +305,9 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::LogRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.log_unary_owned(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.log_unary_owned(ctx, req)
+                        .await?
+                        .encode::<crate::proto::bench::v1::LogResponse>(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -365,7 +316,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -380,14 +331,14 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::BenchRequestView,
                     >(request, format)?;
-                    let (resp_stream, ctx) = svc.server_stream(ctx, req).await?;
-                    Ok((
-                        ::connectrpc::dispatcher::codegen::encode_response_stream(
-                            resp_stream,
-                            format,
-                        ),
-                        ctx,
-                    ))
+                    let resp = svc.server_stream(ctx, req).await?;
+                    Ok(
+                        resp
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
+                                s,
+                                format,
+                            )),
+                    )
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_streaming(path),
@@ -396,7 +347,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -411,12 +362,9 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<
                         crate::proto::bench::v1::__buffa::view::BenchRequestView,
                     >(requests, format);
-                    let (res, ctx) = svc.client_stream(ctx, req_stream).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.client_stream(ctx, req_stream)
+                        .await?
+                        .encode::<crate::proto::bench::v1::BenchResponse>(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -425,7 +373,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -440,14 +388,14 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<
                         crate::proto::bench::v1::__buffa::view::BenchRequestView,
                     >(requests, format);
-                    let (resp_stream, ctx) = svc.bidi_stream(ctx, req_stream).await?;
-                    Ok((
-                        ::connectrpc::dispatcher::codegen::encode_response_stream(
-                            resp_stream,
-                            format,
-                        ),
-                        ctx,
-                    ))
+                    let resp = svc.bidi_stream(ctx, req_stream).await?;
+                    Ok(
+                        resp
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
+                                s,
+                                format,
+                            )),
+                    )
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_streaming(path),
@@ -781,14 +729,15 @@ pub trait EchoService: Send + Sync + 'static {
     /// Handle the Echo RPC.
     fn echo(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::v1::__buffa::view::EchoRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::v1::EchoResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::v1::EchoResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -885,7 +834,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -900,12 +849,9 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::EchoRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.echo(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.echo(ctx, req)
+                        .await?
+                        .encode::<crate::proto::bench::v1::EchoResponse>(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -914,7 +860,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -929,7 +875,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -944,7 +890,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -1086,14 +1032,15 @@ pub trait LogIngestService: Send + Sync + 'static {
     /// Handle the Ingest RPC.
     fn ingest(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::v1::__buffa::view::LogRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::v1::LogIngestResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::v1::LogIngestResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -1190,7 +1137,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -1205,12 +1152,9 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::LogRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.ingest(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.ingest(ctx, req)
+                        .await?
+                        .encode::<crate::proto::bench::v1::LogIngestResponse>(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -1219,7 +1163,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -1234,7 +1178,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -1249,7 +1193,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {

--- a/benches/rpc/src/generated/connect/bench_noutf8.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.rs
@@ -17,14 +17,15 @@ pub trait LogIngestService: Send + Sync + 'static {
     /// Handle the Ingest RPC.
     fn ingest(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::noutf8::v1::__buffa::view::LogRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::noutf8::v1::LogIngestResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::noutf8::v1::LogIngestResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -121,7 +122,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -136,12 +137,11 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::noutf8::v1::__buffa::view::LogRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.ingest(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.ingest(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::bench::noutf8::v1::LogIngestResponse,
+                        >(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -150,7 +150,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -165,7 +165,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -180,7 +180,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {

--- a/benches/rpc/src/generated/connect/echo_bloat.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.rs
@@ -22,14 +22,15 @@ pub trait BloatEchoService: Send + Sync + 'static {
     /// Handle the Echo RPC.
     fn echo(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::bench::v1::__buffa::view::BloatEchoView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::bench::v1::BloatEcho, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::bench::v1::BloatEcho,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -126,7 +127,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -141,12 +142,9 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::BloatEchoView,
                     >(request, format)?;
-                    let (res, ctx) = svc.echo(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.echo(ctx, req)
+                        .await?
+                        .encode::<crate::proto::bench::v1::BloatEcho>(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -155,7 +153,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -170,7 +168,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -185,7 +183,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {

--- a/benches/rpc/src/generated/connect/fortune.rs
+++ b/benches/rpc/src/generated/connect/fortune.rs
@@ -17,14 +17,15 @@ pub trait FortuneService: Send + Sync + 'static {
     /// Handle the GetFortunes RPC.
     fn get_fortunes(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::fortune::v1::__buffa::view::GetFortunesRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::fortune::v1::GetFortunesResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::fortune::v1::GetFortunesResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -121,7 +122,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -136,12 +137,9 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::fortune::v1::__buffa::view::GetFortunesRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.get_fortunes(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.get_fortunes(ctx, req)
+                        .await?
+                        .encode::<crate::proto::fortune::v1::GetFortunesResponse>(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -150,7 +148,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -165,7 +163,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -180,7 +178,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {

--- a/benches/rpc/src/lib.rs
+++ b/benches/rpc/src/lib.rs
@@ -68,7 +68,7 @@ impl BenchService for BenchServiceImpl {
                 ))
             }
         });
-        Ok(Response::stream(stream))
+        Response::stream_ok(stream)
     }
 
     async fn client_stream(
@@ -143,7 +143,7 @@ impl BenchService for BenchServiceImpl {
             }
         });
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        Ok(Response::stream(stream))
+        Response::stream_ok(stream)
     }
 }
 

--- a/benches/rpc/src/lib.rs
+++ b/benches/rpc/src/lib.rs
@@ -39,11 +39,10 @@ impl BenchService for BenchServiceImpl {
         req: OwnedView<BenchRequestView<'static>>,
     ) -> ServiceResult<BenchResponse> {
         let req = req.to_owned_message();
-        Ok(BenchResponse {
+        Response::ok(BenchResponse {
             payload: req.payload,
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     async fn server_stream(
@@ -82,11 +81,10 @@ impl BenchService for BenchServiceImpl {
             let req = req?.to_owned_message();
             last_payload = req.payload;
         }
-        Ok(BenchResponse {
+        Response::ok(BenchResponse {
             payload: last_payload,
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     async fn log_unary(
@@ -97,11 +95,10 @@ impl BenchService for BenchServiceImpl {
         // Realistic handler: iterate records, read string fields, compute aggregate.
         // All field access is zero-copy via &str borrows from the request buffer.
         let count = process_log_records_view(&req.records);
-        Ok(LogResponse {
+        Response::ok(LogResponse {
             count,
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     async fn log_unary_owned(
@@ -112,11 +109,10 @@ impl BenchService for BenchServiceImpl {
         // Same handler logic but using owned types (pre-OwnedView path).
         let req = req.to_owned_message();
         let count = process_log_records_owned(&req.records);
-        Ok(LogResponse {
+        Response::ok(LogResponse {
             count,
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     async fn bidi_stream(

--- a/benches/rpc/src/lib.rs
+++ b/benches/rpc/src/lib.rs
@@ -19,13 +19,15 @@ pub use proto::bench::v1::__buffa::view::{
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use buffa::view::OwnedView;
 use connectrpc::client::{ClientConfig, HttpClient};
-use connectrpc::{CodecFormat, ConnectError, Context, Protocol, Router};
-use futures::{Stream, StreamExt};
+use connectrpc::{
+    CodecFormat, ConnectError, Protocol, RequestContext, Response, Router, ServiceResult,
+    ServiceStream,
+};
+use futures::StreamExt;
 
 /// Echo-style bench service that reflects payloads back.
 pub struct BenchServiceImpl;
@@ -33,30 +35,22 @@ pub struct BenchServiceImpl;
 impl BenchService for BenchServiceImpl {
     async fn unary(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<BenchRequestView<'static>>,
-    ) -> Result<(BenchResponse, Context), ConnectError> {
+    ) -> ServiceResult<BenchResponse> {
         let req = req.to_owned_message();
-        Ok((
-            BenchResponse {
-                payload: req.payload,
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(BenchResponse {
+            payload: req.payload,
+            ..Default::default()
+        }
+        .into())
     }
 
     async fn server_stream(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<BenchRequestView<'static>>,
-    ) -> Result<
-        (
-            Pin<Box<dyn Stream<Item = Result<BenchResponse, ConnectError>> + Send>>,
-            Context,
-        ),
-        ConnectError,
-    > {
+    ) -> ServiceResult<ServiceStream<BenchResponse>> {
         let req = req.to_owned_message();
         let count = req.response_count;
         let payload = req.payload;
@@ -75,83 +69,61 @@ impl BenchService for BenchServiceImpl {
                 ))
             }
         });
-        Ok((Box::pin(stream), ctx))
+        Ok(Response::stream(stream))
     }
 
     async fn client_stream(
         &self,
-        ctx: Context,
-        mut requests: Pin<
-            Box<
-                dyn Stream<Item = Result<OwnedView<BenchRequestView<'static>>, ConnectError>>
-                    + Send,
-            >,
-        >,
-    ) -> Result<(BenchResponse, Context), ConnectError> {
+        _ctx: RequestContext,
+        mut requests: ServiceStream<OwnedView<BenchRequestView<'static>>>,
+    ) -> ServiceResult<BenchResponse> {
         let mut last_payload = Default::default();
         while let Some(req) = requests.next().await {
             let req = req?.to_owned_message();
             last_payload = req.payload;
         }
-        Ok((
-            BenchResponse {
-                payload: last_payload,
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(BenchResponse {
+            payload: last_payload,
+            ..Default::default()
+        }
+        .into())
     }
 
     async fn log_unary(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<LogRequestView<'static>>,
-    ) -> Result<(LogResponse, Context), ConnectError> {
+    ) -> ServiceResult<LogResponse> {
         // Realistic handler: iterate records, read string fields, compute aggregate.
         // All field access is zero-copy via &str borrows from the request buffer.
         let count = process_log_records_view(&req.records);
-        Ok((
-            LogResponse {
-                count,
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(LogResponse {
+            count,
+            ..Default::default()
+        }
+        .into())
     }
 
     async fn log_unary_owned(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<LogRequestView<'static>>,
-    ) -> Result<(LogResponse, Context), ConnectError> {
+    ) -> ServiceResult<LogResponse> {
         // Same handler logic but using owned types (pre-OwnedView path).
         let req = req.to_owned_message();
         let count = process_log_records_owned(&req.records);
-        Ok((
-            LogResponse {
-                count,
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(LogResponse {
+            count,
+            ..Default::default()
+        }
+        .into())
     }
 
     async fn bidi_stream(
         &self,
-        ctx: Context,
-        requests: Pin<
-            Box<
-                dyn Stream<Item = Result<OwnedView<BenchRequestView<'static>>, ConnectError>>
-                    + Send,
-            >,
-        >,
-    ) -> Result<
-        (
-            Pin<Box<dyn Stream<Item = Result<BenchResponse, ConnectError>> + Send>>,
-            Context,
-        ),
-        ConnectError,
-    > {
+        _ctx: RequestContext,
+        requests: ServiceStream<OwnedView<BenchRequestView<'static>>>,
+    ) -> ServiceResult<ServiceStream<BenchResponse>> {
         // Map stream to owned types before spawning to satisfy Send bounds
         let mut requests = Box::pin(requests.map(|r| r.map(|v| v.to_owned_message())));
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<BenchResponse, ConnectError>>(1);
@@ -175,7 +147,7 @@ impl BenchService for BenchServiceImpl {
             }
         });
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        Ok((Box::pin(stream), ctx))
+        Ok(Response::stream(stream))
     }
 }
 

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -331,7 +331,7 @@ impl ConformanceService for ConformanceServiceImpl {
         // Handle response definition
         if !request.response_definition.is_set() {
             // No response definition - return empty stream
-            return Ok(Response::stream(futures::stream::empty()));
+            return Response::stream_ok(futures::stream::empty());
         }
         let def = &*request.response_definition;
 
@@ -566,7 +566,7 @@ impl ConformanceService for ConformanceServiceImpl {
             Some(Err(e)) => return Err(e),
             None => {
                 // Empty request stream — return empty response stream
-                return Ok(Response::stream(futures::stream::empty()));
+                return Response::stream_ok(futures::stream::empty());
             }
         };
 

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -6,7 +6,6 @@
 //! 3. Writes `ServerCompatResponse` with host:port to stdout
 //! 4. Handles test RPC calls from the conformance runner
 
-use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -16,12 +15,12 @@ use buffa::view::OwnedView;
 use buffa_types::google::protobuf::Any;
 use connectrpc::ConnectError;
 use connectrpc::ConnectRpcService;
-use connectrpc::Context;
 use connectrpc::Limits;
 use connectrpc::Router;
 use connectrpc::error::ErrorDetail;
 use connectrpc::rustls;
 use connectrpc::server::Server;
+use connectrpc::{RequestContext, Response, ServiceResult, ServiceStream};
 use connectrpc_conformance::BidiStreamRequest;
 use connectrpc_conformance::BidiStreamResponse;
 use connectrpc_conformance::ClientStreamRequest;
@@ -47,7 +46,6 @@ use connectrpc_conformance::proto::connectrpc::conformance::v1::__buffa::view::{
 };
 use connectrpc_conformance::read_message;
 use connectrpc_conformance::write_message;
-use futures::Stream;
 use futures::StreamExt;
 use http::HeaderName;
 use http::HeaderValue;
@@ -80,7 +78,7 @@ struct ConformanceServiceImpl;
 
 /// Build request info from the context and encoded request bytes.
 fn build_request_info(
-    ctx: &Context,
+    ctx: &RequestContext,
     request_bytes: &[u8],
     type_url: &str,
 ) -> connectrpc_conformance::conformance_payload::RequestInfo {
@@ -157,69 +155,43 @@ async fn apply_response_delay(def: &UnaryResponseDefinition) {
     }
 }
 
-/// Apply response headers and trailers from the response definition to the context.
-fn apply_response_headers_trailers(mut ctx: Context, def: &UnaryResponseDefinition) -> Context {
-    // Apply response headers
-    for header in &def.response_headers {
+/// Convert the proto `Header` list to an `http::HeaderMap`.
+fn to_header_map(headers: &[Header]) -> http::HeaderMap {
+    let mut out = http::HeaderMap::new();
+    for header in headers {
         if let Ok(name) = HeaderName::try_from(&header.name) {
             for val in &header.value {
                 if let Ok(value) = HeaderValue::try_from(val) {
-                    ctx.response_headers.append(name.clone(), value);
+                    out.append(name.clone(), value);
                 }
             }
         }
     }
-
-    // Apply response trailers
-    for header in &def.response_trailers {
-        if let Ok(name) = HeaderName::try_from(&header.name) {
-            for val in &header.value {
-                if let Ok(value) = HeaderValue::try_from(val) {
-                    ctx.trailers.append(name.clone(), value);
-                }
-            }
-        }
-    }
-
-    ctx
+    out
 }
 
-/// Apply response headers and trailers from a streaming response definition to the context.
-fn apply_stream_response_headers_trailers(
-    mut ctx: Context,
-    def: &StreamResponseDefinition,
-) -> Context {
-    // Apply response headers
-    for header in &def.response_headers {
-        if let Ok(name) = HeaderName::try_from(&header.name) {
-            for val in &header.value {
-                if let Ok(value) = HeaderValue::try_from(val) {
-                    ctx.response_headers.append(name.clone(), value);
-                }
-            }
-        }
-    }
+/// Wrap a body with the response headers/trailers from the unary definition.
+fn unary_response<B>(body: B, def: &UnaryResponseDefinition) -> Response<B> {
+    let mut resp = Response::new(body);
+    resp.headers = to_header_map(&def.response_headers);
+    resp.trailers = to_header_map(&def.response_trailers);
+    resp
+}
 
-    // Apply response trailers
-    for header in &def.response_trailers {
-        if let Ok(name) = HeaderName::try_from(&header.name) {
-            for val in &header.value {
-                if let Ok(value) = HeaderValue::try_from(val) {
-                    ctx.trailers.append(name.clone(), value);
-                }
-            }
-        }
-    }
-
-    ctx
+/// Wrap a body with the response headers/trailers from the stream definition.
+fn stream_response<B>(body: B, def: &StreamResponseDefinition) -> Response<B> {
+    let mut resp = Response::new(body);
+    resp.headers = to_header_map(&def.response_headers);
+    resp.trailers = to_header_map(&def.response_trailers);
+    resp
 }
 
 impl ConformanceService for ConformanceServiceImpl {
     async fn unary(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<UnaryRequestView<'static>>,
-    ) -> Result<(UnaryResponse, Context), ConnectError> {
+    ) -> ServiceResult<UnaryResponse> {
         tracing::debug!("Received unary request");
 
         // Build request info with headers
@@ -230,43 +202,29 @@ impl ConformanceService for ConformanceServiceImpl {
         );
 
         let request = request.to_owned_message();
+        let def = request.response_definition.as_option();
 
-        // Handle response definition
-        let (data, ctx) = if request.response_definition.is_set() {
-            let def = &*request.response_definition;
+        if let Some(def) = def {
             apply_response_delay(def).await;
+        }
 
-            match &def.response {
-                Some(
-                    connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::ResponseData(d),
-                ) => {
-                    // Apply response headers and trailers from definition
-                    let ctx = apply_response_headers_trailers(ctx, def);
-                    (d.clone(), ctx)
-                }
-                Some(connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::Error(e)) => {
-                    // Apply response headers and trailers from definition to the error
-                    let ctx = apply_response_headers_trailers(ctx, def);
-
-                    // Return error with request info in details
-                    let code = e
-                        .code
-                        .as_known()
-                        .unwrap_or(connectrpc_conformance::Code::CODE_INTERNAL);
-                    let msg = e.message.clone().unwrap_or_default();
-                    let error = ConnectError::new(code_to_connect_error(code), msg)
-                        .with_detail(request_info_error_detail(request_info))
-                        .with_headers(ctx.response_headers)
-                        .with_trailers(ctx.trailers);
-                    return Err(error);
-                }
-                None => {
-                    let ctx = apply_response_headers_trailers(ctx, def);
-                    (vec![], ctx)
-                }
+        let data = match def.and_then(|d| d.response.as_ref()) {
+            Some(
+                connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::ResponseData(d),
+            ) => d.clone(),
+            Some(connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::Error(e)) => {
+                let def = def.unwrap();
+                let code = e
+                    .code
+                    .as_known()
+                    .unwrap_or(connectrpc_conformance::Code::CODE_INTERNAL);
+                let msg = e.message.clone().unwrap_or_default();
+                return Err(ConnectError::new(code_to_connect_error(code), msg)
+                    .with_detail(request_info_error_detail(request_info))
+                    .with_headers(to_header_map(&def.response_headers))
+                    .with_trailers(to_header_map(&def.response_trailers)));
             }
-        } else {
-            (vec![], ctx)
+            None => vec![],
         };
 
         let payload = ConformancePayload {
@@ -275,19 +233,22 @@ impl ConformanceService for ConformanceServiceImpl {
             ..Default::default()
         };
 
-        let response = UnaryResponse {
+        let body = UnaryResponse {
             payload: payload.into(),
             ..Default::default()
         };
 
-        Ok((response, ctx))
+        Ok(match def {
+            Some(def) => unary_response(body, def),
+            None => body.into(),
+        })
     }
 
     async fn idempotent_unary(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<IdempotentUnaryRequestView<'static>>,
-    ) -> Result<(IdempotentUnaryResponse, Context), ConnectError> {
+    ) -> ServiceResult<IdempotentUnaryResponse> {
         tracing::debug!("Received idempotent_unary request");
 
         // Build request info with headers
@@ -298,41 +259,29 @@ impl ConformanceService for ConformanceServiceImpl {
         );
 
         let request = request.to_owned_message();
+        let def = request.response_definition.as_option();
 
-        // Handle response definition
-        let (data, ctx) = if request.response_definition.is_set() {
-            let def = &*request.response_definition;
+        if let Some(def) = def {
             apply_response_delay(def).await;
+        }
 
-            match &def.response {
-                Some(
-                    connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::ResponseData(d),
-                ) => {
-                    let ctx = apply_response_headers_trailers(ctx, def);
-                    (d.clone(), ctx)
-                }
-                Some(connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::Error(e)) => {
-                    // Apply response headers and trailers from definition to the error
-                    let ctx = apply_response_headers_trailers(ctx, def);
-
-                    let code = e
-                        .code
-                        .as_known()
-                        .unwrap_or(connectrpc_conformance::Code::CODE_INTERNAL);
-                    let msg = e.message.clone().unwrap_or_default();
-                    let error = ConnectError::new(code_to_connect_error(code), msg)
-                        .with_detail(request_info_error_detail(request_info))
-                        .with_headers(ctx.response_headers)
-                        .with_trailers(ctx.trailers);
-                    return Err(error);
-                }
-                None => {
-                    let ctx = apply_response_headers_trailers(ctx, def);
-                    (vec![], ctx)
-                }
+        let data = match def.and_then(|d| d.response.as_ref()) {
+            Some(
+                connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::ResponseData(d),
+            ) => d.clone(),
+            Some(connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::Error(e)) => {
+                let def = def.unwrap();
+                let code = e
+                    .code
+                    .as_known()
+                    .unwrap_or(connectrpc_conformance::Code::CODE_INTERNAL);
+                let msg = e.message.clone().unwrap_or_default();
+                return Err(ConnectError::new(code_to_connect_error(code), msg)
+                    .with_detail(request_info_error_detail(request_info))
+                    .with_headers(to_header_map(&def.response_headers))
+                    .with_trailers(to_header_map(&def.response_trailers)));
             }
-        } else {
-            (vec![], ctx)
+            None => vec![],
         };
 
         let payload = ConformancePayload {
@@ -341,19 +290,22 @@ impl ConformanceService for ConformanceServiceImpl {
             ..Default::default()
         };
 
-        let response = IdempotentUnaryResponse {
+        let body = IdempotentUnaryResponse {
             payload: payload.into(),
             ..Default::default()
         };
 
-        Ok((response, ctx))
+        Ok(match def {
+            Some(def) => unary_response(body, def),
+            None => body.into(),
+        })
     }
 
     async fn unimplemented(
         &self,
-        _ctx: Context,
+        _ctx: RequestContext,
         _request: OwnedView<UnimplementedRequestView<'static>>,
-    ) -> Result<(UnimplementedResponse, Context), ConnectError> {
+    ) -> ServiceResult<UnimplementedResponse> {
         // This endpoint should always return unimplemented
         Err(ConnectError::unimplemented(
             "ConformanceService.Unimplemented is not implemented",
@@ -362,15 +314,9 @@ impl ConformanceService for ConformanceServiceImpl {
 
     async fn server_stream(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<ServerStreamRequestView<'static>>,
-    ) -> Result<
-        (
-            Pin<Box<dyn Stream<Item = Result<ServerStreamResponse, ConnectError>> + Send>>,
-            Context,
-        ),
-        ConnectError,
-    > {
+    ) -> ServiceResult<ServiceStream<ServerStreamResponse>> {
         tracing::debug!("Received server_stream request");
 
         // Build request info with headers
@@ -385,15 +331,9 @@ impl ConformanceService for ConformanceServiceImpl {
         // Handle response definition
         if !request.response_definition.is_set() {
             // No response definition - return empty stream
-            let stream: Pin<
-                Box<dyn Stream<Item = Result<ServerStreamResponse, ConnectError>> + Send>,
-            > = Box::pin(futures::stream::empty());
-            return Ok((stream, ctx));
+            return Ok(Response::stream(futures::stream::empty()));
         }
         let def = &*request.response_definition;
-
-        // Apply response headers and trailers
-        let ctx = apply_stream_response_headers_trailers(ctx, def);
 
         // Get response data
         let response_data = def.response_data.clone();
@@ -414,16 +354,16 @@ impl ConformanceService for ConformanceServiceImpl {
                 let msg = e.message.clone().unwrap_or_default();
                 let error = ConnectError::new(code_to_connect_error(code), msg)
                     .with_detail(request_info_error_detail(request_info))
-                    .with_headers(ctx.response_headers)
-                    .with_trailers(ctx.trailers);
+                    .with_headers(to_header_map(&def.response_headers))
+                    .with_trailers(to_header_map(&def.response_trailers));
                 return Err(error);
             }
 
-            // No error, return empty stream
-            let stream: Pin<
-                Box<dyn Stream<Item = Result<ServerStreamResponse, ConnectError>> + Send>,
-            > = Box::pin(futures::stream::empty());
-            return Ok((stream, ctx));
+            // No error, return empty stream with headers/trailers from def
+            return Ok(stream_response(
+                Box::pin(futures::stream::empty()) as ServiceStream<_>,
+                def,
+            ));
         }
 
         // Create stream that yields responses
@@ -481,23 +421,14 @@ impl ConformanceService for ConformanceServiceImpl {
             },
         );
 
-        let boxed_stream: Pin<
-            Box<dyn Stream<Item = Result<ServerStreamResponse, ConnectError>> + Send>,
-        > = Box::pin(stream);
-
-        Ok((boxed_stream, ctx))
+        Ok(stream_response(Box::pin(stream) as ServiceStream<_>, def))
     }
 
     async fn client_stream(
         &self,
-        ctx: Context,
-        requests: Pin<
-            Box<
-                dyn Stream<Item = Result<OwnedView<ClientStreamRequestView<'static>>, ConnectError>>
-                    + Send,
-            >,
-        >,
-    ) -> Result<(ClientStreamResponse, Context), ConnectError> {
+        ctx: RequestContext,
+        requests: ServiceStream<OwnedView<ClientStreamRequestView<'static>>>,
+    ) -> ServiceResult<ClientStreamResponse> {
         tracing::debug!("Received client_stream request");
 
         // The conformance protocol requires all request messages to be available
@@ -571,36 +502,27 @@ impl ConformanceService for ConformanceServiceImpl {
             }
         });
 
-        let (data, ctx) = if let Some(def) = &def {
+        if let Some(def) = &def {
             apply_response_delay(def).await;
+        }
 
-            match &def.response {
-                Some(
-                    connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::ResponseData(d),
-                ) => {
-                    let ctx = apply_response_headers_trailers(ctx, def);
-                    (d.clone(), ctx)
-                }
-                Some(connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::Error(e)) => {
-                    let ctx = apply_response_headers_trailers(ctx, def);
-                    let code = e
-                        .code
-                        .as_known()
-                        .unwrap_or(connectrpc_conformance::Code::CODE_INTERNAL);
-                    let msg = e.message.clone().unwrap_or_default();
-                    let error = ConnectError::new(code_to_connect_error(code), msg)
-                        .with_detail(request_info_error_detail(request_info))
-                        .with_headers(ctx.response_headers)
-                        .with_trailers(ctx.trailers);
-                    return Err(error);
-                }
-                None => {
-                    let ctx = apply_response_headers_trailers(ctx, def);
-                    (vec![], ctx)
-                }
+        let data = match def.as_ref().and_then(|d| d.response.as_ref()) {
+            Some(
+                connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::ResponseData(d),
+            ) => d.clone(),
+            Some(connectrpc_conformance::__buffa::oneof::unary_response_definition::Response::Error(e)) => {
+                let def = def.as_ref().unwrap();
+                let code = e
+                    .code
+                    .as_known()
+                    .unwrap_or(connectrpc_conformance::Code::CODE_INTERNAL);
+                let msg = e.message.clone().unwrap_or_default();
+                return Err(ConnectError::new(code_to_connect_error(code), msg)
+                    .with_detail(request_info_error_detail(request_info))
+                    .with_headers(to_header_map(&def.response_headers))
+                    .with_trailers(to_header_map(&def.response_trailers)));
             }
-        } else {
-            (vec![], ctx)
+            None => vec![],
         };
 
         let payload = ConformancePayload {
@@ -609,30 +531,22 @@ impl ConformanceService for ConformanceServiceImpl {
             ..Default::default()
         };
 
-        let response = ClientStreamResponse {
+        let body = ClientStreamResponse {
             payload: payload.into(),
             ..Default::default()
         };
 
-        Ok((response, ctx))
+        Ok(match &def {
+            Some(def) => unary_response(body, def),
+            None => body.into(),
+        })
     }
 
     async fn bidi_stream(
         &self,
-        ctx: Context,
-        requests: Pin<
-            Box<
-                dyn Stream<Item = Result<OwnedView<BidiStreamRequestView<'static>>, ConnectError>>
-                    + Send,
-            >,
-        >,
-    ) -> Result<
-        (
-            Pin<Box<dyn Stream<Item = Result<BidiStreamResponse, ConnectError>> + Send>>,
-            Context,
-        ),
-        ConnectError,
-    > {
+        ctx: RequestContext,
+        requests: ServiceStream<OwnedView<BidiStreamRequestView<'static>>>,
+    ) -> ServiceResult<ServiceStream<BidiStreamResponse>> {
         tracing::debug!("Received bidi_stream request");
 
         // Convert OwnedView items to owned types. The conformance protocol
@@ -652,10 +566,7 @@ impl ConformanceService for ConformanceServiceImpl {
             Some(Err(e)) => return Err(e),
             None => {
                 // Empty request stream — return empty response stream
-                let stream: Pin<
-                    Box<dyn Stream<Item = Result<BidiStreamResponse, ConnectError>> + Send>,
-                > = Box::pin(futures::stream::empty());
-                return Ok((stream, ctx));
+                return Ok(Response::stream(futures::stream::empty()));
             }
         };
 
@@ -666,11 +577,18 @@ impl ConformanceService for ConformanceServiceImpl {
         };
         let full_duplex = first_msg.full_duplex;
 
-        // Apply response headers/trailers from definition
-        let ctx = if let Some(ref def) = def {
-            apply_stream_response_headers_trailers(ctx, def)
-        } else {
-            ctx
+        // Response headers/trailers from the definition; applied to whichever
+        // Response<B> arm we return.
+        let wrap = |stream: ServiceStream<BidiStreamResponse>| match &def {
+            Some(d) => stream_response(stream, d),
+            None => Response::new(stream),
+        };
+        let (resp_headers, resp_trailers) = match &def {
+            Some(d) => (
+                to_header_map(&d.response_headers),
+                to_header_map(&d.response_trailers),
+            ),
+            None => (http::HeaderMap::new(), http::HeaderMap::new()),
         };
 
         // Build initial request info from headers
@@ -744,8 +662,8 @@ impl ConformanceService for ConformanceServiceImpl {
                 let msg = e.message.clone().unwrap_or_default();
                 let error = ConnectError::new(code_to_connect_error(code), msg)
                     .with_detail(request_info_error_detail(request_info))
-                    .with_headers(ctx.response_headers)
-                    .with_trailers(ctx.trailers);
+                    .with_headers(resp_headers)
+                    .with_trailers(resp_trailers);
                 return Err(error);
             }
 
@@ -906,11 +824,7 @@ impl ConformanceService for ConformanceServiceImpl {
                 },
             );
 
-            let boxed_stream: Pin<
-                Box<dyn Stream<Item = Result<BidiStreamResponse, ConnectError>> + Send>,
-            > = Box::pin(stream);
-
-            Ok((boxed_stream, ctx))
+            Ok(wrap(Box::pin(stream)))
         } else {
             // Half-duplex mode: collect all requests first, then send responses.
             // Echo all request properties in the first response only.
@@ -943,10 +857,7 @@ impl ConformanceService for ConformanceServiceImpl {
 
             let Some(ref def) = def else {
                 // No response definition — return empty stream
-                let stream: Pin<
-                    Box<dyn Stream<Item = Result<BidiStreamResponse, ConnectError>> + Send>,
-                > = Box::pin(futures::stream::empty());
-                return Ok((stream, ctx));
+                return Ok(wrap(Box::pin(futures::stream::empty())));
             };
 
             let response_data = def.response_data.clone();
@@ -967,16 +878,13 @@ impl ConformanceService for ConformanceServiceImpl {
                     let msg = e.message.clone().unwrap_or_default();
                     let error = ConnectError::new(code_to_connect_error(code), msg)
                         .with_detail(request_info_error_detail(request_info))
-                        .with_headers(ctx.response_headers)
-                        .with_trailers(ctx.trailers);
+                        .with_headers(resp_headers)
+                        .with_trailers(resp_trailers);
                     return Err(error);
                 }
 
                 // No error, return empty stream
-                let stream: Pin<
-                    Box<dyn Stream<Item = Result<BidiStreamResponse, ConnectError>> + Send>,
-                > = Box::pin(futures::stream::empty());
-                return Ok((stream, ctx));
+                return Ok(wrap(Box::pin(futures::stream::empty())));
             }
 
             // Create stream that yields responses
@@ -1030,11 +938,7 @@ impl ConformanceService for ConformanceServiceImpl {
                 },
             );
 
-            let boxed_stream: Pin<
-                Box<dyn Stream<Item = Result<BidiStreamResponse, ConnectError>> + Send>,
-            > = Box::pin(stream);
-
-            Ok((boxed_stream, ctx))
+            Ok(wrap(Box::pin(stream)))
         }
     }
 }

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.rs
@@ -30,19 +30,17 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// The returned payload should only contain the request info.
     fn unary(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::connectrpc::conformance::v1::__buffa::view::UnaryRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::connectrpc::conformance::v1::UnaryResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// A server-streaming operation. The request indicates the response headers,
@@ -64,28 +62,17 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// sent or an error is thrown.
     fn server_stream(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::connectrpc::conformance::v1::__buffa::view::ServerStreamRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
-                ::std::pin::Pin<
-                    Box<
-                        dyn ::futures::Stream<
-                            Item = Result<
-                                crate::proto::connectrpc::conformance::v1::ServerStreamResponse,
-                                ::connectrpc::ConnectError,
-                            >,
-                        > + Send,
-                    >,
-                >,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            ::connectrpc::ServiceStream<
+                crate::proto::connectrpc::conformance::v1::ServerStreamResponse,
+            >,
         >,
     > + Send;
     /// A client-streaming operation. The first request indicates the response
@@ -104,28 +91,19 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// The returned payload should only contain the request info.
     fn client_stream(
         &self,
-        ctx: ::connectrpc::Context,
-        requests: ::std::pin::Pin<
-            Box<
-                dyn ::futures::Stream<
-                    Item = Result<
-                        ::buffa::view::OwnedView<
-                            crate::proto::connectrpc::conformance::v1::__buffa::view::ClientStreamRequestView<
-                                'static,
-                            >,
-                        >,
-                        ::connectrpc::ConnectError,
-                    >,
-                > + Send,
+        ctx: ::connectrpc::RequestContext,
+        requests: ::connectrpc::ServiceStream<
+            ::buffa::view::OwnedView<
+                crate::proto::connectrpc::conformance::v1::__buffa::view::ClientStreamRequestView<
+                    'static,
+                >,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::connectrpc::conformance::v1::ClientStreamResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// A bidirectional-streaming operation. The first request indicates the response
@@ -166,56 +144,36 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// long in between sending each response message.
     fn bidi_stream(
         &self,
-        ctx: ::connectrpc::Context,
-        requests: ::std::pin::Pin<
-            Box<
-                dyn ::futures::Stream<
-                    Item = Result<
-                        ::buffa::view::OwnedView<
-                            crate::proto::connectrpc::conformance::v1::__buffa::view::BidiStreamRequestView<
-                                'static,
-                            >,
-                        >,
-                        ::connectrpc::ConnectError,
-                    >,
-                > + Send,
+        ctx: ::connectrpc::RequestContext,
+        requests: ::connectrpc::ServiceStream<
+            ::buffa::view::OwnedView<
+                crate::proto::connectrpc::conformance::v1::__buffa::view::BidiStreamRequestView<
+                    'static,
+                >,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
-                ::std::pin::Pin<
-                    Box<
-                        dyn ::futures::Stream<
-                            Item = Result<
-                                crate::proto::connectrpc::conformance::v1::BidiStreamResponse,
-                                ::connectrpc::ConnectError,
-                            >,
-                        > + Send,
-                    >,
-                >,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            ::connectrpc::ServiceStream<
+                crate::proto::connectrpc::conformance::v1::BidiStreamResponse,
+            >,
         >,
     > + Send;
     /// A unary endpoint that the server should not implement and should instead
     /// return an unimplemented error when invoked.
     fn unimplemented(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::connectrpc::conformance::v1::__buffa::view::UnimplementedRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::connectrpc::conformance::v1::UnimplementedResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// A unary endpoint denoted as having no side effects (i.e. idempotent).
@@ -223,19 +181,17 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// leverage query parameters to send data.
     fn idempotent_unary(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::connectrpc::conformance::v1::__buffa::view::IdempotentUnaryRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::connectrpc::conformance::v1::IdempotentUnaryResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -408,7 +364,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -424,12 +380,11 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::UnaryRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.unary(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.unary(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::connectrpc::conformance::v1::UnaryResponse,
+                        >(format)
                 })
             }
             "Unimplemented" => {
@@ -438,12 +393,11 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::UnimplementedRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.unimplemented(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.unimplemented(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::connectrpc::conformance::v1::UnimplementedResponse,
+                        >(format)
                 })
             }
             "IdempotentUnary" => {
@@ -452,12 +406,11 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::IdempotentUnaryRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.idempotent_unary(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.idempotent_unary(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::connectrpc::conformance::v1::IdempotentUnaryResponse,
+                        >(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -466,7 +419,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -482,14 +435,14 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::ServerStreamRequestView,
                     >(request, format)?;
-                    let (resp_stream, ctx) = svc.server_stream(ctx, req).await?;
-                    Ok((
-                        ::connectrpc::dispatcher::codegen::encode_response_stream(
-                            resp_stream,
-                            format,
-                        ),
-                        ctx,
-                    ))
+                    let resp = svc.server_stream(ctx, req).await?;
+                    Ok(
+                        resp
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
+                                s,
+                                format,
+                            )),
+                    )
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_streaming(path),
@@ -498,7 +451,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -514,12 +467,11 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::ClientStreamRequestView,
                     >(requests, format);
-                    let (res, ctx) = svc.client_stream(ctx, req_stream).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.client_stream(ctx, req_stream)
+                        .await?
+                        .encode::<
+                            crate::proto::connectrpc::conformance::v1::ClientStreamResponse,
+                        >(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -528,7 +480,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -544,14 +496,14 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::BidiStreamRequestView,
                     >(requests, format);
-                    let (resp_stream, ctx) = svc.bidi_stream(ctx, req_stream).await?;
-                    Ok((
-                        ::connectrpc::dispatcher::codegen::encode_response_stream(
-                            resp_stream,
-                            format,
-                        ),
-                        ctx,
-                    ))
+                    let resp = svc.bidi_stream(ctx, req_stream).await?;
+                    Ok(
+                        resp
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
+                                s,
+                                format,
+                            )),
+                    )
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_streaming(path),

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -905,6 +905,7 @@ fn generate_service_server(
         let method_name = m.name.as_deref().unwrap_or("");
         let method_snake = make_field_ident(&method_name.to_snake_case());
         let input_view = resolver.rust_view_type(m.input_type.as_deref().unwrap_or(""), package)?;
+        let output_type = resolver.rust_type(m.output_type.as_deref().unwrap_or(""), package)?;
         let cs = m.client_streaming.unwrap_or(false);
         let ss = m.server_streaming.unwrap_or(false);
 
@@ -915,8 +916,8 @@ fn generate_service_server(
                     let svc = ::std::sync::Arc::clone(&self.inner);
                     Box::pin(async move {
                         let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<#input_view>(requests, format);
-                        let (resp_stream, ctx) = svc.#method_snake(ctx, req_stream).await?;
-                        Ok((::connectrpc::dispatcher::codegen::encode_response_stream(resp_stream, format), ctx))
+                        let resp = svc.#method_snake(ctx, req_stream).await?;
+                        Ok(resp.map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(s, format)))
                     })
                 }
             });
@@ -927,9 +928,7 @@ fn generate_service_server(
                     let svc = ::std::sync::Arc::clone(&self.inner);
                     Box::pin(async move {
                         let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<#input_view>(requests, format);
-                        let (res, ctx) = svc.#method_snake(ctx, req_stream).await?;
-                        let bytes = ::connectrpc::dispatcher::codegen::encode_response(&res, format)?;
-                        Ok((bytes, ctx))
+                        svc.#method_snake(ctx, req_stream).await?.encode::<#output_type>(format)
                     })
                 }
             });
@@ -940,8 +939,8 @@ fn generate_service_server(
                     let svc = ::std::sync::Arc::clone(&self.inner);
                     Box::pin(async move {
                         let req = ::connectrpc::dispatcher::codegen::decode_request_view::<#input_view>(request, format)?;
-                        let (resp_stream, ctx) = svc.#method_snake(ctx, req).await?;
-                        Ok((::connectrpc::dispatcher::codegen::encode_response_stream(resp_stream, format), ctx))
+                        let resp = svc.#method_snake(ctx, req).await?;
+                        Ok(resp.map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(s, format)))
                     })
                 }
             });
@@ -952,9 +951,7 @@ fn generate_service_server(
                     let svc = ::std::sync::Arc::clone(&self.inner);
                     Box::pin(async move {
                         let req = ::connectrpc::dispatcher::codegen::decode_request_view::<#input_view>(request, format)?;
-                        let (res, ctx) = svc.#method_snake(ctx, req).await?;
-                        let bytes = ::connectrpc::dispatcher::codegen::encode_response(&res, format)?;
-                        Ok((bytes, ctx))
+                        svc.#method_snake(ctx, req).await?.encode::<#output_type>(format)
                     })
                 }
             });
@@ -1013,7 +1010,7 @@ fn generate_service_server(
             fn call_unary(
                 &self,
                 path: &str,
-                ctx: ::connectrpc::Context,
+                ctx: ::connectrpc::RequestContext,
                 request: ::buffa::bytes::Bytes,
                 format: ::connectrpc::CodecFormat,
             ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -1031,7 +1028,7 @@ fn generate_service_server(
             fn call_server_streaming(
                 &self,
                 path: &str,
-                ctx: ::connectrpc::Context,
+                ctx: ::connectrpc::RequestContext,
                 request: ::buffa::bytes::Bytes,
                 format: ::connectrpc::CodecFormat,
             ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -1048,7 +1045,7 @@ fn generate_service_server(
             fn call_client_streaming(
                 &self,
                 path: &str,
-                ctx: ::connectrpc::Context,
+                ctx: ::connectrpc::RequestContext,
                 requests: ::connectrpc::dispatcher::codegen::RequestStream,
                 format: ::connectrpc::CodecFormat,
             ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -1065,7 +1062,7 @@ fn generate_service_server(
             fn call_bidi_streaming(
                 &self,
                 path: &str,
-                ctx: ::connectrpc::Context,
+                ctx: ::connectrpc::RequestContext,
                 requests: ::connectrpc::dispatcher::codegen::RequestStream,
                 format: ::connectrpc::CodecFormat,
             ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -1117,9 +1114,9 @@ fn generate_trait_method(
             #method_doc_tokens
             fn #method_snake(
                 &self,
-                ctx: ::connectrpc::Context,
+                ctx: ::connectrpc::RequestContext,
                 request: ::buffa::view::OwnedView<#input_view_type<'static>>,
-            ) -> impl ::std::future::Future<Output = Result<(::std::pin::Pin<Box<dyn ::futures::Stream<Item = Result<#output_type, ::connectrpc::ConnectError>> + Send>>, ::connectrpc::Context), ::connectrpc::ConnectError>> + Send;
+            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<::connectrpc::ServiceStream<#output_type>>> + Send;
         })
     } else if client_streaming && !server_streaming {
         // Client streaming method
@@ -1127,9 +1124,9 @@ fn generate_trait_method(
             #method_doc_tokens
             fn #method_snake(
                 &self,
-                ctx: ::connectrpc::Context,
-                requests: ::std::pin::Pin<Box<dyn ::futures::Stream<Item = Result<::buffa::view::OwnedView<#input_view_type<'static>>, ::connectrpc::ConnectError>> + Send>>,
-            ) -> impl ::std::future::Future<Output = Result<(#output_type, ::connectrpc::Context), ::connectrpc::ConnectError>> + Send;
+                ctx: ::connectrpc::RequestContext,
+                requests: ::connectrpc::ServiceStream<::buffa::view::OwnedView<#input_view_type<'static>>>,
+            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<impl ::connectrpc::Encodable<#output_type> + Send + 'static + use<Self>>> + Send;
         })
     } else if client_streaming && server_streaming {
         // Bidi streaming method
@@ -1137,9 +1134,9 @@ fn generate_trait_method(
             #method_doc_tokens
             fn #method_snake(
                 &self,
-                ctx: ::connectrpc::Context,
-                requests: ::std::pin::Pin<Box<dyn ::futures::Stream<Item = Result<::buffa::view::OwnedView<#input_view_type<'static>>, ::connectrpc::ConnectError>> + Send>>,
-            ) -> impl ::std::future::Future<Output = Result<(::std::pin::Pin<Box<dyn ::futures::Stream<Item = Result<#output_type, ::connectrpc::ConnectError>> + Send>>, ::connectrpc::Context), ::connectrpc::ConnectError>> + Send;
+                ctx: ::connectrpc::RequestContext,
+                requests: ::connectrpc::ServiceStream<::buffa::view::OwnedView<#input_view_type<'static>>>,
+            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<::connectrpc::ServiceStream<#output_type>>> + Send;
         })
     } else {
         // Unary method
@@ -1147,9 +1144,9 @@ fn generate_trait_method(
             #method_doc_tokens
             fn #method_snake(
                 &self,
-                ctx: ::connectrpc::Context,
+                ctx: ::connectrpc::RequestContext,
                 request: ::buffa::view::OwnedView<#input_view_type<'static>>,
-            ) -> impl ::std::future::Future<Output = Result<(#output_type, ::connectrpc::Context), ::connectrpc::ConnectError>> + Send;
+            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<impl ::connectrpc::Encodable<#output_type> + Send + 'static + use<Self>>> + Send;
         })
     }
 }

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -23,7 +23,7 @@ use crate::codec::CodecFormat;
 use crate::error::ConnectError;
 use crate::handler::BoxFuture;
 use crate::handler::BoxStream;
-use crate::handler::Context;
+use crate::response::{EncodedResponse, RequestContext};
 use crate::router::MethodKind;
 
 /// Description of a method returned by [`Dispatcher::lookup`].
@@ -80,11 +80,15 @@ impl MethodDescriptor {
 }
 
 /// Result type for unary and client-streaming handler calls.
-pub type UnaryResult = BoxFuture<'static, Result<(Bytes, Context), ConnectError>>;
+pub type UnaryResult = BoxFuture<'static, Result<EncodedResponse, ConnectError>>;
 
 /// Result type for server-streaming and bidi-streaming handler calls.
-pub type StreamingResult =
-    BoxFuture<'static, Result<(BoxStream<Result<Bytes, ConnectError>>, Context), ConnectError>>;
+///
+/// The body is a stream of pre-encoded message bytes.
+pub type StreamingResult = BoxFuture<
+    'static,
+    Result<crate::response::Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError>,
+>;
 
 /// A stream of raw request message bytes (client-streaming / bidi input).
 pub type RequestStream = BoxStream<Result<Bytes, ConnectError>>;
@@ -121,7 +125,7 @@ pub trait Dispatcher: Send + Sync + 'static {
     fn call_unary(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
     ) -> UnaryResult;
@@ -132,7 +136,7 @@ pub trait Dispatcher: Send + Sync + 'static {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
     ) -> StreamingResult;
@@ -143,7 +147,7 @@ pub trait Dispatcher: Send + Sync + 'static {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         requests: RequestStream,
         format: CodecFormat,
     ) -> UnaryResult;
@@ -154,7 +158,7 @@ pub trait Dispatcher: Send + Sync + 'static {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         requests: RequestStream,
         format: CodecFormat,
     ) -> StreamingResult;
@@ -217,7 +221,7 @@ impl<A: Dispatcher, B: Dispatcher> Dispatcher for Chain<A, B> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
     ) -> UnaryResult {
@@ -231,7 +235,7 @@ impl<A: Dispatcher, B: Dispatcher> Dispatcher for Chain<A, B> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
     ) -> StreamingResult {
@@ -245,7 +249,7 @@ impl<A: Dispatcher, B: Dispatcher> Dispatcher for Chain<A, B> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         requests: RequestStream,
         format: CodecFormat,
     ) -> UnaryResult {
@@ -259,7 +263,7 @@ impl<A: Dispatcher, B: Dispatcher> Dispatcher for Chain<A, B> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: Context,
+        ctx: RequestContext,
         requests: RequestStream,
         format: CodecFormat,
     ) -> StreamingResult {
@@ -301,7 +305,7 @@ pub mod codegen {
     // Re-exports that generated code needs direct access to.
     pub use crate::handler::BoxFuture;
     pub use crate::handler::decode_request_view;
-    pub use crate::handler::encode_response;
+    pub use crate::response::EncodedResponse;
 
     pub use super::MethodDescriptor;
     pub use super::RequestStream;
@@ -324,6 +328,7 @@ pub mod codegen {
         Res: Message + Serialize + Send + 'static,
         S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
     {
+        use crate::response::Encodable;
         Box::pin(
             futures::stream::unfold(
                 (
@@ -332,7 +337,7 @@ pub mod codegen {
                     format,
                 ),
                 async |(mut s, fmt)| match s.next().await {
-                    Some(Ok(res)) => Some((encode_response(&res, fmt), (s, fmt))),
+                    Some(Ok(res)) => Some((Encodable::<Res>::encode(&res, fmt), (s, fmt))),
                     Some(Err(e)) => Some((Err(e), (s, fmt))),
                     None => None,
                 },

--- a/connectrpc/src/error.rs
+++ b/connectrpc/src/error.rs
@@ -448,9 +448,26 @@ impl From<std::io::Error> for ConnectError {
     }
 }
 
+/// Lets `Response::try_with_header(..)?` propagate naturally inside a
+/// handler.
+impl From<http::Error> for ConnectError {
+    fn from(err: http::Error) -> Self {
+        Self::internal(err.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn from_http_error_is_internal() {
+        let http_err: http::Error = http::HeaderValue::from_bytes(b"bad\nval")
+            .unwrap_err()
+            .into();
+        let e: ConnectError = http_err.into();
+        assert_eq!(e.code, ErrorCode::Internal);
+    }
 
     #[test]
     fn test_grpc_code_round_trip() {

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -1,7 +1,14 @@
 //! Handler traits for implementing RPC methods.
 //!
-//! This module defines the traits that RPC method implementations must satisfy,
-//! supporting both unary and streaming RPC patterns.
+//! This module defines the traits that RPC method implementations must
+//! satisfy. Generated `FooService` traits are the primary surface; these
+//! lower-level traits exist for the [`Router`](crate::Router) path that
+//! registers handlers without codegen.
+//!
+//! Handlers receive a read-only [`RequestContext`] and return a
+//! [`Response<B>`](crate::Response) carrying the body plus any response
+//! headers/trailers/compression hint. See [`crate::response`] for the
+//! type definitions.
 
 use std::pin::Pin;
 use std::sync::Arc;
@@ -16,10 +23,11 @@ use serde::de::DeserializeOwned;
 
 use crate::codec::CodecFormat;
 use crate::error::ConnectError;
+use crate::response::{
+    Encodable, EncodedResponse, RequestContext, Response, ServiceResult, ServiceStream,
+};
 
 /// Decode a request message from bytes using the specified codec format.
-///
-/// This helper is used by both unary and streaming handler wrappers to avoid duplication.
 pub(crate) fn decode_request<Req>(request: &Bytes, format: CodecFormat) -> Result<Req, ConnectError>
 where
     Req: Message + DeserializeOwned,
@@ -34,133 +42,121 @@ where
     }
 }
 
-/// Encode a response message to bytes using the specified codec format.
-///
-/// This helper is used by both unary and streaming handler wrappers to avoid duplication.
-#[doc(hidden)] // exposed only for dispatcher::codegen (generated code)
-pub fn encode_response<Res>(res: &Res, format: CodecFormat) -> Result<Bytes, ConnectError>
-where
-    Res: Message + Serialize,
-{
-    match format {
-        CodecFormat::Proto => Ok(res.encode_to_bytes()),
-        CodecFormat::Json => serde_json::to_vec(res)
-            .map(Bytes::from)
-            .map_err(|e| ConnectError::internal(format!("failed to encode JSON response: {e}"))),
-    }
-}
-
-/// Context passed to RPC handlers.
-#[derive(Debug, Clone, Default)]
-pub struct Context {
-    /// Request headers.
-    pub headers: http::HeaderMap,
-    /// Response headers to be set by the handler.
-    pub response_headers: http::HeaderMap,
-    /// Response trailers to be set by the handler.
-    pub trailers: http::HeaderMap,
-    /// Request timeout/deadline, if specified.
-    pub deadline: Option<std::time::Instant>,
-    /// Whether to compress the response. `None` uses the server's compression
-    /// policy. Set to `Some(false)` to disable compression for this response,
-    /// or `Some(true)` to force it.
-    pub compress_response: Option<bool>,
-    /// Request extensions carried from the underlying `http::Request`.
-    ///
-    /// This is the passthrough for connection-scoped metadata that a
-    /// tower layer in front of the service can attach — TLS peer
-    /// certificates, remote socket address, auth context, etc. The
-    /// dispatch path moves `parts.extensions` here verbatim; handlers
-    /// read it with `ctx.extensions.get::<T>()`.
-    pub extensions: http::Extensions,
-}
-
-impl Context {
-    /// Create a new context with the given headers.
-    pub fn new(headers: http::HeaderMap) -> Self {
-        Self {
-            headers,
-            response_headers: http::HeaderMap::new(),
-            trailers: http::HeaderMap::new(),
-            deadline: None,
-            compress_response: None,
-            extensions: http::Extensions::new(),
-        }
-    }
-
-    /// Set the request deadline (absolute `Instant`).
-    ///
-    /// Used by the server dispatch paths to expose the parsed timeout
-    /// to handlers, allowing deadline propagation to downstream calls.
-    #[must_use]
-    pub fn with_deadline(mut self, deadline: Option<std::time::Instant>) -> Self {
-        self.deadline = deadline;
-        self
-    }
-
-    /// Attach request extensions captured from the underlying `http::Request`.
-    ///
-    /// Used by the server dispatch paths; see [`Context::extensions`].
-    #[must_use]
-    pub fn with_extensions(mut self, extensions: http::Extensions) -> Self {
-        self.extensions = extensions;
-        self
-    }
-
-    /// Set a response trailer.
-    pub fn set_trailer(&mut self, key: http::header::HeaderName, value: http::header::HeaderValue) {
-        self.trailers.insert(key, value);
-    }
-
-    /// Set whether to compress the response for this RPC.
-    pub fn set_compression(&mut self, enabled: bool) {
-        self.compress_response = Some(enabled);
-    }
-
-    /// Get a request header value.
-    pub fn header(&self, key: &http::header::HeaderName) -> Option<&http::header::HeaderValue> {
-        self.headers.get(key)
-    }
-}
-
 /// Type alias for a boxed future used in handlers.
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Trait for unary RPC handlers.
+/// Type alias for a boxed stream of encoded response bytes.
+pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
+
+/// Map a stream of typed responses through [`Encodable`].
+fn encode_body_stream<Res, S>(
+    stream: S,
+    format: CodecFormat,
+) -> BoxStream<Result<Bytes, ConnectError>>
+where
+    Res: Message + Serialize + Send + 'static,
+    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+{
+    use futures::StreamExt as _;
+    Box::pin(
+        futures::stream::unfold(
+            (
+                Box::pin(stream) as Pin<Box<dyn Stream<Item = Result<Res, ConnectError>> + Send>>,
+                format,
+            ),
+            async |(mut s, fmt)| match s.next().await {
+                Some(Ok(res)) => Some((Encodable::<Res>::encode(&res, fmt), (s, fmt))),
+                Some(Err(e)) => Some((Err(e), (s, fmt))),
+                None => None,
+            },
+        )
+        .fuse(),
+    )
+}
+
+// ============================================================================
+// Type-erased handler boundaries (Router → service.rs)
+// ============================================================================
+
+/// Type-erased unary handler for use in the router.
+pub(crate) trait ErasedHandler: Send + Sync {
+    /// Handle a request with raw bytes and specified codec format.
+    fn call_erased(
+        &self,
+        ctx: RequestContext,
+        request: Bytes,
+        format: CodecFormat,
+    ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>>;
+
+    /// Check if this is a streaming handler.
+    #[allow(dead_code)]
+    fn is_streaming(&self) -> bool;
+}
+
+/// Result type for erased streaming handlers.
+pub(crate) type StreamingHandlerResult =
+    BoxFuture<'static, Result<Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError>>;
+
+/// Type-erased server-streaming handler for use in the router.
+pub(crate) trait ErasedStreamingHandler: Send + Sync {
+    /// Handle a streaming request with raw bytes and specified codec format.
+    fn call_erased(
+        &self,
+        ctx: RequestContext,
+        request: Bytes,
+        format: CodecFormat,
+    ) -> StreamingHandlerResult;
+}
+
+/// Type-erased client-streaming handler for use in the router.
+pub(crate) trait ErasedClientStreamingHandler: Send + Sync {
+    /// Handle a client streaming request with a stream of raw message bytes.
+    fn call_erased(
+        &self,
+        ctx: RequestContext,
+        requests: BoxStream<Result<Bytes, ConnectError>>,
+        format: CodecFormat,
+    ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>>;
+}
+
+/// Type-erased bidi-streaming handler for use in the router.
+pub(crate) trait ErasedBidiStreamingHandler: Send + Sync {
+    /// Handle a bidi streaming request with a stream of raw message bytes.
+    fn call_erased(
+        &self,
+        ctx: RequestContext,
+        requests: BoxStream<Result<Bytes, ConnectError>>,
+        format: CodecFormat,
+    ) -> StreamingHandlerResult;
+}
+
+// ============================================================================
+// Unary handler (owned request)
+// ============================================================================
+
+/// Trait for unary RPC handlers (owned request type).
 ///
-/// A unary handler takes a single request message and returns a single response.
-///
-/// # Context Ownership
-///
-/// The handler takes ownership of [`Context`] and returns it along with the response.
-/// This design is intentional for async compatibility:
-///
-/// - The returned future is `'static`, meaning it cannot borrow from external state
-/// - Taking ownership allows the future to move the `Context` into itself
-/// - Using `&mut Context` would require non-`'static` lifetimes, complicating tower integration
-///
-/// Handlers should set response headers/trailers on the context before returning:
-///
-/// ```ignore
-/// async fn my_handler(mut ctx: Context, req: MyRequest) -> Result<(MyResponse, Context), ConnectError> {
-///     ctx.response_headers.insert("x-custom-header", "value".parse().unwrap());
-///     Ok((MyResponse::default(), ctx))
-/// }
-/// ```
+/// Handlers return a [`Response<Self::Body>`](crate::Response) where
+/// `Body` is any type [`Encodable`] as `Res` — typically `Res` itself.
+/// The happy path is `Ok(res.into())`.
 pub trait Handler<Req, Res>: Send + Sync + 'static
 where
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
 {
+    /// The response body type. Typically `Res`; the [`Encodable`] bound
+    /// lets handlers return a borrowing view in a follow-up.
+    type Body: Encodable<Res> + Send + 'static;
+
     /// Handle a unary RPC request.
     fn call(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: Req,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>>;
+    ) -> BoxFuture<'static, ServiceResult<Self::Body>>;
 }
 
-/// Wrapper that implements Handler for async functions.
+/// Wrapper that implements [`Handler`] for async functions.
 pub struct FnHandler<F> {
     f: Arc<F>,
 }
@@ -172,125 +168,35 @@ impl<F> FnHandler<F> {
     }
 }
 
-impl<F, Fut, Req, Res> Handler<Req, Res> for FnHandler<F>
+impl<F, Fut, Req, Res, B> Handler<Req, Res> for FnHandler<F>
 where
-    F: Fn(Context, Req) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, Req) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
-    fn call(
-        &self,
-        ctx: Context,
-        request: Req,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>> {
+    type Body = B;
+
+    fn call(&self, ctx: RequestContext, request: Req) -> BoxFuture<'static, ServiceResult<B>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, request).await })
     }
 }
 
-/// Trait for server streaming RPC handlers.
-///
-/// A streaming handler takes a single request and returns a stream of responses.
-pub trait StreamingHandler<Req, Res>: Send + Sync + 'static
+/// Helper function to create a handler from an async function.
+pub fn handler_fn<F, Fut, Req, Res, B>(f: F) -> FnHandler<F>
 where
+    F: Fn(RequestContext, Req) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
-    /// The stream type returned by this handler.
-    type Stream: Stream<Item = Result<Res, ConnectError>> + Send + 'static;
-
-    /// Handle a server streaming RPC request.
-    fn call(
-        &self,
-        ctx: Context,
-        request: Req,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>>;
-}
-
-/// Wrapper that implements StreamingHandler for async functions.
-pub struct FnStreamingHandler<F> {
-    f: Arc<F>,
-}
-
-impl<F> FnStreamingHandler<F> {
-    /// Create a new function streaming handler.
-    pub fn new(f: F) -> Self {
-        Self { f: Arc::new(f) }
-    }
-}
-
-impl<F, Fut, S, Req, Res> StreamingHandler<Req, Res> for FnStreamingHandler<F>
-where
-    F: Fn(Context, Req) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
-    Req: Message + Send + 'static,
-    Res: Message + Send + 'static,
-{
-    type Stream = S;
-
-    fn call(
-        &self,
-        ctx: Context,
-        request: Req,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>> {
-        let f = Arc::clone(&self.f);
-        Box::pin(async move { f(ctx, request).await })
-    }
-}
-
-/// Helper function to create a streaming handler from an async function.
-///
-/// This is the recommended way to create streaming handlers from async functions.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use connectrpc::{streaming_handler_fn, Context, ConnectError};
-/// use futures::stream;
-///
-/// async fn my_handler(ctx: Context, req: MyRequest) -> Result<(impl Stream<Item = Result<MyResponse, ConnectError>>, Context), ConnectError> {
-///     let responses = stream::iter(vec![
-///         Ok(MyResponse { ... }),
-///         Ok(MyResponse { ... }),
-///     ]);
-///     Ok((responses, ctx))
-/// }
-///
-/// let router = Router::new()
-///     .route_server_stream("my.Service", "Method", streaming_handler_fn(my_handler));
-/// ```
-pub fn streaming_handler_fn<F, Fut, S, Req, Res>(f: F) -> FnStreamingHandler<F>
-where
-    F: Fn(Context, Req) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
-    Req: Message + Send + 'static,
-    Res: Message + Send + 'static,
-{
-    FnStreamingHandler::new(f)
-}
-
-/// Type-erased handler for use in the router.
-pub(crate) trait ErasedHandler: Send + Sync {
-    /// Handle a request with raw bytes and specified codec format.
-    fn call_erased(
-        &self,
-        ctx: Context,
-        request: Bytes,
-        format: CodecFormat,
-    ) -> BoxFuture<'static, Result<(Bytes, Context), ConnectError>>;
-
-    /// Check if this is a streaming handler.
-    #[allow(dead_code)]
-    fn is_streaming(&self) -> bool;
+    FnHandler::new(f)
 }
 
 /// Wrapper to erase the types from a unary handler.
-///
-/// The request and response types must implement both buffa::Message (for proto encoding)
-/// and serde traits (for JSON encoding).
 pub(crate) struct UnaryHandlerWrapper<H, Req, Res>
 where
     H: Handler<Req, Res>,
@@ -324,16 +230,14 @@ where
 {
     fn call_erased(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
-    ) -> BoxFuture<'static, Result<(Bytes, Context), ConnectError>> {
+    ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>> {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
             let req: Req = decode_request(&request, format)?;
-            let (res, ctx) = handler.call(ctx, req).await?;
-            let response_bytes = encode_response(&res, format)?;
-            Ok((response_bytes, ctx))
+            handler.call(ctx, req).await?.encode::<Res>(format)
         })
     }
 
@@ -342,26 +246,65 @@ where
     }
 }
 
-/// Type alias for a boxed stream of encoded response bytes.
-pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
+// ============================================================================
+// Server-streaming handler (owned request)
+// ============================================================================
 
-/// Type-erased streaming handler for use in the router.
-pub(crate) trait ErasedStreamingHandler: Send + Sync {
-    /// Handle a streaming request with raw bytes and specified codec format.
-    ///
-    /// Returns the initial context (with response headers) and a stream of encoded response bytes.
-    /// The stream yields `Result<Bytes, ConnectError>` for each response message.
-    fn call_erased(
+/// Trait for server streaming RPC handlers.
+///
+/// Stream items are the owned `Res` (view-out for streams is a follow-up).
+pub trait StreamingHandler<Req, Res>: Send + Sync + 'static
+where
+    Req: Message + Send + 'static,
+    Res: Message + Send + 'static,
+{
+    /// Handle a server streaming RPC request.
+    fn call(
         &self,
-        ctx: Context,
-        request: Bytes,
-        format: CodecFormat,
-    ) -> StreamingHandlerResult;
+        ctx: RequestContext,
+        request: Req,
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
 }
 
-/// Result type for erased streaming handlers.
-pub(crate) type StreamingHandlerResult =
-    BoxFuture<'static, Result<(BoxStream<Result<Bytes, ConnectError>>, Context), ConnectError>>;
+/// Wrapper that implements [`StreamingHandler`] for async functions.
+pub struct FnStreamingHandler<F> {
+    f: Arc<F>,
+}
+
+impl<F> FnStreamingHandler<F> {
+    /// Create a new function streaming handler.
+    pub fn new(f: F) -> Self {
+        Self { f: Arc::new(f) }
+    }
+}
+
+impl<F, Fut, Req, Res> StreamingHandler<Req, Res> for FnStreamingHandler<F>
+where
+    F: Fn(RequestContext, Req) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Req: Message + Send + 'static,
+    Res: Message + Send + 'static,
+{
+    fn call(
+        &self,
+        ctx: RequestContext,
+        request: Req,
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
+        let f = Arc::clone(&self.f);
+        Box::pin(async move { f(ctx, request).await })
+    }
+}
+
+/// Helper function to create a streaming handler from an async function.
+pub fn streaming_handler_fn<F, Fut, Req, Res>(f: F) -> FnStreamingHandler<F>
+where
+    F: Fn(RequestContext, Req) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Req: Message + Send + 'static,
+    Res: Message + Send + 'static,
+{
+    FnStreamingHandler::new(f)
+}
 
 /// Wrapper to erase the types from a server streaming handler.
 pub(crate) struct ServerStreamingHandlerWrapper<H, Req, Res>
@@ -397,87 +340,41 @@ where
 {
     fn call_erased(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
     ) -> StreamingHandlerResult {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
             let req: Req = decode_request(&request, format)?;
-            let (stream, ctx) = handler.call(ctx, req).await?;
-
-            // Map the stream to encode each response
-            // Use .fuse() to make the stream safe to poll after returning None
-            let encoded_stream: BoxStream<Result<Bytes, ConnectError>> = {
-                use futures::StreamExt as _;
-                Box::pin(
-                    futures::stream::unfold(
-                        (
-                            Box::pin(stream)
-                                as Pin<Box<dyn Stream<Item = Result<Res, ConnectError>> + Send>>,
-                            format,
-                        ),
-                        async |(mut stream, format)| match stream.next().await {
-                            Some(Ok(res)) => {
-                                let encoded = encode_response(&res, format);
-                                Some((encoded, (stream, format)))
-                            }
-                            Some(Err(e)) => Some((Err(e), (stream, format))),
-                            None => None,
-                        },
-                    )
-                    .fuse(),
-                )
-            };
-
-            Ok((encoded_stream, ctx))
+            let resp = handler.call(ctx, req).await?;
+            Ok(resp.map_body(|s| encode_body_stream(s, format)))
         })
     }
 }
 
-/// Helper function to create a handler from an async function.
-///
-/// This is the recommended way to create handlers from async functions.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use connectrpc::{handler_fn, Context, ConnectError};
-///
-/// async fn my_handler(ctx: Context, req: MyRequest) -> Result<(MyResponse, Context), ConnectError> {
-///     Ok((MyResponse { ... }, ctx))
-/// }
-///
-/// let router = Router::new()
-///     .route("my.Service", "Method", handler_fn(my_handler));
-/// ```
-pub fn handler_fn<F, Fut, Req, Res>(f: F) -> FnHandler<F>
-where
-    F: Fn(Context, Req) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
-    Req: Message + Send + 'static,
-    Res: Message + Send + 'static,
-{
-    FnHandler::new(f)
-}
+// ============================================================================
+// Client-streaming handler (owned request)
+// ============================================================================
 
 /// Trait for client streaming RPC handlers.
-///
-/// A client streaming handler receives a stream of request messages and returns a single response.
 pub trait ClientStreamingHandler<Req, Res>: Send + Sync + 'static
 where
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
 {
+    /// The response body type. Typically `Res`.
+    type Body: Encodable<Res> + Send + 'static;
+
     /// Handle a client streaming RPC request.
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<Req, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>>;
+        ctx: RequestContext,
+        requests: ServiceStream<Req>,
+    ) -> BoxFuture<'static, ServiceResult<Self::Body>>;
 }
 
-/// Wrapper that implements ClientStreamingHandler for async functions.
+/// Wrapper that implements [`ClientStreamingHandler`] for async functions.
 pub struct FnClientStreamingHandler<F> {
     f: Arc<F>,
 }
@@ -489,43 +386,36 @@ impl<F> FnClientStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, Req, Res> ClientStreamingHandler<Req, Res> for FnClientStreamingHandler<F>
+impl<F, Fut, Req, Res, B> ClientStreamingHandler<Req, Res> for FnClientStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<Req, ConnectError>>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<Req>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
+    type Body = B;
+
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<Req, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>> {
+        ctx: RequestContext,
+        requests: ServiceStream<Req>,
+    ) -> BoxFuture<'static, ServiceResult<B>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, requests).await })
     }
 }
 
 /// Helper function to create a client streaming handler from an async function.
-pub fn client_streaming_handler_fn<F, Fut, Req, Res>(f: F) -> FnClientStreamingHandler<F>
+pub fn client_streaming_handler_fn<F, Fut, Req, Res, B>(f: F) -> FnClientStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<Req, ConnectError>>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<Req>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
     FnClientStreamingHandler::new(f)
-}
-
-/// Type-erased client streaming handler for use in the router.
-pub(crate) trait ErasedClientStreamingHandler: Send + Sync {
-    /// Handle a client streaming request with a stream of raw message bytes.
-    fn call_erased(
-        &self,
-        ctx: Context,
-        requests: BoxStream<Result<Bytes, ConnectError>>,
-        format: CodecFormat,
-    ) -> BoxFuture<'static, Result<(Bytes, Context), ConnectError>>;
 }
 
 /// Wrapper to erase the types from a client streaming handler.
@@ -562,46 +452,43 @@ where
 {
     fn call_erased(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         requests: BoxStream<Result<Bytes, ConnectError>>,
         format: CodecFormat,
-    ) -> BoxFuture<'static, Result<(Bytes, Context), ConnectError>> {
+    ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>> {
         use futures::StreamExt as _;
-
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            // Map the raw bytes stream through decode to create a typed stream
-            let request_stream: BoxStream<Result<Req, ConnectError>> = Box::pin(
+            let request_stream: ServiceStream<Req> = Box::pin(
                 requests.map(move |result| result.and_then(|raw| decode_request(&raw, format))),
             );
-
-            let (res, ctx) = handler.call(ctx, request_stream).await?;
-            let response_bytes = encode_response(&res, format)?;
-            Ok((response_bytes, ctx))
+            handler
+                .call(ctx, request_stream)
+                .await?
+                .encode::<Res>(format)
         })
     }
 }
 
+// ============================================================================
+// Bidi-streaming handler (owned request)
+// ============================================================================
+
 /// Trait for bidirectional streaming RPC handlers.
-///
-/// A bidi streaming handler receives a stream of request messages and returns a stream of responses.
 pub trait BidiStreamingHandler<Req, Res>: Send + Sync + 'static
 where
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
 {
-    /// The stream type returned by this handler.
-    type Stream: Stream<Item = Result<Res, ConnectError>> + Send + 'static;
-
     /// Handle a bidi streaming RPC request.
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<Req, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>>;
+        ctx: RequestContext,
+        requests: ServiceStream<Req>,
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
 }
 
-/// Wrapper that implements BidiStreamingHandler for async functions.
+/// Wrapper that implements [`BidiStreamingHandler`] for async functions.
 pub struct FnBidiStreamingHandler<F> {
     f: Arc<F>,
 }
@@ -613,40 +500,86 @@ impl<F> FnBidiStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, S, Req, Res> BidiStreamingHandler<Req, Res> for FnBidiStreamingHandler<F>
+impl<F, Fut, Req, Res> BidiStreamingHandler<Req, Res> for FnBidiStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<Req, ConnectError>>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<Req>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
 {
-    type Stream = S;
-
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<Req, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>> {
+        ctx: RequestContext,
+        requests: ServiceStream<Req>,
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, requests).await })
     }
 }
 
 /// Helper function to create a bidi streaming handler from an async function.
-pub fn bidi_streaming_handler_fn<F, Fut, S, Req, Res>(f: F) -> FnBidiStreamingHandler<F>
+pub fn bidi_streaming_handler_fn<F, Fut, Req, Res>(f: F) -> FnBidiStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<Req, ConnectError>>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<Req>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
 {
     FnBidiStreamingHandler::new(f)
 }
 
+/// Wrapper to erase the types from a bidi streaming handler.
+pub(crate) struct BidiStreamingHandlerWrapper<H, Req, Res>
+where
+    H: BidiStreamingHandler<Req, Res>,
+    Req: Message + DeserializeOwned + Send + 'static,
+    Res: Message + Serialize + Send + 'static,
+{
+    handler: Arc<H>,
+    _phantom: std::marker::PhantomData<fn(Req) -> Res>,
+}
+
+impl<H, Req, Res> BidiStreamingHandlerWrapper<H, Req, Res>
+where
+    H: BidiStreamingHandler<Req, Res>,
+    Req: Message + DeserializeOwned + Send + 'static,
+    Res: Message + Serialize + Send + 'static,
+{
+    /// Create a new wrapper around the given bidi streaming handler.
+    pub fn new(handler: H) -> Self {
+        Self {
+            handler: Arc::new(handler),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<H, Req, Res> ErasedBidiStreamingHandler for BidiStreamingHandlerWrapper<H, Req, Res>
+where
+    H: BidiStreamingHandler<Req, Res>,
+    Req: Message + DeserializeOwned + Send + 'static,
+    Res: Message + Serialize + Send + 'static,
+{
+    fn call_erased(
+        &self,
+        ctx: RequestContext,
+        requests: BoxStream<Result<Bytes, ConnectError>>,
+        format: CodecFormat,
+    ) -> StreamingHandlerResult {
+        use futures::StreamExt as _;
+        let handler = Arc::clone(&self.handler);
+        Box::pin(async move {
+            let request_stream: ServiceStream<Req> = Box::pin(
+                requests.map(move |result| result.and_then(|raw| decode_request(&raw, format))),
+            );
+            let resp = handler.call(ctx, request_stream).await?;
+            Ok(resp.map_body(|s| encode_body_stream(s, format)))
+        })
+    }
+}
+
 // ============================================================================
-// View-based handler infrastructure (zero-copy request deserialization)
+// View-based handlers (zero-copy request views)
 // ============================================================================
 
 /// Decode a request as an `OwnedView` from bytes using the specified codec format.
@@ -685,15 +618,18 @@ where
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
+    /// The response body type. Typically `Res`.
+    type Body: Encodable<Res> + Send + 'static;
+
     /// Handle a unary RPC request with a zero-copy view.
     fn call(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<ReqView>,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>>;
+    ) -> BoxFuture<'static, ServiceResult<Self::Body>>;
 }
 
-/// Wrapper that implements ViewHandler for async functions.
+/// Wrapper that implements [`ViewHandler`] for async functions.
 pub struct FnViewHandler<F> {
     f: Arc<F>,
 }
@@ -705,30 +641,34 @@ impl<F> FnViewHandler<F> {
     }
 }
 
-impl<F, Fut, ReqView, Res> ViewHandler<ReqView, Res> for FnViewHandler<F>
+impl<F, Fut, ReqView, Res, B> ViewHandler<ReqView, Res> for FnViewHandler<F>
 where
-    F: Fn(Context, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
+    type Body = B;
+
     fn call(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<ReqView>,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>> {
+    ) -> BoxFuture<'static, ServiceResult<B>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, request).await })
     }
 }
 
 /// Helper function to create a view handler from an async function.
-pub fn view_handler_fn<F, Fut, ReqView, Res>(f: F) -> FnViewHandler<F>
+pub fn view_handler_fn<F, Fut, ReqView, Res, B>(f: F) -> FnViewHandler<F>
 where
-    F: Fn(Context, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
     FnViewHandler::new(f)
 }
@@ -769,16 +709,14 @@ where
 {
     fn call_erased(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
-    ) -> BoxFuture<'static, Result<(Bytes, Context), ConnectError>> {
+    ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>> {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
             let req = decode_request_view::<ReqView>(request, format)?;
-            let (res, ctx) = handler.call(ctx, req).await?;
-            let response_bytes = encode_response(&res, format)?;
-            Ok((response_bytes, ctx))
+            handler.call(ctx, req).await?.encode::<Res>(format)
         })
     }
 
@@ -793,18 +731,15 @@ where
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
-    /// The stream type returned by this handler.
-    type Stream: Stream<Item = Result<Res, ConnectError>> + Send + 'static;
-
     /// Handle a server streaming RPC request with a zero-copy view.
     fn call(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<ReqView>,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>>;
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
 }
 
-/// Wrapper that implements ViewStreamingHandler for async functions.
+/// Wrapper that implements [`ViewStreamingHandler`] for async functions.
 pub struct FnViewStreamingHandler<F> {
     f: Arc<F>,
 }
@@ -816,32 +751,28 @@ impl<F> FnViewStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, S, ReqView, Res> ViewStreamingHandler<ReqView, Res> for FnViewStreamingHandler<F>
+impl<F, Fut, ReqView, Res> ViewStreamingHandler<ReqView, Res> for FnViewStreamingHandler<F>
 where
-    F: Fn(Context, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
-    type Stream = S;
-
     fn call(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<ReqView>,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>> {
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, request).await })
     }
 }
 
 /// Helper function to create a view streaming handler from an async function.
-pub fn view_streaming_handler_fn<F, Fut, S, ReqView, Res>(f: F) -> FnViewStreamingHandler<F>
+pub fn view_streaming_handler_fn<F, Fut, ReqView, Res>(f: F) -> FnViewStreamingHandler<F>
 where
-    F: Fn(Context, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
@@ -884,38 +815,15 @@ where
 {
     fn call_erased(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         request: Bytes,
         format: CodecFormat,
     ) -> StreamingHandlerResult {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
             let req = decode_request_view::<ReqView>(request, format)?;
-            let (stream, ctx) = handler.call(ctx, req).await?;
-
-            let encoded_stream: BoxStream<Result<Bytes, ConnectError>> = {
-                use futures::StreamExt as _;
-                Box::pin(
-                    futures::stream::unfold(
-                        (
-                            Box::pin(stream)
-                                as Pin<Box<dyn Stream<Item = Result<Res, ConnectError>> + Send>>,
-                            format,
-                        ),
-                        async |(mut stream, format)| match stream.next().await {
-                            Some(Ok(res)) => {
-                                let encoded = encode_response(&res, format);
-                                Some((encoded, (stream, format)))
-                            }
-                            Some(Err(e)) => Some((Err(e), (stream, format))),
-                            None => None,
-                        },
-                    )
-                    .fuse(),
-                )
-            };
-
-            Ok((encoded_stream, ctx))
+            let resp = handler.call(ctx, req).await?;
+            Ok(resp.map_body(|s| encode_body_stream(s, format)))
         })
     }
 }
@@ -926,15 +834,18 @@ where
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
+    /// The response body type. Typically `Res`.
+    type Body: Encodable<Res> + Send + 'static;
+
     /// Handle a client streaming RPC request with zero-copy view items.
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<OwnedView<ReqView>, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>>;
+        ctx: RequestContext,
+        requests: ServiceStream<OwnedView<ReqView>>,
+    ) -> BoxFuture<'static, ServiceResult<Self::Body>>;
 }
 
-/// Wrapper that implements ViewClientStreamingHandler for async functions.
+/// Wrapper that implements [`ViewClientStreamingHandler`] for async functions.
 pub struct FnViewClientStreamingHandler<F> {
     f: Arc<F>,
 }
@@ -946,39 +857,37 @@ impl<F> FnViewClientStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, ReqView, Res> ViewClientStreamingHandler<ReqView, Res>
+impl<F, Fut, ReqView, Res, B> ViewClientStreamingHandler<ReqView, Res>
     for FnViewClientStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<OwnedView<ReqView>, ConnectError>>) -> Fut
-        + Send
-        + Sync
-        + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<OwnedView<ReqView>>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
+    type Body = B;
+
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<OwnedView<ReqView>, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Res, Context), ConnectError>> {
+        ctx: RequestContext,
+        requests: ServiceStream<OwnedView<ReqView>>,
+    ) -> BoxFuture<'static, ServiceResult<B>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, requests).await })
     }
 }
 
 /// Helper function to create a view client streaming handler from an async function.
-pub fn view_client_streaming_handler_fn<F, Fut, ReqView, Res>(
+pub fn view_client_streaming_handler_fn<F, Fut, ReqView, Res, B>(
     f: F,
 ) -> FnViewClientStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<OwnedView<ReqView>, ConnectError>>) -> Fut
-        + Send
-        + Sync
-        + 'static,
-    Fut: Future<Output = Result<(Res, Context), ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<OwnedView<ReqView>>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<B>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
     FnViewClientStreamingHandler::new(f)
 }
@@ -1020,22 +929,21 @@ where
 {
     fn call_erased(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         requests: BoxStream<Result<Bytes, ConnectError>>,
         format: CodecFormat,
-    ) -> BoxFuture<'static, Result<(Bytes, Context), ConnectError>> {
+    ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>> {
         use futures::StreamExt as _;
-
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let request_stream: BoxStream<Result<OwnedView<ReqView>, ConnectError>> =
+            let request_stream: ServiceStream<OwnedView<ReqView>> =
                 Box::pin(requests.map(move |result| {
                     result.and_then(|raw| decode_request_view::<ReqView>(raw, format))
                 }));
-
-            let (res, ctx) = handler.call(ctx, request_stream).await?;
-            let response_bytes = encode_response(&res, format)?;
-            Ok((response_bytes, ctx))
+            handler
+                .call(ctx, request_stream)
+                .await?
+                .encode::<Res>(format)
         })
     }
 }
@@ -1046,18 +954,15 @@ where
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
-    /// The stream type returned by this handler.
-    type Stream: Stream<Item = Result<Res, ConnectError>> + Send + 'static;
-
     /// Handle a bidi streaming RPC request with zero-copy view items.
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<OwnedView<ReqView>, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>>;
+        ctx: RequestContext,
+        requests: ServiceStream<OwnedView<ReqView>>,
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
 }
 
-/// Wrapper that implements ViewBidiStreamingHandler for async functions.
+/// Wrapper that implements [`ViewBidiStreamingHandler`] for async functions.
 pub struct FnViewBidiStreamingHandler<F> {
     f: Arc<F>,
 }
@@ -1069,41 +974,28 @@ impl<F> FnViewBidiStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, S, ReqView, Res> ViewBidiStreamingHandler<ReqView, Res>
-    for FnViewBidiStreamingHandler<F>
+impl<F, Fut, ReqView, Res> ViewBidiStreamingHandler<ReqView, Res> for FnViewBidiStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<OwnedView<ReqView>, ConnectError>>) -> Fut
-        + Send
-        + Sync
-        + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<OwnedView<ReqView>>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
-    type Stream = S;
-
     fn call(
         &self,
-        ctx: Context,
-        requests: BoxStream<Result<OwnedView<ReqView>, ConnectError>>,
-    ) -> BoxFuture<'static, Result<(Self::Stream, Context), ConnectError>> {
+        ctx: RequestContext,
+        requests: ServiceStream<OwnedView<ReqView>>,
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, requests).await })
     }
 }
 
 /// Helper function to create a view bidi streaming handler from an async function.
-pub fn view_bidi_streaming_handler_fn<F, Fut, S, ReqView, Res>(
-    f: F,
-) -> FnViewBidiStreamingHandler<F>
+pub fn view_bidi_streaming_handler_fn<F, Fut, ReqView, Res>(f: F) -> FnViewBidiStreamingHandler<F>
 where
-    F: Fn(Context, BoxStream<Result<OwnedView<ReqView>, ConnectError>>) -> Fut
-        + Send
-        + Sync
-        + 'static,
-    Fut: Future<Output = Result<(S, Context), ConnectError>> + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+    F: Fn(RequestContext, ServiceStream<OwnedView<ReqView>>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
@@ -1147,130 +1039,19 @@ where
 {
     fn call_erased(
         &self,
-        ctx: Context,
+        ctx: RequestContext,
         requests: BoxStream<Result<Bytes, ConnectError>>,
         format: CodecFormat,
     ) -> StreamingHandlerResult {
         use futures::StreamExt as _;
-
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let request_stream: BoxStream<Result<OwnedView<ReqView>, ConnectError>> =
+            let request_stream: ServiceStream<OwnedView<ReqView>> =
                 Box::pin(requests.map(move |result| {
                     result.and_then(|raw| decode_request_view::<ReqView>(raw, format))
                 }));
-
-            let (stream, ctx) = handler.call(ctx, request_stream).await?;
-
-            let encoded_stream: BoxStream<Result<Bytes, ConnectError>> = {
-                Box::pin(
-                    futures::stream::unfold(
-                        (
-                            Box::pin(stream)
-                                as Pin<Box<dyn Stream<Item = Result<Res, ConnectError>> + Send>>,
-                            format,
-                        ),
-                        async |(mut stream, format)| match stream.next().await {
-                            Some(Ok(res)) => {
-                                let encoded = encode_response(&res, format);
-                                Some((encoded, (stream, format)))
-                            }
-                            Some(Err(e)) => Some((Err(e), (stream, format))),
-                            None => None,
-                        },
-                    )
-                    .fuse(),
-                )
-            };
-
-            Ok((encoded_stream, ctx))
-        })
-    }
-}
-
-/// Type-erased bidi streaming handler for use in the router.
-pub(crate) trait ErasedBidiStreamingHandler: Send + Sync {
-    /// Handle a bidi streaming request with a stream of raw message bytes.
-    fn call_erased(
-        &self,
-        ctx: Context,
-        requests: BoxStream<Result<Bytes, ConnectError>>,
-        format: CodecFormat,
-    ) -> StreamingHandlerResult;
-}
-
-/// Wrapper to erase the types from a bidi streaming handler.
-pub(crate) struct BidiStreamingHandlerWrapper<H, Req, Res>
-where
-    H: BidiStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
-{
-    handler: Arc<H>,
-    _phantom: std::marker::PhantomData<fn(Req) -> Res>,
-}
-
-impl<H, Req, Res> BidiStreamingHandlerWrapper<H, Req, Res>
-where
-    H: BidiStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
-{
-    /// Create a new wrapper around the given bidi streaming handler.
-    pub fn new(handler: H) -> Self {
-        Self {
-            handler: Arc::new(handler),
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<H, Req, Res> ErasedBidiStreamingHandler for BidiStreamingHandlerWrapper<H, Req, Res>
-where
-    H: BidiStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
-{
-    fn call_erased(
-        &self,
-        ctx: Context,
-        requests: BoxStream<Result<Bytes, ConnectError>>,
-        format: CodecFormat,
-    ) -> StreamingHandlerResult {
-        use futures::StreamExt as _;
-
-        let handler = Arc::clone(&self.handler);
-        Box::pin(async move {
-            // Map the raw bytes stream through decode to create a typed stream
-            let request_stream: BoxStream<Result<Req, ConnectError>> = Box::pin(
-                requests.map(move |result| result.and_then(|raw| decode_request(&raw, format))),
-            );
-
-            let (stream, ctx) = handler.call(ctx, request_stream).await?;
-
-            // Map the stream to encode each response
-            let encoded_stream: BoxStream<Result<Bytes, ConnectError>> = {
-                Box::pin(
-                    futures::stream::unfold(
-                        (
-                            Box::pin(stream)
-                                as Pin<Box<dyn Stream<Item = Result<Res, ConnectError>> + Send>>,
-                            format,
-                        ),
-                        async |(mut stream, format)| match stream.next().await {
-                            Some(Ok(res)) => {
-                                let encoded = encode_response(&res, format);
-                                Some((encoded, (stream, format)))
-                            }
-                            Some(Err(e)) => Some((Err(e), (stream, format))),
-                            None => None,
-                        },
-                    )
-                    .fuse(),
-                )
-            };
-
-            Ok((encoded_stream, ctx))
+            let resp = handler.call(ctx, request_stream).await?;
+            Ok(resp.map_body(|s| encode_body_stream(s, format)))
         })
     }
 }
@@ -1280,8 +1061,6 @@ mod tests {
     use super::*;
     use buffa_types::google::protobuf::__buffa::view::StringValueView;
     use buffa_types::google::protobuf::StringValue;
-
-    // ── decode_request / encode_response (owned types) ─────────────────
 
     #[test]
     fn test_decode_request_proto() {
@@ -1293,7 +1072,6 @@ mod tests {
 
     #[test]
     fn test_decode_request_json() {
-        // StringValue serializes as a bare JSON string per WKT mapping
         let encoded = Bytes::from_static(b"\"world\"");
         let decoded: StringValue = decode_request(&encoded, CodecFormat::Json).unwrap();
         assert_eq!(decoded.value, "world");
@@ -1314,52 +1092,15 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_response_proto() {
-        let msg = StringValue::from("reply");
-        let encoded = encode_response(&msg, CodecFormat::Proto).unwrap();
-        // Round-trip to verify
-        let decoded = StringValue::decode_from_slice(&encoded).unwrap();
-        assert_eq!(decoded.value, "reply");
-    }
-
-    #[test]
-    fn test_encode_response_json() {
-        let msg = StringValue::from("reply");
-        let encoded = encode_response(&msg, CodecFormat::Json).unwrap();
-        // StringValue serializes as a bare JSON string
-        assert_eq!(&encoded[..], b"\"reply\"");
-    }
-
-    #[test]
-    fn test_proto_roundtrip() {
-        let msg = StringValue::from("roundtrip");
-        let encoded = encode_response(&msg, CodecFormat::Proto).unwrap();
-        let decoded: StringValue = decode_request(&encoded, CodecFormat::Proto).unwrap();
-        assert_eq!(decoded, msg);
-    }
-
-    #[test]
-    fn test_json_roundtrip() {
-        let msg = StringValue::from("roundtrip");
-        let encoded = encode_response(&msg, CodecFormat::Json).unwrap();
-        let decoded: StringValue = decode_request(&encoded, CodecFormat::Json).unwrap();
-        assert_eq!(decoded.value, msg.value);
-    }
-
-    // ── decode_request_view (zero-copy views) ───────────────────────────
-
-    #[test]
     fn test_decode_request_view_proto() {
         let msg = StringValue::from("view-test");
         let encoded = Bytes::from(msg.encode_to_vec());
         let view = decode_request_view::<StringValueView>(encoded, CodecFormat::Proto).unwrap();
-        // OwnedView derefs to the inner view
         assert_eq!(view.value, "view-test");
     }
 
     #[test]
     fn test_decode_request_view_json() {
-        // JSON path: deserialize to owned, re-encode to proto, decode as view
         let encoded = Bytes::from_static(b"\"json-view\"");
         let view = decode_request_view::<StringValueView>(encoded, CodecFormat::Json).unwrap();
         assert_eq!(view.value, "json-view");
@@ -1370,70 +1111,5 @@ mod tests {
         let garbage = Bytes::from_static(&[0xFF, 0xFF, 0xFF]);
         let err = decode_request_view::<StringValueView>(garbage, CodecFormat::Proto).unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
-    }
-
-    // ── Context helpers ────────────────────────────────────────────────
-
-    #[test]
-    fn test_context_new() {
-        let mut headers = http::HeaderMap::new();
-        headers.insert("x-custom", http::HeaderValue::from_static("value"));
-        let ctx = Context::new(headers);
-        assert_eq!(
-            ctx.header(&http::header::HeaderName::from_static("x-custom"))
-                .unwrap(),
-            "value"
-        );
-        assert!(ctx.response_headers.is_empty());
-        assert!(ctx.trailers.is_empty());
-        assert!(ctx.deadline.is_none());
-        assert!(ctx.compress_response.is_none());
-    }
-
-    #[test]
-    fn test_context_set_trailer() {
-        let mut ctx = Context::default();
-        ctx.set_trailer(
-            http::header::HeaderName::from_static("x-trailer"),
-            http::HeaderValue::from_static("trailer-value"),
-        );
-        assert_eq!(ctx.trailers.get("x-trailer").unwrap(), "trailer-value");
-    }
-
-    #[test]
-    fn test_context_set_compression() {
-        let mut ctx = Context::default();
-        ctx.set_compression(true);
-        assert_eq!(ctx.compress_response, Some(true));
-        ctx.set_compression(false);
-        assert_eq!(ctx.compress_response, Some(false));
-    }
-
-    #[test]
-    fn test_context_with_deadline() {
-        // Server dispatch paths must populate deadline so handlers can
-        // propagate it to downstream calls (e.g. as a grpc-timeout header).
-        let now = std::time::Instant::now();
-        let deadline = now + std::time::Duration::from_secs(5);
-        let ctx = Context::new(http::HeaderMap::new()).with_deadline(Some(deadline));
-        assert_eq!(ctx.deadline, Some(deadline));
-
-        let ctx = Context::new(http::HeaderMap::new()).with_deadline(None);
-        assert_eq!(ctx.deadline, None);
-    }
-
-    #[test]
-    fn test_context_with_extensions() {
-        #[derive(Clone, Debug, PartialEq)]
-        struct Peer(u32);
-
-        let mut ext = http::Extensions::new();
-        ext.insert(Peer(42));
-        let ctx = Context::new(http::HeaderMap::new()).with_extensions(ext);
-        assert_eq!(ctx.extensions.get::<Peer>(), Some(&Peer(42)));
-
-        // Default-constructed context has empty extensions.
-        let ctx = Context::default();
-        assert!(ctx.extensions.get::<Peer>().is_none());
     }
 }

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -9,6 +9,18 @@
 //! [`Response<B>`](crate::Response) carrying the body plus any response
 //! headers/trailers/compression hint. See [`crate::response`] for the
 //! type definitions.
+//!
+//! # Why response metadata lives on `Response<B>`
+//!
+//! The earlier `Context` design conflated request-side reads
+//! (`headers`, `deadline`, `extensions`) with response-side writes
+//! (`response_headers`, `trailers`, `compress_response`) on one struct
+//! that the handler took ownership of and threaded back. Splitting it
+//! gives a clean in/out separation: handlers that don't touch response
+//! metadata bind `_ctx` and return `Ok(body.into())` with no `mut`
+//! ceremony, while handlers that do attach metadata get a fluent
+//! builder (`Response::new(body).with_header(..).with_trailer(..)`)
+//! instead of field-mutation followed by `Ok((body, ctx))`.
 
 use std::pin::Pin;
 use std::sync::Arc;

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -160,6 +160,7 @@ pub mod error;
 pub(crate) mod grpc_status;
 pub mod handler;
 pub mod protocol;
+pub mod response;
 pub mod router;
 pub mod service;
 
@@ -189,10 +190,9 @@ pub use dispatcher::Chain;
 pub use dispatcher::Dispatcher;
 pub use dispatcher::MethodDescriptor;
 
-// Handler traits and context
+// Handler traits and request/response types
 pub use handler::BidiStreamingHandler;
 pub use handler::ClientStreamingHandler;
-pub use handler::Context;
 pub use handler::Handler;
 pub use handler::StreamingHandler;
 pub use handler::ViewBidiStreamingHandler;
@@ -207,6 +207,11 @@ pub use handler::view_bidi_streaming_handler_fn;
 pub use handler::view_client_streaming_handler_fn;
 pub use handler::view_handler_fn;
 pub use handler::view_streaming_handler_fn;
+pub use response::Encodable;
+pub use response::RequestContext;
+pub use response::Response;
+pub use response::ServiceResult;
+pub use response::ServiceStream;
 
 // Error types
 pub use error::ConnectError;

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -208,6 +208,7 @@ pub use handler::view_client_streaming_handler_fn;
 pub use handler::view_handler_fn;
 pub use handler::view_streaming_handler_fn;
 pub use response::Encodable;
+pub use response::EncodedResponse;
 pub use response::RequestContext;
 pub use response::Response;
 pub use response::ServiceResult;

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -197,6 +197,15 @@ impl<B> From<B> for Response<B> {
     }
 }
 
+impl<T> Response<ServiceStream<T>> {
+    /// Wrap a streaming body, boxing and unsize-coercing it to
+    /// [`ServiceStream<T>`]. Handles the explicit coercion that
+    /// `Ok(Box::pin(s).into())` would otherwise need.
+    pub fn stream(s: impl Stream<Item = Result<T, ConnectError>> + Send + 'static) -> Self {
+        Self::new(Box::pin(s))
+    }
+}
+
 /// Result type returned by handler trait methods.
 ///
 /// `B` is the body type — typically the owned response message, or any

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -1,0 +1,352 @@
+//! Handler request/response types.
+//!
+//! This module splits the old `Context` struct into a read-only
+//! [`RequestContext`] (passed *into* handlers) and a [`Response<B>`]
+//! wrapper (returned *from* handlers). The body type `B` is bounded by
+//! [`Encodable<M>`] in the generated trait so handlers can return either
+//! the owned message `M` or, in a follow-up, a borrowing view.
+
+use std::pin::Pin;
+use std::time::Instant;
+
+use buffa::Message;
+use bytes::Bytes;
+use futures::Stream;
+use http::HeaderMap;
+use http::header::{HeaderName, HeaderValue};
+use serde::Serialize;
+
+use crate::codec::CodecFormat;
+use crate::error::ConnectError;
+
+// ---------------------------------------------------------------------------
+// RequestContext
+// ---------------------------------------------------------------------------
+
+/// Read-only request context passed to RPC handlers.
+///
+/// Carries the request headers, parsed deadline, and any
+/// connection-scoped extensions (peer address, TLS certs, auth context)
+/// inserted by a tower layer in front of the service. Handlers do *not*
+/// return this; response-side metadata lives on [`Response`].
+#[derive(Debug, Clone, Default)]
+pub struct RequestContext {
+    /// Request headers (after protocol-prefix stripping).
+    pub headers: HeaderMap,
+    /// Absolute request deadline parsed from the protocol's timeout header,
+    /// if any. Propagate to downstream calls.
+    pub deadline: Option<Instant>,
+    /// Request extensions carried from the underlying `http::Request`.
+    ///
+    /// This is the passthrough for connection-scoped metadata that a
+    /// tower layer in front of the service can attach — TLS peer
+    /// certificates, remote socket address, auth context, etc. The
+    /// dispatch path moves `parts.extensions` here verbatim; handlers
+    /// read it with `ctx.extensions.get::<T>()`.
+    pub extensions: http::Extensions,
+}
+
+impl RequestContext {
+    /// Create a new context with the given request headers.
+    pub fn new(headers: HeaderMap) -> Self {
+        Self {
+            headers,
+            deadline: None,
+            extensions: http::Extensions::new(),
+        }
+    }
+
+    /// Set the request deadline (absolute `Instant`).
+    #[must_use]
+    pub fn with_deadline(mut self, deadline: Option<Instant>) -> Self {
+        self.deadline = deadline;
+        self
+    }
+
+    /// Attach request extensions captured from the underlying `http::Request`.
+    #[must_use]
+    pub fn with_extensions(mut self, extensions: http::Extensions) -> Self {
+        self.extensions = extensions;
+        self
+    }
+
+    /// Get a request header value.
+    pub fn header(&self, key: &HeaderName) -> Option<&HeaderValue> {
+        self.headers.get(key)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response<B>
+// ---------------------------------------------------------------------------
+
+/// Handler response wrapper: a body plus optional response headers,
+/// trailers, and compression hint.
+///
+/// `B` is bounded by [`Encodable<M>`] in the generated service trait so
+/// handlers can return the owned message `M` (the common case), or any
+/// type that encodes to the same wire bytes.
+///
+/// # Happy path
+///
+/// `From<B>` makes `Ok(body.into())` the shortest spelling:
+///
+/// ```rust,ignore
+/// async fn say(&self, _ctx: RequestContext, req: OwnedSayRequestView)
+///     -> ServiceResult<SayResponse>
+/// {
+///     Ok(SayResponse { sentence: reply, ..Default::default() }.into())
+/// }
+/// ```
+///
+/// # With metadata
+///
+/// ```rust,ignore
+/// Ok(Response::new(reply)
+///     .with_header("x-request-id", id)
+///     .with_trailer("x-timing", elapsed))
+/// ```
+#[derive(Debug, Clone)]
+pub struct Response<B> {
+    /// The response body.
+    pub body: B,
+    /// Response headers to send before the body.
+    pub headers: HeaderMap,
+    /// Trailers to send after the body. Sent as HTTP/2 trailing
+    /// HEADERS for gRPC, or as `trailer-`-prefixed headers / the
+    /// EndStreamResponse JSON for Connect.
+    pub trailers: HeaderMap,
+    /// Whether to compress the response. `None` uses the server's
+    /// compression policy; `Some(false)` disables compression for this
+    /// response, `Some(true)` forces it.
+    pub compress: Option<bool>,
+}
+
+impl<B> Response<B> {
+    /// Wrap a body with empty response metadata.
+    pub fn new(body: B) -> Self {
+        Self {
+            body,
+            headers: HeaderMap::new(),
+            trailers: HeaderMap::new(),
+            compress: None,
+        }
+    }
+
+    /// Append a response header.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` or `value` cannot be converted into the
+    /// corresponding header type. Use the `headers` field directly for
+    /// fallible insertion.
+    #[must_use]
+    pub fn with_header<K, V>(mut self, name: K, value: V) -> Self
+    where
+        K: TryInto<HeaderName>,
+        K::Error: std::fmt::Debug,
+        V: TryInto<HeaderValue>,
+        V::Error: std::fmt::Debug,
+    {
+        self.headers
+            .append(name.try_into().unwrap(), value.try_into().unwrap());
+        self
+    }
+
+    /// Append a response trailer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` or `value` cannot be converted into the
+    /// corresponding header type. Use the `trailers` field directly for
+    /// fallible insertion.
+    #[must_use]
+    pub fn with_trailer<K, V>(mut self, name: K, value: V) -> Self
+    where
+        K: TryInto<HeaderName>,
+        K::Error: std::fmt::Debug,
+        V: TryInto<HeaderValue>,
+        V::Error: std::fmt::Debug,
+    {
+        self.trailers
+            .append(name.try_into().unwrap(), value.try_into().unwrap());
+        self
+    }
+
+    /// Override the server's compression policy for this response.
+    #[must_use]
+    pub fn compress(mut self, enabled: bool) -> Self {
+        self.compress = Some(enabled);
+        self
+    }
+
+    /// Replace the body, preserving headers/trailers/compression.
+    pub fn map_body<C>(self, f: impl FnOnce(B) -> C) -> Response<C> {
+        Response {
+            body: f(self.body),
+            headers: self.headers,
+            trailers: self.trailers,
+            compress: self.compress,
+        }
+    }
+}
+
+impl<B> From<B> for Response<B> {
+    fn from(body: B) -> Self {
+        Self::new(body)
+    }
+}
+
+/// Result type returned by handler trait methods.
+///
+/// `B` is the body type — typically the owned response message, or any
+/// `impl Encodable<M>`.
+pub type ServiceResult<B> = Result<Response<B>, ConnectError>;
+
+/// Boxed `Send` stream of `Result<T, ConnectError>`.
+///
+/// Used as the request type for client/bidi-streaming handlers and the
+/// body type for server/bidi-streaming responses.
+pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> + Send>>;
+
+// ---------------------------------------------------------------------------
+// Encodable<M>
+// ---------------------------------------------------------------------------
+
+/// Encodes to the same wire bytes as proto message `M`.
+///
+/// This is the bound on the response body in generated trait methods.
+/// The blanket impl for `M: Message + Serialize` covers the owned
+/// message; a follow-up change adds an impl for buffa's `MView<'_>` so
+/// handlers can return borrowed responses.
+///
+/// `encode` is fallible: the owned-message impl never errors, but a
+/// view-body impl is proto-only (view types lack `Serialize`) and must
+/// error on `CodecFormat::Json`.
+pub trait Encodable<M> {
+    /// Encode `self` as wire bytes for `M` in the requested format.
+    fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError>;
+}
+
+impl<M: Message + Serialize> Encodable<M> for M {
+    fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError> {
+        match codec {
+            CodecFormat::Proto => Ok(self.encode_to_bytes()),
+            CodecFormat::Json => serde_json::to_vec(self).map(Bytes::from).map_err(|e| {
+                ConnectError::internal(format!("failed to encode JSON response: {e}"))
+            }),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EncodedResponse (dispatcher boundary)
+// ---------------------------------------------------------------------------
+
+/// A [`Response`] with the body already encoded to bytes.
+///
+/// This is what the [`Dispatcher`](crate::Dispatcher) returns to the
+/// protocol layer — encoding happens inside the dispatcher so the body
+/// type stays generic across the trait boundary.
+pub type EncodedResponse = Response<Bytes>;
+
+impl<B> Response<B> {
+    /// Encode the body to bytes via [`Encodable<M>`], preserving
+    /// response metadata.
+    #[doc(hidden)] // exposed for dispatcher::codegen (generated code)
+    pub fn encode<M>(self, codec: CodecFormat) -> Result<EncodedResponse, ConnectError>
+    where
+        B: Encodable<M>,
+    {
+        let bytes = self.body.encode(codec)?;
+        Ok(Response {
+            body: bytes,
+            headers: self.headers,
+            trailers: self.trailers,
+            compress: self.compress,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use buffa_types::google::protobuf::StringValue;
+
+    #[test]
+    fn response_from_body() {
+        let r: Response<StringValue> = StringValue::from("hi").into();
+        assert_eq!(r.body.value, "hi");
+        assert!(r.headers.is_empty());
+        assert!(r.trailers.is_empty());
+        assert_eq!(r.compress, None);
+    }
+
+    #[test]
+    fn response_builder() {
+        let r = Response::new(StringValue::from("hi"))
+            .with_header("x-a", "1")
+            .with_trailer("x-b", "2")
+            .compress(true);
+        assert_eq!(r.headers.get("x-a").unwrap(), "1");
+        assert_eq!(r.trailers.get("x-b").unwrap(), "2");
+        assert_eq!(r.compress, Some(true));
+    }
+
+    #[test]
+    fn encodable_owned_proto() {
+        let m = StringValue::from("hello");
+        let bytes = Encodable::<StringValue>::encode(&m, CodecFormat::Proto).unwrap();
+        assert_eq!(
+            StringValue::decode_from_slice(&bytes).unwrap().value,
+            "hello"
+        );
+    }
+
+    #[test]
+    fn encodable_owned_json() {
+        let m = StringValue::from("hello");
+        let bytes = Encodable::<StringValue>::encode(&m, CodecFormat::Json).unwrap();
+        assert_eq!(&bytes[..], b"\"hello\"");
+    }
+
+    #[test]
+    fn response_encode() {
+        let r = Response::new(StringValue::from("hi")).with_header("x-a", "1");
+        let enc = r.encode::<StringValue>(CodecFormat::Proto).unwrap();
+        assert_eq!(enc.headers.get("x-a").unwrap(), "1");
+        assert_eq!(
+            StringValue::decode_from_slice(&enc.body).unwrap().value,
+            "hi"
+        );
+    }
+
+    #[test]
+    fn request_context_new() {
+        let mut h = HeaderMap::new();
+        h.insert("x-custom", HeaderValue::from_static("v"));
+        let ctx = RequestContext::new(h);
+        assert_eq!(
+            ctx.header(&HeaderName::from_static("x-custom")).unwrap(),
+            "v"
+        );
+        assert!(ctx.deadline.is_none());
+    }
+
+    #[test]
+    fn request_context_with_deadline() {
+        let d = Instant::now();
+        let ctx = RequestContext::new(HeaderMap::new()).with_deadline(Some(d));
+        assert_eq!(ctx.deadline, Some(d));
+    }
+
+    #[test]
+    fn request_context_with_extensions() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct Peer(u32);
+        let mut ext = http::Extensions::new();
+        ext.insert(Peer(7));
+        let ctx = RequestContext::new(HeaderMap::new()).with_extensions(ext);
+        assert_eq!(ctx.extensions.get::<Peer>(), Some(&Peer(7)));
+    }
+}

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -135,11 +135,16 @@ impl<B> Response<B> {
 
     /// Append a response header.
     ///
+    /// Uses [`HeaderMap::append`], so calling twice with the same name
+    /// accumulates values rather than replacing.
+    ///
     /// # Panics
     ///
     /// Panics if `name` or `value` cannot be converted into the
-    /// corresponding header type. Use the `headers` field directly for
-    /// fallible insertion.
+    /// corresponding header type (invalid characters, non-ASCII name,
+    /// etc.). Use [`try_with_header`](Self::try_with_header) for
+    /// dynamic values, or the `headers` field directly for full
+    /// control.
     #[must_use]
     pub fn with_header<K, V>(mut self, name: K, value: V) -> Self
     where
@@ -153,13 +158,37 @@ impl<B> Response<B> {
         self
     }
 
+    /// Append a response header, returning an error if `name` or
+    /// `value` is invalid.
+    ///
+    /// Non-panicking sibling of [`with_header`](Self::with_header) for
+    /// dynamic values. Uses [`HeaderMap::append`], so repeated calls
+    /// accumulate.
+    pub fn try_with_header<K, V>(mut self, name: K, value: V) -> Result<Self, http::Error>
+    where
+        K: TryInto<HeaderName>,
+        K::Error: Into<http::Error>,
+        V: TryInto<HeaderValue>,
+        V::Error: Into<http::Error>,
+    {
+        self.headers.append(
+            name.try_into().map_err(Into::into)?,
+            value.try_into().map_err(Into::into)?,
+        );
+        Ok(self)
+    }
+
     /// Append a response trailer.
+    ///
+    /// Uses [`HeaderMap::append`], so calling twice with the same name
+    /// accumulates values rather than replacing.
     ///
     /// # Panics
     ///
     /// Panics if `name` or `value` cannot be converted into the
-    /// corresponding header type. Use the `trailers` field directly for
-    /// fallible insertion.
+    /// corresponding header type. Use
+    /// [`try_with_trailer`](Self::try_with_trailer) for dynamic
+    /// values, or the `trailers` field directly for full control.
     #[must_use]
     pub fn with_trailer<K, V>(mut self, name: K, value: V) -> Self
     where
@@ -171,6 +200,26 @@ impl<B> Response<B> {
         self.trailers
             .append(name.try_into().unwrap(), value.try_into().unwrap());
         self
+    }
+
+    /// Append a response trailer, returning an error if `name` or
+    /// `value` is invalid.
+    ///
+    /// Non-panicking sibling of [`with_trailer`](Self::with_trailer)
+    /// for dynamic values. Uses [`HeaderMap::append`], so repeated
+    /// calls accumulate.
+    pub fn try_with_trailer<K, V>(mut self, name: K, value: V) -> Result<Self, http::Error>
+    where
+        K: TryInto<HeaderName>,
+        K::Error: Into<http::Error>,
+        V: TryInto<HeaderValue>,
+        V::Error: Into<http::Error>,
+    {
+        self.trailers.append(
+            name.try_into().map_err(Into::into)?,
+            value.try_into().map_err(Into::into)?,
+        );
+        Ok(self)
     }
 
     /// Override the server's compression policy for this response.
@@ -228,6 +277,11 @@ pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> +
 /// The blanket impl for `M: Message + Serialize` covers the owned
 /// message; a follow-up change adds an impl for buffa's `MView<'_>` so
 /// handlers can return borrowed responses.
+///
+/// # Contract
+///
+/// Implementations must produce bytes that decode as a valid `M` in
+/// the given format.
 ///
 /// `encode` is fallible: the owned-message impl never errors, but a
 /// view-body impl is proto-only (view types lack `Serialize`) and must
@@ -347,6 +401,62 @@ mod tests {
         let d = Instant::now();
         let ctx = RequestContext::new(HeaderMap::new()).with_deadline(Some(d));
         assert_eq!(ctx.deadline, Some(d));
+    }
+
+    #[test]
+    fn response_map_body_preserves_metadata() {
+        let r = Response::new(2u32)
+            .with_header("x-h", "1")
+            .with_trailer("x-t", "2")
+            .compress(true);
+        let r = r.map_body(|n| n.to_string());
+        assert_eq!(r.body, "2");
+        assert_eq!(r.headers.get("x-h").unwrap(), "1");
+        assert_eq!(r.trailers.get("x-t").unwrap(), "2");
+        assert_eq!(r.compress, Some(true));
+    }
+
+    #[tokio::test]
+    async fn response_stream_yields_items() {
+        use futures::StreamExt;
+        let r: Response<ServiceStream<i32>> =
+            Response::stream(futures::stream::iter([Ok(1), Ok(2), Ok(3)]));
+        let collected: Vec<_> = r.body.map(|x| x.unwrap()).collect().await;
+        assert_eq!(collected, vec![1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn with_header_panics_on_invalid_name() {
+        let _ = Response::new(()).with_header("invalid header name", "v");
+    }
+
+    #[test]
+    fn try_with_header_errors_on_invalid_name() {
+        let err = Response::new(())
+            .try_with_header("invalid header name", "v")
+            .unwrap_err();
+        assert!(err.is::<http::header::InvalidHeaderName>());
+    }
+
+    #[test]
+    fn try_with_header_ok_appends() {
+        let r = Response::new(())
+            .try_with_header("x-a", "1")
+            .unwrap()
+            .try_with_header("x-a", "2")
+            .unwrap();
+        let vals: Vec<_> = r.headers.get_all("x-a").iter().collect();
+        assert_eq!(vals.len(), 2);
+    }
+
+    #[test]
+    fn try_with_trailer_errors_on_invalid_value() {
+        // Newlines are not permitted in header values.
+        let err = Response::new(())
+            .try_with_trailer("x-t", "bad\nvalue")
+            .unwrap_err();
+        assert!(err.is::<http::header::InvalidHeaderValue>());
     }
 
     #[test]

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -4,7 +4,8 @@
 //! [`RequestContext`] (passed *into* handlers) and a [`Response<B>`]
 //! wrapper (returned *from* handlers). The body type `B` is bounded by
 //! [`Encodable<M>`] in the generated trait so handlers can return either
-//! the owned message `M` or, in a follow-up, a borrowing view.
+//! the owned message `M` or a borrowing view (see the `MaybeBorrowed`
+//! type).
 
 use std::pin::Pin;
 use std::time::Instant;
@@ -71,7 +72,7 @@ impl RequestContext {
     }
 
     /// Get a request header value.
-    pub fn header(&self, key: &HeaderName) -> Option<&HeaderValue> {
+    pub fn header(&self, key: impl http::header::AsHeaderName) -> Option<&HeaderValue> {
         self.headers.get(key)
     }
 }
@@ -89,13 +90,13 @@ impl RequestContext {
 ///
 /// # Happy path
 ///
-/// `From<B>` makes `Ok(body.into())` the shortest spelling:
+/// [`Response::ok`] is the bare-body shorthand:
 ///
 /// ```rust,ignore
 /// async fn say(&self, _ctx: RequestContext, req: OwnedSayRequestView)
 ///     -> ServiceResult<SayResponse>
 /// {
-///     Ok(SayResponse { sentence: reply, ..Default::default() }.into())
+///     Response::ok(SayResponse { sentence: reply, ..Default::default() })
 /// }
 /// ```
 ///
@@ -233,9 +234,12 @@ impl<B> Response<B> {
     }
 
     /// Override the server's compression policy for this response.
+    ///
+    /// `true` forces compression, `false` disables it, `None` (or
+    /// never calling this) defers to the server's policy.
     #[must_use]
-    pub fn compress(mut self, enabled: bool) -> Self {
-        self.compress = Some(enabled);
+    pub fn compress(mut self, enabled: impl Into<Option<bool>>) -> Self {
+        self.compress = enabled.into();
         self
     }
 
@@ -263,6 +267,14 @@ impl<T> Response<ServiceStream<T>> {
     pub fn stream(s: impl Stream<Item = Result<T, ConnectError>> + Send + 'static) -> Self {
         Self::new(Box::pin(s))
     }
+
+    /// Shorthand for `Ok(Response::stream(s))` — the bare-stream
+    /// happy path.
+    pub fn stream_ok(
+        s: impl Stream<Item = Result<T, ConnectError>> + Send + 'static,
+    ) -> ServiceResult<ServiceStream<T>> {
+        Ok(Self::stream(s))
+    }
 }
 
 /// Result type returned by handler trait methods.
@@ -285,7 +297,7 @@ pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> +
 ///
 /// This is the bound on the response body in generated trait methods.
 /// The blanket impl for `M: Message + Serialize` covers the owned
-/// message; a follow-up change adds an impl for buffa's `MView<'_>` so
+/// message; the `MaybeBorrowed` type covers buffa's `MView<'_>` so
 /// handlers can return borrowed responses.
 ///
 /// # Contract
@@ -345,6 +357,30 @@ impl<B> Response<B> {
 mod tests {
     use super::*;
     use buffa_types::google::protobuf::StringValue;
+
+    #[tokio::test]
+    async fn response_stream_ok_shorthand() {
+        use futures::StreamExt;
+        let r: ServiceResult<ServiceStream<i32>> =
+            Response::stream_ok(futures::stream::iter([Ok(7)]));
+        let collected: Vec<_> = r.unwrap().body.map(|x| x.unwrap()).collect().await;
+        assert_eq!(collected, vec![7]);
+    }
+
+    #[test]
+    fn compress_tristate() {
+        assert_eq!(Response::new(()).compress(true).compress, Some(true));
+        assert_eq!(Response::new(()).compress(false).compress, Some(false));
+        assert_eq!(Response::new(()).compress(None).compress, None);
+    }
+
+    #[test]
+    fn header_accepts_str() {
+        let mut h = HeaderMap::new();
+        h.insert("x-custom", HeaderValue::from_static("v"));
+        let ctx = RequestContext::new(h);
+        assert_eq!(ctx.header("x-custom").unwrap(), "v");
+    }
 
     #[test]
     fn response_ok_shorthand() {
@@ -408,7 +444,7 @@ mod tests {
         h.insert("x-custom", HeaderValue::from_static("v"));
         let ctx = RequestContext::new(h);
         assert_eq!(
-            ctx.header(&HeaderName::from_static("x-custom")).unwrap(),
+            ctx.header(HeaderName::from_static("x-custom")).unwrap(),
             "v"
         );
         assert!(ctx.deadline.is_none());

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -123,6 +123,16 @@ pub struct Response<B> {
 }
 
 impl<B> Response<B> {
+    /// Shorthand for `Ok(Response::from(body))` — the bare-body happy
+    /// path.
+    ///
+    /// Use `Ok(Response::new(body).with_header(...))` when setting
+    /// response metadata; this constructor is for the common case of
+    /// "just the body".
+    pub fn ok(body: B) -> ServiceResult<B> {
+        Ok(Self::from(body))
+    }
+
     /// Wrap a body with empty response metadata.
     pub fn new(body: B) -> Self {
         Self {
@@ -335,6 +345,14 @@ impl<B> Response<B> {
 mod tests {
     use super::*;
     use buffa_types::google::protobuf::StringValue;
+
+    #[test]
+    fn response_ok_shorthand() {
+        let r: ServiceResult<u32> = Response::ok(42);
+        let r = r.unwrap();
+        assert_eq!(r.body, 42);
+        assert!(r.headers.is_empty());
+    }
 
     #[test]
     fn response_from_body() {

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -433,7 +433,7 @@ impl crate::dispatcher::Dispatcher for Router {
     fn call_unary(
         &self,
         path: &str,
-        ctx: crate::handler::Context,
+        ctx: crate::response::RequestContext,
         request: bytes::Bytes,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::UnaryResult {
@@ -446,7 +446,7 @@ impl crate::dispatcher::Dispatcher for Router {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: crate::handler::Context,
+        ctx: crate::response::RequestContext,
         request: bytes::Bytes,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::StreamingResult {
@@ -459,7 +459,7 @@ impl crate::dispatcher::Dispatcher for Router {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: crate::handler::Context,
+        ctx: crate::response::RequestContext,
         requests: crate::dispatcher::RequestStream,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::UnaryResult {
@@ -472,7 +472,7 @@ impl crate::dispatcher::Dispatcher for Router {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: crate::handler::Context,
+        ctx: crate::response::RequestContext,
         requests: crate::dispatcher::RequestStream,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::StreamingResult {

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -766,17 +766,19 @@ mod tests {
         let router = Router::new().route(
             "svc",
             "Slow",
-            crate::handler_fn(move |ctx: crate::Context, _req: buffa_types::Empty| {
-                let chans = Arc::clone(&chans);
-                async move {
-                    let taken = chans.lock().unwrap().take();
-                    if let Some((entered_tx, release_rx)) = taken {
-                        entered_tx.send(()).ok();
-                        release_rx.await.ok();
+            crate::handler_fn(
+                move |_ctx: crate::RequestContext, _req: buffa_types::Empty| {
+                    let chans = Arc::clone(&chans);
+                    async move {
+                        let taken = chans.lock().unwrap().take();
+                        if let Some((entered_tx, release_rx)) = taken {
+                            entered_tx.send(()).ok();
+                            release_rx.await.ok();
+                        }
+                        Ok(buffa_types::Empty::default().into())
                     }
-                    Ok((buffa_types::Empty::default(), ctx))
-                }
-            }),
+                },
+            ),
         );
 
         let bound = Server::bind("127.0.0.1:0").await.unwrap();
@@ -950,13 +952,15 @@ mod tests {
         let router = Router::new().route(
             "svc",
             "Echo",
-            crate::handler_fn(move |ctx: crate::Context, _req: buffa_types::Empty| {
-                let cap = Arc::clone(&handler_captured);
-                async move {
-                    *cap.lock().unwrap() = ctx.extensions.get::<PeerAddr>().cloned();
-                    Ok((buffa_types::Empty::default(), ctx))
-                }
-            }),
+            crate::handler_fn(
+                move |ctx: crate::RequestContext, _req: buffa_types::Empty| {
+                    let cap = Arc::clone(&handler_captured);
+                    async move {
+                        *cap.lock().unwrap() = ctx.extensions.get::<PeerAddr>().cloned();
+                        Ok(buffa_types::Empty::default().into())
+                    }
+                },
+            ),
         );
 
         let bound = Server::bind("127.0.0.1:0").await.unwrap();
@@ -1065,13 +1069,15 @@ mod tests {
         let router = Router::new().route(
             "svc",
             "Echo",
-            crate::handler_fn(move |ctx: crate::Context, _req: buffa_types::Empty| {
-                let cap = Arc::clone(&handler_captured);
-                async move {
-                    *cap.lock().unwrap() = ctx.extensions.get::<PeerCerts>().cloned();
-                    Ok((buffa_types::Empty::default(), ctx))
-                }
-            }),
+            crate::handler_fn(
+                move |ctx: crate::RequestContext, _req: buffa_types::Empty| {
+                    let cap = Arc::clone(&handler_captured);
+                    async move {
+                        *cap.lock().unwrap() = ctx.extensions.get::<PeerCerts>().cloned();
+                        Ok(buffa_types::Empty::default().into())
+                    }
+                },
+            ),
         );
 
         let bound = Server::bind("127.0.0.1:0")

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -775,7 +775,7 @@ mod tests {
                             entered_tx.send(()).ok();
                             release_rx.await.ok();
                         }
-                        Ok(buffa_types::Empty::default().into())
+                        crate::Response::ok(buffa_types::Empty::default())
                     }
                 },
             ),
@@ -957,7 +957,7 @@ mod tests {
                     let cap = Arc::clone(&handler_captured);
                     async move {
                         *cap.lock().unwrap() = ctx.extensions.get::<PeerAddr>().cloned();
-                        Ok(buffa_types::Empty::default().into())
+                        crate::Response::ok(buffa_types::Empty::default())
                     }
                 },
             ),
@@ -1074,7 +1074,7 @@ mod tests {
                     let cap = Arc::clone(&handler_captured);
                     async move {
                         *cap.lock().unwrap() = ctx.extensions.get::<PeerCerts>().cloned();
-                        Ok(buffa_types::Empty::default().into())
+                        crate::Response::ok(buffa_types::Empty::default())
                     }
                 },
             ),

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -3393,7 +3393,7 @@ mod tests {
                 let cap = Arc::clone(&handler_captured);
                 async move {
                     *cap.lock().unwrap() = ctx.extensions.get::<PeerTag>().cloned();
-                    Ok(buffa_types::Empty::default().into())
+                    crate::Response::ok(buffa_types::Empty::default())
                 }
             }),
         );

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -60,8 +60,8 @@ use crate::dispatcher::Dispatcher;
 use crate::envelope::Envelope;
 use crate::error::ConnectError;
 use crate::handler::BoxStream;
-use crate::handler::Context;
 use crate::protocol::Protocol;
+use crate::response::{EncodedResponse, RequestContext};
 use crate::router::MethodKind;
 use crate::router::Router;
 
@@ -751,12 +751,11 @@ impl StreamingResponseBody {
     /// HEADERS frames.
     fn new(
         response_stream: BoxStream<Result<Bytes, ConnectError>>,
-        ctx: Context,
+        trailers: http::HeaderMap,
         protocol: Protocol,
         compression: Option<(Arc<CompressionRegistry>, &'static str)>,
         compression_policy: CompressionPolicy,
     ) -> Self {
-        let trailers = ctx.trailers.clone();
         let inner: Pin<Box<dyn Stream<Item = Result<Frame<Bytes>, Infallible>> + Send>> =
             match protocol {
                 Protocol::Grpc => Box::pin(create_grpc_envelope_stream(
@@ -1565,12 +1564,12 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers)
+    let ctx = RequestContext::new(metadata.headers)
         .with_deadline(deadline)
         .with_extensions(extensions);
 
     // Call the handler with the appropriate codec format, applying timeout if specified
-    let (response_body, ctx) = if let Some(timeout) = metadata.timeout {
+    let resp: EncodedResponse = if let Some(timeout) = metadata.timeout {
         tokio::time::timeout(
             timeout,
             dispatcher.call_unary(&path, ctx, body, codec_format),
@@ -1588,18 +1587,18 @@ where
     );
 
     // Compress response body if negotiated, respecting the compression policy
-    let effective_policy = compression_policy.with_override(ctx.compress_response);
+    let effective_policy = compression_policy.with_override(resp.compress);
     let (final_body, content_encoding) = if let Some(encoding) = response_encoding {
-        if !effective_policy.should_compress(response_body.len()) {
-            (response_body, None)
+        if !effective_policy.should_compress(resp.body.len()) {
+            (resp.body, None)
         } else {
-            match compression.compress(encoding, &response_body) {
+            match compression.compress(encoding, &resp.body) {
                 Ok(compressed) => (compressed, Some(encoding)),
-                Err(_) => (response_body, None), // Fall back to uncompressed
+                Err(_) => (resp.body, None), // Fall back to uncompressed
             }
         }
     } else {
-        (response_body, None)
+        (resp.body, None)
     };
 
     // Build response with the same content type as the request
@@ -1618,12 +1617,12 @@ where
     }
 
     // Add response headers set by the handler
-    for (key, value) in ctx.response_headers.iter() {
+    for (key, value) in resp.headers.iter() {
         response = response.header(key, value);
     }
 
     // Add trailers as trailer- prefixed headers
-    let response = add_trailers(response, &ctx.trailers);
+    let response = add_trailers(response, &resp.trailers);
 
     response
         .body(Full::new(final_body))
@@ -1777,7 +1776,7 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers)
+    let ctx = RequestContext::new(metadata.headers)
         .with_deadline(deadline)
         .with_extensions(extensions);
 
@@ -1801,7 +1800,7 @@ where
             .await
     };
 
-    let (response_bytes, ctx) = match handler_result {
+    let resp = match handler_result {
         Ok(result) => result,
         Err(e) => return grpc_unary_error(&e),
     };
@@ -1813,20 +1812,20 @@ where
     );
 
     // Encode response into a gRPC envelope (5-byte header + payload)
-    let effective_policy = compression_policy.with_override(ctx.compress_response);
+    let effective_policy = compression_policy.with_override(resp.compress);
     let encoded_data = if let Some(encoding) = response_encoding
-        && effective_policy.should_compress(response_bytes.len())
+        && effective_policy.should_compress(resp.body.len())
     {
-        match compression.compress(encoding, &response_bytes) {
+        match compression.compress(encoding, &resp.body) {
             Ok(compressed) => Envelope::compressed(compressed).encode(),
-            Err(_) => Envelope::data(response_bytes).encode(),
+            Err(_) => Envelope::data(resp.body).encode(),
         }
     } else {
-        Envelope::data(response_bytes).encode()
+        Envelope::data(resp.body).encode()
     };
 
-    // Build gRPC trailers from context
-    let grpc_trailers = build_grpc_trailers(None, &ctx.trailers);
+    // Build gRPC trailers
+    let grpc_trailers = build_grpc_trailers(None, &resp.trailers);
 
     // Build the trailers in the appropriate format for the protocol
     let trailers = match protocol {
@@ -1851,7 +1850,7 @@ where
     }
 
     // Add response headers set by the handler
-    for (key, value) in ctx.response_headers.iter() {
+    for (key, value) in resp.headers.iter() {
         response = response.header(key, value);
     }
 
@@ -2061,56 +2060,53 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers)
+    let ctx = RequestContext::new(metadata.headers)
         .with_deadline(deadline)
         .with_extensions(extensions);
 
     // Call the handler with the appropriate codec format.
     // For gRPC unary handlers, we wrap the single response in a one-item stream.
-    let (response_stream, ctx): (BoxStream<Result<Bytes, ConnectError>>, Context) =
-        match dispatch_kind {
-            StreamingDispatchKind::ServerStreaming => {
-                let fut = dispatcher.call_server_streaming(&path, ctx, request_body, codec_format);
-                let handler_result = if let Some(timeout) = metadata.timeout {
-                    match tokio::time::timeout(timeout, fut).await {
-                        Ok(result) => result,
-                        Err(_) => {
-                            let err = ConnectError::deadline_exceeded("request timeout");
-                            return streaming_error_response(&err, protocol, codec_format);
-                        }
-                    }
-                } else {
-                    fut.await
-                };
-                match handler_result {
+    let resp = match dispatch_kind {
+        StreamingDispatchKind::ServerStreaming => {
+            let fut = dispatcher.call_server_streaming(&path, ctx, request_body, codec_format);
+            let handler_result = if let Some(timeout) = metadata.timeout {
+                match tokio::time::timeout(timeout, fut).await {
                     Ok(result) => result,
-                    Err(e) => return streaming_error_response(&e, protocol, codec_format),
-                }
-            }
-            StreamingDispatchKind::Unary => {
-                let fut = dispatcher.call_unary(&path, ctx, request_body, codec_format);
-                let handler_result = if let Some(timeout) = metadata.timeout {
-                    match tokio::time::timeout(timeout, fut).await {
-                        Ok(result) => result,
-                        Err(_) => {
-                            let err = ConnectError::deadline_exceeded("request timeout");
-                            return streaming_error_response(&err, protocol, codec_format);
-                        }
+                    Err(_) => {
+                        let err = ConnectError::deadline_exceeded("request timeout");
+                        return streaming_error_response(&err, protocol, codec_format);
                     }
-                } else {
-                    fut.await
-                };
-                match handler_result {
-                    Ok((response_bytes, ctx)) => {
-                        // Wrap single response in a one-item stream
-                        let stream: BoxStream<Result<Bytes, ConnectError>> =
-                            Box::pin(futures::stream::once(async move { Ok(response_bytes) }));
-                        (stream, ctx)
-                    }
-                    Err(e) => return streaming_error_response(&e, protocol, codec_format),
                 }
+            } else {
+                fut.await
+            };
+            match handler_result {
+                Ok(result) => result,
+                Err(e) => return streaming_error_response(&e, protocol, codec_format),
             }
-        };
+        }
+        StreamingDispatchKind::Unary => {
+            let fut = dispatcher.call_unary(&path, ctx, request_body, codec_format);
+            let handler_result = if let Some(timeout) = metadata.timeout {
+                match tokio::time::timeout(timeout, fut).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        let err = ConnectError::deadline_exceeded("request timeout");
+                        return streaming_error_response(&err, protocol, codec_format);
+                    }
+                }
+            } else {
+                fut.await
+            };
+            match handler_result {
+                // Wrap single response in a one-item stream
+                Ok(r) => r.map_body(|bytes| -> BoxStream<Result<Bytes, ConnectError>> {
+                    Box::pin(futures::stream::once(async move { Ok(bytes) }))
+                }),
+                Err(e) => return streaming_error_response(&e, protocol, codec_format),
+            }
+        }
+    };
 
     // Negotiate response compression for streaming
     let response_encoding = compression.negotiate_encoding(
@@ -2135,15 +2131,15 @@ where
     }
 
     // Add response headers set by the handler
-    for (key, value) in ctx.response_headers.iter() {
+    for (key, value) in resp.headers.iter() {
         response = response.header(key, value);
     }
 
     let stream_compression = response_encoding.map(|encoding| (compression, encoding));
-    let effective_policy = compression_policy.with_override(ctx.compress_response);
+    let effective_policy = compression_policy.with_override(resp.compress);
     let body = StreamingResponseBody::new(
-        response_stream,
-        ctx,
+        resp.body,
+        resp.trailers,
         protocol,
         stream_compression,
         effective_policy,
@@ -2200,7 +2196,7 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers)
+    let ctx = RequestContext::new(metadata.headers)
         .with_deadline(deadline)
         .with_extensions(extensions);
 
@@ -2228,7 +2224,7 @@ where
             .await
     };
 
-    let (response_bytes, ctx) = match handler_result {
+    let resp = match handler_result {
         Ok(result) => result,
         Err(e) => {
             drop(reader_task);
@@ -2258,17 +2254,17 @@ where
     }
 
     // Add response headers set by the handler
-    for (key, value) in ctx.response_headers.iter() {
+    for (key, value) in resp.headers.iter() {
         response = response.header(key, value);
     }
 
     let stream_compression = response_encoding.map(|encoding| (compression, encoding));
     let response_stream: BoxStream<Result<Bytes, ConnectError>> =
-        Box::pin(futures::stream::once(async { Ok(response_bytes) }));
-    let effective_policy = compression_policy.with_override(ctx.compress_response);
+        Box::pin(futures::stream::once(async { Ok(resp.body) }));
+    let effective_policy = compression_policy.with_override(resp.compress);
     let body = StreamingResponseBody::new(
         response_stream,
-        ctx,
+        resp.trailers,
         protocol,
         stream_compression,
         effective_policy,
@@ -2443,7 +2439,7 @@ where
     let deadline = metadata
         .timeout
         .and_then(|t| std::time::Instant::now().checked_add(t));
-    let ctx = Context::new(metadata.headers)
+    let ctx = RequestContext::new(metadata.headers)
         .with_deadline(deadline)
         .with_extensions(extensions);
 
@@ -2468,7 +2464,7 @@ where
             .await
     };
 
-    let (response_stream, ctx) = match handler_result {
+    let resp = match handler_result {
         Ok(result) => result,
         Err(e) => {
             drop(reader_task);
@@ -2499,15 +2495,15 @@ where
     }
 
     // Add response headers set by the handler
-    for (key, value) in ctx.response_headers.iter() {
+    for (key, value) in resp.headers.iter() {
         response = response.header(key, value);
     }
 
     let stream_compression = response_encoding.map(|encoding| (compression, encoding));
-    let effective_policy = compression_policy.with_override(ctx.compress_response);
+    let effective_policy = compression_policy.with_override(resp.compress);
     let body = StreamingResponseBody::new(
-        response_stream,
-        ctx,
+        resp.body,
+        resp.trailers,
         protocol,
         stream_compression,
         effective_policy,
@@ -3393,11 +3389,11 @@ mod tests {
         let router = Router::new().route(
             "svc",
             "Method",
-            crate::handler_fn(move |ctx: Context, _req: buffa_types::Empty| {
+            crate::handler_fn(move |ctx: RequestContext, _req: buffa_types::Empty| {
                 let cap = Arc::clone(&handler_captured);
                 async move {
                     *cap.lock().unwrap() = ctx.extensions.get::<PeerTag>().cloned();
-                    Ok((buffa_types::Empty::default(), ctx))
+                    Ok(buffa_types::Empty::default().into())
                 }
             }),
         );

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -123,7 +123,7 @@ Implement the service:
 // src/main.rs
 use std::sync::Arc;
 use buffa::view::OwnedView;
-use connectrpc::{ConnectError, Context, Router};
+use connectrpc::{RequestContext, Router, ServiceResult};
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
@@ -136,16 +136,14 @@ struct MyGreet;
 impl GreetService for MyGreet {
     async fn greet(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<GreetRequestView<'static>>,
-    ) -> Result<(GreetResponse, Context), ConnectError> {
-        Ok((
-            GreetResponse {
-                greeting: format!("Hello, {}!", req.name),
-                ..Default::default()
-            },
-            ctx,
-        ))
+    ) -> ServiceResult<GreetResponse> {
+        Ok(GreetResponse {
+            greeting: format!("Hello, {}!", req.name),
+            ..Default::default()
+        }
+        .into())
     }
 }
 
@@ -218,25 +216,24 @@ trait name matches the proto service name (`GreetService` becomes
 
 ### Handler signatures
 
-Unary handlers take a `Context` plus an `OwnedView<RequestView<'static>>`,
-and return `(Response, Context)` or a `ConnectError`:
+Unary handlers take a read-only `RequestContext` plus an
+`OwnedView<RequestView<'static>>`, and return
+`ServiceResult<ResponseType>`:
 
 ```rust
 impl GreetService for MyGreet {
     async fn greet(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         req: OwnedView<GreetRequestView<'static>>,
-    ) -> Result<(GreetResponse, Context), ConnectError> {
+    ) -> ServiceResult<GreetResponse> {
         // req derefs to the view: zero-copy field access.
         // String fields are &str borrowed from the request buffer.
-        Ok((
-            GreetResponse {
-                greeting: format!("Hello, {}!", req.name),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(GreetResponse {
+            greeting: format!("Hello, {}!", req.name),
+            ..Default::default()
+        }
+        .into())
     }
 }
 ```
@@ -246,44 +243,44 @@ allocating - `req.name` is a `&str` directly into the request bytes.
 Call `.to_owned_message()` to get the prost-style owned struct when
 you need it.
 
-### The `Context` parameter
+### `RequestContext` and `Response`
 
-`Context` carries per-call metadata in both directions:
+Request-side metadata lives on `RequestContext` (passed in);
+response-side metadata lives on `Response<B>` (returned):
 
-| Field | Direction | Purpose |
-|---|---|---|
-| `headers` | request | Caller-supplied headers (read with `ctx.header(name)` or `ctx.headers.get(...)`) |
-| `response_headers` | response | Headers to send back, set in handler before returning |
-| `trailers` | response | Trailers to send back, set via `ctx.set_trailer(name, value)` |
-| `deadline` | request | Absolute `Instant` if the caller set a timeout |
-| `extensions` | request | `http::Extensions` carried from the underlying `http::Request` |
-| `compress_response` | response | Override the server's compression policy for this RPC |
+| `RequestContext` field | Purpose |
+|---|---|
+| `headers` | Caller-supplied headers (read with `ctx.header(name)` or `ctx.headers.get(...)`) |
+| `deadline` | Absolute `Instant` if the caller set a timeout |
+| `extensions` | `http::Extensions` carried from the underlying `http::Request` |
 
-The handler **takes ownership** of `Context` and **returns it** with
-the response. This is intentional: the returned future is `'static`,
-so the context cannot be borrowed across the await. Set
-response headers or trailers before returning:
+| `Response<B>` field | Purpose |
+|---|---|
+| `body` | The response message (or `ServiceStream<M>` for streaming) |
+| `headers` | Headers to send before the body |
+| `trailers` | Trailers to send after the body |
+| `compress` | Override the server's compression policy for this RPC |
+
+`ServiceResult<B>` is `Result<Response<B>, ConnectError>`. The happy
+path is `Ok(body.into())`; to attach response metadata, use the
+builder:
 
 ```rust
 async fn greet(
     &self,
-    mut ctx: Context,
+    _ctx: RequestContext,
     req: OwnedView<GreetRequestView<'static>>,
-) -> Result<(GreetResponse, Context), ConnectError> {
-    ctx.response_headers
-        .insert("x-greet-version", "v2".parse().unwrap());
-    ctx.set_trailer(
-        http::header::HeaderName::from_static("x-server-id"),
-        "node-7".parse().unwrap(),
-    );
-    Ok((/* response */, ctx))
+) -> ServiceResult<GreetResponse> {
+    Ok(Response::new(GreetResponse { /* ... */ })
+        .with_header("x-greet-version", "v2")
+        .with_trailer("x-server-id", "node-7"))
 }
 ```
 
-`Context::extensions` is the passthrough channel for tower-layer state:
+`RequestContext::extensions` is the passthrough channel for tower-layer state:
 a custom auth layer can stamp a `UserId` into the request's
 `http::Extensions`, and the dispatcher forwards that map verbatim into
-`Context::extensions` for the handler to read with
+`RequestContext::extensions` for the handler to read with
 `ctx.extensions.get::<UserId>()`. See [Tower middleware](#tower-middleware)
 for the full pattern.
 
@@ -348,27 +345,22 @@ signatures are summarized below.
 
 The streaming-handler trait signatures use `Pin<Box<dyn Stream<...> +
 Send>>` for both inbound and outbound streams. That's verbose, so the
-snippets here use two local type aliases (the same ones used in
-[`examples/streaming-tour/src/server.rs`](../examples/streaming-tour/src/server.rs)):
-
-```rust
-type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> + Send>>;
-type RequestStream<V> = Pin<Box<dyn Stream<Item = Result<OwnedView<V>, ConnectError>> + Send>>;
-```
+snippets here use `connectrpc::ServiceStream<T>` (a boxed `Send`
+stream of `Result<T, ConnectError>`).
 
 ### Server streaming
 
 The handler returns a stream of responses. Use any `futures::Stream`
-you like, then box-pin it:
+you like, then wrap it with `Response::stream`:
 
 ```rust
 async fn range(
     &self,
-    ctx: Context,
+    _ctx: RequestContext,
     req: OwnedView<RangeRequestView<'static>>,
-) -> Result<(ResponseStream<RangeResponse>, Context), ConnectError> {
+) -> ServiceResult<ServiceStream<RangeResponse>> {
     let stream = futures::stream::iter(/* ... */);
-    Ok((Box::pin(stream), ctx))
+    Ok(Response::stream(stream))
 }
 ```
 
@@ -380,14 +372,14 @@ response:
 ```rust
 async fn sum(
     &self,
-    ctx: Context,
-    mut requests: RequestStream<SumRequestView<'static>>,
-) -> Result<(SumResponse, Context), ConnectError> {
+    _ctx: RequestContext,
+    mut requests: ServiceStream<OwnedView<SumRequestView<'static>>>,
+) -> ServiceResult<SumResponse> {
     let mut total: i64 = 0;
     while let Some(req) = requests.next().await {
         total += req?.value.unwrap_or(0) as i64;
     }
-    Ok((SumResponse { total: Some(total), ..Default::default() }, ctx))
+    Ok(SumResponse { total: Some(total), ..Default::default() }.into())
 }
 ```
 
@@ -399,12 +391,12 @@ emit messages independently:
 ```rust
 async fn running_sum(
     &self,
-    ctx: Context,
-    requests: RequestStream<RunningSumRequestView<'static>>,
-) -> Result<(ResponseStream<RunningSumResponse>, Context), ConnectError> {
+    _ctx: RequestContext,
+    requests: ServiceStream<OwnedView<RunningSumRequestView<'static>>>,
+) -> ServiceResult<ServiceStream<RunningSumResponse>> {
     // Map the request stream to a response stream however you like.
     let response_stream = futures::stream::unfold(/* ... */);
-    Ok((Box::pin(response_stream), ctx))
+    Ok(Response::stream(response_stream))
 }
 ```
 
@@ -491,7 +483,7 @@ ServiceBuilder accepts.
 ### Passing data from a layer to a handler
 
 The dispatch path moves the request's `http::Extensions` into
-`Context::extensions` verbatim. So a middleware that inserts a value
+`RequestContext::extensions` verbatim. So a middleware that inserts a value
 via `req.extensions_mut().insert(value)` makes that value available to
 the handler via `ctx.extensions.get::<T>()`. This is the canonical way
 to pass per-request state from middleware (auth identity, trace IDs,
@@ -748,18 +740,19 @@ honor the client's `connect-content-encoding` request header (or
 ### Per-RPC compression control
 
 A handler can override the server's compression policy for a single
-response by setting `Context::set_compression`:
+response via `Response::compress`:
 
 ```rust
 async fn greet(
     &self,
-    mut ctx: Context,
+    _ctx: RequestContext,
     req: OwnedView<GreetRequestView<'static>>,
-) -> Result<(GreetResponse, Context), ConnectError> {
+) -> ServiceResult<GreetResponse> {
+    let mut resp = Response::new(/* ... */);
     if response_is_huge() {
-        ctx.set_compression(true);  // force compress this response
+        resp = resp.compress(true);  // force compress this response
     }
-    Ok((/* ... */, ctx))
+    Ok(resp)
 }
 ```
 
@@ -801,7 +794,7 @@ let service = ConnectRpcService::new(router).with_compression(registry);
 | Example | What it covers |
 |---|---|
 | [`streaming-tour/`](../examples/streaming-tour) | All four RPC types (unary, server stream, client stream, bidi) on a trivial NumberService. Smallest demo of handler signatures and client invocation patterns. |
-| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `Context::extensions`, response trailers via `Context::set_trailer`. Client demos `ClientConfig::default_header` and `CallOptions::with_timeout`. |
+| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions`, response trailers via `Context::set_trailer`. Client demos `ClientConfig::default_header` and `CallOptions::with_timeout`. |
 | [`eliza/`](../examples/eliza) | Production-shaped streaming app: a port of the `connectrpc/examples-go` ELIZA demo. Server-streaming Introduce + bidi-streaming Converse, TLS, mTLS, CORS, IPv6, both server and client binaries, interoperates with the hosted Go reference at `demo.connectrpc.com`. |
 | [`multiservice/`](../examples/multiservice) | Multiple proto packages compiled together with `buf generate`, multiple services on one server, well-known type usage. |
 | [`wasm-client/`](../examples/wasm-client) | Browser fetch transport: same generated client used from `wasm32-unknown-unknown` with a custom `ClientTransport` backed by `web-sys::fetch`. |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -286,7 +286,7 @@ for the full pattern.
 
 The generated trait declares unary/client-stream returns as
 `ServiceResult<impl Encodable<M>>` so handlers can return either the
-owned `M` or (in a follow-up) a borrowed view that encodes as `M`.
+owned `M` or a borrowing view (see the `MaybeBorrowed` type).
 Writing your impl as `-> ServiceResult<FooResponse>` *refines* that
 opaque bound to a concrete type, which triggers
 `refining_impl_trait_internal` / `refining_impl_trait_reachable`. This
@@ -365,7 +365,9 @@ stream of `Result<T, ConnectError>`).
 ### Server streaming
 
 The handler returns a stream of responses. Use any `futures::Stream`
-you like, then wrap it with `Response::stream`:
+you like, then wrap it with `Response::stream_ok` (or
+`Ok(Response::stream(s).with_header(...))` if you need response
+metadata):
 
 ```rust
 async fn range(
@@ -374,7 +376,7 @@ async fn range(
     req: OwnedView<RangeRequestView<'static>>,
 ) -> ServiceResult<ServiceStream<RangeResponse>> {
     let stream = futures::stream::iter(/* ... */);
-    Ok(Response::stream(stream))
+    Response::stream_ok(stream)
 }
 ```
 
@@ -410,7 +412,7 @@ async fn running_sum(
 ) -> ServiceResult<ServiceStream<RunningSumResponse>> {
     // Map the request stream to a response stream however you like.
     let response_stream = futures::stream::unfold(/* ... */);
-    Ok(Response::stream(response_stream))
+    Response::stream_ok(response_stream)
 }
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -284,6 +284,22 @@ a custom auth layer can stamp a `UserId` into the request's
 `ctx.extensions.get::<UserId>()`. See [Tower middleware](#tower-middleware)
 for the full pattern.
 
+### The `refining_impl_trait` lint
+
+The generated trait declares unary/client-stream returns as
+`ServiceResult<impl Encodable<M>>` so handlers can return either the
+owned `M` or (in a follow-up) a borrowed view that encodes as `M`.
+Writing your impl as `-> ServiceResult<FooResponse>` *refines* that
+opaque bound to a concrete type, which triggers
+`refining_impl_trait_internal` / `refining_impl_trait_reachable`. This
+is intentional - the refinement is the point. Add at your crate root:
+
+```rust
+#![allow(refining_impl_trait_internal, refining_impl_trait_reachable)]
+```
+
+or `#[allow(refining_impl_trait)]` on the impl block.
+
 ### Returning errors
 
 Handlers return `ConnectError` for failures. Each error carries an
@@ -794,7 +810,7 @@ let service = ConnectRpcService::new(router).with_compression(registry);
 | Example | What it covers |
 |---|---|
 | [`streaming-tour/`](../examples/streaming-tour) | All four RPC types (unary, server stream, client stream, bidi) on a trivial NumberService. Smallest demo of handler signatures and client invocation patterns. |
-| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions`, response trailers via `Context::set_trailer`. Client demos `ClientConfig::default_header` and `CallOptions::with_timeout`. |
+| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions`, response trailers via `Response::with_trailer`. Client demos `ClientConfig::default_header` and `CallOptions::with_timeout`. |
 | [`eliza/`](../examples/eliza) | Production-shaped streaming app: a port of the `connectrpc/examples-go` ELIZA demo. Server-streaming Introduce + bidi-streaming Converse, TLS, mTLS, CORS, IPv6, both server and client binaries, interoperates with the hosted Go reference at `demo.connectrpc.com`. |
 | [`multiservice/`](../examples/multiservice) | Multiple proto packages compiled together with `buf generate`, multiple services on one server, well-known type usage. |
 | [`wasm-client/`](../examples/wasm-client) | Browser fetch transport: same generated client used from `wasm32-unknown-unknown` with a custom `ClientTransport` backed by `web-sys::fetch`. |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -123,7 +123,7 @@ Implement the service:
 // src/main.rs
 use std::sync::Arc;
 use buffa::view::OwnedView;
-use connectrpc::{RequestContext, Router, ServiceResult};
+use connectrpc::{RequestContext, Response, Router, ServiceResult};
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
@@ -139,11 +139,10 @@ impl GreetService for MyGreet {
         _ctx: RequestContext,
         req: OwnedView<GreetRequestView<'static>>,
     ) -> ServiceResult<GreetResponse> {
-        Ok(GreetResponse {
+        Response::ok(GreetResponse {
             greeting: format!("Hello, {}!", req.name),
             ..Default::default()
-        }
-        .into())
+        })
     }
 }
 
@@ -229,11 +228,10 @@ impl GreetService for MyGreet {
     ) -> ServiceResult<GreetResponse> {
         // req derefs to the view: zero-copy field access.
         // String fields are &str borrowed from the request buffer.
-        Ok(GreetResponse {
+        Response::ok(GreetResponse {
             greeting: format!("Hello, {}!", req.name),
             ..Default::default()
-        }
-        .into())
+        })
     }
 }
 ```
@@ -262,7 +260,7 @@ response-side metadata lives on `Response<B>` (returned):
 | `compress` | Override the server's compression policy for this RPC |
 
 `ServiceResult<B>` is `Result<Response<B>, ConnectError>`. The happy
-path is `Ok(body.into())`; to attach response metadata, use the
+path is `Response::ok(body)`; to attach response metadata, use the
 builder:
 
 ```rust
@@ -395,7 +393,7 @@ async fn sum(
     while let Some(req) = requests.next().await {
         total += req?.value.unwrap_or(0) as i64;
     }
-    Ok(SumResponse { total: Some(total), ..Default::default() }.into())
+    Response::ok(SumResponse { total: Some(total), ..Default::default() })
 }
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -282,6 +282,19 @@ a custom auth layer can stamp a `UserId` into the request's
 `ctx.extensions.get::<UserId>()`. See [Tower middleware](#tower-middleware)
 for the full pattern.
 
+### What you see vs. what you write
+
+The generated trait declares unary methods with the full RPITIT bounds:
+
+    fn say(&self, ctx: RequestContext, req: ...)
+        -> impl Future<Output = ServiceResult<impl Encodable<SayResponse> + Send + 'static + use<Self>>> + Send;
+
+That is what `cargo doc` and rust-analyzer hover show. You never write
+that form in an impl - `async fn` desugars the outer `impl Future`, and
+returning `ServiceResult<SayResponse>` (the concrete owned type) refines
+the `impl Encodable<...>` bound. The short form in the examples above is
+all you need.
+
 ### The `refining_impl_trait` lint
 
 The generated trait declares unary/client-stream returns as

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.rs
@@ -22,14 +22,15 @@ pub trait ElizaService: Send + Sync + 'static {
     /// Say is a unary RPC. Eliza responds to the prompt with a single sentence.
     fn say(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::connectrpc::eliza::v1::__buffa::view::SayRequestView<'static>,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (crate::proto::connectrpc::eliza::v1::SayResponse, ::connectrpc::Context),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
+                crate::proto::connectrpc::eliza::v1::SayResponse,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// Converse is a bidirectional RPC. The caller may exchange multiple
@@ -37,65 +38,36 @@ pub trait ElizaService: Send + Sync + 'static {
     /// responds to each ConverseRequest with a ConverseResponse.
     fn converse(
         &self,
-        ctx: ::connectrpc::Context,
-        requests: ::std::pin::Pin<
-            Box<
-                dyn ::futures::Stream<
-                    Item = Result<
-                        ::buffa::view::OwnedView<
-                            crate::proto::connectrpc::eliza::v1::__buffa::view::ConverseRequestView<
-                                'static,
-                            >,
-                        >,
-                        ::connectrpc::ConnectError,
-                    >,
-                > + Send,
+        ctx: ::connectrpc::RequestContext,
+        requests: ::connectrpc::ServiceStream<
+            ::buffa::view::OwnedView<
+                crate::proto::connectrpc::eliza::v1::__buffa::view::ConverseRequestView<
+                    'static,
+                >,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
-                ::std::pin::Pin<
-                    Box<
-                        dyn ::futures::Stream<
-                            Item = Result<
-                                crate::proto::connectrpc::eliza::v1::ConverseResponse,
-                                ::connectrpc::ConnectError,
-                            >,
-                        > + Send,
-                    >,
-                >,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            ::connectrpc::ServiceStream<
+                crate::proto::connectrpc::eliza::v1::ConverseResponse,
+            >,
         >,
     > + Send;
     /// Introduce is a server streaming RPC. Given the caller's name, Eliza
     /// returns a stream of sentences to introduce itself.
     fn introduce(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::connectrpc::eliza::v1::__buffa::view::IntroduceRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
-                ::std::pin::Pin<
-                    Box<
-                        dyn ::futures::Stream<
-                            Item = Result<
-                                crate::proto::connectrpc::eliza::v1::IntroduceResponse,
-                                ::connectrpc::ConnectError,
-                            >,
-                        > + Send,
-                    >,
-                >,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+        Output = ::connectrpc::ServiceResult<
+            ::connectrpc::ServiceStream<
+                crate::proto::connectrpc::eliza::v1::IntroduceResponse,
+            >,
         >,
     > + Send;
 }
@@ -224,7 +196,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -239,12 +211,11 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::eliza::v1::__buffa::view::SayRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.say(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.say(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::connectrpc::eliza::v1::SayResponse,
+                        >(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -253,7 +224,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -268,14 +239,14 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::eliza::v1::__buffa::view::IntroduceRequestView,
                     >(request, format)?;
-                    let (resp_stream, ctx) = svc.introduce(ctx, req).await?;
-                    Ok((
-                        ::connectrpc::dispatcher::codegen::encode_response_stream(
-                            resp_stream,
-                            format,
-                        ),
-                        ctx,
-                    ))
+                    let resp = svc.introduce(ctx, req).await?;
+                    Ok(
+                        resp
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
+                                s,
+                                format,
+                            )),
+                    )
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_streaming(path),
@@ -284,7 +255,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -299,7 +270,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -314,14 +285,14 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<
                         crate::proto::connectrpc::eliza::v1::__buffa::view::ConverseRequestView,
                     >(requests, format);
-                    let (resp_stream, ctx) = svc.converse(ctx, req_stream).await?;
-                    Ok((
-                        ::connectrpc::dispatcher::codegen::encode_response_stream(
-                            resp_stream,
-                            format,
-                        ),
-                        ctx,
-                    ))
+                    let resp = svc.converse(ctx, req_stream).await?;
+                    Ok(
+                        resp
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
+                                s,
+                                format,
+                            )),
+                    )
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_streaming(path),

--- a/examples/eliza/src/main.rs
+++ b/examples/eliza/src/main.rs
@@ -44,9 +44,7 @@ use proto::connectrpc::eliza::v1::__buffa::view::*;
 use proto::connectrpc::eliza::v1::*;
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectError, Context, Router as ConnectRouter};
-use futures::Stream;
-use std::pin::Pin;
+use connectrpc::{RequestContext, Router as ConnectRouter, ServiceResult, ServiceStream};
 use std::sync::Arc;
 use tokio::time::{Duration, sleep};
 
@@ -69,32 +67,24 @@ impl ElizaServer {
 impl ElizaService for ElizaServer {
     async fn say(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<SayRequestView<'static>>,
-    ) -> Result<(SayResponse, Context), ConnectError> {
+    ) -> ServiceResult<SayResponse> {
         // `request.sentence` is a `&str` borrow into the decoded buffer.
         // No allocation, no copy — `eliza::reply` just reads it.
         let (reply, _end_session) = eliza::reply(request.sentence);
-        Ok((
-            SayResponse {
-                sentence: reply,
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(SayResponse {
+            sentence: reply,
+            ..Default::default()
+        }
+        .into())
     }
 
     async fn introduce(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<IntroduceRequestView<'static>>,
-    ) -> Result<
-        (
-            Pin<Box<dyn Stream<Item = Result<IntroduceResponse, ConnectError>> + Send>>,
-            Context,
-        ),
-        ConnectError,
-    > {
+    ) -> ServiceResult<ServiceStream<IntroduceResponse>> {
         let delay = self.stream_delay;
 
         // Zero-copy read of the name; fall back to a default for the empty case.
@@ -125,28 +115,14 @@ impl ElizaService for ElizaServer {
                 ))
             });
 
-        Ok((
-            Box::pin(response_stream) as Pin<Box<dyn Stream<Item = _> + Send>>,
-            ctx,
-        ))
+        Ok((Box::pin(response_stream) as ServiceStream<_>).into())
     }
 
     async fn converse(
         &self,
-        ctx: Context,
-        requests: Pin<
-            Box<
-                dyn Stream<Item = Result<OwnedView<ConverseRequestView<'static>>, ConnectError>>
-                    + Send,
-            >,
-        >,
-    ) -> Result<
-        (
-            Pin<Box<dyn Stream<Item = Result<ConverseResponse, ConnectError>> + Send>>,
-            Context,
-        ),
-        ConnectError,
-    > {
+        _ctx: RequestContext,
+        requests: ServiceStream<OwnedView<ConverseRequestView<'static>>>,
+    ) -> ServiceResult<ServiceStream<ConverseResponse>> {
         use futures::StreamExt;
 
         // Unfold over the request stream so we can end the response stream
@@ -180,10 +156,7 @@ impl ElizaService for ElizaServer {
             },
         );
 
-        Ok((
-            Box::pin(response_stream) as Pin<Box<dyn Stream<Item = _> + Send>>,
-            ctx,
-        ))
+        Ok((Box::pin(response_stream) as ServiceStream<_>).into())
     }
 }
 

--- a/examples/eliza/src/main.rs
+++ b/examples/eliza/src/main.rs
@@ -114,7 +114,7 @@ impl ElizaService for ElizaServer {
                 ))
             });
 
-        Ok((Box::pin(response_stream) as ServiceStream<_>).into())
+        Response::stream_ok(response_stream)
     }
 
     async fn converse(
@@ -155,7 +155,7 @@ impl ElizaService for ElizaServer {
             },
         );
 
-        Ok((Box::pin(response_stream) as ServiceStream<_>).into())
+        Response::stream_ok(response_stream)
     }
 }
 

--- a/examples/eliza/src/main.rs
+++ b/examples/eliza/src/main.rs
@@ -44,7 +44,7 @@ use proto::connectrpc::eliza::v1::__buffa::view::*;
 use proto::connectrpc::eliza::v1::*;
 
 use buffa::view::OwnedView;
-use connectrpc::{RequestContext, Router as ConnectRouter, ServiceResult, ServiceStream};
+use connectrpc::{RequestContext, Response, Router as ConnectRouter, ServiceResult, ServiceStream};
 use std::sync::Arc;
 use tokio::time::{Duration, sleep};
 
@@ -73,11 +73,10 @@ impl ElizaService for ElizaServer {
         // `request.sentence` is a `&str` borrow into the decoded buffer.
         // No allocation, no copy — `eliza::reply` just reads it.
         let (reply, _end_session) = eliza::reply(request.sentence);
-        Ok(SayResponse {
+        Response::ok(SayResponse {
             sentence: reply,
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     async fn introduce(

--- a/examples/middleware/src/server.rs
+++ b/examples/middleware/src/server.rs
@@ -27,7 +27,7 @@ use axum::extract::{Request, State};
 use axum::middleware::Next;
 use axum::response::Response;
 use buffa::view::OwnedView;
-use connectrpc::{ConnectError, Context, ErrorCode, Router};
+use connectrpc::{ConnectError, ErrorCode, RequestContext, Router, ServiceResult};
 use http_body_util::BodyExt;
 use tower::ServiceBuilder;
 use tower_http::timeout::TimeoutLayer;
@@ -137,9 +137,9 @@ struct SecretServiceImpl {
 impl SecretService for SecretServiceImpl {
     async fn get_secret(
         &self,
-        mut ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<GetSecretRequestView<'static>>,
-    ) -> Result<(GetSecretResponse, Context), ConnectError> {
+    ) -> ServiceResult<GetSecretResponse> {
         // The auth layer stamped UserId into the http::Request extensions,
         // which the connect dispatcher then forwarded into ctx.extensions.
         let user = ctx
@@ -170,18 +170,11 @@ impl SecretService for SecretServiceImpl {
 
         // Stamp the serving user into a response trailer so the client
         // (or any tracing middleware downstream) can attribute the read.
-        ctx.set_trailer(
-            http::header::HeaderName::from_static("x-served-by"),
-            user.0.parse().unwrap(),
-        );
-
-        Ok((
-            GetSecretResponse {
-                value: Some(value.clone()),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(connectrpc::Response::new(GetSecretResponse {
+            value: Some(value.clone()),
+            ..Default::default()
+        })
+        .with_trailer("x-served-by", user.0))
     }
 }
 

--- a/examples/middleware/tests/e2e.rs
+++ b/examples/middleware/tests/e2e.rs
@@ -11,7 +11,7 @@ use axum::middleware::Next;
 use axum::response::Response;
 use buffa::view::OwnedView;
 use connectrpc::client::{ClientConfig, HttpClient};
-use connectrpc::{ConnectError, Context, ErrorCode, Router};
+use connectrpc::{ConnectError, ErrorCode, RequestContext, Router, ServiceResult};
 use http_body_util::BodyExt;
 use tower::ServiceBuilder;
 use tower_http::timeout::TimeoutLayer;
@@ -98,9 +98,9 @@ struct SecretServiceImpl {
 impl SecretService for SecretServiceImpl {
     async fn get_secret(
         &self,
-        mut ctx: Context,
+        ctx: RequestContext,
         request: OwnedView<GetSecretRequestView<'static>>,
-    ) -> Result<(GetSecretResponse, Context), ConnectError> {
+    ) -> ServiceResult<GetSecretResponse> {
         let user = ctx
             .extensions
             .get::<UserId>()
@@ -117,17 +117,11 @@ impl SecretService for SecretServiceImpl {
                 format!("user {:?} cannot read {name:?}", user.0),
             ));
         }
-        ctx.set_trailer(
-            http::header::HeaderName::from_static("x-served-by"),
-            user.0.parse().unwrap(),
-        );
-        Ok((
-            GetSecretResponse {
-                value: Some(value.clone()),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(connectrpc::Response::new(GetSecretResponse {
+            value: Some(value.clone()),
+            ..Default::default()
+        })
+        .with_trailer("x-served-by", user.0))
     }
 }
 

--- a/examples/multiservice/src/bin/server.rs
+++ b/examples/multiservice/src/bin/server.rs
@@ -21,8 +21,8 @@ use buffa_types::google::protobuf::Struct;
 use buffa_types::google::protobuf::Timestamp;
 use buffa_types::google::protobuf::Value;
 use connectrpc::ConnectError;
-use connectrpc::Context;
 use connectrpc::Router as ConnectRouter;
+use connectrpc::{RequestContext, ServiceResult};
 use multiservice_example::proto::anthropic::connectrpc::greet::v1::__buffa::view::GreetRequestView;
 use multiservice_example::proto::anthropic::connectrpc::math::v1::__buffa::view::AddRequestView;
 use multiservice_example::proto::anthropic::connectrpc::wkt::v1::__buffa::view::{
@@ -36,9 +36,9 @@ struct MyGreetService;
 impl GreetService for MyGreetService {
     async fn greet(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<GreetRequestView<'static>>,
-    ) -> Result<(GreetResponse, Context), ConnectError> {
+    ) -> ServiceResult<GreetResponse> {
         let request = request.to_owned_message();
         tracing::info!("Received greet request for: {}", request.name);
 
@@ -50,7 +50,7 @@ impl GreetService for MyGreetService {
             message: format!("Hello, {}!", request.name),
             ..Default::default()
         };
-        Ok((response, ctx))
+        Ok(response.into())
     }
 }
 
@@ -60,9 +60,9 @@ struct MyMathService;
 impl MathService for MyMathService {
     async fn add(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<AddRequestView<'static>>,
-    ) -> Result<(AddResponse, Context), ConnectError> {
+    ) -> ServiceResult<AddResponse> {
         let request = request.to_owned_message();
         tracing::info!("Received add request: {} + {}", request.a, request.b);
 
@@ -75,7 +75,7 @@ impl MathService for MyMathService {
             result,
             ..Default::default()
         };
-        Ok((response, ctx))
+        Ok(response.into())
     }
 }
 
@@ -86,9 +86,9 @@ struct MyWellKnownTypesService;
 impl WellKnownTypesService for MyWellKnownTypesService {
     async fn create_event(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<CreateEventRequestView<'static>>,
-    ) -> Result<(CreateEventResponse, Context), ConnectError> {
+    ) -> ServiceResult<CreateEventResponse> {
         let request = request.to_owned_message();
         tracing::info!("Received create_event request: {:?}", request.name);
 
@@ -131,14 +131,14 @@ impl WellKnownTypesService for MyWellKnownTypesService {
             event: event.into(),
             ..Default::default()
         };
-        Ok((response, ctx))
+        Ok(response.into())
     }
 
     async fn calculate_duration(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<CalculateDurationRequestView<'static>>,
-    ) -> Result<(CalculateDurationResponse, Context), ConnectError> {
+    ) -> ServiceResult<CalculateDurationResponse> {
         let request = request.to_owned_message();
         tracing::info!("Received calculate_duration request");
 
@@ -165,14 +165,14 @@ impl WellKnownTypesService for MyWellKnownTypesService {
             duration: duration.into(),
             ..Default::default()
         };
-        Ok((response, ctx))
+        Ok(response.into())
     }
 
     async fn process_metadata(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<ProcessMetadataRequestView<'static>>,
-    ) -> Result<(ProcessMetadataResponse, Context), ConnectError> {
+    ) -> ServiceResult<ProcessMetadataResponse> {
         let request = request.to_owned_message();
         tracing::info!("Received process_metadata request");
 
@@ -208,7 +208,7 @@ impl WellKnownTypesService for MyWellKnownTypesService {
             field_count,
             ..Default::default()
         };
-        Ok((response, ctx))
+        Ok(response.into())
     }
 }
 

--- a/examples/multiservice/src/bin/server.rs
+++ b/examples/multiservice/src/bin/server.rs
@@ -22,7 +22,7 @@ use buffa_types::google::protobuf::Timestamp;
 use buffa_types::google::protobuf::Value;
 use connectrpc::ConnectError;
 use connectrpc::Router as ConnectRouter;
-use connectrpc::{RequestContext, ServiceResult};
+use connectrpc::{RequestContext, Response, ServiceResult};
 use multiservice_example::proto::anthropic::connectrpc::greet::v1::__buffa::view::GreetRequestView;
 use multiservice_example::proto::anthropic::connectrpc::math::v1::__buffa::view::AddRequestView;
 use multiservice_example::proto::anthropic::connectrpc::wkt::v1::__buffa::view::{
@@ -50,7 +50,7 @@ impl GreetService for MyGreetService {
             message: format!("Hello, {}!", request.name),
             ..Default::default()
         };
-        Ok(response.into())
+        Response::ok(response)
     }
 }
 
@@ -75,7 +75,7 @@ impl MathService for MyMathService {
             result,
             ..Default::default()
         };
-        Ok(response.into())
+        Response::ok(response)
     }
 }
 
@@ -131,7 +131,7 @@ impl WellKnownTypesService for MyWellKnownTypesService {
             event: event.into(),
             ..Default::default()
         };
-        Ok(response.into())
+        Response::ok(response)
     }
 
     async fn calculate_duration(
@@ -165,7 +165,7 @@ impl WellKnownTypesService for MyWellKnownTypesService {
             duration: duration.into(),
             ..Default::default()
         };
-        Ok(response.into())
+        Response::ok(response)
     }
 
     async fn process_metadata(
@@ -208,7 +208,7 @@ impl WellKnownTypesService for MyWellKnownTypesService {
             field_count,
             ..Default::default()
         };
-        Ok(response.into())
+        Response::ok(response)
     }
 }
 

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.rs
@@ -18,19 +18,17 @@ pub trait GreetService: Send + Sync + 'static {
     /// This method has no side effects and supports GET requests.
     fn greet(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::anthropic::connectrpc::greet::v1::__buffa::view::GreetRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::anthropic::connectrpc::greet::v1::GreetResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -127,7 +125,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -143,12 +141,11 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::greet::v1::__buffa::view::GreetRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.greet(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.greet(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::anthropic::connectrpc::greet::v1::GreetResponse,
+                        >(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -157,7 +154,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -173,7 +170,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -189,7 +186,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.rs
@@ -17,19 +17,17 @@ pub trait MathService: Send + Sync + 'static {
     /// Add returns the sum of two numbers.
     fn add(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::anthropic::connectrpc::math::v1::__buffa::view::AddRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::anthropic::connectrpc::math::v1::AddResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -126,7 +124,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -142,12 +140,11 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::math::v1::__buffa::view::AddRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.add(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.add(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::anthropic::connectrpc::math::v1::AddResponse,
+                        >(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -156,7 +153,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -172,7 +169,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -188,7 +185,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.rs
@@ -17,55 +17,49 @@ pub trait WellKnownTypesService: Send + Sync + 'static {
     /// CreateEvent creates an event with a timestamp.
     fn create_event(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::CreateEventRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::anthropic::connectrpc::wkt::v1::CreateEventResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// CalculateDuration calculates the duration between two timestamps.
     fn calculate_duration(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::CalculateDurationRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::anthropic::connectrpc::wkt::v1::CalculateDurationResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
     /// ProcessMetadata processes arbitrary metadata as a Struct.
     fn process_metadata(
         &self,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::view::OwnedView<
             crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::ProcessMetadataRequestView<
                 'static,
             >,
         >,
     ) -> impl ::std::future::Future<
-        Output = Result<
-            (
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<
                 crate::proto::anthropic::connectrpc::wkt::v1::ProcessMetadataResponse,
-                ::connectrpc::Context,
-            ),
-            ::connectrpc::ConnectError,
+            > + Send + 'static + use<Self>,
         >,
     > + Send;
 }
@@ -192,7 +186,7 @@ for WellKnownTypesServiceServer<T> {
     fn call_unary(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -208,12 +202,11 @@ for WellKnownTypesServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::CreateEventRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.create_event(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.create_event(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::anthropic::connectrpc::wkt::v1::CreateEventResponse,
+                        >(format)
                 })
             }
             "CalculateDuration" => {
@@ -222,12 +215,11 @@ for WellKnownTypesServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::CalculateDurationRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.calculate_duration(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.calculate_duration(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::anthropic::connectrpc::wkt::v1::CalculateDurationResponse,
+                        >(format)
                 })
             }
             "ProcessMetadata" => {
@@ -236,12 +228,11 @@ for WellKnownTypesServiceServer<T> {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::ProcessMetadataRequestView,
                     >(request, format)?;
-                    let (res, ctx) = svc.process_metadata(ctx, req).await?;
-                    let bytes = ::connectrpc::dispatcher::codegen::encode_response(
-                        &res,
-                        format,
-                    )?;
-                    Ok((bytes, ctx))
+                    svc.process_metadata(ctx, req)
+                        .await?
+                        .encode::<
+                            crate::proto::anthropic::connectrpc::wkt::v1::ProcessMetadataResponse,
+                        >(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -250,7 +241,7 @@ for WellKnownTypesServiceServer<T> {
     fn call_server_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         request: ::buffa::bytes::Bytes,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {
@@ -266,7 +257,7 @@ for WellKnownTypesServiceServer<T> {
     fn call_client_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
@@ -282,7 +273,7 @@ for WellKnownTypesServiceServer<T> {
     fn call_bidi_streaming(
         &self,
         path: &str,
-        ctx: ::connectrpc::Context,
+        ctx: ::connectrpc::RequestContext,
         requests: ::connectrpc::dispatcher::codegen::RequestStream,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::StreamingResult {

--- a/examples/streaming-tour/src/server.rs
+++ b/examples/streaming-tour/src/server.rs
@@ -13,12 +13,11 @@
 //! cargo run -p streaming-tour-example --bin streaming-tour-client
 //! ```
 
-use std::pin::Pin;
 use std::sync::Arc;
 
 use buffa::view::OwnedView;
-use connectrpc::{ConnectError, Context, Router};
-use futures::{Stream, StreamExt};
+use connectrpc::{RequestContext, Response, Router, ServiceResult, ServiceStream};
+use futures::StreamExt;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
@@ -32,9 +31,8 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 // Local type aliases that flatten the streaming-handler signatures.
 // The verbose `Pin<Box<dyn Stream<...> + Send>>` form is what the
 // generated traits expect today; these aliases are pure sugar at the
-// call site (pending broader handler-trait ergonomics work).
-type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> + Send>>;
-type RequestStream<V> = Pin<Box<dyn Stream<Item = Result<OwnedView<V>, ConnectError>> + Send>>;
+// call site.
+type RequestStream<V> = ServiceStream<OwnedView<V>>;
 
 /// Trivial NumberService implementation. Each method demonstrates one
 /// of the four RPC patterns.
@@ -44,28 +42,26 @@ impl NumberService for NumberServiceImpl {
     /// Unary: square the input value.
     async fn square(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<SquareRequestView<'static>>,
-    ) -> Result<(SquareResponse, Context), ConnectError> {
+    ) -> ServiceResult<SquareResponse> {
         // Edition 2023 default presence is EXPLICIT, so scalar fields
         // are Option<T>. unwrap_or(0) treats unset as zero, mirroring
         // the proto3 implicit-presence semantics.
         let v = request.value.unwrap_or(0) as i64;
-        Ok((
-            SquareResponse {
-                squared: Some(v * v),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(SquareResponse {
+            squared: Some(v * v),
+            ..Default::default()
+        }
+        .into())
     }
 
     /// Server streaming: emit `count` consecutive integers from `start`.
     async fn range(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<RangeRequestView<'static>>,
-    ) -> Result<(ResponseStream<RangeResponse>, Context), ConnectError> {
+    ) -> ServiceResult<ServiceStream<RangeResponse>> {
         let start = request.start.unwrap_or(0);
         let count = request.count.unwrap_or(0).max(0);
         let stream = futures::stream::iter((0..count).map(move |i| {
@@ -74,34 +70,32 @@ impl NumberService for NumberServiceImpl {
                 ..Default::default()
             })
         }));
-        Ok((Box::pin(stream), ctx))
+        Ok(Response::stream(stream))
     }
 
     /// Client streaming: drain the request stream, return the total.
     async fn sum(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         mut requests: RequestStream<SumRequestView<'static>>,
-    ) -> Result<(SumResponse, Context), ConnectError> {
+    ) -> ServiceResult<SumResponse> {
         let mut total: i64 = 0;
         while let Some(req) = requests.next().await {
             total += req?.value.unwrap_or(0) as i64;
         }
-        Ok((
-            SumResponse {
-                total: Some(total),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(SumResponse {
+            total: Some(total),
+            ..Default::default()
+        }
+        .into())
     }
 
     /// Bidirectional streaming: emit a running total after each request.
     async fn running_sum(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         requests: RequestStream<RunningSumRequestView<'static>>,
-    ) -> Result<(ResponseStream<RunningSumResponse>, Context), ConnectError> {
+    ) -> ServiceResult<ServiceStream<RunningSumResponse>> {
         let response_stream =
             futures::stream::unfold((requests, 0i64), |(mut requests, mut total)| async move {
                 match requests.next().await? {
@@ -118,7 +112,7 @@ impl NumberService for NumberServiceImpl {
                     Err(e) => Some((Err(e), (requests, total))),
                 }
             });
-        Ok((Box::pin(response_stream), ctx))
+        Ok(Response::stream(response_stream))
     }
 }
 

--- a/examples/streaming-tour/src/server.rs
+++ b/examples/streaming-tour/src/server.rs
@@ -49,11 +49,10 @@ impl NumberService for NumberServiceImpl {
         // are Option<T>. unwrap_or(0) treats unset as zero, mirroring
         // the proto3 implicit-presence semantics.
         let v = request.value.unwrap_or(0) as i64;
-        Ok(SquareResponse {
+        Response::ok(SquareResponse {
             squared: Some(v * v),
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     /// Server streaming: emit `count` consecutive integers from `start`.
@@ -83,11 +82,10 @@ impl NumberService for NumberServiceImpl {
         while let Some(req) = requests.next().await {
             total += req?.value.unwrap_or(0) as i64;
         }
-        Ok(SumResponse {
+        Response::ok(SumResponse {
             total: Some(total),
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     /// Bidirectional streaming: emit a running total after each request.

--- a/examples/streaming-tour/src/server.rs
+++ b/examples/streaming-tour/src/server.rs
@@ -69,7 +69,7 @@ impl NumberService for NumberServiceImpl {
                 ..Default::default()
             })
         }));
-        Ok(Response::stream(stream))
+        Response::stream_ok(stream)
     }
 
     /// Client streaming: drain the request stream, return the total.
@@ -110,7 +110,7 @@ impl NumberService for NumberServiceImpl {
                     Err(e) => Some((Err(e), (requests, total))),
                 }
             });
-        Ok(Response::stream(response_stream))
+        Response::stream_ok(response_stream)
     }
 }
 

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -27,11 +27,10 @@ impl NumberService for NumberServiceImpl {
         request: OwnedView<SquareRequestView<'static>>,
     ) -> ServiceResult<SquareResponse> {
         let v = request.value.unwrap_or(0) as i64;
-        Ok(SquareResponse {
+        Response::ok(SquareResponse {
             squared: Some(v * v),
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     async fn range(
@@ -59,11 +58,10 @@ impl NumberService for NumberServiceImpl {
         while let Some(req) = requests.next().await {
             total += req?.value.unwrap_or(0) as i64;
         }
-        Ok(SumResponse {
+        Response::ok(SumResponse {
             total: Some(total),
             ..Default::default()
-        }
-        .into())
+        })
     }
 
     async fn running_sum(

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -46,7 +46,7 @@ impl NumberService for NumberServiceImpl {
                 ..Default::default()
             })
         }));
-        Ok(Response::stream(stream))
+        Response::stream_ok(stream)
     }
 
     async fn sum(
@@ -85,7 +85,7 @@ impl NumberService for NumberServiceImpl {
                     Err(e) => Some((Err(e), (requests, total))),
                 }
             });
-        Ok(Response::stream(response_stream))
+        Response::stream_ok(response_stream)
     }
 }
 

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use buffa::view::OwnedView;
 use connectrpc::client::{ClientConfig, HttpClient};
-use connectrpc::{ConnectError, Context, Router};
+use connectrpc::{ConnectError, RequestContext, Response, Router, ServiceResult, ServiceStream};
 use futures::{Stream, StreamExt};
 
 pub mod proto {
@@ -26,24 +26,22 @@ struct NumberServiceImpl;
 impl NumberService for NumberServiceImpl {
     async fn square(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<SquareRequestView<'static>>,
-    ) -> Result<(SquareResponse, Context), ConnectError> {
+    ) -> ServiceResult<SquareResponse> {
         let v = request.value.unwrap_or(0) as i64;
-        Ok((
-            SquareResponse {
-                squared: Some(v * v),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(SquareResponse {
+            squared: Some(v * v),
+            ..Default::default()
+        }
+        .into())
     }
 
     async fn range(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         request: OwnedView<RangeRequestView<'static>>,
-    ) -> Result<(ResponseStream<RangeResponse>, Context), ConnectError> {
+    ) -> ServiceResult<ServiceStream<RangeResponse>> {
         let start = request.start.unwrap_or(0);
         let count = request.count.unwrap_or(0).max(0);
         let stream = futures::stream::iter((0..count).map(move |i| {
@@ -52,32 +50,30 @@ impl NumberService for NumberServiceImpl {
                 ..Default::default()
             })
         }));
-        Ok((Box::pin(stream), ctx))
+        Ok(Response::stream(stream))
     }
 
     async fn sum(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         mut requests: RequestStream<SumRequestView<'static>>,
-    ) -> Result<(SumResponse, Context), ConnectError> {
+    ) -> ServiceResult<SumResponse> {
         let mut total: i64 = 0;
         while let Some(req) = requests.next().await {
             total += req?.value.unwrap_or(0) as i64;
         }
-        Ok((
-            SumResponse {
-                total: Some(total),
-                ..Default::default()
-            },
-            ctx,
-        ))
+        Ok(SumResponse {
+            total: Some(total),
+            ..Default::default()
+        }
+        .into())
     }
 
     async fn running_sum(
         &self,
-        ctx: Context,
+        _ctx: RequestContext,
         requests: RequestStream<RunningSumRequestView<'static>>,
-    ) -> Result<(ResponseStream<RunningSumResponse>, Context), ConnectError> {
+    ) -> ServiceResult<ServiceStream<RunningSumResponse>> {
         let response_stream =
             futures::stream::unfold((requests, 0i64), |(mut requests, mut total)| async move {
                 match requests.next().await? {
@@ -94,7 +90,7 @@ impl NumberService for NumberServiceImpl {
                     Err(e) => Some((Err(e), (requests, total))),
                 }
             });
-        Ok((Box::pin(response_stream), ctx))
+        Ok(Response::stream(response_stream))
     }
 }
 

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -1,13 +1,12 @@
 //! End-to-end test: spin up the NumberService in-process, exercise all
 //! four RPC types over a real TCP socket, assert expected results.
 
-use std::pin::Pin;
 use std::sync::Arc;
 
 use buffa::view::OwnedView;
 use connectrpc::client::{ClientConfig, HttpClient};
-use connectrpc::{ConnectError, RequestContext, Response, Router, ServiceResult, ServiceStream};
-use futures::{Stream, StreamExt};
+use connectrpc::{RequestContext, Response, Router, ServiceResult, ServiceStream};
+use futures::StreamExt;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
@@ -16,10 +15,8 @@ pub mod proto {
 use proto::anthropic::connectrpc::tour::v1::__buffa::view::*;
 use proto::anthropic::connectrpc::tour::v1::*;
 
-// Local type aliases that flatten the streaming-handler signatures.
-// See src/server.rs for the rationale.
-type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> + Send>>;
-type RequestStream<V> = Pin<Box<dyn Stream<Item = Result<OwnedView<V>, ConnectError>> + Send>>;
+// Local alias that flattens client/bidi-stream request parameters.
+type RequestStream<V> = ServiceStream<OwnedView<V>>;
 
 struct NumberServiceImpl;
 

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -63,7 +63,7 @@ mod tests {
                     i + 1,
                 ))
             });
-            Ok(Response::stream(stream))
+            Response::stream_ok(stream)
         }
 
         async fn client_stream(
@@ -115,7 +115,7 @@ mod tests {
                 }
             });
             let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-            Ok(Response::stream(stream))
+            Response::stream_ok(stream)
         }
     }
 

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -33,12 +33,11 @@ mod tests {
             request: OwnedView<EchoRequestView<'static>>,
         ) -> ServiceResult<EchoResponse> {
             let request = request.to_owned_message();
-            Ok(EchoResponse {
+            Response::ok(EchoResponse {
                 sequence: request.sequence,
                 data: request.data,
                 ..Default::default()
-            }
-            .into())
+            })
         }
 
         async fn server_stream(
@@ -79,12 +78,11 @@ mod tests {
                 count += 1;
                 parts.push(req.data);
             }
-            Ok(EchoResponse {
+            Response::ok(EchoResponse {
                 sequence: count,
                 data: parts.join(","),
                 ..Default::default()
-            }
-            .into())
+            })
         }
 
         async fn bidi_stream(

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -6,13 +6,16 @@ pub use proto::test::echo::v1::*;
 
 #[cfg(test)]
 mod tests {
-    use std::pin::Pin;
+
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     use connectrpc::client::{ClientConfig, ClientTransport, HttpClient};
-    use connectrpc::{ConnectError, ConnectRpcService, Context, Router};
-    use futures::{Stream, StreamExt};
+    use connectrpc::{
+        ConnectError, ConnectRpcService, RequestContext, Response, Router, ServiceResult,
+        ServiceStream,
+    };
+    use futures::StreamExt;
     use tokio::net::TcpListener;
 
     use super::*;
@@ -26,31 +29,23 @@ mod tests {
     impl EchoService for TestEchoService {
         async fn echo(
             &self,
-            ctx: Context,
+            _ctx: RequestContext,
             request: OwnedView<EchoRequestView<'static>>,
-        ) -> Result<(EchoResponse, Context), ConnectError> {
+        ) -> ServiceResult<EchoResponse> {
             let request = request.to_owned_message();
-            Ok((
-                EchoResponse {
-                    sequence: request.sequence,
-                    data: request.data,
-                    ..Default::default()
-                },
-                ctx,
-            ))
+            Ok(EchoResponse {
+                sequence: request.sequence,
+                data: request.data,
+                ..Default::default()
+            }
+            .into())
         }
 
         async fn server_stream(
             &self,
-            ctx: Context,
+            _ctx: RequestContext,
             request: OwnedView<EchoRequestView<'static>>,
-        ) -> Result<
-            (
-                Pin<Box<dyn Stream<Item = Result<EchoResponse, ConnectError>> + Send>>,
-                Context,
-            ),
-            ConnectError,
-        > {
+        ) -> ServiceResult<ServiceStream<EchoResponse>> {
             let request = request.to_owned_message();
             let count = request.sequence;
             let stream = futures::stream::unfold(0, move |i| async move {
@@ -69,19 +64,14 @@ mod tests {
                     i + 1,
                 ))
             });
-            Ok((Box::pin(stream), ctx))
+            Ok(Response::stream(stream))
         }
 
         async fn client_stream(
             &self,
-            ctx: Context,
-            mut requests: Pin<
-                Box<
-                    dyn Stream<Item = Result<OwnedView<EchoRequestView<'static>>, ConnectError>>
-                        + Send,
-                >,
-            >,
-        ) -> Result<(EchoResponse, Context), ConnectError> {
+            _ctx: RequestContext,
+            mut requests: ServiceStream<OwnedView<EchoRequestView<'static>>>,
+        ) -> ServiceResult<EchoResponse> {
             let mut count = 0i32;
             let mut parts = Vec::new();
             while let Some(req) = requests.next().await {
@@ -89,32 +79,19 @@ mod tests {
                 count += 1;
                 parts.push(req.data);
             }
-            Ok((
-                EchoResponse {
-                    sequence: count,
-                    data: parts.join(","),
-                    ..Default::default()
-                },
-                ctx,
-            ))
+            Ok(EchoResponse {
+                sequence: count,
+                data: parts.join(","),
+                ..Default::default()
+            }
+            .into())
         }
 
         async fn bidi_stream(
             &self,
-            ctx: Context,
-            requests: Pin<
-                Box<
-                    dyn Stream<Item = Result<OwnedView<EchoRequestView<'static>>, ConnectError>>
-                        + Send,
-                >,
-            >,
-        ) -> Result<
-            (
-                Pin<Box<dyn Stream<Item = Result<EchoResponse, ConnectError>> + Send>>,
-                Context,
-            ),
-            ConnectError,
-        > {
+            _ctx: RequestContext,
+            requests: ServiceStream<OwnedView<EchoRequestView<'static>>>,
+        ) -> ServiceResult<ServiceStream<EchoResponse>> {
             // Map stream to owned types before spawning to satisfy Send bounds
             let mut requests = Box::pin(requests.map(|r| r.map(|v| v.to_owned_message())));
             // Echo each request back immediately via an mpsc channel.
@@ -140,7 +117,7 @@ mod tests {
                 }
             });
             let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-            Ok((Box::pin(stream), ctx))
+            Ok(Response::stream(stream))
         }
     }
 


### PR DESCRIPTION
Fixes #7
Closes #51

## What

Replaces the in/out-conflated `Context` struct with a read-only `RequestContext` (passed in) and a `Response<B>` wrapper (returned). A handler implementation now looks like:

```rust
async fn say(&self, _ctx: RequestContext, req: OwnedView<SayRequestView<'static>>)
    -> ServiceResult<SayResponse>
{
    Response::ok(SayResponse { sentence: reply, ..Default::default() })
}
```

The generated **trait definition** (what `cargo doc` / rust-analyzer hover shows, not what you write) is denser because it spells out the RPITIT bounds:

```rust
// unary / client-stream
fn say(&self, ctx: RequestContext, req: OwnedView<SayRequestView<'static>>)
    -> impl Future<Output = ServiceResult<impl Encodable<SayResponse> + Send + 'static + use<Self>>> + Send;

// server-stream / bidi
fn introduce(&self, ctx: RequestContext, req: ...)
    -> impl Future<Output = ServiceResult<ServiceStream<IntroduceResponse>>> + Send;
```

`async fn` desugars the outer `impl Future`, and writing `-> ServiceResult<SayResponse>` (concrete) refines the `impl Encodable<...>` bound, so impls never spell out the long form. #67 (stacked on this PR) emits a per-message `OwnedSayRequestView` alias, shortening the `req` param too; the aliases are transparent so existing long-form impls remain valid.

With response metadata:

```rust
Ok(Response::new(reply)
    .with_header("x-request-id", id)
    .with_trailer("x-timing", elapsed))
```

Streaming bodies:

```rust
Response::stream_ok(futures::stream::iter(items))
```

## New `connectrpc::response` module

- `RequestContext` - read-only request headers, deadline, extensions. `header(name)` takes `impl AsHeaderName` so `ctx.header("x-foo")` works without constructing a `HeaderName`.
- `Response<B>` - body + response headers/trailers/compression hint. Public fields plus a builder; `From<B>` for the bare-body case.
  - `Response::ok(body) -> ServiceResult<B>` - bare-body happy path.
  - `Response::stream_ok(s) -> ServiceResult<ServiceStream<T>>` - streaming happy path (boxes + unsize-coerces).
  - `with_header` / `with_trailer` (panic on invalid name/value, append semantics) and `try_with_header` / `try_with_trailer` (fallible, return `http::Error` which now `From`-converts into `ConnectError` so `?` works in handlers).
  - `compress(impl Into<Option<bool>>)` - tri-state (true/false/None for server default).
- `Encodable<M>` - "encodes to the same wire bytes as `M`". One method, `encode(&self, CodecFormat) -> Result<Bytes, ConnectError>`. Only the owned `M: Message + Serialize` implements it in this PR; #67 adds view-body impls so handlers can return borrowed responses.
- `ServiceResult<B>` / `ServiceStream<T>` - aliases that collapse the `Result<Response<B>, ConnectError>` and `Pin<Box<dyn Stream<...>>>` noise out of every signature.
- `EncodedResponse` - the bytes+headers+trailers+compress tuple the dispatcher passes to the protocol layer. Re-exported at the crate root for hand-written `Dispatcher` impls.

## RPITIT notes

- The inner `impl Encodable<M>` carries `+ use<Self>` precise capture. Without it, Rust 2024's default capture pulls `&self`'s lifetime into the opaque body type, breaking the `register()`-path closures.
- Impls returning `-> ServiceResult<SayResponse>` refine the trait's `impl Encodable<M>` bound. This is the design intent, so `refining_impl_trait` is allowed at the workspace level and the user guide has a section telling downstream crates to do the same.
- The `'a` lifetime threading (response borrows from `&'a self`) lands in #67 alongside the view-body impl that exercises it.

## Migration

```rust
// before
async fn say(&self, ctx: Context, req: ...) -> Result<(SayResponse, Context), ConnectError> {
    Ok((SayResponse { ... }, ctx))
}
// after
async fn say(&self, _ctx: RequestContext, req: ...) -> ServiceResult<SayResponse> {
    Response::ok(SayResponse { ... })
}
```

15 in-repo service impls migrated; `docs/guide.md` updated; `Context` removed.

## Verification

- `cargo test --workspace`: 336 passed
- `RUSTFLAGS=-Dwarnings cargo check --all-features --all-targets`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `task conformance:test`: **3600/3600 passed**
- All 12 CI checks green
