### PR TITLE
handler: PreEncoded body type + Encodable items for streaming handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,21 @@ increment the patch version.
   view with a non-`'static` lifetime can't cross the handler boundary;
   `PreEncoded` carries the bytes across instead.
 
-  The `M` type parameter is a compile-time witness:
-  `PreEncoded::from_view(&view)` enforces `M = MView::Owned` so the
-  bytes are guaranteed to decode as `M`; `PreEncoded::proto(bytes)`
-  wraps already-encoded bytes you've produced yourself and takes `M`
-  on trust.
+  The `M` type parameter is a compile-time witness. Three construction
+  paths, in decreasing order of guarantee:
+  `PreEncoded::from_message(&m)` (also `From<&M>`/`.into()`) encodes an
+  owned `M` and the receiver type is the witness;
+  `PreEncoded::from_view(&view)` enforces `M = MView::Owned`;
+  `PreEncoded::from_bytes_unchecked(bytes)` wraps already-encoded bytes
+  from elsewhere — a cache, a blob store, a sidecar — and takes `M` on
+  trust (in debug builds it also decodes once as a `debug_assert!`).
 
-  Proto-only, like the per-output-type view-body impls. JSON clients
-  receive an `unimplemented` error; if your service must support JSON,
-  build the owned message and return it (or `MaybeBorrowed::Owned`) on
-  every path.
+  Optimized for the proto codec, where the bytes pass through verbatim.
+  JSON requests fall back to decoding the proto bytes as `M` and
+  re-serializing — slow, but a working response rather than a runtime
+  `unimplemented` error. Services with significant JSON traffic should
+  build and return the owned message (or `MaybeBorrowed::Owned`) so the
+  codec layer can skip the proto round-trip.
 
 ### Breaking
 
@@ -53,8 +58,9 @@ need a one-line edit.
   service trait or the `*_handler_fn` closure helpers, neither of which
   is affected — codegen handles the new shape and the helpers infer
   `type Item` from the closure return. Hand-rolled `impl
-  StreamingHandler` blocks must add `type Item = Res;`. (At the time of
-  this change there are two such impls across all known consumers.)
+  StreamingHandler` blocks must add `type Item = Res;`. We surveyed the
+  in-tree consumers and found two; if you have hand-rolled impls,
+  expect a single one-line addition per impl block.
 
 - **Generated server-streaming and bidi-streaming trait methods now
   declare `ServiceStream<impl Encodable<Out> + Send + use<Self>>`**
@@ -71,15 +77,14 @@ need a one-line edit.
   regenerate** (the same regeneration footgun documented in 0.4.0).
   `connectrpc-build` users (build.rs) are unaffected.
 
-- **`encode_response_stream` / `encode_body_stream` gain a `B` type
-  parameter** for the stream item type. `Res` is no longer derivable
-  from the item type alone (the closure return type doesn't constrain
-  which `Res` to project through `Encodable<Res>`), so callers must
-  turbofish:
-  `encode_response_stream::<Res, _, _>(s, format)`. The generated
-  dispatcher and route-registration code does this; only consumers that
-  call `dispatcher::codegen::encode_response_stream` directly need to
-  update. We are not aware of any.
+- **`dispatcher::codegen::encode_response_stream` gains a `B` type
+  parameter** for the stream item type. The generated dispatcher and
+  route-registration code passes `Res` explicitly because the trait
+  method's stream item is the *opaque* `impl Encodable<Out>` (RPITIT),
+  which can't be unified against the `Encodable<Res>` impls. Only
+  consumers that call `dispatcher::codegen::encode_response_stream`
+  directly need to turbofish `encode_response_stream::<Res, _, _>(s,
+  format)`. We are not aware of any.
 
 ## [0.4.2] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,29 +33,43 @@ increment the patch version.
 
 ### Breaking
 
+These are breaking under semver but the practical blast radius is
+narrow. The common consumer surfaces — `impl <GeneratedServiceTrait>`
+blocks and `*_handler_fn` registrations — compile unchanged. Only
+hand-rolled `impl StreamingHandler`/`impl BidiStreamingHandler` blocks
+and direct callers of `dispatcher::codegen::encode_response_stream`
+need a one-line edit.
+
 - **Streaming handler traits gain `type Item: Encodable<Res>`** and
   return `ServiceStream<Self::Item>` instead of `ServiceStream<Res>` —
   brings `StreamingHandler`, `BidiStreamingHandler`,
   `ViewStreamingHandler`, and `ViewBidiStreamingHandler` to parity with
-  unary `Handler::Body`. Stream items can now be `PreEncoded`,
-  `MaybeBorrowed`, or any `Encodable<Res>`; previously they had to be
-  the owned `Res` itself.
+  unary `Handler::Body` (added in 0.4.0). Stream items can now be
+  `PreEncoded`, `MaybeBorrowed`, or any `Encodable<Res>`; previously
+  they had to be the owned `Res` itself.
 
-  Existing handlers that yield `ServiceStream<Res>` are unchanged
-  behaviorally — `Res: Encodable<Res>` via the blanket impl. Custom
-  `impl StreamingHandler` (etc.) blocks must add `type Item = Res;`.
-  The `*_handler_fn` helpers infer it.
+  These are the lower-level escape-hatch traits behind `Router`, not
+  the primary handler surface. Most consumers use the codegen-generated
+  service trait or the `*_handler_fn` closure helpers, neither of which
+  is affected — codegen handles the new shape and the helpers infer
+  `type Item` from the closure return. Hand-rolled `impl
+  StreamingHandler` blocks must add `type Item = Res;`. (At the time of
+  this change there are two such impls across all known consumers.)
 
 - **Generated server-streaming and bidi-streaming trait methods now
   declare `ServiceStream<impl Encodable<Out> + Send + use<Self>>`**
-  instead of `ServiceStream<Out>`. Handler implementations that yield
-  the owned `Out` are unchanged. Handlers that want to yield
-  `PreEncoded` items must do so from `'static` data — the `use<Self>`
-  precise-capturing clause excludes `&self`'s lifetime, so views built
-  inside the stream body must encode to bytes before the borrow ends.
+  instead of `ServiceStream<Out>`. **Existing `impl <Service>` blocks
+  that return `ServiceStream<Out>` compile unchanged via RPITIT
+  refinement** (the same mechanism the unary path used since 0.4.0; the
+  `refining_impl_trait` lint suppression documented in 0.4.1 covers the
+  streaming case too). Handlers that want to yield `PreEncoded` items
+  must do so from `'static` data — the `use<Self>` precise-capturing
+  clause excludes `&self`'s lifetime, so views built inside the stream
+  body must encode to bytes before the borrow ends.
 
   **Consumers with checked-in `protoc-gen-connect-rust` output must
-  regenerate.** `connectrpc-build` users (build.rs) are unaffected.
+  regenerate** (the same regeneration footgun documented in 0.4.0).
+  `connectrpc-build` users (build.rs) are unaffected.
 
 - **`encode_response_stream` / `encode_body_stream` gain a `B` type
   parameter** for the stream item type. `Res` is no longer derivable
@@ -65,7 +79,7 @@ increment the patch version.
   `encode_response_stream::<Res, _, _>(s, format)`. The generated
   dispatcher and route-registration code does this; only consumers that
   call `dispatcher::codegen::encode_response_stream` directly need to
-  update.
+  update. We are not aware of any.
 
 ## [0.4.2] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,63 @@ increment the patch version.
 
 ## [Unreleased]
 
+### Added
+
+- **`PreEncoded<M>` response body** — wraps already-encoded protobuf
+  bytes and satisfies `Encodable<M>`. Use when the handler builds and
+  encodes a borrowing view internally — e.g. a `*View<'a>` borrowing
+  from a local snapshot held in `Arc` — rather than returning the view
+  itself. The `'static` bound on handler bodies and stream items means a
+  view with a non-`'static` lifetime can't cross the handler boundary;
+  `PreEncoded` carries the bytes across instead.
+
+  The `M` type parameter is a compile-time witness:
+  `PreEncoded::from_view(&view)` enforces `M = MView::Owned` so the
+  bytes are guaranteed to decode as `M`; `PreEncoded::proto(bytes)`
+  wraps already-encoded bytes you've produced yourself and takes `M`
+  on trust.
+
+  Proto-only, like the per-output-type view-body impls. JSON clients
+  receive an `unimplemented` error; if your service must support JSON,
+  build the owned message and return it (or `MaybeBorrowed::Owned`) on
+  every path.
+
+### Breaking
+
+- **Streaming handler traits gain `type Item: Encodable<Res>`** and
+  return `ServiceStream<Self::Item>` instead of `ServiceStream<Res>` —
+  brings `StreamingHandler`, `BidiStreamingHandler`,
+  `ViewStreamingHandler`, and `ViewBidiStreamingHandler` to parity with
+  unary `Handler::Body`. Stream items can now be `PreEncoded`,
+  `MaybeBorrowed`, or any `Encodable<Res>`; previously they had to be
+  the owned `Res` itself.
+
+  Existing handlers that yield `ServiceStream<Res>` are unchanged
+  behaviorally — `Res: Encodable<Res>` via the blanket impl. Custom
+  `impl StreamingHandler` (etc.) blocks must add `type Item = Res;`.
+  The `*_handler_fn` helpers infer it.
+
+- **Generated server-streaming and bidi-streaming trait methods now
+  declare `ServiceStream<impl Encodable<Out> + Send + use<Self>>`**
+  instead of `ServiceStream<Out>`. Handler implementations that yield
+  the owned `Out` are unchanged. Handlers that want to yield
+  `PreEncoded` items must do so from `'static` data — the `use<Self>`
+  precise-capturing clause excludes `&self`'s lifetime, so views built
+  inside the stream body must encode to bytes before the borrow ends.
+
+  **Consumers with checked-in `protoc-gen-connect-rust` output must
+  regenerate.** `connectrpc-build` users (build.rs) are unaffected.
+
+- **`encode_response_stream` / `encode_body_stream` gain a `B` type
+  parameter** for the stream item type. `Res` is no longer derivable
+  from the item type alone (the closure return type doesn't constrain
+  which `Res` to project through `Encodable<Res>`), so callers must
+  turbofish:
+  `encode_response_stream::<Res, _, _>(s, format)`. The generated
+  dispatcher and route-registration code does this; only consumers that
+  call `dispatcher::codegen::encode_response_stream` directly need to
+  update.
+
 ## [0.4.2] - 2026-05-07
 
 ### Added

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -127,10 +127,22 @@ pub const BENCH_SERVICE_SERVICE_NAME: &str = "bench.v1.BenchService";
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait BenchService: Send + Sync + 'static {
     /// Handle the Unary RPC.
@@ -876,10 +888,22 @@ pub const ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.EchoService";
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait EchoService: Send + Sync + 'static {
     /// Handle the Echo RPC.
@@ -1194,10 +1218,22 @@ pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.v1.LogIngestService";
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait LogIngestService: Send + Sync + 'static {
     /// Handle the Ingest RPC.

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -154,7 +154,11 @@ pub trait BenchService: Send + Sync + 'static {
         request: OwnedBenchRequestView,
     ) -> impl ::std::future::Future<
         Output = ::connectrpc::ServiceResult<
-            ::connectrpc::ServiceStream<crate::proto::bench::v1::BenchResponse>,
+            ::connectrpc::ServiceStream<
+                impl ::connectrpc::Encodable<
+                    crate::proto::bench::v1::BenchResponse,
+                > + Send + use<Self>,
+            >,
         >,
     > + Send;
     /// Handle the ClientStream RPC.
@@ -178,7 +182,11 @@ pub trait BenchService: Send + Sync + 'static {
         requests: ::connectrpc::ServiceStream<OwnedBenchRequestView>,
     ) -> impl ::std::future::Future<
         Output = ::connectrpc::ServiceResult<
-            ::connectrpc::ServiceStream<crate::proto::bench::v1::BenchResponse>,
+            ::connectrpc::ServiceStream<
+                impl ::connectrpc::Encodable<
+                    crate::proto::bench::v1::BenchResponse,
+                > + Send + use<Self>,
+            >,
         >,
     > + Send;
     /// Handle the LogUnary RPC.
@@ -253,7 +261,11 @@ impl<S: BenchService> BenchServiceExt for S {
                     })
                 },
             )
