### PR TITLE
ci: bump cla-github-action to 1ecf0d2f (impersonation guard, co-author trailers)

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -19,10 +19,11 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Upstream contributor-assistant/github-action was archived 2026-03-23
-        # still on Node 20 (deprecated 2026-06-02). This fork bumps the
-        # runtime to Node 24 and fixes a false-failure where the check
-        # would go red after logging "All contributors have signed".
-        uses: iainmcgin/cla-github-action@eeb7f3ffa305b600c6e873578b9ea78ca11a5f3e  # v2.7.1
+        # still on Node 20 (deprecated 2026-06-02). This fork bumps to Node 24
+        # and adds: an impersonation guard (PR opener must be an author or
+        # co-author of at least one commit), Co-authored-by trailer support,
+        # and actionable unlinked-email guidance.
+        uses: iainmcgin/cla-github-action@1ecf0d2f19b665777f5b0cda149104238cc6c493
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Bumps the CLA assistant action from `eeb7f3f` (v2.7.1) to `1ecf0d2f`.

## What's new in the action

- **Impersonation guard** — new `require-opener-as-author` input (default `true`): fails the check if the PR opener is not recorded as an author or `Co-authored-by` of any commit in the PR. Guards against an attacker opening a PR whose commits are attributed to a trusted identity. Emits an `opener_not_in_commits` output regardless of pass/fail. Runs before the allowlist filter, so allowlisted maintainers are not exempt.
- **PR opener and `Co-authored-by:` trailers join the committer set** — previously only `commit.author` was checked. The PR submitter and any co-author trailers must now also sign (or be allowlisted). Noreply-form trailer emails (`<id>+<login>@users.noreply.github.com`) are parsed directly to login/id.
- **Actionable unlinked-email guidance** — when a commit author's email is not linked to any GitHub user, the bot now posts a `> [!WARNING]` block listing each unlinked email with concrete remediation (link at github.com/settings/emails, or rewrite commands).
- Dead-404-path bugfix (signatures-file bootstrap now works first-time), broken-markdown fix in the signed list, pagination for comments/runs/commits, TypeScript 6, knip/publint/actionlint.
- Removed `signed-empty-commit-message` input (we don't use it).

## Config

Kept `require-opener-as-author` at the default `true`. No new inputs wired. Allowlist preserved verbatim.

## Operational impact

- **Author-rewrite for unlinked-email contributors** (e.g. the recent author-rewrite on PR #59) — still works: the contributor is the PR opener and appears via the `Co-authored-by:` trailer, so no opener mismatch. They are now correctly required to sign.
- **Signed-squash for unsigned fork commits** — the squash commit message **must include** `Co-authored-by: <login> <id+login@users.noreply.github.com>` for the PR opener, or the impersonation guard will fail the check.

## Note

`pull_request_target` runs the workflow from the **base** branch, so this PR's own CLA check still uses the old `eeb7f3f` pin. The new action is first exercised on the next PR opened/synced after this merges.

Fixes #72
