### PR TITLE
ci(cla): bump cla-github-action pin to v3.0.0

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -24,7 +24,7 @@ jobs:
         # co-author of at least one commit), Co-authored-by trailer support,
         # email-based allowlist matching, automatic retry of transient
         # GitHub 5xx errors, and actionable unlinked-email guidance.
-        uses: iainmcgin/cla-github-action@5b54183037a58ba5ade5ea9b3e1872d969730f77 # master (sha-pinned)
+        uses: iainmcgin/cla-github-action@3e58ace6af840f66fcd80f68c08d76559140df5e # v3.0.0 (sha-pinned)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
[`iainmcgin/cla-github-action`](https://github.com/iainmcgin/cla-github-action) now has a tagged release, [v3.0.0](https://github.com/iainmcgin/cla-github-action/releases/tag/v3.0.0). This bumps the SHA pin to the release commit and annotates it with the tag name, matching the `# <tag> (sha-pinned)` convention used by the other action pins in this repo, so an auditor can cross-reference the SHA against a published release.

```diff
-        uses: iainmcgin/cla-github-action@5b54183037a58ba5ade5ea9b3e1872d969730f77 # master (sha-pinned)
+        uses: iainmcgin/cla-github-action@3e58ace6af840f66fcd80f68c08d76559140df5e # v3.0.0 (sha-pinned)
```

Diff between the previous pin (`5b54183`) and the new one (`3e58ace`) is [the CHANGELOG release note](https://github.com/iainmcgin/cla-github-action/compare/5b54183037a58ba5ade5ea9b3e1872d969730f77...3e58ace6af840f66fcd80f68c08d76559140df5e) only — no code change.