-            .route_view_server_stream(
+            .route_view_server_stream::<
+                _,
+                _,
+                crate::proto::bench::v1::BenchResponse,
+            >(
                 BENCH_SERVICE_SERVICE_NAME,
                 "ServerStream",
                 ::connectrpc::view_streaming_handler_fn({
@@ -279,7 +291,11 @@ impl<S: BenchService> BenchServiceExt for S {
                     }
                 }),
             )
-            .route_view_bidi_stream(
+            .route_view_bidi_stream::<
+                _,
+                _,
+                crate::proto::bench::v1::BenchResponse,
+            >(
                 BENCH_SERVICE_SERVICE_NAME,
                 "BidiStream",
                 ::connectrpc::view_bidi_streaming_handler_fn({
@@ -461,10 +477,11 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let resp = svc.server_stream(ctx, req).await?;
                     Ok(
                         resp
-                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
-                                s,
-                                format,
-                            )),
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<
+                                crate::proto::bench::v1::BenchResponse,
+                                _,
+                                _,
+                            >(s, format)),
                     )
                 })
             }
@@ -518,10 +535,11 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                     let resp = svc.bidi_stream(ctx, req_stream).await?;
                     Ok(
                         resp
-                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
-                                s,
-                                format,
-                            )),
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<
+                                crate::proto::bench::v1::BenchResponse,
+                                _,
+                                _,
+                            >(s, format)),
                     )
                 })
             }

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -47,10 +47,22 @@ pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.noutf8.v1.LogIngestServ
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait LogIngestService: Send + Sync + 'static {
     /// Handle the Ingest RPC.

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -48,10 +48,22 @@ pub const BLOAT_ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.BloatEchoService";
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait BloatEchoService: Send + Sync + 'static {
     /// Handle the Echo RPC.

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -45,10 +45,22 @@ pub const FILTER_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.filter.v1.Fi
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait FilterService: Send + Sync + 'static {
     /// Handle the Redact RPC.

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -47,10 +47,22 @@ pub const FORTUNE_SERVICE_SERVICE_NAME: &str = "fortune.v1.FortuneService";
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait FortuneService: Send + Sync + 'static {
     /// Handle the GetFortunes RPC.

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -250,10 +250,22 @@ pub const CONFORMANCE_SERVICE_SERVICE_NAME: &str = "connectrpc.conformance.v1.Co
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait ConformanceService: Send + Sync + 'static {
     /// A unary operation. The request indicates the response headers and trailers

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -304,7 +304,9 @@ pub trait ConformanceService: Send + Sync + 'static {
     ) -> impl ::std::future::Future<
         Output = ::connectrpc::ServiceResult<
             ::connectrpc::ServiceStream<
-                crate::proto::connectrpc::conformance::v1::ServerStreamResponse,
+                impl ::connectrpc::Encodable<
+                    crate::proto::connectrpc::conformance::v1::ServerStreamResponse,
+                > + Send + use<Self>,
             >,
         >,
     > + Send;
@@ -378,7 +380,9 @@ pub trait ConformanceService: Send + Sync + 'static {
     ) -> impl ::std::future::Future<
         Output = ::connectrpc::ServiceResult<
             ::connectrpc::ServiceStream<
-                crate::proto::connectrpc::conformance::v1::BidiStreamResponse,
+                impl ::connectrpc::Encodable<
+                    crate::proto::connectrpc::conformance::v1::BidiStreamResponse,
+                > + Send + use<Self>,
             >,
         >,
     > + Send;
@@ -459,7 +463,11 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     })
                 },
             )
-            .route_view_server_stream(
+            .route_view_server_stream::<
+                _,
+                _,
+                crate::proto::connectrpc::conformance::v1::ServerStreamResponse,
+            >(
                 CONFORMANCE_SERVICE_SERVICE_NAME,
                 "ServerStream",
                 ::connectrpc::view_streaming_handler_fn({
@@ -487,7 +495,11 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     }
                 }),
             )
-            .route_view_bidi_stream(
+            .route_view_bidi_stream::<
+                _,
+                _,
+                crate::proto::connectrpc::conformance::v1::BidiStreamResponse,
+            >(
                 CONFORMANCE_SERVICE_SERVICE_NAME,
                 "BidiStream",
                 ::connectrpc::view_bidi_streaming_handler_fn({
@@ -681,10 +693,11 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let resp = svc.server_stream(ctx, req).await?;
                     Ok(
                         resp
-                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
-                                s,
-                                format,
-                            )),
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<
+                                crate::proto::connectrpc::conformance::v1::ServerStreamResponse,
+                                _,
+                                _,
+                            >(s, format)),
                     )
                 })
             }
