### PR TITLE
connectrpc: add include_generated!() macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,11 +87,16 @@ increment the patch version.
 
 ### Added
 
+- **`connectrpc::include_generated!()`**: shorthand macro for
+  `include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"))`, mirroring
+  `tonic::include_proto!`. An optional filename argument supports
+  projects that customise the output via `Config::include_file` ([#50]).
 - **`connectrpc-build`**: `Config::emit_rerun_directives(bool)` to suppress
   the `cargo:rerun-if-changed=` lines when running outside a Cargo
   `build.rs` context (e.g. from a Bazel genrule or standalone host tool).
   Default remains `true`.
 
+[#50]: https://github.com/anthropics/connect-rust/issues/50
 [#7]: https://github.com/anthropics/connect-rust/issues/7
 [#34]: https://github.com/anthropics/connect-rust/issues/34
 [#61]: https://github.com/anthropics/connect-rust/issues/61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,9 +108,10 @@ increment the patch version.
 ### Added
 
 - **`connectrpc::include_generated!()`**: shorthand macro for
-  `include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"))`, mirroring
-  `tonic::include_proto!`. An optional filename argument supports
-  projects that customise the output via `Config::include_file` ([#50]).
+  `include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"))`. An optional
+  filename argument (note: a filename including `.rs`, **not** a proto
+  package name as in `tonic::include_proto!`) supports projects that
+  customise the output via `Config::include_file` ([#50]).
 - **`connectrpc-build`**: `Config::emit_rerun_directives(bool)` to suppress
   the `cargo:rerun-if-changed=` lines when running outside a Cargo
   `build.rs` context (e.g. from a Bazel genrule or standalone host tool).

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ fn main() {
 
 ```rust
 // lib.rs
-include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+pub mod proto {
+    connectrpc::include_generated!();
+}
 ```
 
 ### Implement the server

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ```rust,ignore
 //! // lib.rs
-//! include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+//! connectrpc::include_generated!();
 //! ```
 //!
 //! # Requirements
@@ -202,7 +202,7 @@ impl Config {
     /// it from your crate root:
     ///
     /// ```rust,ignore
-    /// include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    /// connectrpc::include_generated!();
     /// ```
     #[must_use]
     pub fn include_file(mut self, name: impl Into<String>) -> Self {

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -284,3 +284,81 @@ pub use server::PeerCerts;
 /// / [`Http2Connection::connect_tls`](client::Http2Connection::connect_tls).
 #[cfg(any(feature = "server-tls", feature = "client-tls"))]
 pub use rustls;
+
+/// Include the generated ConnectRPC file from `$OUT_DIR`.
+///
+/// Shorthand for `include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"))`.
+///
+/// Requires `Config::include_file` in `build.rs` (the no-arg form assumes
+/// the filename `"_connectrpc.rs"`):
+///
+/// ```rust,ignore
+/// // build.rs
+/// connectrpc_build::Config::new()
+///     .files(&["proto/my_service.proto"])
+///     .includes(&["proto/"])
+///     .include_file("_connectrpc.rs")
+///     .compile()
+///     .unwrap();
+/// ```
+///
+/// ```rust,ignore
+/// // src/lib.rs
+/// pub mod proto {
+///     connectrpc::include_generated!();
+/// }
+/// ```
+///
+/// `OUT_DIR` is resolved in the **calling crate's** compilation context.
+///
+/// If you customised the output filename via `Config::include_file`, pass the
+/// **filename** (including the `.rs` extension) as a string literal. Unlike
+/// `tonic::include_proto!`, this argument is a filename, not a proto package
+/// name:
+///
+/// ```rust,ignore
+/// pub mod proto {
+///     connectrpc::include_generated!("my_output.rs");
+/// }
+/// ```
+///
+/// # Notes
+///
+/// - This macro is only for the `build.rs`/`OUT_DIR` workflow. If you use
+///   `buf generate` to write files into `src/generated/`, use `#[path]`:
+///
+///   ```rust,ignore
+///   #[path = "generated/proto/mod.rs"]
+///   pub mod proto;
+///   ```
+///
+/// - If `Config::out_dir` was used to redirect output away from `$OUT_DIR`,
+///   this macro does not apply; use `#[path]` or raw `include!` instead.
+///
+/// - If your proto package hierarchy contains a module named `connectrpc`,
+///   the crate name may be shadowed in scope. Use the absolute path to avoid
+///   the ambiguity:
+///
+///   ```rust,ignore
+///   mod proto {
+///       ::connectrpc::include_generated!();
+///   }
+///   ```
+///
+/// # Compile errors
+///
+/// This macro produces a compile error (not a runtime panic) if:
+///
+/// - `OUT_DIR` is not set — the crate is not being built by Cargo.
+/// - The generated file does not exist — `Config::include_file` was not
+///   called in `build.rs`, or the filename passed to the one-arg form does
+///   not match what was passed to `Config::include_file`.
+#[macro_export]
+macro_rules! include_generated {
+    () => {
+        include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    };
+    ($file:literal) => {
+        include!(concat!(env!("OUT_DIR"), "/", $file));
+    };
+}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -126,7 +126,7 @@ use buffa::view::OwnedView;
 use connectrpc::{RequestContext, Response, Router, ServiceResult};
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 use proto::greet::v1::*;
 use proto::greet::v1::__buffa::view::*;
@@ -191,7 +191,8 @@ fn main() {
 ```
 
 Output is unified: message types and service stubs in one file per
-proto, assembled via a single `include!`. Best for simple projects.
+proto, included into your crate with `connectrpc::include_generated!()`.
+Best for simple projects.
 
 ### `buf generate` (checked-in code, production-grade)
 
@@ -206,6 +207,23 @@ See the README's
 [Code generation section](../README.md#generate-rust-code) for plugin
 installation, `buf.gen.yaml` configuration, and the `buffa_module`
 shorthand for cross-tree references.
+
+### Inclusion patterns side-by-side
+
+Both workflows produce the same runtime API. The only difference is how
+you include the generated code into your crate:
+
+```rust
+// connectrpc-build (build.rs) users:
+pub mod proto { connectrpc::include_generated!(); }
+
+// buf generate users:
+#[path = "generated/proto/mod.rs"]
+pub mod proto;
+```
+
+The underlying difference (`OUT_DIR` vs a known source path) is honest
+and visible, but the call-site shape is parallel.
 
 ## Implementing servers
 

--- a/examples/middleware/src/client.rs
+++ b/examples/middleware/src/client.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use connectrpc::client::{CallOptions, ClientConfig, HttpClient};
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 
 use proto::anthropic::connectrpc::middleware_demo::v1::*;

--- a/examples/middleware/src/server.rs
+++ b/examples/middleware/src/server.rs
@@ -34,7 +34,7 @@ use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 
 use proto::anthropic::connectrpc::middleware_demo::v1::__buffa::view::*;

--- a/examples/middleware/tests/e2e.rs
+++ b/examples/middleware/tests/e2e.rs
@@ -18,7 +18,7 @@ use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 
 use proto::anthropic::connectrpc::middleware_demo::v1::__buffa::view::*;

--- a/examples/streaming-tour/src/client.rs
+++ b/examples/streaming-tour/src/client.rs
@@ -4,7 +4,7 @@
 use connectrpc::client::{ClientConfig, HttpClient};
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 
 use proto::anthropic::connectrpc::tour::v1::*;

--- a/examples/streaming-tour/src/server.rs
+++ b/examples/streaming-tour/src/server.rs
@@ -20,7 +20,7 @@ use connectrpc::{RequestContext, Response, Router, ServiceResult, ServiceStream}
 use futures::StreamExt;
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 
 use proto::anthropic::connectrpc::tour::v1::__buffa::view::*;

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -9,7 +9,7 @@ use connectrpc::{RequestContext, Response, Router, ServiceResult, ServiceStream}
 use futures::StreamExt;
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 
 use proto::anthropic::connectrpc::tour::v1::__buffa::view::*;

--- a/examples/wasm-client/src/lib.rs
+++ b/examples/wasm-client/src/lib.rs
@@ -13,7 +13,9 @@
 mod transport;
 
 mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    // `::connectrpc` required: the generated file declares `pub mod connectrpc`
+    // inside this module, which would shadow the crate name if the path were relative.
+    ::connectrpc::include_generated!();
 }
 
 use ::connectrpc::client::ClientConfig;

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
+    connectrpc::include_generated!();
 }
 pub use proto::test::echo::v1::__buffa::view::*;
 pub use proto::test::echo::v1::*;


### PR DESCRIPTION
Closes #50.

Every build.rs user writes the same three-nested-macro boilerplate to
include the generated file. This is the `connectrpc` analogue of
`tonic::include_proto!()`:

```rust
// Before
pub mod proto {
    include!(concat!(env!("OUT_DIR"), "/_connectrpc.rs"));
}

// After
pub mod proto {
    connectrpc::include_generated!();
}
```

An optional `$file` argument supports projects that customised the
output filename via `Config::include_file`. Unlike `tonic::include_proto!`,
the argument is a **filename** (including `.rs` extension), not a proto
package name.

## Changes

- `connectrpc/src/lib.rs` — new `include_generated!()` macro with full doc
- `connectrpc-build/src/lib.rs` — updated 2 doc examples
- `docs/guide.md` — quick-start snippet updated; side-by-side inclusion
  pattern comparison added to the Code generation section
- `CHANGELOG.md` — entry under `[Unreleased] ### Added`
- 8 call sites in `examples/` and `tests/` updated

## Verification

- `cargo clippy --workspace --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — all pass
- `cargo +1.88 check --workspace --all-features --all-targets` — clean

The macro expands to a compile-time `include!` call and has no
unit-testable behaviour. Coverage is provided by the 8 updated usage
sites, all of which compile and run under the CI Test and Examples jobs.
