### PR TITLE
connectrpc-build: add Config::emit_rerun_directives(bool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ increment the patch version.
   accessors), and the `Debug` output for an unset map now shows
   `None` instead of `{}`.
 
+### Added
+
+- **`connectrpc-build`**: `Config::emit_rerun_directives(bool)` to suppress
+  the `cargo:rerun-if-changed=` lines when running outside a Cargo
+  `build.rs` context (e.g. from a Bazel genrule or standalone host tool).
+  Default remains `true`.
+
 [#34]: https://github.com/anthropics/connect-rust/issues/34
 [#61]: https://github.com/anthropics/connect-rust/issues/61
 [buffa#22]: https://github.com/anthropics/buffa/pull/22

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -62,6 +62,7 @@ pub struct Config {
     out_dir: Option<PathBuf>,
     descriptor_source: DescriptorSource,
     include_file: Option<String>,
+    emit_rerun_directives: bool,
     options: Options,
 }
 
@@ -74,6 +75,7 @@ impl Config {
             out_dir: None,
             descriptor_source: DescriptorSource::default(),
             include_file: None,
+            emit_rerun_directives: true,
             options: Options::default(),
         }
     }
@@ -101,6 +103,17 @@ impl Config {
     #[must_use]
     pub fn out_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.out_dir = Some(dir.into());
+        self
+    }
+
+    /// Emit `cargo:rerun-if-changed=` directives to stdout (default: `true`).
+    ///
+    /// Set to `false` when running outside a Cargo `build.rs` context (e.g.
+    /// from a Bazel genrule or a standalone host tool) where the directives
+    /// are noise on stdout rather than instructions to a build system.
+    #[must_use]
+    pub fn emit_rerun_directives(mut self, enabled: bool) -> Self {
+        self.emit_rerun_directives = enabled;
         self
     }
 
@@ -290,13 +303,15 @@ impl Config {
         // on-disk paths; emitting `rerun-if-changed` for them points cargo at
         // missing files and forces a rebuild on every invocation. The `.pb`
         // path is the only real input in that mode.
-        match &self.descriptor_source {
-            DescriptorSource::Precompiled(p) => {
-                println!("cargo:rerun-if-changed={}", p.display());
-            }
-            DescriptorSource::Protoc | DescriptorSource::Buf => {
-                for f in &self.files {
-                    println!("cargo:rerun-if-changed={}", f.display());
+        if self.emit_rerun_directives {
+            match &self.descriptor_source {
+                DescriptorSource::Precompiled(p) => {
+                    println!("cargo:rerun-if-changed={}", p.display());
+                }
+                DescriptorSource::Protoc | DescriptorSource::Buf => {
+                    for f in &self.files {
+                        println!("cargo:rerun-if-changed={}", f.display());
+                    }
                 }
             }
         }
@@ -575,7 +590,14 @@ mod tests {
         assert!(!cfg.options.buffa.strict_utf8_mapping);
         assert!(cfg.options.buffa.generate_json);
         assert!(cfg.options.buffa.emit_register_fn);
+        assert!(cfg.emit_rerun_directives);
         assert!(matches!(cfg.descriptor_source, DescriptorSource::Protoc));
+    }
+
+    #[test]
+    fn config_emit_rerun_directives_toggle() {
+        let cfg = Config::new().emit_rerun_directives(false);
+        assert!(!cfg.emit_rerun_directives);
     }
 
     #[test]

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -298,20 +298,22 @@ impl Config {
             write_if_changed(&include_path, include_src.as_bytes())?;
         }
 
-        // 6. Cargo re-run triggers. In Precompiled mode `self.files` holds
-        // proto-relative names (per the docs on `descriptor_set()`), not
-        // on-disk paths; emitting `rerun-if-changed` for them points cargo at
-        // missing files and forces a rebuild on every invocation. The `.pb`
-        // path is the only real input in that mode.
-        if self.emit_rerun_directives {
-            match &self.descriptor_source {
-                DescriptorSource::Precompiled(p) => {
-                    println!("cargo:rerun-if-changed={}", p.display());
-                }
-                DescriptorSource::Protoc | DescriptorSource::Buf => {
-                    for f in &self.files {
-                        println!("cargo:rerun-if-changed={}", f.display());
-                    }
+        // 6. Cargo re-run triggers. Skipped entirely for non-Cargo callers.
+        // In Precompiled mode `self.files` holds proto-relative names (per
+        // the docs on `descriptor_set()`), not on-disk paths; emitting
+        // `rerun-if-changed` for them points cargo at missing files and
+        // forces a rebuild on every invocation. The `.pb` path is the only
+        // real input in that mode.
+        if !self.emit_rerun_directives {
+            return Ok(());
+        }
+        match &self.descriptor_source {
+            DescriptorSource::Precompiled(p) => {
+                println!("cargo:rerun-if-changed={}", p.display());
+            }
+            DescriptorSource::Protoc | DescriptorSource::Buf => {
+                for f in &self.files {
+                    println!("cargo:rerun-if-changed={}", f.display());
                 }
             }
         }


### PR DESCRIPTION
Fixes #68

`Config::compile()` unconditionally prints `cargo:rerun-if-changed=...`
to stdout. Correct for `build.rs`; noise for non-Cargo callers (Bazel
genrules, standalone host tools) that have to capture and discard it.

Adds `Config::emit_rerun_directives(bool)` (default `true`) so callers
outside a Cargo build script can opt out:

```rust
connectrpc_build::Config::new()
    .files(&protos)
    .out_dir(out)
    .emit_rerun_directives(false)
    .compile()?;
```

Net +29 lines. Additive; default behaviour unchanged.
