### PR TITLE
add CONTRIBUTING.md, project CLAUDE.md, and rust-api-ergonomics-reviewer agent

### DIFF
--- a/.claude/agents/rust-api-ergonomics-reviewer.md
+++ b/.claude/agents/rust-api-ergonomics-reviewer.md
@@ -1,0 +1,72 @@
+---
+name: rust-api-ergonomics-reviewer
+description: Reviews Rust library/framework code from the downstream consumer's perspective. Focuses on API clarity, idiomaticity, happy-path friction, footguns, and what users will actually see in their editor and compiler output. Complements rust-code-reviewer (which covers correctness/safety/perf).
+tools: Read, Glob, Grep
+model: opus
+---
+
+You are reviewing Rust code that will be **consumed as a library or framework**. Your job is not to find bugs the test suite would catch - it is to find the things a downstream user will trip over, squint at, or have to read the source to understand. Adopt the perspective of someone integrating this crate into their project for the first time.
+
+## What to look for
+
+### 1. Happy-path friction
+For the most common use case, write out exactly what the user types. Count the ceremony.
+- How many imports do they need? Are the right things re-exported at the crate root?
+- How many wrapper layers (`Ok(...)`, `.into()`, `Box::pin(...)`, type annotations) between "I have the value" and "I returned it"?
+- Does struct-update syntax (`..Default::default()`) work, or is the type `#[non_exhaustive]` so they must mutate-after-default? Is the doc honest about which?
+- Is there a one-liner constructor for the 80% case, or does every caller assemble the same three-field builder?
+
+If the shortest correct spelling is longer than the obvious-but-wrong one, flag it.
+
+### 2. Downstream compiler output
+The user compiles *their* crate, not this one. What lands in their terminal?
+- Lints that fire at the **impl site**, not the trait site (`refining_impl_trait`, `async_fn_in_trait`, `private_bounds`). A workspace-level `allow` here does nothing for them.
+- Type errors when they get a bound slightly wrong. Write the broken version; read the error. Is the fix discoverable from the message, or does it mention an internal type they've never heard of?
+- `#[must_use]` on builders that are easy to drop mid-chain.
+- Deprecation paths: does `#[deprecated]` point at the replacement?
+
+### 3. Runtime surprises the type system doesn't prevent
+- Builder methods that **panic** on invalid input (`TryInto` in disguise). Is there a fallible sibling? Is the panic documented at the call site, not three hops away?
+- Behavioral asymmetry across configurations: a method that works for one codec/protocol/feature but errors for another, with nothing in the signature to warn you. The user finds out from a 500 in production.
+- `.append` vs `.insert` semantics on anything map-like. If `with_foo` accumulates, say so.
+- Order-dependence in builders: does `.a().b()` differ from `.b().a()`? Wholesale-replace methods that silently discard earlier calls.
+
+### 4. Type-signature honesty
+- Is there a doc-only invariant the type system could express? ("Implementations must produce bytes that decode as `M`" is a contract; consider whether a sealed trait, newtype, or associated-type bound could carry it.)
+- Public fields the docs tell you not to touch - either enforce it (private + accessors) or own the exposure.
+- `'static` bounds that will later relax to `'a` - call out that a follow-up break is coming, or land both at once.
+- `impl Trait` in return position: what does the user see in rust-analyzer's hover? An opaque type with no methods is a dead end.
+
+### 5. Naming & semantic precision
+- Error code/variant choice: is this `Internal` (we broke) or `Unimplemented` (you asked for something we don't do) or `InvalidArgument` (you broke)? The difference is whether the user retries, files a bug, or fixes their code.
+- `new` vs `with_*` vs `from_*` vs `build` - is the convention consistent within the crate?
+- Abbreviations and jargon in public names. `ctx`/`req`/`resp` are fine; project-internal codenames are not.
+- Does the name match the std/ecosystem analogue? Users pattern-match on `Cow`, `Arc`, `IntoIterator`; a `MaybeBorrowed` that's almost-but-not-quite `Cow` should say how it differs.
+
+### 6. Documentation drift & honesty
+- "A follow-up will add X" - is this PR the follow-up? Stale future-tense is worse than no comment.
+- Intra-doc links that won't resolve (`[`ForeignType::method`]` on a non-dependency).
+- Examples that don't compile against the current API. Doc-tests catch some; prose snippets in guides catch none.
+- CHANGELOG migration guidance: can a user mechanically apply it, or does it just describe the new shape?
+
+### 7. Generated-code ergonomics (codegen crates)
+- What does the user's `cargo doc` show for generated types? Are the trait bounds readable or a wall of `Pin<Box<dyn Stream<Item = Result<...>>>>`? Ship type aliases.
+- Does generated code trigger lints in the user's crate (`clippy::use_self`, `dead_code` on unused variants)? They can't edit it.
+- Multi-file/multi-package emission: if two inputs reference the same type, do you emit duplicate impls (E0119) in their crate?
+
+## What NOT to spend time on
+- Correctness bugs the test suite or conformance suite would catch. Assume those ran.
+- Performance, unless the API shape *forces* an allocation/copy the user can't avoid.
+- Internal (`pub(crate)`) code style, unless it leaks into public error messages or docs.
+- Unsafe soundness - that's `rust-code-reviewer`'s lane.
+
+## Output format
+Group by severity (High / Medium / Low). For each finding:
+- **One-line statement of what the user experiences** ("Downstream impls trigger `refining_impl_trait` on every method").
+- File:line.
+- Why it matters from the consumer's seat.
+- Concrete fix or the trade-off if there isn't a clean one.
+
+End with **Positive observations**: ergonomic choices that worked, so they don't get regressed. Be specific - "the `Response::ok(body)` shorthand removes the `.into()` tail" is useful; "good API design" is not.
+
+Keep it under 1500 words. If you can't find anything above Low, say so in two sentences and stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# connect-rust — Claude Code Instructions
+
+## Pre-Commit Code Review
+
+Before producing a commit, run **both** review agents in parallel (single
+message, two Agent tool calls):
+
+- `rust-code-reviewer` — correctness, safety, ownership/lifetimes, performance
+- `rust-api-ergonomics-reviewer` — downstream-consumer perspective:
+  happy-path friction, lints that fire in user crates, runtime footguns,
+  doc drift, generated-code readability
+
+The two are complementary (different lenses on the same diff) and produce
+largely non-overlapping findings. Address all **Critical**, **High**, and
+**Medium** findings from both. For **Low** / advisory findings, flag these
+to the user to decide.
+
+For changes that touch only internal/test/bench code with no public-API
+surface, the ergonomics reviewer may be skipped.
+
+## Regenerating Checked-In Code
+
+If a change to `connectrpc-codegen` (or a buffa version bump) affects
+generated output, regenerate before committing or CI's diff check will fail:
+
+```bash
+task generate:all
+```
+
+This rebuilds the protoc plugins from the sibling `../buffa` checkout and
+regenerates `conformance/`, `examples/{eliza,multiservice}/`, and
+`benches/rpc/` checked-in code.
+
+## Local buffa Override
+
+`task buffa:link` / `task buffa:unlink` toggle a `.cargo/config.toml`
+path-override to build against the sibling `../buffa` checkout instead of
+crates.io. CI does not have the override, so it always builds against the
+workspace `[patch.crates-io]` git pin (or crates.io once that's dropped).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # connect-rust — Claude Code Instructions
 
+@CONTRIBUTING.md
+
 ## Pre-Commit Code Review
 
 Before producing a commit, run **both** review agents in parallel (single
@@ -17,23 +19,3 @@ to the user to decide.
 
 For changes that touch only internal/test/bench code with no public-API
 surface, the ergonomics reviewer may be skipped.
-
-## Regenerating Checked-In Code
-
-If a change to `connectrpc-codegen` (or a buffa version bump) affects
-generated output, regenerate before committing or CI's diff check will fail:
-
-```bash
-task generate:all
-```
-
-This rebuilds the protoc plugins from the sibling `../buffa` checkout and
-regenerates `conformance/`, `examples/{eliza,multiservice}/`, and
-`benches/rpc/` checked-in code.
-
-## Local buffa Override
-
-`task buffa:link` / `task buffa:unlink` toggle a `.cargo/config.toml`
-path-override to build against the sibling `../buffa` checkout instead of
-crates.io. CI does not have the override, so it always builds against the
-workspace `[patch.crates-io]` git pin (or crates.io once that's dropped).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to connect-rust
+
+See [`docs/guide.md`](docs/guide.md) for the user-facing handler/client API
+and the [README](README.md) for the workspace layout.
+
+## Prerequisites
+
+- **Rust 1.88+** (MSRV; the codebase uses let-chains).
+- **`protoc` v27+** — the test and example protos use editions syntax
+  (`edition = "2023"`). Ubuntu's apt `protobuf-compiler` (v21) is too old;
+  install from the [protobuf releases] page or via `arduino/setup-protoc`
+  in CI. `task generate:all` and the `connectrpc-build` consumers need it.
+- **`buf`** — used to drive regeneration of the checked-in code (the
+  `buf.gen.yaml` files invoke locally-built plugins).
+- **`task`** ([go-task]) — the repo's command runner. `task --list` shows
+  everything.
+
+[protobuf releases]: https://github.com/protocolbuffers/protobuf/releases
+[go-task]: https://taskfile.dev
+
+## Change Size
+
+Keep each change to **≤ 250 lines net** (additions minus deletions,
+excluding test files and `*/generated/*`) wherever possible. If a task
+naturally exceeds that, split it into focused, self-contained PRs or
+commits.
+
+## Test Coverage
+
+Every change must include unit tests. Target **≥ 80% line coverage** for
+new code. Reaching 100% is not required when the remaining paths would
+require artificial tests, but coverage gaps must be intentional and
+justified. Tests live in `#[cfg(test)]` modules colocated with the code
+they test; the `tests/streaming` crate is the in-workspace e2e consumer
+of `connectrpc-build`.
+
+## Rust Conventions
+
+- Run `task lint` and `task test` before every commit (or `task ci` to
+  also run docs, minimal-features, and the multiservice example).
+- Public API items require doc comments (`///`); include `# Errors` /
+  `# Panics` sections where applicable.
+- Every `unsafe` block requires a `// SAFETY:` comment explaining the
+  invariant.
+- Avoid `.unwrap()` outside tests and provably-safe paths.
+- `#[inline]` only with full-path profiling evidence.
+
+## Code Generation (`connectrpc-codegen`)
+
+All code generation uses `quote!` blocks rather than string manipulation;
+`prettyplease` formats the final `TokenStream` into readable Rust source.
+The pipeline mirrors buffa's: accumulate `TokenStream` → `syn::parse2` →
+`prettyplease::unparse`.
+
+Key rules:
+
+- **Regular `//` comments** are not tokens and are silently dropped by
+  `quote!`. Only doc comments (`///` → `#[doc = "..."]`) survive.
+- **Identifiers** must go through `format_ident!` (or `Ident::new_raw`
+  for Rust keywords). Never interpolate raw strings as identifiers.
+- **Type paths** resolved from the descriptor context use
+  `rust_path_to_tokens` (which wraps `syn::parse_str::<syn::Path>`).
+- Generated code uses **fully-qualified paths everywhere**
+  (`::connectrpc::...`, `::buffa::...`) — no `use` statements at module
+  scope. This lets multiple generated files be `include!`d into the same
+  Rust module without E0252 collisions.
+
+## Conformance Tests
+
+The Connect protocol [conformance suite] runs against both server and
+client implementations. `task conformance:download` fetches the runner;
+`task conformance:build` builds the binaries.
+
+[conformance suite]: https://github.com/connectrpc/conformance
+
+| Suite | Task | Tests |
+|---|---|---:|
+| Server default (all protocols) | `task conformance:test` | 3600 |
+| Server Connect-only | `task conformance:test-connect-only` | 1192 |
+| Server Connect+TLS | `task conformance:test-connect-tls` | 2396 |
+| Client Connect | `task conformance:test-client-connect-only` | 2580 |
+| Client gRPC | `task conformance:test-client-grpc-only` | 1454 |
+| Client gRPC-Web | `task conformance:test-client-grpc-web-only` | 2838 |
+
+A healthy run ends with `N passed, 0 failed`. CI runs the server-default
+and the three client suites.
+
+## Checked-In Generated Code
+
+Four directories contain checked-in `buf generate` output and **must be
+regenerated** whenever `connectrpc-codegen` output changes (or the buffa
+dependency is bumped):
+
+- `conformance/src/generated/`
+- `examples/eliza/src/generated/`
+- `examples/multiservice/src/generated/`
+- `benches/rpc/src/generated/`
+
+Regenerate all of them with:
+
+```bash
+task generate:all
+```
+
+This rebuilds `protoc-gen-connect-rust` (and the sibling buffa plugins
+from `../buffa`) in release mode, then runs `buf generate` in each
+directory. CI does not have a separate stale-check job — stale generated
+code surfaces as compile errors in `Check`/`Test` instead.
+
+## Building Against a Local buffa Checkout
+
+To test combined speculative changes across both repos:
+
+```bash
+task buffa:link     # writes .cargo/config.toml pointing at ../buffa
+task buffa:unlink   # removes the override; reverts to crates.io / [patch]
+```
+
+The override is gitignored and never reaches CI or `cargo publish`.
+
+## Continuous Integration
+
+GitHub Actions CI (`.github/workflows/ci.yml`) runs on every push to
+`main` and on all pull requests. Jobs:
+
+- **Check** — `cargo check --workspace --all-features --all-targets`
+  with `RUSTFLAGS=-Dwarnings`
+- **Test** — `cargo test --workspace`
+- **Clippy** — workspace, all targets, `-D warnings`
+- **Format** — nightly `cargo fmt --check`
+- **Documentation** — `cargo doc` with broken-intra-doc-links denied
+- **MSRV (1.88)** — `cargo check` on the pinned minimum toolchain
+- **Examples** — builds and runs the example crates
+- **Minimal features** — `cargo check -p connectrpc --no-default-features`
+- **Wasm** — `wasm32-unknown-unknown` build of the client example
+- **Conformance (server)** / **Conformance (client)** — full suites


### PR DESCRIPTION
Adds a project-level `rust-api-ergonomics-reviewer` agent and a
`CLAUDE.md` instructing both reviewers to run in parallel before commits.

The ergonomics agent reviews from the downstream consumer's perspective:
happy-path friction, lints that fire in *user* crates (not this
workspace), runtime footguns the type system doesn't prevent, doc drift,
and generated-code readability. Test-driven on #66/#67 it surfaced ~10
findings the general `rust-code-reviewer` didn't (streaming/unary
shorthand asymmetry, `try_with_header` not `?`-able, missing
`Owned#{Msg}View` aliases, CHANGELOG/code error-code mismatch, etc.).

`CLAUDE.md` also notes the `task generate:all` regenerate workflow and
the `buffa:link` override.
