### PR TITLE
fix(connectrpc-build): suppress unused_qualifications + impl_trait_redundant_captures in generated mod.rs

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -8,10 +8,22 @@ name: Publish to crates.io
 # token. Once Trusted Publishing is configured per crate and the secret is
 # removed, publishes run entirely over OIDC with no stored credentials.
 
-# No `push: tags` trigger — crates.io publish is manual-only. The release
-# workflow (binaries + GitHub release) is tag-triggered; this one is not, so
-# a patch tag can't accidentally publish before you've dry-run-verified.
+# Tag-triggered (`v*`) for releases, mirroring buffa's publish-crates
+# workflow. The `workflow_dispatch` path remains for re-runs and dry-run
+# verification. On a tag push `inputs.dry_run` is undefined → falsy → no
+# `--dry-run` flag, so a tag push is always a real publish.
+#
+# Supply-chain guards: the "release tags" repository ruleset restricts
+# `refs/tags/v*` creation/update/deletion to repository admins and
+# requires signed tags, so a non-admin cannot push a tag that triggers
+# this. The `crates-io` GitHub Environment additionally restricts which
+# refs may run inside it (`v*` tags and `main`), so a feature branch
+# cannot dispatch a publish either. There is no human-approval gate on
+# the publish step itself once a release tag exists; if that is wanted,
+# add a required-reviewer to the `crates-io` environment.
 on:
+  push:
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       dry_run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ increment the patch version.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-07
+
+### Fixed
+
+- **`connectrpc-build`: generated `mod.rs` `#[allow(...)]` now suppresses
+  `unused_qualifications` and `impl_trait_redundant_captures`.** The 0.4.0
+  trait method RPIT carries a `use<'a, Self>` precise-capturing clause that
+  is required for edition-2021 consumers but redundant under edition 2024,
+  and buffa 0.5 codegen references sibling types through the canonical
+  `__buffa::view::*` path even when a shorter natural-path re-export exists
+  (the re-export can be shadowed by a same-named proto type). Both lints
+  fired against the generated code in workspaces that opt them in (or build
+  with `-D warnings`). The two extra entries in the `#[allow(...)]`
+  block scope the suppression to the `pub mod <pkg>` tree and don't touch
+  hand-written code.
+
+  Also documenting one related lint with no codegen-side workaround:
+  `refining_impl_trait_internal` (`warn` by default since rust 1.86,
+  rust-lang/rust#121718) fires on every handler `impl`, because the
+  generated trait declares `ServiceResult<impl Encodable<Out> + ...>`
+  while the handler returns `ServiceResult<Out>`. The refinement is
+  intentional — it is what lets handlers return either an owned
+  message, a borrowed view, or a `MaybeBorrowed<M, V>` — and is benign
+  for handler impls, which are not part of the service's public API.
+  There is no place in the generated module tree where `#[allow(...)]`
+  could reach the handler impl. Consumers who deny warnings should set
+  `refining_impl_trait_internal = "allow"` in `[lints.rust]` (or
+  workspace lints) or `#[allow(refining_impl_trait)]` on each handler
+  `impl` block.
+
 ## [0.4.0] - 2026-05-06
 
 This release tracks buffa 0.5.0. **Consumers with checked-in

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ The core crate compiles for `wasm32-unknown-unknown`. Generated clients are gene
 
 ```toml
 [dependencies]
-connectrpc = { version = "0.2", default-features = false, features = ["gzip"] }
+connectrpc = { version = "0.4", default-features = false, features = ["gzip"] }
 ```
 
 ### Minimal build (no compression)

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-build"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -501,9 +501,21 @@ fn generate_include_file(entries: &[(String, String)], relative: bool) -> String
         }
         for (name, child) in &node.children {
             let ident = buffa_codegen::idents::escape_mod_ident(name);
+            // `unused_qualifications`: buffa-codegen always references
+            // sibling types through the canonical `__buffa::view::*` path
+            // even when a shorter natural-path re-export exists, because
+            // the re-export can be shadowed by a proto type with the same
+            // name. The qualification is intentional, not "unused".
+            //
+            // `impl_trait_redundant_captures`: the `use<'a, Self>` precise-
+            // capturing clause on trait method RPITs is required for
+            // edition-2021 consumers (which capture only `'static` by
+            // default) but redundant under edition 2024. Codegen targets
+            // both editions and cannot know the consumer's at write time.
             writeln!(
                 out,
                 "{indent}#[allow(dead_code, non_camel_case_types, unused_imports, \
+                 unused_qualifications, impl_trait_redundant_captures, \
                  clippy::derivable_impls, clippy::match_single_binding)]"
             )
             .unwrap();

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-codegen"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/examples/bazel/Cargo.toml
+++ b/examples/bazel/Cargo.toml
@@ -16,8 +16,8 @@ publish = false
 path = "stub.rs"
 
 [dependencies]
-buffa = { version = "0.5.0", features = ["json"] }
-connectrpc = { version = "0.4.0", default-features = false, features = ["server", "client"] }
+buffa = { version = "0.5.1", features = ["json"] }
+connectrpc = { version = "0.4.1", default-features = false, features = ["server", "client"] }
 futures = "0.3"
 http-body = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Adds `unused_qualifications` and `impl_trait_redundant_captures` to the `#[allow(...)]` block `connectrpc-build` writes into the generated `mod.rs` package tree, and documents the related `refining_impl_trait_internal` lint.

## Why

The 0.4.0 codegen output trips two rustc lints in workspaces that build with `-D warnings`:

- **`impl_trait_redundant_captures`**: trait method RPITs carry a `use<'a, Self>` precise-capturing clause. It is required for edition-2021 consumers (RPIT-in-trait captures only `'static` by default there) but redundant under edition 2024 (which captures all in-scope generics by default). Codegen targets both editions and cannot know the consumer's at write time, so the clause must stay — but it shouldn't warn.

- **`unused_qualifications`**: buffa 0.5 codegen always references sibling types through the canonical `pkg::__buffa::view::*` path even when a shorter natural-path re-export exists, because the re-export can be shadowed by a same-named proto type. The qualification is intentional. (Suppressed redundantly here on top of anthropics/buffa#102 for `connectrpc-build` consumers whose `protoc-gen-buffa` toolchain hasn't picked up that release yet.)

Both lints fire at locations under the generated `pub mod <pkg>` tree that `connectrpc_build::Config::include_file()` writes, so the right scope for the suppression is the same `#[allow(...)]` block that already carries `dead_code`, `unused_imports`, etc.

## `refining_impl_trait_internal` — known limitation, no codegen-side fix

This release also documents (CHANGELOG only) that `refining_impl_trait_internal` (`warn` by default since rust 1.86, rust-lang/rust#121718) fires on every handler `impl`, because the generated trait declares `ServiceResult<impl Encodable<Out> + …>` while the handler returns `ServiceResult<Out>`. The refinement is intentional — it lets handlers return either an owned message, a borrowed view, or `MaybeBorrowed<M, V>` — and is benign for handler impls. There is no place in the generated module tree where `#[allow(...)]` could reach the consumer's handler impl. Consumers who deny warnings should set `refining_impl_trait_internal = "allow"` in `[lints.rust]` (or workspace lints) or `#[allow(refining_impl_trait)]` on each handler `impl` block.

## Verification

- `cargo test -p connectrpc-build -p connectrpc-codegen --lib`: 18 + 35 passed
- `cargo build -p eliza-example -p multiservice-example`: clean
- `cargo clippy -p connectrpc-conformance -p eliza-example -- -D warnings`: clean
