### PR TITLE
ci: bump cla-github-action to 73f6929 (email-based allowlist)

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -22,12 +22,17 @@ jobs:
         # still on Node 20 (deprecated 2026-06-02). This fork bumps to Node 24
         # and adds: an impersonation guard (PR opener must be an author or
         # co-author of at least one commit), Co-authored-by trailer support,
-        # and actionable unlinked-email guidance.
-        uses: iainmcgin/cla-github-action@1ecf0d2f19b665777f5b0cda149104238cc6c493
+        # email-based allowlist matching, and actionable unlinked-email
+        # guidance.
+        uses: iainmcgin/cla-github-action@73f6929f697892cfd60edf04bae4f28ac2909b08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
           path-to-signatures: "signatures/cla.json"
           branch: "cla-signatures"
-          allowlist: "iainmcgin,asacamano,dependabot[bot],github-actions[bot],renovate[bot]"
+          # noreply@anthropic.com is the email AI assistants use on
+          # Co-authored-by trailers (e.g. Claude). Allowlisting it suppresses
+          # the synthetic co-author from the CLA check; the PR opener still
+          # has to sign.
+          allowlist: "iainmcgin,asacamano,dependabot[bot],github-actions[bot],renovate[bot],noreply@anthropic.com"


### PR DESCRIPTION
Bumps `iainmcgin/cla-github-action` to `73f6929` and allowlists `noreply@anthropic.com`.

The new revision adds email-based matching to the allowlist alongside the existing name-based match. AI assistants commonly add `Co-authored-by:` trailers like `Claude Opus 4.7 <noreply@anthropic.com>`, and the impersonation guard added in the previous bump correctly counts those as committers — without an email allowlist, every PR with such a trailer fails the CLA check. The new entry suppresses the synthetic identity once. The PR opener still has to sign.

Tests on the action: 100/100 pass, including new cases for exact email match, `*@anthropic.com` glob, and the no-email-supplied path.

Caught while reviewing PR #63 — connyay's commit there carries a `Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>` trailer that was failing the CLA check after the previous bump landed on main.