@@ -742,10 +755,11 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                     let resp = svc.bidi_stream(ctx, req_stream).await?;
                     Ok(
                         resp
-                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
-                                s,
-                                format,
-                            )),
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<
+                                crate::proto::connectrpc::conformance::v1::BidiStreamResponse,
+                                _,
+                                _,
+                            >(s, format)),
                     )
                 })
             }

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1014,10 +1014,21 @@ fn generate_service(
          [buffa user guide](https://github.com/anthropics/buffa/blob/main/docs/guide.md#ownedview-in-async-trait-implementations)\n\
          for zero-copy access patterns and when `to_owned_message()` is needed.\n\n\
          The `impl Encodable<Out>` return bound accepts the owned `Out`, the\n\
-         generated `OutView<'_>` / `OwnedOutView`, or\n\
-         [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not\n\
-         emitted for output types mapped via `extern_path` (the impl would be\n\
-         an orphan); return owned for WKT/extern outputs."
+         generated `OutView<'_>` / `OwnedOutView`,\n\
+         [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or\n\
+         [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a\n\
+         non-`'static` view internally and pass the bytes across the handler\n\
+         boundary. View bodies are not emitted for output types mapped via\n\
+         `extern_path` (the impl would be an orphan); return owned for\n\
+         WKT/extern outputs.\n\n\
+         Server-streaming and bidi-streaming methods return\n\
+         `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The\n\
+         `use<Self>` precise-capturing clause excludes `&self`'s lifetime\n\
+         (unary methods use `use<'a, Self>` and may borrow), so stream items\n\
+         must be `'static`. To stream view-encoded data, encode each item\n\
+         inside the stream body and yield\n\
+         [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming\n\
+         example` doc."
     );
     let service_doc_tokens = doc_attrs(&full_doc);
 

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1040,9 +1040,15 @@ fn generate_service(
             let server_streaming = m.server_streaming.unwrap_or(false);
 
             if server_streaming && !client_streaming {
-                // Server streaming method
+                // Server streaming method. The trait method returns
+                // `ServiceStream<impl Encodable<Out>>`; `Res = Out` is no
+                // longer derivable from the opaque item type, so it must
+                // be turbofished.
+                let output_type = resolver
+                    .rust_type(m.output_type.as_deref().unwrap_or(""), package)
+                    .unwrap();
                 quote! {
-                    .route_view_server_stream(
+                    .route_view_server_stream::<_, _, #output_type>(
                         #service_name_const,
                         #method_name,
                         ::connectrpc::view_streaming_handler_fn({
@@ -1075,9 +1081,13 @@ fn generate_service(
                     )
                 }
             } else if client_streaming && server_streaming {
-                // Bidi streaming method
+                // Bidi streaming method. Same turbofish need as server
+                // streaming above.
+                let output_type = resolver
+                    .rust_type(m.output_type.as_deref().unwrap_or(""), package)
+                    .unwrap();
                 quote! {
-                    .route_view_bidi_stream(
+                    .route_view_bidi_stream::<_, _, #output_type>(
                         #service_name_const,
                         #method_name,
                         ::connectrpc::view_bidi_streaming_handler_fn({
@@ -1357,7 +1367,7 @@ fn generate_service_server(
                     Box::pin(async move {
                         let req_stream = ::connectrpc::dispatcher::codegen::decode_view_request_stream::<#input_view>(requests, format);
                         let resp = svc.#method_snake(ctx, req_stream).await?;
-                        Ok(resp.map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(s, format)))
+                        Ok(resp.map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<#output_type, _, _>(s, format)))
                     })
                 }
             });
@@ -1380,7 +1390,7 @@ fn generate_service_server(
                     Box::pin(async move {
                         let req = ::connectrpc::dispatcher::codegen::decode_request_view::<#input_view>(request, format)?;
                         let resp = svc.#method_snake(ctx, req).await?;
-                        Ok(resp.map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(s, format)))
+                        Ok(resp.map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<#output_type, _, _>(s, format)))
                     })
                 }
             });
@@ -1559,14 +1569,20 @@ fn generate_trait_method(
     };
 
     if server_streaming && !client_streaming {
-        // Server streaming method
+        // Server streaming method. `impl Encodable<...>` lets the handler
+        // yield `Res`, `PreEncoded`, or `MaybeBorrowed` items — same
+        // flexibility as the unary `impl Encodable<...>` body bound.
+        // `use<Self>` opts out of capturing `&self`'s lifetime (RPITITs in
+        // trait methods otherwise capture it by default), since stream
+        // items have to be `'static`. Without it, the generated route
+        // registration's `Arc::clone` closures fail E0597.
         Ok(quote! {
             #method_doc_tokens
             fn #method_snake(
                 &self,
                 ctx: ::connectrpc::RequestContext,
                 request: #input_arg,
-            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<::connectrpc::ServiceStream<#output_type>>> + Send;
+            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<::connectrpc::ServiceStream<impl ::connectrpc::Encodable<#output_type> + Send + use<Self>>>> + Send;
         })
     } else if client_streaming && !server_streaming {
         // Client streaming method
@@ -1580,14 +1596,15 @@ fn generate_trait_method(
             ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<impl ::connectrpc::Encodable<#output_type> + Send + use<'a, Self>>> + Send;
         })
     } else if client_streaming && server_streaming {
-        // Bidi streaming method
+        // Bidi streaming method. Same `impl Encodable<...>` item type and
+        // `use<Self>` capture clause as server streaming above.
         Ok(quote! {
             #method_doc_tokens
             fn #method_snake(
                 &self,
                 ctx: ::connectrpc::RequestContext,
                 requests: ::connectrpc::ServiceStream<#input_arg>,
-            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<::connectrpc::ServiceStream<#output_type>>> + Send;
+            ) -> impl ::std::future::Future<Output = ::connectrpc::ServiceResult<::connectrpc::ServiceStream<impl ::connectrpc::Encodable<#output_type> + Send + use<Self>>>> + Send;
         })
     } else {
         // Unary method
@@ -2191,6 +2208,80 @@ mod tests {
             .count()
                 >= 2,
             "client-streaming and bidi should both inline the streamed request type: {code}"
+        );
+    }
+
+    #[test]
+    fn streaming_methods_use_encodable_item_type() {
+        // Server-streaming and bidi methods should declare their stream
+        // item type as `impl Encodable<Out> + Send + use<Self>` rather than
+        // the bare `Out`, so handlers can return `PreEncoded` /
+        // `MaybeBorrowed` items. The dispatcher and route-registration
+        // arms must both turbofish `Res` since `Encodable<M>` for
+        // `PreEncoded` is generic over `M` (so `Res` is no longer
+        // derivable from the opaque item type).
+        let file = FileDescriptorProto {
+            name: Some("ex/v1/svc.proto".into()),
+            package: Some("ex.v1".into()),
+            message_type: vec![
+                DescriptorProto {
+                    name: Some("Req".into()),
+                    ..Default::default()
+                },
+                DescriptorProto {
+                    name: Some("Resp".into()),
+                    ..Default::default()
+                },
+            ],
+            service: vec![ServiceDescriptorProto {
+                name: Some("Svc".into()),
+                method: vec![
+                    MethodDescriptorProto {
+                        name: Some("ServerStream".into()),
+                        input_type: Some(".ex.v1.Req".into()),
+                        output_type: Some(".ex.v1.Resp".into()),
+                        server_streaming: Some(true),
+                        ..Default::default()
+                    },
+                    MethodDescriptorProto {
+                        name: Some("Bidi".into()),
+                        input_type: Some(".ex.v1.Req".into()),
+                        output_type: Some(".ex.v1.Resp".into()),
+                        client_streaming: Some(true),
+                        server_streaming: Some(true),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let code = gen_file(std::slice::from_ref(&file), 0, &[], false).unwrap();
+
+        // Trait method declares `ServiceStream<impl Encodable<Resp> + ...>`.
+        assert_eq!(
+            code.matches(":: connectrpc :: ServiceStream < impl :: connectrpc :: Encodable < Resp > + Send + use < Self >>")
+                .count(),
+            2,
+            "server-streaming and bidi should both use the Encodable item type: {code}"
+        );
+
+        // Dispatcher arms turbofish `Res` to encode_response_stream.
+        assert_eq!(
+            code.matches("encode_response_stream :: < Resp , _ , _ >")
+                .count(),
+            2,
+            "dispatcher arms must turbofish Res to encode_response_stream: {code}"
+        );
+
+        // Route registrations turbofish `Res` to route_view_*_stream.
+        assert!(
+            code.contains("route_view_server_stream :: < _ , _ , Resp >"),
+            "route_view_server_stream must turbofish Res: {code}"
+        );
+        assert!(
+            code.contains("route_view_bidi_stream :: < _ , _ , Resp >"),
+            "route_view_bidi_stream must turbofish Res: {code}"
         );
     }
 

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -295,7 +295,6 @@ pub mod codegen {
     use bytes::Bytes;
     use futures::Stream;
     use futures::StreamExt;
-    use serde::Serialize;
     use serde::de::DeserializeOwned;
 
     use crate::codec::CodecFormat;
@@ -314,26 +313,32 @@ pub mod codegen {
     pub use super::unimplemented_streaming;
     pub use super::unimplemented_unary;
 
-    /// Map a stream of typed responses through `encode_response`.
+    /// Map a stream of typed responses through [`Encodable::encode`].
     ///
     /// Used by generated `call_server_streaming` and `call_bidi_streaming`
-    /// arms to convert the handler's `Stream<Item = Result<Res, _>>` into
+    /// arms to convert the handler's `Stream<Item = Result<B, _>>` into
     /// the `Stream<Item = Result<Bytes, _>>` that the dispatcher protocol
-    /// requires.
-    pub fn encode_response_stream<Res, S>(
+    /// requires. `B` is any [`Encodable<Res>`] — typically `Res` itself,
+    /// but may be [`PreEncoded`](crate::PreEncoded) or
+    /// [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
+    /// borrowing views per item.
+    ///
+    /// [`Encodable`]: crate::Encodable
+    /// [`Encodable::encode`]: crate::Encodable::encode
+    pub fn encode_response_stream<Res, B, S>(
         stream: S,
         format: CodecFormat,
     ) -> BoxStream<Result<Bytes, ConnectError>>
     where
-        Res: Message + Serialize + Send + 'static,
-        S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+        Res: Message + Send + 'static,
+        B: crate::Encodable<Res> + Send + 'static,
+        S: Stream<Item = Result<B, ConnectError>> + Send + 'static,
     {
         use crate::response::Encodable;
         Box::pin(
             futures::stream::unfold(
                 (
-                    Box::pin(stream)
-                        as Pin<Box<dyn Stream<Item = Result<Res, ConnectError>> + Send>>,
+                    Box::pin(stream) as Pin<Box<dyn Stream<Item = Result<B, ConnectError>> + Send>>,
                     format,
                 ),
                 async |(mut s, fmt)| match s.next().await {

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -318,7 +318,7 @@ pub mod codegen {
     /// Used by generated `call_server_streaming` and `call_bidi_streaming`
     /// arms to convert the handler's `Stream<Item = Result<B, _>>` into
     /// the `Stream<Item = Result<Bytes, _>>` that the dispatcher protocol
-    /// requires. `B` is any [`Encodable<Res>`] — typically `Res` itself,
+    /// requires. `B` is any [`Encodable<Res>`](crate::Encodable) — typically `Res` itself,
     /// but may be [`PreEncoded`](crate::PreEncoded) or
     /// [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
     /// borrowing views per item.

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -61,19 +61,24 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 
 /// Map a stream of typed responses through [`Encodable`].
-fn encode_body_stream<Res, S>(
+///
+/// `B` is any [`Encodable<Res>`] — typically `Res` itself, but may be
+/// [`PreEncoded`](crate::PreEncoded) or [`MaybeBorrowed`](crate::MaybeBorrowed)
+/// for handlers that encode borrowing views per item.
+fn encode_body_stream<Res, B, S>(
     stream: S,
     format: CodecFormat,
 ) -> BoxStream<Result<Bytes, ConnectError>>
 where
-    Res: Message + Serialize + Send + 'static,
-    S: Stream<Item = Result<Res, ConnectError>> + Send + 'static,
+    Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
+    S: Stream<Item = Result<B, ConnectError>> + Send + 'static,
 {
     use futures::StreamExt as _;
     Box::pin(
         futures::stream::unfold(
             (
-                Box::pin(stream) as Pin<Box<dyn Stream<Item = Result<Res, ConnectError>> + Send>>,
+                Box::pin(stream) as Pin<Box<dyn Stream<Item = Result<B, ConnectError>> + Send>>,
                 format,
             ),
             async |(mut s, fmt)| match s.next().await {
@@ -265,18 +270,33 @@ where
 
 /// Trait for server streaming RPC handlers.
 ///
-/// Stream items are the owned `Res` (view-out for streams is a follow-up).
+/// # Migrating from connectrpc 0.4.x
+///
+/// `Item` is new in 0.5: a hand-written `impl StreamingHandler` previously
+/// returned `ServiceStream<Res>`; add `type Item = Res;` to keep the same
+/// behavior. Generated traits and the [`streaming_handler_fn`] helper
+/// infer it.
 pub trait StreamingHandler<Req, Res>: Send + Sync + 'static
 where
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
 {
+    /// The stream item type. Typically `Res` itself; may be
+    /// [`PreEncoded`](crate::PreEncoded) or
+    /// [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
+    /// borrowing views per item.
+    ///
+    /// Items must be `'static` — a stream item cannot borrow `&self` or a
+    /// per-call snapshot. To stream view-encoded data, encode each item
+    /// inside the stream's body and yield [`PreEncoded`](crate::PreEncoded).
+    type Item: Encodable<Res> + Send + 'static;
+
     /// Handle a server streaming RPC request.
     fn call(
         &self,
         ctx: RequestContext,
         request: Req,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Self::Item>>>;
 }
 
 /// Wrapper that implements [`StreamingHandler`] for async functions.
@@ -291,30 +311,47 @@ impl<F> FnStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, Req, Res> StreamingHandler<Req, Res> for FnStreamingHandler<F>
+impl<F, Fut, Req, Res, B> StreamingHandler<Req, Res> for FnStreamingHandler<F>
 where
     F: Fn(RequestContext, Req) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
+    type Item = B;
+
     fn call(
         &self,
         ctx: RequestContext,
         request: Req,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<B>>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, request).await })
     }
 }
 
 /// Helper function to create a streaming handler from an async function.
-pub fn streaming_handler_fn<F, Fut, Req, Res>(f: F) -> FnStreamingHandler<F>
+///
+/// When the closure yields owned `Res` items, all type parameters are
+/// inferred. When it yields a generic [`Encodable`] body like
+/// [`PreEncoded<Res>`](crate::PreEncoded), `Res` is no longer derivable
+/// from the item type and must be turbofished:
+///
+/// ```rust,ignore
+/// streaming_handler_fn::<_, _, MyRequest, MyResponse, PreEncoded<MyResponse>>(handler)
+/// ```
+///
+/// The codegen-emitted route registrations (`route_view_server_stream::<_,
+/// _, Out>`) supply `Res` for you, so this only affects hand-written
+/// `Router` registrations.
+pub fn streaming_handler_fn<F, Fut, Req, Res, B>(f: F) -> FnStreamingHandler<F>
 where
     F: Fn(RequestContext, Req) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
     FnStreamingHandler::new(f)
 }
@@ -324,7 +361,7 @@ pub(crate) struct ServerStreamingHandlerWrapper<H, Req, Res>
 where
     H: StreamingHandler<Req, Res>,
     Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(Req) -> Res>,
@@ -334,7 +371,7 @@ impl<H, Req, Res> ServerStreamingHandlerWrapper<H, Req, Res>
 where
     H: StreamingHandler<Req, Res>,
     Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     /// Create a new wrapper around the given streaming handler.
     pub fn new(handler: H) -> Self {
@@ -349,7 +386,7 @@ impl<H, Req, Res> ErasedStreamingHandler for ServerStreamingHandlerWrapper<H, Re
 where
     H: StreamingHandler<Req, Res>,
     Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     fn call_erased(
         &self,
@@ -488,17 +525,28 @@ where
 // ============================================================================
 
 /// Trait for bidirectional streaming RPC handlers.
+///
+/// # Migrating from connectrpc 0.4.x
+///
+/// `Item` is new in 0.5: hand-written impls add `type Item = Res;`.
+/// See [`StreamingHandler`] for details.
 pub trait BidiStreamingHandler<Req, Res>: Send + Sync + 'static
 where
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
 {
+    /// The stream item type. Typically `Res` itself; may be
+    /// [`PreEncoded`](crate::PreEncoded) or
+    /// [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
+    /// borrowing views per item. See [`StreamingHandler::Item`].
+    type Item: Encodable<Res> + Send + 'static;
+
     /// Handle a bidi streaming RPC request.
     fn call(
         &self,
         ctx: RequestContext,
         requests: ServiceStream<Req>,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Self::Item>>>;
 }
 
 /// Wrapper that implements [`BidiStreamingHandler`] for async functions.
@@ -513,30 +561,34 @@ impl<F> FnBidiStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, Req, Res> BidiStreamingHandler<Req, Res> for FnBidiStreamingHandler<F>
+impl<F, Fut, Req, Res, B> BidiStreamingHandler<Req, Res> for FnBidiStreamingHandler<F>
 where
     F: Fn(RequestContext, ServiceStream<Req>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
+    type Item = B;
+
     fn call(
         &self,
         ctx: RequestContext,
         requests: ServiceStream<Req>,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<B>>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, requests).await })
     }
 }
 
 /// Helper function to create a bidi streaming handler from an async function.
-pub fn bidi_streaming_handler_fn<F, Fut, Req, Res>(f: F) -> FnBidiStreamingHandler<F>
+pub fn bidi_streaming_handler_fn<F, Fut, Req, Res, B>(f: F) -> FnBidiStreamingHandler<F>
 where
     F: Fn(RequestContext, ServiceStream<Req>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     Req: Message + Send + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
     FnBidiStreamingHandler::new(f)
 }
@@ -546,7 +598,7 @@ pub(crate) struct BidiStreamingHandlerWrapper<H, Req, Res>
 where
     H: BidiStreamingHandler<Req, Res>,
     Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(Req) -> Res>,
@@ -556,7 +608,7 @@ impl<H, Req, Res> BidiStreamingHandlerWrapper<H, Req, Res>
 where
     H: BidiStreamingHandler<Req, Res>,
     Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     /// Create a new wrapper around the given bidi streaming handler.
     pub fn new(handler: H) -> Self {
@@ -571,7 +623,7 @@ impl<H, Req, Res> ErasedBidiStreamingHandler for BidiStreamingHandlerWrapper<H, 
 where
     H: BidiStreamingHandler<Req, Res>,
     Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     fn call_erased(
         &self,
@@ -753,12 +805,18 @@ where
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
+    /// The stream item type. Typically `Res` itself; may be
+    /// [`PreEncoded`](crate::PreEncoded) or
+    /// [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
+    /// borrowing views per item.
+    type Item: Encodable<Res> + Send + 'static;
+
     /// Handle a server streaming RPC request with a zero-copy view.
     fn call(
         &self,
         ctx: RequestContext,
         request: OwnedView<ReqView>,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Self::Item>>>;
 }
 
 /// Wrapper that implements [`ViewStreamingHandler`] for async functions.
@@ -773,30 +831,34 @@ impl<F> FnViewStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, ReqView, Res> ViewStreamingHandler<ReqView, Res> for FnViewStreamingHandler<F>
+impl<F, Fut, ReqView, Res, B> ViewStreamingHandler<ReqView, Res> for FnViewStreamingHandler<F>
 where
     F: Fn(RequestContext, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
+    type Item = B;
+
     fn call(
         &self,
         ctx: RequestContext,
         request: OwnedView<ReqView>,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<B>>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, request).await })
     }
 }
 
 /// Helper function to create a view streaming handler from an async function.
-pub fn view_streaming_handler_fn<F, Fut, ReqView, Res>(f: F) -> FnViewStreamingHandler<F>
+pub fn view_streaming_handler_fn<F, Fut, ReqView, Res, B>(f: F) -> FnViewStreamingHandler<F>
 where
     F: Fn(RequestContext, OwnedView<ReqView>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
     FnViewStreamingHandler::new(f)
 }
@@ -807,7 +869,7 @@ where
     H: ViewStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     ReqView::Owned: Message + DeserializeOwned,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(ReqView) -> Res>,
@@ -818,7 +880,7 @@ where
     H: ViewStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     ReqView::Owned: Message + DeserializeOwned,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     pub fn new(handler: H) -> Self {
         Self {
@@ -833,7 +895,7 @@ where
     H: ViewStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     ReqView::Owned: Message + DeserializeOwned,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     fn call_erased(
         &self,
@@ -967,12 +1029,18 @@ where
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
 {
+    /// The stream item type. Typically `Res` itself; may be
+    /// [`PreEncoded`](crate::PreEncoded) or
+    /// [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
+    /// borrowing views per item.
+    type Item: Encodable<Res> + Send + 'static;
+
     /// Handle a bidi streaming RPC request with zero-copy view items.
     fn call(
         &self,
         ctx: RequestContext,
         requests: ServiceStream<OwnedView<ReqView>>,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>>;
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Self::Item>>>;
 }
 
 /// Wrapper that implements [`ViewBidiStreamingHandler`] for async functions.
@@ -987,30 +1055,37 @@ impl<F> FnViewBidiStreamingHandler<F> {
     }
 }
 
-impl<F, Fut, ReqView, Res> ViewBidiStreamingHandler<ReqView, Res> for FnViewBidiStreamingHandler<F>
+impl<F, Fut, ReqView, Res, B> ViewBidiStreamingHandler<ReqView, Res>
+    for FnViewBidiStreamingHandler<F>
 where
     F: Fn(RequestContext, ServiceStream<OwnedView<ReqView>>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
+    type Item = B;
+
     fn call(
         &self,
         ctx: RequestContext,
         requests: ServiceStream<OwnedView<ReqView>>,
-    ) -> BoxFuture<'static, ServiceResult<ServiceStream<Res>>> {
+    ) -> BoxFuture<'static, ServiceResult<ServiceStream<B>>> {
         let f = Arc::clone(&self.f);
         Box::pin(async move { f(ctx, requests).await })
     }
 }
 
 /// Helper function to create a view bidi streaming handler from an async function.
-pub fn view_bidi_streaming_handler_fn<F, Fut, ReqView, Res>(f: F) -> FnViewBidiStreamingHandler<F>
+pub fn view_bidi_streaming_handler_fn<F, Fut, ReqView, Res, B>(
+    f: F,
+) -> FnViewBidiStreamingHandler<F>
 where
     F: Fn(RequestContext, ServiceStream<OwnedView<ReqView>>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = ServiceResult<ServiceStream<Res>>> + Send + 'static,
+    Fut: Future<Output = ServiceResult<ServiceStream<B>>> + Send + 'static,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     Res: Message + Send + 'static,
+    B: Encodable<Res> + Send + 'static,
 {
     FnViewBidiStreamingHandler::new(f)
 }
@@ -1021,7 +1096,7 @@ where
     H: ViewBidiStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     ReqView::Owned: Message + DeserializeOwned,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(ReqView) -> Res>,
@@ -1032,7 +1107,7 @@ where
     H: ViewBidiStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     ReqView::Owned: Message + DeserializeOwned,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     pub fn new(handler: H) -> Self {
         Self {
@@ -1048,7 +1123,7 @@ where
     H: ViewBidiStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
     ReqView::Owned: Message + DeserializeOwned,
-    Res: Message + Serialize + Send + 'static,
+    Res: Message + Send + 'static,
 {
     fn call_erased(
         &self,
@@ -1124,5 +1199,90 @@ mod tests {
         let garbage = Bytes::from_static(&[0xFF, 0xFF, 0xFF]);
         let err = decode_request_view::<StringValueView>(garbage, CodecFormat::Proto).unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn encode_body_stream_owned_items() {
+        use futures::StreamExt as _;
+        let s = futures::stream::iter([
+            Ok(StringValue::from("a")),
+            Ok(StringValue::from("b")),
+            Err(ConnectError::internal("boom")),
+        ]);
+        let mut out = encode_body_stream::<StringValue, _, _>(s, CodecFormat::Proto);
+        let a = out.next().await.unwrap().unwrap();
+        let b = out.next().await.unwrap().unwrap();
+        assert_eq!(StringValue::decode_from_slice(&a).unwrap().value, "a");
+        assert_eq!(StringValue::decode_from_slice(&b).unwrap().value, "b");
+        assert!(out.next().await.unwrap().is_err());
+        assert!(out.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn encode_body_stream_pre_encoded_items() {
+        use crate::PreEncoded;
+        use futures::StreamExt as _;
+        // A `StreamingHandler` (or `ViewStreamingHandler`) with
+        // `type Item = PreEncoded` yields bytes the handler encoded
+        // internally; the stream must pass them through verbatim.
+        let bytes_a = StringValue::from("a").encode_to_bytes();
+        let bytes_b = StringValue::from("b").encode_to_bytes();
+        let s = futures::stream::iter([
+            Ok(PreEncoded::<StringValue>::proto(bytes_a.clone())),
+            Ok(PreEncoded::<StringValue>::proto(bytes_b.clone())),
+        ]);
+        let mut out =
+            encode_body_stream::<StringValue, PreEncoded<StringValue>, _>(s, CodecFormat::Proto);
+        assert_eq!(out.next().await.unwrap().unwrap(), bytes_a);
+        assert_eq!(out.next().await.unwrap().unwrap(), bytes_b);
+        assert!(out.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn encode_body_stream_pre_encoded_json_unimplemented() {
+        use crate::PreEncoded;
+        use futures::StreamExt as _;
+        let s = futures::stream::iter([Ok(PreEncoded::<StringValue>::proto(Bytes::new()))]);
+        let mut out =
+            encode_body_stream::<StringValue, PreEncoded<StringValue>, _>(s, CodecFormat::Json);
+        let err = out.next().await.unwrap().unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::Unimplemented);
+    }
+
+    #[test]
+    fn streaming_handler_item_is_inferred_from_closure() {
+        // `streaming_handler_fn` infers `Item` from the closure's stream
+        // type. This is a compile-only test: the call type-checks iff
+        // `FnStreamingHandler<F>: StreamingHandler<Req, Res, Item = B>`
+        // unifies for both an owned-message and a `PreEncoded` stream.
+        use crate::PreEncoded;
+
+        fn assert_handler<H, Req, Res, B>(_: &H)
+        where
+            H: StreamingHandler<Req, Res, Item = B>,
+            Req: Message + Send + 'static,
+            Res: Message + Send + 'static,
+            B: Encodable<Res> + Send + 'static,
+        {
+        }
+
+        let owned = streaming_handler_fn(|_ctx: RequestContext, _req: StringValue| async move {
+            Response::stream_ok(futures::stream::iter([Ok(StringValue::from("x"))]))
+        });
+        assert_handler::<_, StringValue, StringValue, StringValue>(&owned);
+
+        // `PreEncoded<M>` is `Encodable<M>` only for its own `M`, but the
+        // *closure* return type `ServiceStream<PreEncoded<StringValue>>`
+        // doesn't constrain `Res` (any `Res` for which `PreEncoded<Res>:
+        // Encodable<Res>` would unify) — it must be turbofished. (The
+        // generated `register_routes` impl turbofishes `Res` at the
+        // `route_view_*_stream::<_, _, Res>(...)` call site for the same
+        // reason.)
+        let pre = streaming_handler_fn::<_, _, StringValue, StringValue, PreEncoded<StringValue>>(
+            |_ctx: RequestContext, _req: StringValue| async move {
+                Response::stream_ok(futures::stream::iter([Ok(PreEncoded::proto(Bytes::new()))]))
+            },
+        );
+        assert_handler::<_, StringValue, StringValue, PreEncoded<StringValue>>(&pre);
     }
 }

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -65,6 +65,12 @@ pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 /// `B` is any [`Encodable<Res>`] — typically `Res` itself, but may be
 /// [`PreEncoded`](crate::PreEncoded) or [`MaybeBorrowed`](crate::MaybeBorrowed)
 /// for handlers that encode borrowing views per item.
+///
+/// Thin re-export wrapper so the four `*StreamingHandlerWrapper`
+/// `call_erased` impls below don't have to spell out the
+/// `dispatcher::codegen` path; the implementation is shared with the
+/// codegen-emitted dispatcher arms (see
+/// [`encode_response_stream`](crate::dispatcher::codegen::encode_response_stream)).
 fn encode_body_stream<Res, B, S>(
     stream: S,
     format: CodecFormat,
@@ -74,21 +80,7 @@ where
     B: Encodable<Res> + Send + 'static,
     S: Stream<Item = Result<B, ConnectError>> + Send + 'static,
 {
-    use futures::StreamExt as _;
-    Box::pin(
-        futures::stream::unfold(
-            (
-                Box::pin(stream) as Pin<Box<dyn Stream<Item = Result<B, ConnectError>> + Send>>,
-                format,
-            ),
-            async |(mut s, fmt)| match s.next().await {
-                Some(Ok(res)) => Some((Encodable::<Res>::encode(&res, fmt), (s, fmt))),
-                Some(Err(e)) => Some((Err(e), (s, fmt))),
-                None => None,
-            },
-        )
-        .fuse(),
-    )
+    crate::dispatcher::codegen::encode_response_stream::<Res, B, S>(stream, format)
 }
 
 // ============================================================================
@@ -333,18 +325,25 @@ where
 
 /// Helper function to create a streaming handler from an async function.
 ///
-/// When the closure yields owned `Res` items, all type parameters are
-/// inferred. When it yields a generic [`Encodable`] body like
-/// [`PreEncoded<Res>`](crate::PreEncoded), `Res` is no longer derivable
-/// from the item type and must be turbofished:
+/// `Res` is inferred from the stream item type `B` whenever the closure
+/// pins `B` to a concrete type — yielding an owned `Res`,
+/// [`PreEncoded::from_view(&view)`](crate::PreEncoded::from_view), or
+/// [`PreEncoded::<MyResponse>::from_bytes_unchecked(bytes)`](crate::PreEncoded::from_bytes_unchecked)
+/// all infer cleanly. Inference only fails when the closure leaves the
+/// message type itself open (e.g. `PreEncoded::from_bytes_unchecked(bytes)`
+/// with no `::<M>`); the simplest fix is to name `M` at the construction
+/// site rather than turbofishing this helper:
 ///
 /// ```rust,ignore
-/// streaming_handler_fn::<_, _, MyRequest, MyResponse, PreEncoded<MyResponse>>(handler)
+/// // `M` named at the construction site — `Res` is inferred:
+/// PreEncoded::<MyResponse>::from_bytes_unchecked(bytes)
 /// ```
 ///
 /// The codegen-emitted route registrations (`route_view_server_stream::<_,
-/// _, Out>`) supply `Res` for you, so this only affects hand-written
-/// `Router` registrations.
+/// _, Out>`) always pin `Res` because the trait method's stream item is the
+/// *opaque* `impl Encodable<Out>`, which can't be unified against the
+/// `Encodable<Res>` impls. Hand-written `Router` registrations don't hit
+/// this unless they leave the message type open.
 pub fn streaming_handler_fn<F, Fut, Req, Res, B>(f: F) -> FnStreamingHandler<F>
 where
     F: Fn(RequestContext, Req) -> Fut + Send + Sync + 'static,
@@ -1224,12 +1223,16 @@ mod tests {
         use futures::StreamExt as _;
         // A `StreamingHandler` (or `ViewStreamingHandler`) with
         // `type Item = PreEncoded` yields bytes the handler encoded
-        // internally; the stream must pass them through verbatim.
+        // internally; the proto codec must pass them through verbatim.
         let bytes_a = StringValue::from("a").encode_to_bytes();
         let bytes_b = StringValue::from("b").encode_to_bytes();
         let s = futures::stream::iter([
-            Ok(PreEncoded::<StringValue>::proto(bytes_a.clone())),
-            Ok(PreEncoded::<StringValue>::proto(bytes_b.clone())),
+            Ok(PreEncoded::<StringValue>::from_bytes_unchecked(
+                bytes_a.clone(),
+            )),
+            Ok(PreEncoded::<StringValue>::from_bytes_unchecked(
+                bytes_b.clone(),
+            )),
         ]);
         let mut out =
             encode_body_stream::<StringValue, PreEncoded<StringValue>, _>(s, CodecFormat::Proto);
@@ -1239,14 +1242,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn encode_body_stream_pre_encoded_json_unimplemented() {
+    async fn encode_body_stream_pre_encoded_json_decodes_per_item() {
         use crate::PreEncoded;
         use futures::StreamExt as _;
-        let s = futures::stream::iter([Ok(PreEncoded::<StringValue>::proto(Bytes::new()))]);
+        // The JSON path decodes the proto bytes back to `M` per item and
+        // re-serializes — slow but correct. Each item should match what
+        // serializing the owned message directly would produce.
+        let m_a = StringValue::from("a");
+        let m_b = StringValue::from("b");
+        let s = futures::stream::iter([
+            Ok(PreEncoded::<StringValue>::from_bytes_unchecked(
+                m_a.encode_to_bytes(),
+            )),
+            Ok(PreEncoded::<StringValue>::from_bytes_unchecked(
+                m_b.encode_to_bytes(),
+            )),
+        ]);
         let mut out =
             encode_body_stream::<StringValue, PreEncoded<StringValue>, _>(s, CodecFormat::Json);
-        let err = out.next().await.unwrap().unwrap_err();
-        assert_eq!(err.code, crate::error::ErrorCode::Unimplemented);
+        assert_eq!(
+            out.next().await.unwrap().unwrap(),
+            Bytes::from(serde_json::to_vec(&m_a).unwrap())
+        );
+        assert_eq!(
+            out.next().await.unwrap().unwrap(),
+            Bytes::from(serde_json::to_vec(&m_b).unwrap())
+        );
+        assert!(out.next().await.is_none());
     }
 
     #[test]
@@ -1271,18 +1293,19 @@ mod tests {
         });
         assert_handler::<_, StringValue, StringValue, StringValue>(&owned);
 
-        // `PreEncoded<M>` is `Encodable<M>` only for its own `M`, but the
-        // *closure* return type `ServiceStream<PreEncoded<StringValue>>`
-        // doesn't constrain `Res` (any `Res` for which `PreEncoded<Res>:
-        // Encodable<Res>` would unify) — it must be turbofished. (The
-        // generated `register_routes` impl turbofishes `Res` at the
-        // `route_view_*_stream::<_, _, Res>(...)` call site for the same
-        // reason.)
-        let pre = streaming_handler_fn::<_, _, StringValue, StringValue, PreEncoded<StringValue>>(
-            |_ctx: RequestContext, _req: StringValue| async move {
-                Response::stream_ok(futures::stream::iter([Ok(PreEncoded::proto(Bytes::new()))]))
-            },
-        );
+        // When the closure pins the `PreEncoded` message type concretely,
+        // `Res` is inferred from the unique `Encodable<M> for PreEncoded<M>`
+        // impl. No turbofish needed on `streaming_handler_fn`. (The codegen
+        // path is different: the trait method's `impl Encodable<Out>` item
+        // is opaque, so the generated `register_routes` impl pins `Res` at
+        // the `route_view_*_stream::<_, _, Res>(...)` call site instead.)
+        let pre = streaming_handler_fn(|_ctx: RequestContext, _req: StringValue| async move {
+            Response::stream_ok(futures::stream::iter([Ok(
+                PreEncoded::<StringValue>::from_bytes_unchecked(
+                    StringValue::from("x").encode_to_bytes(),
+                ),
+            )]))
+        });
         assert_handler::<_, StringValue, StringValue, PreEncoded<StringValue>>(&pre);
     }
 }

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -246,6 +246,7 @@ pub use handler::view_streaming_handler_fn;
 pub use response::Encodable;
 pub use response::EncodedResponse;
 pub use response::MaybeBorrowed;
+pub use response::PreEncoded;
 pub use response::RequestContext;
 pub use response::Response;
 pub use response::ServiceResult;

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -8,11 +8,12 @@
 //! [`OwnedView<MView<'static>>`](buffa::view::OwnedView), or
 //! [`MaybeBorrowed`] for the conditional case.
 
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::time::Instant;
 
 use buffa::Message;
-use buffa::view::ViewEncode;
+use buffa::view::{MessageView, ViewEncode};
 use bytes::Bytes;
 use futures::Stream;
 use http::HeaderMap;
@@ -303,7 +304,9 @@ pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> +
 /// - `MView<'_>` and [`OwnedView<MView<'static>>`](buffa::view::OwnedView),
 ///   emitted by codegen per RPC output type;
 /// - [`MaybeBorrowed<M, V>`] for handlers that conditionally return
-///   either.
+///   either;
+/// - [`PreEncoded`] for handlers that encode a non-`'static` view
+///   internally and pass the bytes across the handler boundary.
 ///
 /// # Contract
 ///
@@ -311,9 +314,10 @@ pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> +
 /// the given format.
 ///
 /// `encode` is fallible: the owned-message impl never errors, but the
-/// view-body impls are proto-only (view types lack `Serialize`) and
-/// return [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented)
-/// for `CodecFormat::Json`.
+/// view-body impls and [`PreEncoded`] are proto-only (view types lack
+/// `Serialize`, and pre-encoded bytes carry no JSON form) and return
+/// [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented) for
+/// `CodecFormat::Json`.
 pub trait Encodable<M> {
     /// Encode `self` as wire bytes for `M` in the requested format.
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError>;
@@ -409,6 +413,138 @@ where
         match self {
             Self::Owned(m) => m.encode(codec),
             Self::Borrowed(v) => v.encode(codec),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PreEncoded
+// ---------------------------------------------------------------------------
+
+/// Pre-encoded protobuf response body for message type `M`.
+///
+/// Use when the handler builds and encodes a borrowing view internally —
+/// e.g. a `FooView<'a>` borrowing from a local snapshot — rather than
+/// returning the view itself. The `'static` bound on `Handler::Body` (and
+/// on streaming items, see the `use<Self>` note in the [`StreamingHandler`]
+/// docs) means a view with a non-`'static` lifetime can't cross the handler
+/// boundary; `PreEncoded` carries the bytes across instead.
+///
+/// The `M` type parameter is a compile-time witness for which RPC output
+/// type the bytes encode. [`PreEncoded::from_view`] enforces it via
+/// `MessageView::Owned`; [`PreEncoded::proto`] takes `M` on trust (you're
+/// asserting the bytes already decode as `M`).
+///
+/// # Streaming example
+///
+/// The motivating shape — a server-streaming handler that builds and
+/// encodes per-item views borrowing from a local store snapshot, then
+/// yields the bytes:
+///
+/// ```rust,ignore
+/// use connectrpc::{PreEncoded, Response, RequestContext, ServiceResult, ServiceStream};
+///
+/// async fn watch(
+///     &self,
+///     _ctx: RequestContext,
+///     req: OwnedWatchRequestView,
+/// ) -> ServiceResult<ServiceStream<PreEncoded<WatchResponse>>> {
+///     let store = self.store.clone();
+///     let stream = futures::stream::unfold(store, |store| async move {
+///         let snapshot = store.load();
+///         // `view` borrows from `snapshot`; encode while the borrow is live.
+///         let view = build_view_from_snapshot(&snapshot);
+///         let item = PreEncoded::from_view(&view);
+///         Some((Ok(item), store))
+///     });
+///     Response::stream_ok(stream)
+/// }
+/// ```
+///
+/// For a unary handler, the same pattern applies — return
+/// `ServiceResult<PreEncoded<MyResponse>>`.
+///
+/// # Codec compatibility
+///
+/// Proto-only — same constraint as the per-output-type view-body impls.
+/// JSON clients receive an [`unimplemented`](crate::ErrorCode::Unimplemented)
+/// error; if your service must support JSON, build the owned message and
+/// return it directly (or [`MaybeBorrowed::Owned`]) on every path.
+///
+/// # Contract
+///
+/// `PreEncoded` is a transparent byte container — it does not validate
+/// the wrapped bytes. [`PreEncoded::from_view`] gives a compile-time
+/// witness via `MessageView::Owned = M`; [`PreEncoded::proto`] trusts the
+/// caller. Returning bytes that don't decode as `M` will produce decode
+/// errors on the client.
+#[must_use = "PreEncoded must be returned from a handler to take effect"]
+pub struct PreEncoded<M> {
+    bytes: Bytes,
+    // `fn() -> M` keeps `PreEncoded<M>` `Send + Sync` regardless of `M`'s
+    // auto-trait surface (the bytes are owned; `M` is only a type witness).
+    _marker: PhantomData<fn() -> M>,
+}
+
+// Manual derives: `#[derive(Debug, Clone)]` would add a spurious `M: Debug` /
+// `M: Clone` bound (PhantomData carries it through to the where-clause).
+impl<M> std::fmt::Debug for PreEncoded<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("PreEncoded").field(&self.bytes).finish()
+    }
+}
+
+impl<M> Clone for PreEncoded<M> {
+    fn clone(&self) -> Self {
+        Self {
+            bytes: self.bytes.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<M> PreEncoded<M> {
+    /// Wrap already-encoded protobuf bytes.
+    ///
+    /// You are asserting the bytes decode as `M`; this is not validated.
+    /// Prefer [`PreEncoded::from_view`] when you have a view in hand —
+    /// it enforces `M` at compile time.
+    pub fn proto(bytes: impl Into<Bytes>) -> Self {
+        Self {
+            bytes: bytes.into(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<M: Message> PreEncoded<M> {
+    /// Encode a [`ViewEncode`] view to protobuf bytes.
+    ///
+    /// The `MessageView<'a, Owned = M>` bound is the compile-time witness
+    /// that the bytes decode as `M` — passing `OtherView<'a>` won't
+    /// type-check unless `OtherView::Owned == M`.
+    pub fn from_view<'a, V>(view: &V) -> Self
+    where
+        V: ViewEncode<'a> + MessageView<'a, Owned = M>,
+    {
+        Self {
+            bytes: view.encode_to_bytes(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+// Coherence note: this impl is well-defined only because `PreEncoded<M>`
+// never implements `Message` or `Serialize` — those would overlap the
+// `impl<M: Message + Serialize> Encodable<M> for M` blanket above. Keep it
+// that way.
+impl<M> Encodable<M> for PreEncoded<M> {
+    fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError> {
+        match codec {
+            CodecFormat::Proto => Ok(self.bytes.clone()),
+            CodecFormat::Json => Err(ConnectError::unimplemented(
+                "pre-encoded body is protobuf-only; build the owned message for JSON-serving handlers",
+            )),
         }
     }
 }
@@ -661,6 +797,60 @@ mod tests {
             MaybeBorrowed::Borrowed(V(StringValueView::default()));
         let err = borrowed.encode(CodecFormat::Json).unwrap_err();
         assert_eq!(err.code, crate::ErrorCode::Unimplemented);
+    }
+
+    #[test]
+    fn pre_encoded_proto_round_trip() {
+        let m = StringValue::from("pre-encoded");
+        let bytes = m.encode_to_bytes();
+        let body = PreEncoded::<StringValue>::proto(bytes.clone());
+        let out = Encodable::<StringValue>::encode(&body, CodecFormat::Proto).unwrap();
+        assert_eq!(out, bytes);
+        assert_eq!(
+            StringValue::decode_from_slice(&out).unwrap().value,
+            "pre-encoded"
+        );
+    }
+
+    #[test]
+    fn pre_encoded_json_unimplemented() {
+        let body = PreEncoded::<StringValue>::proto(Bytes::from_static(&[0x0a, 0x02, b'h', b'i']));
+        let err = Encodable::<StringValue>::encode(&body, CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Unimplemented);
+        assert!(err.message.as_deref().unwrap().contains("protobuf-only"));
+    }
+
+    #[test]
+    fn pre_encoded_from_view() {
+        use buffa::view::ViewEncode;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        let v = StringValueView {
+            value: "from-view",
+            ..Default::default()
+        };
+        // `from_view` infers `M = StringValue` from `StringValueView::Owned`.
+        let body = PreEncoded::from_view(&v);
+        let out = Encodable::<StringValue>::encode(&body, CodecFormat::Proto).unwrap();
+        assert_eq!(out, v.encode_to_bytes());
+        assert_eq!(
+            StringValue::decode_from_slice(&out).unwrap().value,
+            "from-view"
+        );
+    }
+
+    #[test]
+    fn pre_encoded_is_typed() {
+        // `PreEncoded<M>` only implements `Encodable<M>` — the type witness
+        // means `PreEncoded<StringValue>` cannot be used where
+        // `Encodable<Int32Value>` is required. Verified at compile time;
+        // this test just exercises the happy path for both types.
+        use buffa_types::google::protobuf::Int32Value;
+        let s = PreEncoded::<StringValue>::proto(StringValue::from("a").encode_to_bytes());
+        let i = PreEncoded::<Int32Value>::proto(Int32Value::from(1).encode_to_bytes());
+        Encodable::<StringValue>::encode(&s, CodecFormat::Proto).unwrap();
+        Encodable::<Int32Value>::encode(&i, CodecFormat::Proto).unwrap();
+        // The following would not compile:
+        //   Encodable::<Int32Value>::encode(&s, CodecFormat::Proto)
     }
 
     #[test]

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -426,8 +426,9 @@ where
 /// Use when the handler builds and encodes a borrowing view internally —
 /// e.g. a `FooView<'a>` borrowing from a local snapshot — rather than
 /// returning the view itself. The `'static` bound on `Handler::Body` (and
-/// on streaming items, see the `use<Self>` note in the [`StreamingHandler`]
-/// docs) means a view with a non-`'static` lifetime can't cross the handler
+/// on streaming items, see the `use<Self>` note in the
+/// [`StreamingHandler`](crate::StreamingHandler) docs) means a view with a
+/// non-`'static` lifetime can't cross the handler
 /// boundary; `PreEncoded` carries the bytes across instead.
 ///
 /// The `M` type parameter is a compile-time witness for which RPC output

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -313,11 +313,12 @@ pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> +
 /// Implementations must produce bytes that decode as a valid `M` in
 /// the given format.
 ///
-/// `encode` is fallible: the owned-message impl never errors, but the
-/// view-body impls and [`PreEncoded`] are proto-only (view types lack
-/// `Serialize`, and pre-encoded bytes carry no JSON form) and return
+/// `encode` is fallible: the owned-message impl never errors. The
+/// view-body impls are proto-only (view types lack `Serialize`) and return
 /// [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented) for
-/// `CodecFormat::Json`.
+/// `CodecFormat::Json`. [`PreEncoded`] supports both codecs but the JSON
+/// path is a slow fallback (decode + re-serialize) — see its
+/// `# Codec behaviour` doc.
 pub trait Encodable<M> {
     /// Encode `self` as wire bytes for `M` in the requested format.
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError>;
@@ -432,9 +433,24 @@ where
 /// boundary; `PreEncoded` carries the bytes across instead.
 ///
 /// The `M` type parameter is a compile-time witness for which RPC output
-/// type the bytes encode. [`PreEncoded::from_view`] enforces it via
-/// `MessageView::Owned`; [`PreEncoded::proto`] takes `M` on trust (you're
-/// asserting the bytes already decode as `M`).
+/// type the bytes encode. Three construction paths, in decreasing order
+/// of compile-time guarantee:
+///
+/// - [`from_message(&m)`](PreEncoded::from_message) — encodes an owned
+///   `M`; the receiver type *is* the witness.
+/// - [`from_view(&view)`](PreEncoded::from_view) — encodes a borrowing
+///   view; `MessageView::Owned = M` is the witness.
+/// - [`from_bytes_unchecked(bytes)`](PreEncoded::from_bytes_unchecked) —
+///   wraps already-encoded bytes from elsewhere (a cache, storage,
+///   another service). No witness; you're asserting the bytes decode as
+///   `M`.
+///
+/// `from_message` and `from_view` produce the same `PreEncoded<M>` type,
+/// so a stream can mix items built either way (e.g. a cache-hit path
+/// returning the cached owned `M`, a cache-miss path building a view from
+/// a snapshot) — the same role [`MaybeBorrowed`] fills for unary
+/// handlers, but with the encode happening eagerly inside the stream
+/// body.
 ///
 /// # Streaming example
 ///
@@ -465,20 +481,74 @@ where
 /// For a unary handler, the same pattern applies — return
 /// `ServiceResult<PreEncoded<MyResponse>>`.
 ///
-/// # Codec compatibility
+/// # Codec behaviour
 ///
-/// Proto-only — same constraint as the per-output-type view-body impls.
-/// JSON clients receive an [`unimplemented`](crate::ErrorCode::Unimplemented)
-/// error; if your service must support JSON, build the owned message and
-/// return it directly (or [`MaybeBorrowed::Owned`]) on every path.
+/// `PreEncoded` is optimized for the `proto` codec: the wrapped bytes are
+/// passed through verbatim with no re-encoding. The motivating use case
+/// (high-throughput fanout) is proto-only.
+///
+/// For the `json` codec, `PreEncoded` falls back to decoding the bytes as
+/// `M` and re-serializing as JSON. **This is correct but not fast** — a
+/// full proto decode plus a JSON serialize per response (or per stream
+/// item). The fallback exists so that registering a `PreEncoded` handler
+/// on a JSON-capable router degrades gracefully instead of returning a
+/// runtime error. If your service serves a meaningful JSON traffic share,
+/// build and return the owned message (or [`MaybeBorrowed::Owned`])
+/// instead — that lets the codec layer pick the right encoding without
+/// the proto round-trip.
+///
+/// If the wrapped bytes don't decode as `M` (e.g. you passed mismatched
+/// bytes to [`from_bytes_unchecked`](PreEncoded::from_bytes_unchecked)),
+/// the JSON path returns an [`internal`](crate::ErrorCode::Internal)
+/// error at the server; the proto path passes the bytes through and the
+/// client sees a decode error.
+///
+/// ## Codec-dependent fidelity
+///
+/// The proto path is byte-exact; the JSON path is **only as faithful as
+/// decoding the bytes to an owned `M` and re-serializing**. The two
+/// diverge when the wrapped bytes carry information not representable in
+/// `M` itself:
+///
+/// - **Unknown fields** (proto bytes encoded against a *newer* schema
+///   than the server's `M`) are preserved on the proto path and dropped
+///   on the JSON path. This matters only for
+///   [`from_bytes_unchecked`](PreEncoded::from_bytes_unchecked) bytes
+///   sourced externally; bytes produced by
+///   [`from_message`](PreEncoded::from_message) /
+///   [`from_view`](PreEncoded::from_view) cannot carry unknown fields.
+/// - **Non-canonical proto encodings** (out-of-order fields, redundant
+///   length prefixes, repeated non-`repeated` fields) are passed through
+///   verbatim on the proto path and normalized by the decode on the JSON
+///   path.
+///
+/// If byte-exact fidelity across codecs matters (e.g. signature
+/// verification, content-addressed storage), do not use `PreEncoded` with
+/// JSON-capable routes.
+///
+/// ## Cost is selected by the client
+///
+/// The codec is chosen per-request by the client's `Content-Type` header.
+/// For a service that adopted `PreEncoded` for proto throughput, a client
+/// sending JSON requests (intentionally, by misconfiguration, or
+/// adversarially) shifts those requests onto the slow decode-reserialize
+/// path. The marginal cost is bounded by the response size and is usually
+/// small relative to the handler's own work, but a streaming RPC pays it
+/// per item. A service that wants to *enforce* proto-only should reject
+/// non-proto `Content-Type` at the middleware layer (e.g. an axum
+/// middleware that returns `415 Unsupported Media Type`) rather than rely
+/// on the body type — that keeps the policy outside the handler and
+/// applies before the request body is read.
 ///
 /// # Contract
 ///
 /// `PreEncoded` is a transparent byte container — it does not validate
-/// the wrapped bytes. [`PreEncoded::from_view`] gives a compile-time
-/// witness via `MessageView::Owned = M`; [`PreEncoded::proto`] trusts the
-/// caller. Returning bytes that don't decode as `M` will produce decode
-/// errors on the client.
+/// the wrapped bytes on the proto path. [`PreEncoded::from_view`] gives a
+/// compile-time witness via `MessageView::Owned = M`;
+/// [`PreEncoded::from_bytes_unchecked`] trusts the caller. Returning bytes
+/// that don't decode as `M` will produce decode errors on the client (or,
+/// for JSON clients, an `internal` error from the server-side fallback
+/// decode).
 #[must_use = "PreEncoded must be returned from a handler to take effect"]
 pub struct PreEncoded<M> {
     bytes: Bytes,
@@ -504,21 +574,27 @@ impl<M> Clone for PreEncoded<M> {
     }
 }
 
-impl<M> PreEncoded<M> {
-    /// Wrap already-encoded protobuf bytes.
+impl<M: Message> PreEncoded<M> {
+    /// Encode an owned `M` to protobuf bytes.
     ///
-    /// You are asserting the bytes decode as `M`; this is not validated.
-    /// Prefer [`PreEncoded::from_view`] when you have a view in hand —
-    /// it enforces `M` at compile time.
-    pub fn proto(bytes: impl Into<Bytes>) -> Self {
+    /// The receiver type is the compile-time witness — there's no way to
+    /// produce a `PreEncoded<M>` from a `&Other`. This is the right
+    /// constructor when the handler builds an owned `M` and wants to
+    /// share the encoding (e.g. encode once, clone the
+    /// [`Bytes`]-backed `PreEncoded` for N readers in a fanout) or when a
+    /// stream needs to mix owned-message and view-built items under a
+    /// single `type Item = PreEncoded<M>`.
+    ///
+    /// Equivalent to `PreEncoded::from_bytes_unchecked(m.encode_to_bytes())`,
+    /// but with `M` enforced by the type system rather than asserted by
+    /// the caller.
+    pub fn from_message(msg: &M) -> Self {
         Self {
-            bytes: bytes.into(),
+            bytes: msg.encode_to_bytes(),
             _marker: PhantomData,
         }
     }
-}
 
-impl<M: Message> PreEncoded<M> {
     /// Encode a [`ViewEncode`] view to protobuf bytes.
     ///
     /// The `MessageView<'a, Owned = M>` bound is the compile-time witness
@@ -533,19 +609,78 @@ impl<M: Message> PreEncoded<M> {
             _marker: PhantomData,
         }
     }
+
+    /// Wrap already-encoded protobuf bytes without validating them.
+    ///
+    /// Use when the bytes come from somewhere with no structural type
+    /// guarantee — a byte cache, a blob store, a sidecar service. You are
+    /// asserting the bytes decode as `M`; the proto path does not
+    /// validate this. In debug builds, the bytes are decoded once as a
+    /// `debug_assert!` to surface mismatches early.
+    ///
+    /// Prefer [`from_message`](PreEncoded::from_message) when you have an
+    /// owned `M` in hand and [`from_view`](PreEncoded::from_view) when
+    /// you have a view — both enforce `M` at compile time.
+    ///
+    /// Zero-copy for `Bytes` and `Vec<u8>`; passing `&[u8]` allocates and
+    /// copies.
+    pub fn from_bytes_unchecked(bytes: impl Into<Bytes>) -> Self {
+        let bytes = bytes.into();
+        debug_assert!(
+            M::decode_from_slice(&bytes).is_ok(),
+            "PreEncoded::from_bytes_unchecked: bytes do not decode as {}",
+            std::any::type_name::<M>(),
+        );
+        Self {
+            bytes,
+            _marker: PhantomData,
+        }
+    }
 }
 
-// Coherence note: this impl is well-defined only because `PreEncoded<M>`
-// never implements `Message` or `Serialize` — those would overlap the
-// `impl<M: Message + Serialize> Encodable<M> for M` blanket above. Keep it
-// that way.
-impl<M> Encodable<M> for PreEncoded<M> {
+/// Encode an owned `M` to a [`PreEncoded<M>`].
+///
+/// Equivalent to [`PreEncoded::from_message`]; provided for `.into()`
+/// ergonomics.
+impl<M: Message> From<&M> for PreEncoded<M> {
+    fn from(msg: &M) -> Self {
+        Self::from_message(msg)
+    }
+}
+
+// Coherence: this impl is non-overlapping with the
+// `impl<M: Message + Serialize> Encodable<M> for M` blanket above for
+// structural reasons. For the two to overlap, some `T` would have to satisfy
+// both `T: Encodable<T>` (blanket, with `T: Message + Serialize`) and
+// `T = PreEncoded<U>` with `T: Encodable<U>` (this impl) for the *same* trait
+// parameter — i.e. `T = U`, i.e. `PreEncoded<U> = U`, which is infinite. So
+// the impls cannot overlap even if a future change made `PreEncoded` a
+// `Message` (which would only add `PreEncoded<M>: Encodable<PreEncoded<M>>` —
+// a different trait instantiation). No invariant to maintain here.
+//
+// The `M: Message + Serialize` bound matches the blanket so a `PreEncoded<M>`
+// is `Encodable<M>` exactly when an owned `M` would be — and is what makes the
+// JSON fallback path possible (decode as `M`, re-serialize).
+impl<M: Message + Serialize> Encodable<M> for PreEncoded<M> {
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError> {
         match codec {
             CodecFormat::Proto => Ok(self.bytes.clone()),
-            CodecFormat::Json => Err(ConnectError::unimplemented(
-                "pre-encoded body is protobuf-only; build the owned message for JSON-serving handlers",
-            )),
+            // Slow path: decode the proto bytes back to `M`, then serialize
+            // as JSON. This exists for correctness (JSON clients should get
+            // a response, not `unimplemented`), not throughput; the owned
+            // message path skips the proto round-trip and is preferable for
+            // JSON-heavy services. See the type-level docs.
+            CodecFormat::Json => {
+                let msg = M::decode_from_slice(&self.bytes).map_err(|e| {
+                    ConnectError::internal(format!(
+                        "pre-encoded bytes did not decode as {}: {e}",
+                        std::any::type_name::<M>(),
+                    ))
+                })?;
+                serde_json::to_vec(&msg).map(Bytes::from).map_err(|e| {
+                    ConnectError::internal(format!("failed to encode JSON response: {e}"))
+                })
+            }
         }
     }
 }
@@ -804,7 +939,7 @@ mod tests {
     fn pre_encoded_proto_round_trip() {
         let m = StringValue::from("pre-encoded");
         let bytes = m.encode_to_bytes();
-        let body = PreEncoded::<StringValue>::proto(bytes.clone());
+        let body = PreEncoded::<StringValue>::from_bytes_unchecked(bytes.clone());
         let out = Encodable::<StringValue>::encode(&body, CodecFormat::Proto).unwrap();
         assert_eq!(out, bytes);
         assert_eq!(
@@ -814,11 +949,33 @@ mod tests {
     }
 
     #[test]
-    fn pre_encoded_json_unimplemented() {
-        let body = PreEncoded::<StringValue>::proto(Bytes::from_static(&[0x0a, 0x02, b'h', b'i']));
+    fn pre_encoded_json_decodes_then_serializes() {
+        // The JSON path round-trips: proto bytes → owned `M` → JSON. Slow,
+        // but correct — see the `# Codec behaviour` doc on `PreEncoded`.
+        let m = StringValue::from("hi");
+        let body = PreEncoded::<StringValue>::from_bytes_unchecked(m.encode_to_bytes());
+        let out = Encodable::<StringValue>::encode(&body, CodecFormat::Json).unwrap();
+        // Output should match what serializing the owned message directly
+        // would produce.
+        assert_eq!(out, Bytes::from(serde_json::to_vec(&m).unwrap()));
+    }
+
+    #[test]
+    fn pre_encoded_json_decode_failure_is_internal_error() {
+        // `from_bytes_unchecked` is unvalidated on the proto path. The JSON
+        // fallback necessarily decodes; if that fails (the wrapped bytes
+        // were never a valid `M`), the server-side `internal` error surfaces
+        // closer to the construction bug than the proto path would.
+        //
+        // Field 1 (LEN) declares 99 bytes but only 2 follow — guaranteed
+        // truncated for `StringValue`.
+        let body = PreEncoded::<StringValue> {
+            bytes: Bytes::from_static(&[0x0a, 0x63, b'h', b'i']),
+            _marker: std::marker::PhantomData,
+        };
         let err = Encodable::<StringValue>::encode(&body, CodecFormat::Json).unwrap_err();
-        assert_eq!(err.code, crate::ErrorCode::Unimplemented);
-        assert!(err.message.as_deref().unwrap().contains("protobuf-only"));
+        assert_eq!(err.code, crate::ErrorCode::Internal);
+        assert!(err.message.as_deref().unwrap().contains("did not decode"));
     }
 
     #[test]
@@ -840,18 +997,77 @@ mod tests {
     }
 
     #[test]
+    fn pre_encoded_from_message() {
+        let m = StringValue::from("from-message");
+        // `from_message` infers `M` from the receiver — no annotation.
+        let body = PreEncoded::from_message(&m);
+        let out = Encodable::<StringValue>::encode(&body, CodecFormat::Proto).unwrap();
+        assert_eq!(out, m.encode_to_bytes());
+
+        // `From<&M>` is the same conversion via `.into()`.
+        let body2: PreEncoded<StringValue> = (&m).into();
+        let out2 = Encodable::<StringValue>::encode(&body2, CodecFormat::Proto).unwrap();
+        assert_eq!(out2, out);
+    }
+
+    #[test]
+    fn pre_encoded_codec_fidelity_diverges_on_unknown_fields() {
+        // Documents the codec-dependent fidelity caveat: the proto path
+        // is byte-exact (unknown fields preserved); the JSON path
+        // round-trips through `M` (unknown fields dropped). Only relevant
+        // for `from_bytes_unchecked` bytes sourced externally.
+        //
+        // Wire bytes: field 1 = "hi" (the known `StringValue.value`),
+        // plus field 2 = varint 42 (unknown to `StringValue`).
+        let bytes_with_unknown =
+            Bytes::from_static(&[0x0a, 0x02, b'h', b'i', /* tag 2 varint */ 0x10, 42]);
+        let body = PreEncoded::<StringValue> {
+            bytes: bytes_with_unknown.clone(),
+            _marker: std::marker::PhantomData,
+        };
+
+        // Proto: byte-exact passthrough, unknown field preserved.
+        let proto = Encodable::<StringValue>::encode(&body, CodecFormat::Proto).unwrap();
+        assert_eq!(proto, bytes_with_unknown);
+
+        // JSON: round-trips through `StringValue`, which drops the
+        // unknown field. Output equals serializing the bare known
+        // message.
+        let json = Encodable::<StringValue>::encode(&body, CodecFormat::Json).unwrap();
+        assert_eq!(
+            json,
+            Bytes::from(serde_json::to_vec(&StringValue::from("hi")).unwrap())
+        );
+    }
+
+    #[test]
     fn pre_encoded_is_typed() {
         // `PreEncoded<M>` only implements `Encodable<M>` — the type witness
         // means `PreEncoded<StringValue>` cannot be used where
         // `Encodable<Int32Value>` is required. Verified at compile time;
         // this test just exercises the happy path for both types.
         use buffa_types::google::protobuf::Int32Value;
-        let s = PreEncoded::<StringValue>::proto(StringValue::from("a").encode_to_bytes());
-        let i = PreEncoded::<Int32Value>::proto(Int32Value::from(1).encode_to_bytes());
+        let s = PreEncoded::<StringValue>::from_bytes_unchecked(
+            StringValue::from("a").encode_to_bytes(),
+        );
+        let i =
+            PreEncoded::<Int32Value>::from_bytes_unchecked(Int32Value::from(1).encode_to_bytes());
         Encodable::<StringValue>::encode(&s, CodecFormat::Proto).unwrap();
         Encodable::<Int32Value>::encode(&i, CodecFormat::Proto).unwrap();
         // The following would not compile:
         //   Encodable::<Int32Value>::encode(&s, CodecFormat::Proto)
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "do not decode as")]
+    fn pre_encoded_from_bytes_unchecked_debug_asserts() {
+        // In debug builds, `from_bytes_unchecked` decodes once to surface
+        // mismatched bytes early. Field 1 (LEN) declares 99 bytes; only 2
+        // follow.
+        let _ = PreEncoded::<StringValue>::from_bytes_unchecked(Bytes::from_static(&[
+            0x0a, 0x63, b'h', b'i',
+        ]));
     }
 
     #[test]

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -202,7 +202,7 @@ impl Router {
     where
         H: StreamingHandler<Req, Res>,
         Req: Message + DeserializeOwned + Send + 'static,
-        Res: Message + Serialize + Send + 'static,
+        Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ServerStreamingHandlerWrapper::new(handler);
@@ -253,7 +253,7 @@ impl Router {
     where
         H: BidiStreamingHandler<Req, Res>,
         Req: Message + DeserializeOwned + Send + 'static,
-        Res: Message + Serialize + Send + 'static,
+        Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = BidiStreamingHandlerWrapper::new(handler);
@@ -331,7 +331,7 @@ impl Router {
         H: ViewStreamingHandler<ReqView, Res>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
         ReqView::Owned: Message + DeserializeOwned,
-        Res: Message + Serialize + Send + 'static,
+        Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ServerStreamingViewHandlerWrapper::new(handler);
@@ -379,7 +379,7 @@ impl Router {
         H: ViewBidiStreamingHandler<ReqView, Res>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
         ReqView::Owned: Message + DeserializeOwned,
-        Res: Message + Serialize + Send + 'static,
+        Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = BidiStreamingViewHandlerWrapper::new(handler);

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -108,10 +108,22 @@ pub const ELIZA_SERVICE_SERVICE_NAME: &str = "connectrpc.eliza.v1.ElizaService";
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait ElizaService: Send + Sync + 'static {
     /// Say is a unary RPC. Eliza responds to the prompt with a single sentence.

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -138,7 +138,9 @@ pub trait ElizaService: Send + Sync + 'static {
     ) -> impl ::std::future::Future<
         Output = ::connectrpc::ServiceResult<
             ::connectrpc::ServiceStream<
-                crate::proto::connectrpc::eliza::v1::ConverseResponse,
+                impl ::connectrpc::Encodable<
+                    crate::proto::connectrpc::eliza::v1::ConverseResponse,
+                > + Send + use<Self>,
             >,
         >,
     > + Send;
@@ -151,7 +153,9 @@ pub trait ElizaService: Send + Sync + 'static {
     ) -> impl ::std::future::Future<
         Output = ::connectrpc::ServiceResult<
             ::connectrpc::ServiceStream<
-                crate::proto::connectrpc::eliza::v1::IntroduceResponse,
+                impl ::connectrpc::Encodable<
+                    crate::proto::connectrpc::eliza::v1::IntroduceResponse,
+                > + Send + use<Self>,
             >,
         >,
     > + Send;
@@ -201,7 +205,11 @@ impl<S: ElizaService> ElizaServiceExt for S {
                     })
                 },
             )
-            .route_view_bidi_stream(
+            .route_view_bidi_stream::<
+                _,
+                _,
+                crate::proto::connectrpc::eliza::v1::ConverseResponse,
+            >(
                 ELIZA_SERVICE_SERVICE_NAME,
                 "Converse",
                 ::connectrpc::view_bidi_streaming_handler_fn({
@@ -212,7 +220,11 @@ impl<S: ElizaService> ElizaServiceExt for S {
                     }
                 }),
             )
-            .route_view_server_stream(
+            .route_view_server_stream::<
+                _,
+                _,
+                crate::proto::connectrpc::eliza::v1::IntroduceResponse,
+            >(
                 ELIZA_SERVICE_SERVICE_NAME,
                 "Introduce",
                 ::connectrpc::view_streaming_handler_fn({
@@ -333,10 +345,11 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                     let resp = svc.introduce(ctx, req).await?;
                     Ok(
                         resp
-                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
-                                s,
-                                format,
-                            )),
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<
+                                crate::proto::connectrpc::eliza::v1::IntroduceResponse,
+                                _,
+                                _,
+                            >(s, format)),
                     )
                 })
             }
@@ -379,10 +392,11 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                     let resp = svc.converse(ctx, req_stream).await?;
                     Ok(
                         resp
-                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream(
-                                s,
-                                format,
-                            )),
+                            .map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<
+                                crate::proto::connectrpc::eliza::v1::ConverseResponse,
+                                _,
+                                _,
+                            >(s, format)),
                     )
                 })
             }

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -59,10 +59,22 @@ pub const GREET_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.greet.v1.Gree
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait GreetService: Send + Sync + 'static {
     /// Greet returns a greeting message for the given name.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -51,10 +51,22 @@ pub const MATH_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.math.v1.MathSe
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait MathService: Send + Sync + 'static {
     /// Add returns the sum of two numbers.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -139,10 +139,22 @@ pub const WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.wk
 /// for zero-copy access patterns and when `to_owned_message()` is needed.
 ///
 /// The `impl Encodable<Out>` return bound accepts the owned `Out`, the
-/// generated `OutView<'_>` / `OwnedOutView`, or
-/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed). View bodies are not
-/// emitted for output types mapped via `extern_path` (the impl would be
-/// an orphan); return owned for WKT/extern outputs.
+/// generated `OutView<'_>` / `OwnedOutView`,
+/// [`MaybeBorrowed`](::connectrpc::MaybeBorrowed), or
+/// [`PreEncoded`](::connectrpc::PreEncoded) for handlers that encode a
+/// non-`'static` view internally and pass the bytes across the handler
+/// boundary. View bodies are not emitted for output types mapped via
+/// `extern_path` (the impl would be an orphan); return owned for
+/// WKT/extern outputs.
+///
+/// Server-streaming and bidi-streaming methods return
+/// `ServiceStream<impl Encodable<Out> + Send + use<Self>>`. The
+/// `use<Self>` precise-capturing clause excludes `&self`'s lifetime
+/// (unary methods use `use<'a, Self>` and may borrow), so stream items
+/// must be `'static`. To stream view-encoded data, encode each item
+/// inside the stream body and yield
+/// [`PreEncoded`](::connectrpc::PreEncoded) — see its `# Streaming
+/// example` doc.
 #[allow(clippy::type_complexity)]
 pub trait WellKnownTypesService: Send + Sync + 'static {
     /// CreateEvent creates an event with a timestamp.

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -605,20 +605,25 @@ mod tests {
             &self,
             _ctx: RequestContext,
             mut requests: ServiceStream<OwnedView<EchoRequestView<'static>>>,
-        ) -> ServiceResult<ServiceStream<EchoResponse>> {
-            // Not exercised by this test; minimal pass-through.
-            let (tx, rx) = tokio::sync::mpsc::channel::<Result<EchoResponse, ConnectError>>(1);
+        ) -> ServiceResult<ServiceStream<connectrpc::PreEncoded<EchoResponse>>> {
+            // Echo each request back as a `PreEncoded` item — same
+            // build-view-encode-yield-bytes pattern as `server_stream`,
+            // exercising the bidi path through `BidiStreamingViewHandlerWrapper`.
+            let (tx, rx) = tokio::sync::mpsc::channel::<
+                Result<connectrpc::PreEncoded<EchoResponse>, ConnectError>,
+            >(1);
             tokio::spawn(async move {
                 while let Some(req) = requests.next().await {
                     match req {
                         Ok(req) => {
-                            let req = req.to_owned_message();
-                            let resp = EchoResponse {
+                            let data = format!("bidi-{}", req.data);
+                            let view = EchoResponseView {
                                 sequence: req.sequence,
-                                data: req.data,
+                                data: &data,
                                 ..Default::default()
                             };
-                            if tx.send(Ok(resp)).await.is_err() {
+                            let item = connectrpc::PreEncoded::from_view(&view);
+                            if tx.send(Ok(item)).await.is_err() {
                                 break;
                             }
                         }
@@ -672,6 +677,85 @@ mod tests {
                 (0, "pre-encoded-0".to_string()),
                 (1, "pre-encoded-1".to_string()),
                 (2, "pre-encoded-2".to_string()),
+            ]
+        );
+    }
+
+    /// Same as [`server_stream_pre_encoded_round_trip`] but for bidi —
+    /// covers the `BidiStreamingViewHandlerWrapper` → `EchoServiceServer`
+    /// → `ConnectRpcService` chain with `type Item = PreEncoded<…>`. Uses
+    /// the same raw-envelope client as
+    /// [`bidi_stream_server_echoes_messages`] (the generated `BidiStream`
+    /// stub needs HTTP/2; this exercises the server side over HTTP/1.1).
+    #[tokio::test]
+    async fn bidi_stream_pre_encoded_round_trip() {
+        use buffa::Message;
+        use bytes::{BufMut, BytesMut};
+
+        let server = EchoServiceServer::new(PreEncodedEchoService);
+        let service = ConnectRpcService::new(server);
+        let app = axum::Router::new().fallback_service(service);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let messages: Vec<EchoRequest> = (0..3)
+            .map(|i| EchoRequest {
+                sequence: i,
+                data: format!("m{i}"),
+                ..Default::default()
+            })
+            .collect();
+
+        // Encode messages as envelope frames.
+        let mut body = BytesMut::new();
+        for msg in &messages {
+            let data = msg.encode_to_vec();
+            body.put_u8(0); // flags: no compression
+            body.put_u32(data.len() as u32);
+            body.extend_from_slice(&data);
+        }
+
+        let client = HttpClient::plaintext();
+        let uri: http::Uri = format!("http://{addr}/{ECHO_SERVICE_SERVICE_NAME}/BidiStream")
+            .parse()
+            .unwrap();
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(uri)
+            .header("content-type", "application/connect+proto")
+            .header("connect-protocol-version", "1")
+            .body(connectrpc::client::full_body(body.freeze()))
+            .unwrap();
+
+        let response = client.send(request).await.unwrap();
+        assert_eq!(response.status(), 200);
+
+        use http_body_util::BodyExt;
+        let response_body = response.into_body().collect().await.unwrap().to_bytes();
+        let mut cursor = &response_body[..];
+        let mut got = Vec::new();
+        while cursor.len() >= 5 {
+            let flags = cursor[0];
+            let len = u32::from_be_bytes([cursor[1], cursor[2], cursor[3], cursor[4]]) as usize;
+            cursor = &cursor[5..];
+            if flags & 0x02 != 0 {
+                cursor = &cursor[len..];
+                continue;
+            }
+            let data = &cursor[..len];
+            cursor = &cursor[len..];
+            let resp = EchoResponse::decode_from_slice(data).unwrap();
+            got.push((resp.sequence, resp.data));
+        }
+        assert_eq!(
+            got,
+            vec![
+                (0, "bidi-m0".to_string()),
+                (1, "bidi-m1".to_string()),
+                (2, "bidi-m2".to_string()),
             ]
         );
     }

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -540,6 +540,142 @@ mod tests {
         assert_eq!(resp.status(), 404);
     }
 
+    /// Test echo service whose `server_stream` yields `PreEncoded` items —
+    /// the handler builds and encodes per-item views (here from owned data,
+    /// but the lifetime story is the same as borrowing from a snapshot:
+    /// the view is encoded inside the stream body, not returned).
+    struct PreEncodedEchoService;
+
+    impl EchoService for PreEncodedEchoService {
+        async fn echo(
+            &self,
+            _ctx: RequestContext,
+            request: OwnedView<EchoRequestView<'static>>,
+        ) -> ServiceResult<EchoResponse> {
+            let request = request.to_owned_message();
+            Response::ok(EchoResponse {
+                sequence: request.sequence,
+                data: request.data,
+                ..Default::default()
+            })
+        }
+
+        async fn server_stream(
+            &self,
+            _ctx: RequestContext,
+            request: OwnedView<EchoRequestView<'static>>,
+        ) -> ServiceResult<ServiceStream<connectrpc::PreEncoded<EchoResponse>>> {
+            let count = request.sequence;
+            let stream = futures::stream::unfold(0, move |i| async move {
+                if i >= count {
+                    return None;
+                }
+                // Build a per-item view, encode it while the borrowed `data`
+                // is in scope, yield only the bytes. This is the pattern a
+                // handler that borrows from a local store snapshot uses.
+                let data = format!("pre-encoded-{i}");
+                let view = EchoResponseView {
+                    sequence: i,
+                    data: &data,
+                    ..Default::default()
+                };
+                let item = connectrpc::PreEncoded::from_view(&view);
+                Some((Ok(item), i + 1))
+            });
+            Response::stream_ok(stream)
+        }
+
+        async fn client_stream(
+            &self,
+            _ctx: RequestContext,
+            mut requests: ServiceStream<OwnedView<EchoRequestView<'static>>>,
+        ) -> ServiceResult<EchoResponse> {
+            let mut count = 0i32;
+            while requests.next().await.is_some() {
+                count += 1;
+            }
+            Response::ok(EchoResponse {
+                sequence: count,
+                data: String::new(),
+                ..Default::default()
+            })
+        }
+
+        async fn bidi_stream(
+            &self,
+            _ctx: RequestContext,
+            mut requests: ServiceStream<OwnedView<EchoRequestView<'static>>>,
+        ) -> ServiceResult<ServiceStream<EchoResponse>> {
+            // Not exercised by this test; minimal pass-through.
+            let (tx, rx) = tokio::sync::mpsc::channel::<Result<EchoResponse, ConnectError>>(1);
+            tokio::spawn(async move {
+                while let Some(req) = requests.next().await {
+                    match req {
+                        Ok(req) => {
+                            let req = req.to_owned_message();
+                            let resp = EchoResponse {
+                                sequence: req.sequence,
+                                data: req.data,
+                                ..Default::default()
+                            };
+                            if tx.send(Ok(resp)).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(e)).await;
+                            break;
+                        }
+                    }
+                }
+            });
+            let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+            Response::stream_ok(stream)
+        }
+    }
+
+    /// Integration test for [`PreEncoded`](connectrpc::PreEncoded) stream
+    /// items: handler → dispatcher → wire frames → client decode. This is
+    /// the path the `type Item: Encodable<Res>` change to streaming
+    /// handlers unlocks — the unit tests in `handler.rs` cover
+    /// `encode_body_stream` in isolation; this exercises the full
+    /// `ServerStreamingViewHandlerWrapper` → `EchoServiceServer` →
+    /// `ConnectRpcService` chain.
+    #[tokio::test]
+    async fn server_stream_pre_encoded_round_trip() {
+        let server = EchoServiceServer::new(PreEncodedEchoService);
+        let service = ConnectRpcService::new(server);
+        let app = axum::Router::new().fallback_service(service);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = make_client(addr);
+        let mut stream = client
+            .server_stream(EchoRequest {
+                sequence: 3,
+                data: String::new(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let mut got = Vec::new();
+        while let Some(msg) = stream.message().await.unwrap() {
+            got.push((msg.sequence, msg.data.to_string()));
+        }
+        assert_eq!(
+            got,
+            vec![
+                (0, "pre-encoded-0".to_string()),
+                (1, "pre-encoded-1".to_string()),
+                (2, "pre-encoded-2".to_string()),
+            ]
+        );
+    }
+
     /// End-to-end test of `Http2Connection` / `SharedHttp2Connection`.
     ///
     /// Uses the raw h2 transport (no legacy pool) against the monomorphic


### PR DESCRIPTION
## Why

A handler that builds a `*View<'a>` from local app state (e.g. a resolver snapshot held in `Arc`) can't satisfy `Handler::Body: 'static` or `ServiceStream<Res>` today — the only ViewEncode-friendly bodies are request-buffer-backed (`OwnedView`, `MaybeBorrowed`). Such handlers need to encode the view internally while the snapshot is still in scope, then return the bytes.

This unblocks the dominant ViewEncode use case for high-throughput servers: 1-source-to-N-readers fanout where each per-reader response borrows from a shared decoded source. Codec-layer benches (`benches/rpc/echo_bloat.rs`, fanout sweep at N=64) show ~3.5× over the move-baseline; resolver-shaped workloads (~1k endpoints with string-map metadata per response) measure 2.8–4.2× depending on compression.

## What

### `PreEncoded<M>`

An `Encodable<M>` body that wraps already-encoded protobuf bytes, with a `PhantomData<fn() -> M>` witness so the type system enforces the bytes belong to the right RPC. `PreEncoded::from_view(&view)` constrains `V: MessageView<'a, Owned = M>` for a compile-time match.

**Proto-only by design.** JSON clients receive `unimplemented`, same as the existing per-output-type view-body impls. ViewEncode is a high-throughput optimization; JSON is not a high-throughput codec, and supporting both would add a runtime format check on every encode for no realistic consumer.

```rust
async fn resolve(&self, _ctx: RequestContext, req: ...)
    -> ServiceResult<PreEncoded<ResolveResponse>>
{
    let snapshot = self.store.load();
    let view = build_view_from_snapshot(&snapshot, &req);
    Response::ok(PreEncoded::from_view(&view))
}
```

### `type Item: Encodable<Res>` on streaming handlers

`StreamingHandler`, `BidiStreamingHandler`, and their `View*` variants gain `type Item: Encodable<Res> + Send + 'static` and return `ServiceStream<Self::Item>` — bringing them to parity with unary `Handler::Body` (which got the same treatment in 0.4.0). `encode_body_stream` / `encode_response_stream` are generalized over `B: Encodable<Res>`. Codegen emits the streaming trait method as `ServiceStream<impl Encodable<Out> + Send + use<Self>>`.

Vestigial `Res: Serialize` bounds dropped from the streaming wrappers — they only call `Encodable::encode`, which is codec-agnostic.

## Breaking — but the practical surface is narrow

This is breaking under semver, but the practical blast radius is much smaller than the trait change suggests:

- **`impl <GeneratedServiceTrait>` blocks compile unchanged.** The generated trait declares `ServiceStream<impl Encodable<Out> + Send + use<Self>>` (RPITIT). Existing handler impls returning `ServiceStream<Out>` still compile via RPITIT refinement — the same mechanism the unary `Body` path has used since 0.4.0, with the same `allow(refining_impl_trait)` already documented in 0.4.1. Verified: `tests/streaming/src/lib.rs`'s pre-existing handlers were not touched in this diff.
- **`*_handler_fn` callers compile unchanged.** The helpers infer `type Item` from the closure return type.
- **Only hand-rolled `impl StreamingHandler` / `impl BidiStreamingHandler` blocks need an edit** — a one-line `type Item = Res;`. These are the low-level escape-hatch traits behind `Router`, not the primary handler surface. At the time of this PR there are two such impls across all known consumers.
- **Checked-in `protoc-gen-connect-rust` output must be regenerated** — same regeneration footgun documented in 0.4.0; `connectrpc-build` users are unaffected.

A non-breaking alternative was considered (a separate `Router::route_server_stream_pre_encoded(...)` registration path that bypasses `StreamingHandler` entirely). It works, but permanently doubles the registration API surface and needs a per-method codegen flag, all to avoid a 2-line migration. The `type Item` shape is the cleaner long-term API and the precedent (unary `Body` in 0.4.0) was a bigger break and shipped without issue.

## Size

~700 lines net (excluding generated). Over the usual 250 guideline because the change is coupled: the trait, `encode_body_stream`, the dispatcher, the codegen, and the regenerated checked-in code all have to move together — splitting would leave intermediate states uncompilable.

## Tests

- Unit: `PreEncoded::proto`/`from_view` round-trip + JSON-unimplemented + typed-witness assertion.
- Streaming: `streaming_handler_item_is_inferred_from_closure` (compile-time inference check), `encode_body_stream` with `PreEncoded` items.
- Integration: `server_stream_pre_encoded_round_trip` in `tests/streaming/` — registers a streaming handler with `type Item = PreEncoded<EchoResponse>`, runs through the full server → axum → client → decode chain.
- All workspace tests pass; clippy `-D warnings` clean; nightly fmt clean.

## Notes for reviewers

- **Hand-rolled `streaming_handler_fn` users** must turbofish `Res` (`streaming_handler_fn::<_, _, Req, Res, PreEncoded<Res>>(...)`) since the generic body type makes it non-inferable. The codegen-driven path (the common case) hides this. Documented on the helper's doc comment.