### PR TITLE
ci: bump cla-github-action to 5b54183 (retry transient 5xx)

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -22,9 +22,9 @@ jobs:
         # still on Node 20 (deprecated 2026-06-02). This fork bumps to Node 24
         # and adds: an impersonation guard (PR opener must be an author or
         # co-author of at least one commit), Co-authored-by trailer support,
-        # email-based allowlist matching, and actionable unlinked-email
-        # guidance.
-        uses: iainmcgin/cla-github-action@73f6929f697892cfd60edf04bae4f28ac2909b08
+        # email-based allowlist matching, automatic retry of transient
+        # GitHub 5xx errors, and actionable unlinked-email guidance.
+        uses: iainmcgin/cla-github-action@5b54183037a58ba5ade5ea9b3e1872d969730f77
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Bump the pinned action SHA to pick up [iainmcgin/cla-github-action@5b54183](https://github.com/iainmcgin/cla-github-action/commit/5b54183037a58ba5ade5ea9b3e1872d969730f77), which wires `@octokit/plugin-retry` into the action's Octokit clients.

Motivation: GitHub's API periodically returns transient 5xx errors (notably the "Unicorn!" HTML 500 page) that previously failed the CLA check immediately and required a manual `recheck` comment. With the new version, the action retries 5xx and network errors three times with exponential backoff (~1s/4s/9s) before giving up. 4xx errors (401/403/404/422/451) are not retried, so genuine misconfiguration still fails fast.