### PR TITLE
client: ClientConfig/CallOptions accessors, rename builders to with_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,42 @@ need a one-line edit.
   directly need to turbofish `encode_response_stream::<Res, _, _>(s,
   format)`. We are not aware of any.
 
+### Changed
+
+- **`ClientConfig` and `CallOptions` fields are now `pub(crate)`.**
+  Both structs are `#[non_exhaustive]`, so struct-literal and
+  functional-update construction was already rejected by the compiler
+  outside the crate (E0639); the `pub` fields just made the rustdoc
+  suggest a path that didn't compile. Each field now has a same-named
+  read accessor (`config.protocol()`, `config.base_uri()`,
+  `options.timeout()`, `options.headers()`, …). To free the bare names
+  for accessors, the `ClientConfig` setter methods were renamed to the
+  `with_*` form already used by `CallOptions`, and one `CallOptions`
+  setter was renamed to match its field:
+
+  | Type | Before | After |
+  |---|---|---|
+  | `ClientConfig` | `.protocol(p)` | `.with_protocol(p)` |
+  | `ClientConfig` | `.codec_format(f)` | `.with_codec_format(f)` |
+  | `ClientConfig` | `.compression(r)` | `.with_compression(r)` |
+  | `ClientConfig` | `.compression_policy(p)` | `.with_compression_policy(p)` |
+  | `ClientConfig` | `.default_timeout(t)` | `.with_default_timeout(t)` |
+  | `ClientConfig` | `.default_max_message_size(s)` | `.with_default_max_message_size(s)` |
+  | `ClientConfig` | `.default_header(n, v)` | `.with_default_header(n, v)` |
+  | `ClientConfig` | `.default_headers(h)` | `.with_default_headers(h)` |
+  | `CallOptions` | `.with_compression(b)` | `.with_compress(b)` |
+
+  `ClientConfig::new(uri)`, `.json()`, `.proto()`, and
+  `.compress_requests(e)` are unchanged. The remaining `CallOptions`
+  builders (`with_timeout`, `with_header`, …) are unchanged. Migrating
+  reads: `config.protocol` → `config.protocol()`, `options.timeout` →
+  `options.timeout()`.
+
+  If you see `error[E0061]: this method takes 0 arguments but 1 argument
+  was supplied` on a `ClientConfig` builder call, you've hit the rename:
+  the same-named read accessor now occupies the old name. Prefix the
+  call with `with_` per the table above.
+
 ## [0.4.2] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ picks them up automatically:
 
 ```rust
 let config = ClientConfig::new("http://localhost:8080".parse()?)
-    .default_timeout(Duration::from_secs(30))
-    .default_header("authorization", "Bearer ...");
+    .with_default_timeout(Duration::from_secs(30))
+    .with_default_header("authorization", "Bearer ...");
 
 let client = GreetServiceClient::new(http, config);
 

--- a/benches/rpc/benches/cross_impl_bench.rs
+++ b/benches/rpc/benches/cross_impl_bench.rs
@@ -60,13 +60,13 @@ impl Drop for ServerProcess {
 
 fn make_grpc_client(addr: SocketAddr) -> BenchServiceClient<HttpClient> {
     let config =
-        ClientConfig::new(format!("http://{addr}").parse().unwrap()).protocol(Protocol::Grpc);
+        ClientConfig::new(format!("http://{addr}").parse().unwrap()).with_protocol(Protocol::Grpc);
     BenchServiceClient::new(HttpClient::plaintext_http2_only(), config)
 }
 
 fn make_connect_client(addr: SocketAddr) -> BenchServiceClient<HttpClient> {
-    let config =
-        ClientConfig::new(format!("http://{addr}").parse().unwrap()).protocol(Protocol::Connect);
+    let config = ClientConfig::new(format!("http://{addr}").parse().unwrap())
+        .with_protocol(Protocol::Connect);
     BenchServiceClient::new(HttpClient::plaintext(), config)
 }
 
@@ -210,7 +210,7 @@ fn bench_unary_large_grpc(c: &mut Criterion) {
 
     for (impl_name, server) in IMPLS.iter().zip(servers.iter()) {
         let config = ClientConfig::new(format!("http://{}", server.addr()).parse().unwrap())
-            .protocol(Protocol::Grpc)
+            .with_protocol(Protocol::Grpc)
             .compress_requests("gzip");
         let client = BenchServiceClient::new(HttpClient::plaintext_http2_only(), config);
         group.bench_function(BenchmarkId::from_parameter(impl_name), |b| {

--- a/benches/rpc/benches/filter_handler.rs
+++ b/benches/rpc/benches/filter_handler.rs
@@ -141,8 +141,8 @@ fn build_servers() {
 }
 
 fn make_client(addr: SocketAddr) -> FilterServiceClient<HttpClient> {
-    let config =
-        ClientConfig::new(format!("http://{addr}").parse().unwrap()).protocol(Protocol::Connect);
+    let config = ClientConfig::new(format!("http://{addr}").parse().unwrap())
+        .with_protocol(Protocol::Connect);
     FilterServiceClient::new(HttpClient::plaintext(), config)
 }
 

--- a/benches/rpc/benches/rpc_bench.rs
+++ b/benches/rpc/benches/rpc_bench.rs
@@ -152,7 +152,7 @@ fn bench_unary_large(c: &mut Criterion) {
         for protocol in PROTOCOLS {
             let config =
                 connectrpc::client::ClientConfig::new(format!("http://{addr}").parse().unwrap())
-                    .protocol(protocol)
+                    .with_protocol(protocol)
                     .compress_requests(compression);
             let http = if protocol.requires_http2() {
                 HttpClient::plaintext_http2_only()

--- a/benches/rpc/src/bin/echo_bench.rs
+++ b/benches/rpc/src/bin/echo_bench.rs
@@ -146,7 +146,7 @@ async fn bench_server(
     measurement: Duration,
 ) -> BenchResult {
     let config = ClientConfig::new(format!("http://{addr}").parse().expect("valid server URL"))
-        .protocol(protocol);
+        .with_protocol(protocol);
     let http = if protocol.requires_http2() {
         HttpClient::plaintext_http2_only()
     } else {
@@ -248,7 +248,7 @@ async fn bench_server_multiconn(
     measurement: Duration,
 ) -> BenchResult {
     let uri: http::Uri = format!("http://{addr}").parse().expect("valid server URL");
-    let config = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+    let config = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
 
     // Establish N connections eagerly so warmup doesn't include handshakes.
     let mut conns: Vec<SharedHttp2Connection> = Vec::with_capacity(n_conns);

--- a/benches/rpc/src/bin/echo_load.rs
+++ b/benches/rpc/src/bin/echo_load.rs
@@ -26,7 +26,7 @@ async fn main() {
     let n_conns: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(8);
 
     let uri: http::Uri = format!("http://{addr}").parse().unwrap();
-    let config = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+    let config = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
 
     eprintln!(
         "Generating load: {concurrency} tasks × {n_conns} connections for {duration}s against {addr}"

--- a/benches/rpc/src/bin/fortune_bench.rs
+++ b/benches/rpc/src/bin/fortune_bench.rs
@@ -254,7 +254,7 @@ async fn bench_server(
     measurement: Duration,
 ) -> BenchResult {
     let config = ClientConfig::new(format!("http://{addr}").parse().expect("valid server URL"))
-        .protocol(protocol);
+        .with_protocol(protocol);
     let http = if protocol.requires_http2() {
         HttpClient::plaintext_http2_only()
     } else {
@@ -361,7 +361,7 @@ async fn bench_server_multiconn(
     measurement: Duration,
 ) -> BenchResult {
     let uri: http::Uri = format!("http://{addr}").parse().expect("valid server URL");
-    let config = ClientConfig::new(uri.clone()).protocol(protocol);
+    let config = ClientConfig::new(uri.clone()).with_protocol(protocol);
 
     // Establish N connections eagerly so warmup doesn't include handshakes.
     let mut conns: Vec<SharedHttp2Connection> = Vec::with_capacity(n_conns);

--- a/benches/rpc/src/bin/fortune_load.rs
+++ b/benches/rpc/src/bin/fortune_load.rs
@@ -23,7 +23,8 @@ async fn main() {
         _ => Protocol::Connect,
     };
 
-    let config = ClientConfig::new(format!("http://{addr}").parse().unwrap()).protocol(protocol);
+    let config =
+        ClientConfig::new(format!("http://{addr}").parse().unwrap()).with_protocol(protocol);
     let http = if protocol.requires_http2() {
         HttpClient::plaintext_http2_only()
     } else {

--- a/benches/rpc/src/bin/log_bench.rs
+++ b/benches/rpc/src/bin/log_bench.rs
@@ -145,7 +145,7 @@ async fn bench_server(
     measurement: Duration,
 ) -> BenchResult {
     let uri: http::Uri = format!("http://{addr}").parse().expect("valid server URL");
-    let config = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+    let config = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
 
     let mut conns: Vec<SharedHttp2Connection> = Vec::with_capacity(n_conns);
     for _ in 0..n_conns {
@@ -245,7 +245,7 @@ async fn bench_server_noutf8(
     use rpc_bench::proto::bench::noutf8;
 
     let uri: http::Uri = format!("http://{addr}").parse().expect("valid server URL");
-    let config = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+    let config = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
 
     let mut conns: Vec<SharedHttp2Connection> = Vec::with_capacity(n_conns);
     for _ in 0..n_conns {

--- a/benches/rpc/src/bin/log_load.rs
+++ b/benches/rpc/src/bin/log_load.rs
@@ -29,7 +29,7 @@ async fn main() {
     let records_per_batch: usize = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(50);
 
     let uri: http::Uri = format!("http://{addr}").parse().unwrap();
-    let config = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+    let config = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
 
     // Pre-build the request once and clone per RPC. The cloning cost is
     // client-side only; the server's decode work is what we're profiling.

--- a/benches/rpc/src/bin/log_load_noutf8.rs
+++ b/benches/rpc/src/bin/log_load_noutf8.rs
@@ -77,7 +77,7 @@ async fn main() {
     let records_per_batch: usize = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(50);
 
     let uri: http::Uri = format!("http://{addr}").parse().unwrap();
-    let config = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+    let config = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
 
     let request = build_request(records_per_batch);
     let approx_size = {

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -574,7 +574,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = BenchServiceClient::new(conn, config);
 /// let response = client.unary(request).await?;
@@ -1102,7 +1102,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = EchoServiceClient::new(conn, config);
 /// let response = client.echo(request).await?;
@@ -1434,7 +1434,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = LogIngestServiceClient::new(conn, config);
 /// let response = client.ingest(request).await?;

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -265,7 +265,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = LogIngestServiceClient::new(conn, config);
 /// let response = client.ingest(request).await?;

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -262,7 +262,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = BloatEchoServiceClient::new(conn, config);
 /// let response = client.echo(request).await?;

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -267,7 +267,7 @@ impl<T: FilterService> ::connectrpc::Dispatcher for FilterServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = FilterServiceClient::new(conn, config);
 /// let response = client.redact(request).await?;

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -263,7 +263,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = FortuneServiceClient::new(conn, config);
 /// let response = client.get_fortunes(request).await?;

--- a/benches/rpc/src/lib.rs
+++ b/benches/rpc/src/lib.rs
@@ -170,8 +170,8 @@ pub fn make_client(
     codec_format: CodecFormat,
 ) -> BenchServiceClient<HttpClient> {
     let config = ClientConfig::new(format!("http://{addr}").parse().unwrap())
-        .protocol(protocol)
-        .codec_format(codec_format);
+        .with_protocol(protocol)
+        .with_codec_format(codec_format);
     let http = if protocol.requires_http2() {
         HttpClient::plaintext_http2_only()
     } else {

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -487,12 +487,12 @@ async fn do_unary_call(
     )
     .parse()?;
     let mut config = ClientConfig::new(base_uri)
-        .protocol(wire_protocol)
-        .codec_format(match codec {
+        .with_protocol(wire_protocol)
+        .with_codec_format(match codec {
             Codec::CODEC_JSON => CodecFormat::Json,
             _ => CodecFormat::Proto,
         })
-        .compression(registry);
+        .with_compression(registry);
     config = apply_compression(config, compression);
 
     // Build CallOptions: timeout, max_message_size, custom headers
@@ -699,12 +699,12 @@ async fn do_server_stream_call(
     )
     .parse()?;
     let mut config = ClientConfig::new(base_uri)
-        .protocol(wire_protocol)
-        .codec_format(match codec {
+        .with_protocol(wire_protocol)
+        .with_codec_format(match codec {
             Codec::CODEC_JSON => CodecFormat::Json,
             _ => CodecFormat::Proto,
         })
-        .compression(registry);
+        .with_compression(registry);
     config = apply_compression(config, compression);
 
     // Build CallOptions
@@ -1001,12 +1001,12 @@ async fn do_client_stream_call(
     )
     .parse()?;
     let mut config = ClientConfig::new(base_uri)
-        .protocol(wire_protocol)
-        .codec_format(match codec {
+        .with_protocol(wire_protocol)
+        .with_codec_format(match codec {
             Codec::CODEC_JSON => CodecFormat::Json,
             _ => CodecFormat::Proto,
         })
-        .compression(registry);
+        .with_compression(registry);
     config = apply_compression(config, compression);
 
     // Build CallOptions
@@ -1167,12 +1167,12 @@ async fn do_bidi_stream_call(
     )
     .parse()?;
     let mut config = ClientConfig::new(base_uri)
-        .protocol(wire_protocol)
-        .codec_format(match codec {
+        .with_protocol(wire_protocol)
+        .with_codec_format(match codec {
             Codec::CODEC_JSON => CodecFormat::Json,
             _ => CodecFormat::Proto,
         })
-        .compression(registry);
+        .with_compression(registry);
     config = apply_compression(config, compression);
 
     // Build CallOptions
@@ -1584,7 +1584,7 @@ fn apply_compression(config: ClientConfig, compression: Compression) -> ClientCo
     match compression_encoding_name(compression) {
         Some(enc) => config
             .compress_requests(enc)
-            .compression_policy(connectrpc::CompressionPolicy::default().min_size(0)),
+            .with_compression_policy(connectrpc::CompressionPolicy::default().min_size(0)),
         None => config,
     }
 }

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -794,7 +794,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = ConformanceServiceClient::new(conn, config);
 /// let response = client.unary(request).await?;

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1197,7 +1197,7 @@ use connectrpc::Protocol;
 
 let uri: http::Uri = "http://localhost:8080".parse()?;
 let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 
 let client = {client_name_str}::new(conn, config);
 let response = client.{example_method}(request).await?;

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -21,7 +21,7 @@
 //!
 //! let uri: http::Uri = "http://localhost:8080".parse()?;
 //! let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-//! let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+//! let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 //!
 //! // Generated clients take any T: ClientTransport — shared handle is cheap to clone.
 //! let greet = GreetServiceClient::new(conn.clone(), config.clone());
@@ -488,35 +488,34 @@ impl ClientTransport for HttpClient {
 }
 
 /// Configuration for a ConnectRPC client.
+///
+/// Construct with [`ClientConfig::new`] and the `with_*` builder methods,
+/// then read settings back through the accessor methods of the same name:
+///
+/// ```rust
+/// use connectrpc::client::ClientConfig;
+/// use connectrpc::Protocol;
+///
+/// let config = ClientConfig::new("http://localhost:8080".parse().unwrap())
+///     .with_protocol(Protocol::Grpc);
+/// assert_eq!(config.protocol(), Protocol::Grpc);
+/// ```
+///
+/// `ClientConfig` is `#[non_exhaustive]`: new fields may be added in minor
+/// releases. Struct-literal and functional-update construction are not
+/// available outside the crate; use the builder methods.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct ClientConfig {
-    /// The base URI for the service (e.g., "http://localhost:8080").
-    pub base_uri: Uri,
-    /// The wire protocol to use (Connect, gRPC, or gRPC-Web).
-    pub protocol: Protocol,
-    /// The codec format to use (proto or json).
-    pub codec_format: CodecFormat,
-    /// Compression registry for request/response compression.
-    pub compression: CompressionRegistry,
-    /// Request compression encoding (e.g., "gzip"). None means no compression.
-    pub request_compression: Option<String>,
-    /// Compression policy controlling when messages are compressed.
-    pub compression_policy: CompressionPolicy,
-    /// Default request timeout for all calls through this config.
-    ///
-    /// Per-call [`CallOptions::timeout`] overrides this when set.
-    pub default_timeout: Option<Duration>,
-    /// Default maximum decompressed response message size.
-    ///
-    /// Per-call [`CallOptions::max_message_size`] overrides this when set.
-    pub default_max_message_size: Option<usize>,
-    /// Headers applied to every request through this config.
-    ///
-    /// Useful for auth tokens, user-agent, tracing context.
-    /// Per-call [`CallOptions::headers`] with the same name **replace** these
-    /// (options win over config defaults).
-    pub default_headers: http::HeaderMap,
+    pub(crate) base_uri: Uri,
+    pub(crate) protocol: Protocol,
+    pub(crate) codec_format: CodecFormat,
+    pub(crate) compression: CompressionRegistry,
+    pub(crate) request_compression: Option<String>,
+    pub(crate) compression_policy: CompressionPolicy,
+    pub(crate) default_timeout: Option<Duration>,
+    pub(crate) default_max_message_size: Option<usize>,
+    pub(crate) default_headers: http::HeaderMap,
 }
 
 impl ClientConfig {
@@ -537,28 +536,34 @@ impl ClientConfig {
         }
     }
 
+    // ---- builders ---------------------------------------------------------
+
     /// Set the wire protocol (Connect, gRPC, or gRPC-Web).
+    ///
+    /// Read via [`Self::protocol`].
     #[must_use]
-    pub fn protocol(mut self, protocol: Protocol) -> Self {
+    pub fn with_protocol(mut self, protocol: Protocol) -> Self {
         self.protocol = protocol;
         self
     }
 
     /// Set the codec format (proto or json).
+    ///
+    /// Read via [`Self::codec_format`].
     #[must_use]
-    pub fn codec_format(mut self, format: CodecFormat) -> Self {
+    pub fn with_codec_format(mut self, format: CodecFormat) -> Self {
         self.codec_format = format;
         self
     }
 
-    /// Use JSON encoding.
+    /// Use JSON encoding. Shorthand for `with_codec_format(CodecFormat::Json)`.
     #[must_use]
     pub fn json(mut self) -> Self {
         self.codec_format = CodecFormat::Json;
         self
     }
 
-    /// Use protobuf encoding.
+    /// Use protobuf encoding. Shorthand for `with_codec_format(CodecFormat::Proto)`.
     #[must_use]
     pub fn proto(mut self) -> Self {
         self.codec_format = CodecFormat::Proto;
@@ -566,13 +571,17 @@ impl ClientConfig {
     }
 
     /// Set the compression registry.
+    ///
+    /// Read via [`Self::compression`].
     #[must_use]
-    pub fn compression(mut self, registry: CompressionRegistry) -> Self {
+    pub fn with_compression(mut self, registry: CompressionRegistry) -> Self {
         self.compression = registry;
         self
     }
 
     /// Enable request compression with the specified encoding.
+    ///
+    /// Read via [`Self::request_compression`].
     #[must_use]
     pub fn compress_requests(mut self, encoding: impl Into<String>) -> Self {
         self.request_compression = Some(encoding.into());
@@ -580,26 +589,30 @@ impl ClientConfig {
     }
 
     /// Set the compression policy.
+    ///
+    /// Read via [`Self::compression_policy`].
     #[must_use]
-    pub fn compression_policy(mut self, policy: CompressionPolicy) -> Self {
+    pub fn with_compression_policy(mut self, policy: CompressionPolicy) -> Self {
         self.compression_policy = policy;
         self
     }
 
     /// Set a default request timeout for all calls through this config.
     ///
-    /// Per-call [`CallOptions::with_timeout`] overrides this.
+    /// Read via [`Self::default_timeout`]. Per-call
+    /// [`CallOptions::with_timeout`] overrides this.
     #[must_use]
-    pub fn default_timeout(mut self, timeout: Duration) -> Self {
+    pub fn with_default_timeout(mut self, timeout: Duration) -> Self {
         self.default_timeout = Some(timeout);
         self
     }
 
     /// Set a default maximum decompressed response message size.
     ///
-    /// Per-call [`CallOptions::with_max_message_size`] overrides this.
+    /// Read via [`Self::default_max_message_size`]. Per-call
+    /// [`CallOptions::with_max_message_size`] overrides this.
     #[must_use]
-    pub fn default_max_message_size(mut self, size: usize) -> Self {
+    pub fn with_default_max_message_size(mut self, size: usize) -> Self {
         self.default_max_message_size = Some(size);
         self
     }
@@ -607,10 +620,13 @@ impl ClientConfig {
     /// Add a default header applied to every request through this config.
     ///
     /// If the name or value cannot be converted to valid HTTP header components,
-    /// the header is silently ignored. Per-call [`CallOptions::headers`] with
-    /// the same name replace this value (options win over config defaults).
+    /// the header is silently ignored. Per-call [`CallOptions::with_header`]
+    /// entries with the same name **replace** this value (options win over
+    /// config defaults).
+    ///
+    /// Read via [`Self::default_headers`].
     #[must_use]
-    pub fn default_header(
+    pub fn with_default_header(
         mut self,
         name: impl TryInto<http::header::HeaderName>,
         value: impl TryInto<http::header::HeaderValue>,
@@ -622,10 +638,83 @@ impl ClientConfig {
     }
 
     /// Set all default headers at once (replaces any prior default headers).
+    ///
+    /// Read via [`Self::default_headers`].
     #[must_use]
-    pub fn default_headers(mut self, headers: http::HeaderMap) -> Self {
+    pub fn with_default_headers(mut self, headers: http::HeaderMap) -> Self {
         self.default_headers = headers;
         self
+    }
+
+    // ---- accessors --------------------------------------------------------
+
+    /// The base URI for the service (e.g., `http://localhost:8080`).
+    ///
+    /// Set via [`Self::new`].
+    pub fn base_uri(&self) -> &Uri {
+        &self.base_uri
+    }
+
+    /// The wire protocol (Connect, gRPC, or gRPC-Web).
+    ///
+    /// Set via [`Self::with_protocol`].
+    pub fn protocol(&self) -> Protocol {
+        self.protocol
+    }
+
+    /// The codec format (proto or json).
+    ///
+    /// Set via [`Self::with_codec_format`], [`Self::json`], or [`Self::proto`].
+    pub fn codec_format(&self) -> CodecFormat {
+        self.codec_format
+    }
+
+    /// The compression registry used for request/response compression.
+    ///
+    /// Set via [`Self::with_compression`].
+    pub fn compression(&self) -> &CompressionRegistry {
+        &self.compression
+    }
+
+    /// The request compression encoding (e.g., `"gzip"`), if enabled.
+    ///
+    /// Set via [`Self::compress_requests`].
+    pub fn request_compression(&self) -> Option<&str> {
+        self.request_compression.as_deref()
+    }
+
+    /// The compression policy controlling when messages are compressed.
+    ///
+    /// Set via [`Self::with_compression_policy`].
+    pub fn compression_policy(&self) -> CompressionPolicy {
+        self.compression_policy
+    }
+
+    /// The default request timeout for all calls through this config, if set.
+    ///
+    /// Set via [`Self::with_default_timeout`]. Per-call
+    /// [`CallOptions::with_timeout`] overrides this when set.
+    pub fn default_timeout(&self) -> Option<Duration> {
+        self.default_timeout
+    }
+
+    /// The default maximum decompressed response message size, if set.
+    ///
+    /// Set via [`Self::with_default_max_message_size`]. Per-call
+    /// [`CallOptions::with_max_message_size`] overrides this when set.
+    pub fn default_max_message_size(&self) -> Option<usize> {
+        self.default_max_message_size
+    }
+
+    /// The headers applied to every request through this config.
+    ///
+    /// Useful for auth tokens, user-agent, tracing context.
+    /// Per-call [`CallOptions::with_header`] entries with the same name
+    /// **replace** these (options win over config defaults).
+    ///
+    /// Set via [`Self::with_default_header`] / [`Self::with_default_headers`].
+    pub fn default_headers(&self) -> &http::HeaderMap {
+        &self.default_headers
     }
 }
 
@@ -633,6 +722,10 @@ impl ClientConfig {
 ///
 /// Provides per-call configuration such as additional headers and timeouts.
 /// Use [`CallOptions::default()`] for no additional options.
+///
+/// `CallOptions` is `#[non_exhaustive]`: new fields may be added in minor
+/// releases. Construct with [`CallOptions::default()`] and the `with_*`
+/// builder methods, then read settings back through the accessor methods.
 ///
 /// # Example
 ///
@@ -643,31 +736,24 @@ impl ClientConfig {
 /// let options = CallOptions::default()
 ///     .with_timeout(Duration::from_secs(5))
 ///     .with_header("x-request-id", "abc123");
-/// assert_eq!(options.timeout, Some(Duration::from_secs(5)));
-/// assert_eq!(options.headers.get("x-request-id").unwrap(), "abc123");
+/// assert_eq!(options.timeout(), Some(Duration::from_secs(5)));
+/// assert_eq!(options.headers().get("x-request-id").unwrap(), "abc123");
 /// ```
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct CallOptions {
-    /// Additional headers to include in the request.
-    ///
-    /// These are merged into the HTTP request after protocol headers,
-    /// allowing override of any header for advanced use cases.
-    pub headers: http::HeaderMap,
-    /// Request timeout, sent as `connect-timeout-ms`.
-    pub timeout: Option<Duration>,
-    /// Maximum decompressed message size in bytes.
-    ///
-    /// When set, messages exceeding this size after decompression will
-    /// result in a `ResourceExhausted` error. Applies per-message for streaming.
-    pub max_message_size: Option<usize>,
-    /// Per-call compression override. `Some(true)` forces compression,
-    /// `Some(false)` disables it, `None` defers to the policy.
-    pub compress: Option<bool>,
+    pub(crate) headers: http::HeaderMap,
+    pub(crate) timeout: Option<Duration>,
+    pub(crate) max_message_size: Option<usize>,
+    pub(crate) compress: Option<bool>,
 }
 
 impl CallOptions {
+    // ---- builders ---------------------------------------------------------
+
     /// Set the request timeout.
+    ///
+    /// Read via [`Self::timeout`].
     #[must_use]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
@@ -679,6 +765,8 @@ impl CallOptions {
     /// If the name or value cannot be converted to valid HTTP header components,
     /// the header is silently ignored. Use [`try_with_header`](Self::try_with_header)
     /// for fallible insertion.
+    ///
+    /// Read via [`Self::headers`].
     #[must_use]
     pub fn with_header(
         mut self,
@@ -692,6 +780,13 @@ impl CallOptions {
     }
 
     /// Add a request header, returning an error if the name or value is invalid.
+    ///
+    /// Read via [`Self::headers`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorCode::Internal`] if the name or value cannot be
+    /// converted to a valid HTTP header component.
     pub fn try_with_header(
         mut self,
         name: impl TryInto<http::header::HeaderName>,
@@ -708,6 +803,8 @@ impl CallOptions {
     }
 
     /// Add multiple request headers from an iterator.
+    ///
+    /// Read via [`Self::headers`].
     #[must_use]
     pub fn with_headers(
         mut self,
@@ -720,17 +817,60 @@ impl CallOptions {
     }
 
     /// Set the maximum decompressed message size in bytes.
+    ///
+    /// Read via [`Self::max_message_size`].
     #[must_use]
     pub fn with_max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = Some(size);
         self
     }
 
-    /// Override compression for this call.
+    /// Override compression for this call. `Some(true)` forces compression,
+    /// `Some(false)` disables it; not calling this defers to the configured
+    /// [`CompressionPolicy`].
+    ///
+    /// Read via [`Self::compress`].
     #[must_use]
-    pub fn with_compression(mut self, enabled: bool) -> Self {
+    pub fn with_compress(mut self, enabled: bool) -> Self {
         self.compress = Some(enabled);
         self
+    }
+
+    // ---- accessors --------------------------------------------------------
+
+    /// Additional headers to include in the request.
+    ///
+    /// These are merged into the HTTP request after protocol headers,
+    /// allowing override of any header for advanced use cases.
+    ///
+    /// Set via [`Self::with_header`] / [`Self::with_headers`].
+    pub fn headers(&self) -> &http::HeaderMap {
+        &self.headers
+    }
+
+    /// The request timeout, sent as `connect-timeout-ms` / `grpc-timeout`.
+    ///
+    /// Set via [`Self::with_timeout`].
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
+    }
+
+    /// The maximum decompressed message size in bytes.
+    ///
+    /// When set, messages exceeding this size after decompression will
+    /// result in a `ResourceExhausted` error. Applies per-message for streaming.
+    ///
+    /// Set via [`Self::with_max_message_size`].
+    pub fn max_message_size(&self) -> Option<usize> {
+        self.max_message_size
+    }
+
+    /// The per-call compression override. `Some(true)` forces compression,
+    /// `Some(false)` disables it, `None` defers to the policy.
+    ///
+    /// Set via [`Self::with_compress`].
+    pub fn compress(&self) -> Option<bool> {
+        self.compress
     }
 }
 
@@ -1669,10 +1809,10 @@ where
     /// Returns `Ok(Some(msg))` for each message, `Ok(None)` when the stream
     /// ends, or `Err(...)` on protocol/decode/deadline errors.
     ///
-    /// If a deadline was set on this call (via `CallOptions::timeout` or
-    /// `ClientConfig::default_timeout`), each `message()` poll is bounded by
-    /// it — gRPC deadline semantics are whole-call, so a hung server won't
-    /// block indefinitely (matching grpc-java and connect-go).
+    /// If a deadline was set on this call (via [`CallOptions::with_timeout`]
+    /// or [`ClientConfig::with_default_timeout`]), each `message()` poll is
+    /// bounded by it — gRPC deadline semantics are whole-call, so a hung
+    /// server won't block indefinitely (matching grpc-java and connect-go).
     ///
     /// After this returns `Ok(None)`, [`trailers()`](Self::trailers) and
     /// [`error()`](Self::error) become available.
@@ -3273,6 +3413,74 @@ mod tests {
         assert_eq!(config.request_compression, Some("gzip".to_string()));
     }
 
+    #[test]
+    fn client_config_builders_round_trip_through_accessors() {
+        // Each `with_*` builder must be readable back through the bare-name
+        // accessor — the public read contract that replaces direct field
+        // access (#90).
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-base", "v".parse().unwrap());
+
+        let config = ClientConfig::new("http://example.com:8080".parse().unwrap())
+            .with_protocol(Protocol::Grpc)
+            .with_codec_format(CodecFormat::Json)
+            .with_compression(CompressionRegistry::default())
+            .compress_requests("gzip")
+            .with_compression_policy(CompressionPolicy::default())
+            .with_default_timeout(Duration::from_secs(30))
+            .with_default_max_message_size(4096)
+            .with_default_headers(headers.clone())
+            .with_default_header("x-extra", "1");
+
+        assert_eq!(config.base_uri().to_string(), "http://example.com:8080/");
+        assert_eq!(config.protocol(), Protocol::Grpc);
+        assert_eq!(config.codec_format(), CodecFormat::Json);
+        assert_eq!(config.request_compression(), Some("gzip"));
+        assert_eq!(config.default_timeout(), Some(Duration::from_secs(30)));
+        assert_eq!(config.default_max_message_size(), Some(4096));
+        assert_eq!(config.default_headers().get("x-base").unwrap(), "v");
+        assert_eq!(config.default_headers().get("x-extra").unwrap(), "1");
+        // `compression()` and `compression_policy()` return references / copies
+        // of the registry/policy; they don't impl PartialEq, so we just exercise
+        // that the accessors compile and don't panic.
+        let _ = config.compression();
+        let _ = config.compression_policy();
+    }
+
+    #[test]
+    fn client_config_defaults() {
+        let config = ClientConfig::new("http://localhost".parse().unwrap());
+        assert_eq!(config.protocol(), Protocol::Connect);
+        assert_eq!(config.codec_format(), CodecFormat::Proto);
+        assert_eq!(config.request_compression(), None);
+        assert_eq!(config.default_timeout(), None);
+        assert_eq!(config.default_max_message_size(), None);
+        assert!(config.default_headers().is_empty());
+    }
+
+    #[test]
+    fn call_options_builders_round_trip_through_accessors() {
+        let options = CallOptions::default()
+            .with_timeout(Duration::from_secs(5))
+            .with_header("x-request-id", "abc")
+            .with_max_message_size(2048)
+            .with_compress(true);
+
+        assert_eq!(options.timeout(), Some(Duration::from_secs(5)));
+        assert_eq!(options.headers().get("x-request-id").unwrap(), "abc");
+        assert_eq!(options.max_message_size(), Some(2048));
+        assert_eq!(options.compress(), Some(true));
+    }
+
+    #[test]
+    fn call_options_defaults() {
+        let options = CallOptions::default();
+        assert!(options.headers().is_empty());
+        assert_eq!(options.timeout(), None);
+        assert_eq!(options.max_message_size(), None);
+        assert_eq!(options.compress(), None);
+    }
+
     #[cfg(feature = "client")]
     #[test]
     fn test_http_client_plaintext_creation() {
@@ -3639,20 +3847,20 @@ mod tests {
         let config = ClientConfig::new("http://localhost".parse().unwrap());
         assert_eq!(unary_request_content_type(&config), "application/proto");
 
-        let config = config.codec_format(CodecFormat::Json);
+        let config = config.with_codec_format(CodecFormat::Json);
         assert_eq!(unary_request_content_type(&config), "application/json");
     }
 
     #[test]
     fn test_unary_request_content_type_grpc() {
         let config =
-            ClientConfig::new("http://localhost".parse().unwrap()).protocol(Protocol::Grpc);
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
         assert_eq!(
             unary_request_content_type(&config),
             "application/grpc+proto"
         );
 
-        let config = config.codec_format(CodecFormat::Json);
+        let config = config.with_codec_format(CodecFormat::Json);
         assert_eq!(unary_request_content_type(&config), "application/grpc+json");
     }
 
@@ -3664,13 +3872,13 @@ mod tests {
             "application/connect+proto"
         );
 
-        let config = config.protocol(Protocol::Grpc);
+        let config = config.with_protocol(Protocol::Grpc);
         assert_eq!(
             streaming_request_content_type(&config),
             "application/grpc+proto"
         );
 
-        let config = config.protocol(Protocol::GrpcWeb);
+        let config = config.with_protocol(Protocol::GrpcWeb);
         assert_eq!(
             streaming_request_content_type(&config),
             "application/grpc-web+proto"
@@ -3730,7 +3938,7 @@ mod tests {
     #[test]
     fn test_add_unary_request_headers_grpc() {
         let config =
-            ClientConfig::new("http://localhost".parse().unwrap()).protocol(Protocol::Grpc);
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
         let builder = http::Request::builder();
         let builder = add_unary_request_headers(builder, &config, None, None);
         let req = builder.body(()).unwrap();
@@ -3745,7 +3953,7 @@ mod tests {
     #[test]
     fn test_add_unary_request_headers_grpc_web() {
         let config =
-            ClientConfig::new("http://localhost".parse().unwrap()).protocol(Protocol::GrpcWeb);
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
         let builder = http::Request::builder();
         let builder = add_unary_request_headers(builder, &config, None, None);
         let req = builder.body(()).unwrap();
@@ -3760,7 +3968,7 @@ mod tests {
     #[test]
     fn test_add_unary_request_headers_with_timeout() {
         let config =
-            ClientConfig::new("http://localhost".parse().unwrap()).protocol(Protocol::Grpc);
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
         let builder = http::Request::builder();
         let builder =
             add_unary_request_headers(builder, &config, Some(Duration::from_millis(500)), None);
@@ -3916,7 +4124,7 @@ mod tests {
     #[test]
     fn test_add_streaming_request_headers_grpc() {
         let config =
-            ClientConfig::new("http://localhost".parse().unwrap()).protocol(Protocol::Grpc);
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
         let builder = http::Request::builder();
         let builder = add_streaming_request_headers(builder, &config, None);
         let req = builder.body(()).unwrap();
@@ -3934,7 +4142,7 @@ mod tests {
     #[test]
     fn test_client_config_protocol() {
         let config =
-            ClientConfig::new("http://localhost".parse().unwrap()).protocol(Protocol::Grpc);
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
         assert_eq!(config.protocol, Protocol::Grpc);
     }
 
@@ -3950,7 +4158,7 @@ mod tests {
 
     fn headers_for(protocol: Protocol, applied_encoding: Option<&str>) -> http::HeaderMap {
         let config = ClientConfig::new("http://localhost".parse().unwrap())
-            .protocol(protocol)
+            .with_protocol(protocol)
             .compress_requests("gzip");
         let builder = http::Request::builder();
         add_unary_request_headers(builder, &config, None, applied_encoding)
@@ -3996,9 +4204,9 @@ mod tests {
     #[test]
     fn effective_options_uses_config_defaults_when_options_unset() {
         let config = test_config()
-            .default_timeout(Duration::from_secs(30))
-            .default_max_message_size(1024)
-            .default_header("x-trace-id", "cfg-trace");
+            .with_default_timeout(Duration::from_secs(30))
+            .with_default_max_message_size(1024)
+            .with_default_header("x-trace-id", "cfg-trace");
 
         let eff = effective_options(&config, CallOptions::default());
 
@@ -4010,8 +4218,8 @@ mod tests {
     #[test]
     fn effective_options_options_override_config_defaults() {
         let config = test_config()
-            .default_timeout(Duration::from_secs(30))
-            .default_max_message_size(1024);
+            .with_default_timeout(Duration::from_secs(30))
+            .with_default_max_message_size(1024);
 
         let options = CallOptions::default()
             .with_timeout(Duration::from_secs(5))
@@ -4026,7 +4234,7 @@ mod tests {
     #[test]
     fn effective_options_compress_has_no_config_default() {
         let config = test_config();
-        let options = CallOptions::default().with_compression(true);
+        let options = CallOptions::default().with_compress(true);
         let eff = effective_options(&config, options);
         assert_eq!(eff.compress, Some(true));
     }

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 //! let uri: http::Uri = "http://localhost:8080".parse()?;
 //! let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-//! let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+//! let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 //!
 //! let client = GreetServiceClient::new(conn, config);
 //! let response = client.greet(request).await?;
@@ -121,8 +121,8 @@
 //!
 //! ```rust,ignore
 //! let config = ClientConfig::new(uri)
-//!     .default_timeout(Duration::from_secs(30))
-//!     .default_header("authorization", "Bearer ...");
+//!     .with_default_timeout(Duration::from_secs(30))
+//!     .with_default_header("authorization", "Bearer ...");
 //!
 //! let client = GreetServiceClient::new(http, config);
 //! client.greet(req).await?;  // uses 30s timeout + auth header

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -740,9 +740,9 @@ use std::time::Duration;
 use connectrpc::client::ClientConfig;
 
 let config = ClientConfig::new("http://localhost:8080".parse()?)
-    .default_timeout(Duration::from_secs(30))
-    .default_header("authorization", "Bearer demo-token")
-    .default_header("x-trace-id", "trace-12345");
+    .with_default_timeout(Duration::from_secs(30))
+    .with_default_header("authorization", "Bearer demo-token")
+    .with_default_header("x-trace-id", "trace-12345");
 ```
 
 These defaults automatically apply to every call from that client.
@@ -923,7 +923,7 @@ let service = ConnectRpcService::new(router).with_compression(registry);
 | Example | What it covers |
 |---|---|
 | [`streaming-tour/`](../examples/streaming-tour) | All four RPC types (unary, server stream, client stream, bidi) on a trivial NumberService. Smallest demo of handler signatures and client invocation patterns. |
-| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions`, response trailers via `Response::with_trailer`. Client demos `ClientConfig::default_header` and `CallOptions::with_timeout`. |
+| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions`, response trailers via `Response::with_trailer`. Client demos `ClientConfig::with_default_header` and `CallOptions::with_timeout`. |
 | [`mtls-identity/`](../examples/mtls-identity) | mTLS twin of `middleware/`: axum hosted behind `connectrpc::axum::serve_tls`, identity from the client cert's DNS SAN via `PeerCerts` instead of a bearer token, ACL keyed on the cert-derived identity. In-memory `rcgen` PKI; no PEM files. |
 | [`eliza/`](../examples/eliza) | Production-shaped streaming app: a port of the `connectrpc/examples-go` ELIZA demo. Server-streaming Introduce + bidi-streaming Converse, TLS, mTLS, CORS, IPv6, both server and client binaries, interoperates with the hosted Go reference at `demo.connectrpc.com`. |
 | [`multiservice/`](../examples/multiservice) | Multiple proto packages compiled together with `buf generate`, multiple services on one server, well-known type usage. |

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -431,7 +431,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = ElizaServiceClient::new(conn, config);
 /// let response = client.say(request).await?;

--- a/examples/middleware/README.md
+++ b/examples/middleware/README.md
@@ -16,7 +16,7 @@ writes a `x-served-by` response trailer via `Context::set_trailer()`.
 RUST_LOG=info,tower_http=debug \
     cargo run -p middleware-example --bin middleware-server
 
-# Terminal 2: client (sends auth header via ClientConfig::default_header)
+# Terminal 2: client (sends auth header via ClientConfig::with_default_header)
 cargo run -p middleware-example --bin middleware-client
 
 # Or with curl:
@@ -80,9 +80,9 @@ address.
 
 ### Client side (`src/client.rs`)
 
-- **`ClientConfig::default_header`** - sets the auth header once on
+- **`ClientConfig::with_default_header`** - sets the auth header once on
   the client config; every RPC call picks it up automatically.
-- **`ClientConfig::default_timeout`** - default deadline for every
+- **`ClientConfig::with_default_timeout`** - default deadline for every
   call.
 - **`CallOptions::with_timeout`** - per-call deadline override.
   `_with_options` variants let any RPC method take per-call options.

--- a/examples/middleware/src/client.rs
+++ b/examples/middleware/src/client.rs
@@ -1,4 +1,4 @@
-//! Middleware-example client: demonstrates `ClientConfig::default_header`
+//! Middleware-example client: demonstrates `ClientConfig::with_default_header`
 //! for the per-call auth header and `CallOptions::with_timeout` for a
 //! per-call deadline.
 
@@ -23,8 +23,8 @@ async fn main() -> Result<(), BoxError> {
     // automatically. Set per-call defaults here for anything you want
     // applied to all RPCs (auth, tracing IDs, request budget).
     let config = ClientConfig::new(url.parse()?)
-        .default_header("authorization", format!("Bearer {token}"))
-        .default_timeout(Duration::from_secs(10));
+        .with_default_header("authorization", format!("Bearer {token}"))
+        .with_default_timeout(Duration::from_secs(10));
 
     let http = HttpClient::plaintext();
     let client = SecretServiceClient::new(http, config);

--- a/examples/middleware/tests/e2e.rs
+++ b/examples/middleware/tests/e2e.rs
@@ -158,7 +158,7 @@ async fn start_server() -> std::net::SocketAddr {
 
 fn make_client(addr: std::net::SocketAddr, token: &str) -> SecretServiceClient<HttpClient> {
     let config = ClientConfig::new(format!("http://{addr}").parse().unwrap())
-        .default_header("authorization", format!("Bearer {token}"));
+        .with_default_header("authorization", format!("Bearer {token}"));
     SecretServiceClient::new(HttpClient::plaintext(), config)
 }
 

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -282,7 +282,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = GreetServiceClient::new(conn, config);
 /// let response = client.greet(request).await?;

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -273,7 +273,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = MathServiceClient::new(conn, config);
 /// let response = client.add(request).await?;

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -457,7 +457,7 @@ for WellKnownTypesServiceServer<T> {
 ///
 /// let uri: http::Uri = "http://localhost:8080".parse()?;
 /// let conn = Http2Connection::connect_plaintext(uri.clone()).await?.shared(1024);
-/// let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+/// let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
 ///
 /// let client = WellKnownTypesServiceClient::new(conn, config);
 /// let response = client.create_event(request).await?;

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -779,7 +779,7 @@ mod tests {
             .unwrap();
         let shared = conn.shared(64);
 
-        let config = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+        let config = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
         let client = EchoServiceClient::new(shared.clone(), config.clone());
 
         let resp = client
@@ -811,7 +811,7 @@ mod tests {
         let mut handles = Vec::new();
         for i in 0..16 {
             let c = shared.clone();
-            let cfg: ClientConfig = ClientConfig::new(uri.clone()).protocol(Protocol::Grpc);
+            let cfg: ClientConfig = ClientConfig::new(uri.clone()).with_protocol(Protocol::Grpc);
             handles.push(tokio::spawn(async move {
                 let client = EchoServiceClient::new(c, cfg);
                 client
@@ -853,7 +853,7 @@ mod tests {
             .await
             .unwrap()
             .shared(64);
-        let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+        let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
         let client = EchoServiceClient::new(conn, config);
 
         let test = async {
@@ -996,7 +996,7 @@ mod tests {
             .unwrap()
             .shared(64);
 
-        let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
+        let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
         let client = EchoServiceClient::new(conn, config);
 
         let resp = client


### PR DESCRIPTION
Fixes #90.

`ClientConfig` and `CallOptions` are `#[non_exhaustive]` with `pub` fields. Rustdoc shows pub fields, the user reaches for struct-literal or functional-update construction, and gets E0639 with no pointer at the builder methods. This change makes the construction story and the rustdoc agree.

## What changed

Fields are now `pub(crate)`. Reads go through same-named accessors: `config.protocol()`, `config.base_uri()`, `options.timeout()`, `options.headers()`, etc.

To free the bare names for accessors, the `ClientConfig` setter methods are renamed to the `with_*` form already used by `CallOptions`:

| Before | After |
|---|---|
| `.protocol(p)` | `.with_protocol(p)` |
| `.codec_format(f)` | `.with_codec_format(f)` |
| `.compression(r)` | `.with_compression(r)` |
| `.compression_policy(p)` | `.with_compression_policy(p)` |
| `.default_timeout(t)` | `.with_default_timeout(t)` |
| `.default_max_message_size(s)` | `.with_default_max_message_size(s)` |
| `.default_header(n, v)` | `.with_default_header(n, v)` |
| `.default_headers(h)` | `.with_default_headers(h)` |

`ClientConfig::new(uri)`, `.json()`, `.proto()`, `.compress_requests(e)`, and all `CallOptions` builder methods are unchanged.

All workspace consumers (conformance client, examples, benches, tests, docs) updated mechanically. The codegen template's generated client docstring updated and the four checked-in generated directories regenerated — docstring-only diff there.

## Migration

```rust
// before
let config = ClientConfig::new(uri).protocol(Protocol::Grpc);
let timeout = options.timeout;

// after
let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
let timeout = options.timeout();
```

## Out of scope

The issue also flags the invalid-header policy inconsistency (`Response::with_header` panics on invalid input; `ClientConfig::with_default_header` and `CallOptions::with_header` silently drop). Tracking that separately to keep this PR focused on the construction/encapsulation change.

## Reviewer notes

`ClientConfig::with_compression(registry: CompressionRegistry)` and `CallOptions::with_compression(enabled: bool)` now share a name with different argument types. This asymmetry pre-existed (`compression(registry)` vs `with_compression(enabled)`); the rename just makes it visible. Happy to rename `ClientConfig::with_compression` to something like `with_compression_registry` if the collision is too confusing.

SemVer: breaking. Lands in the 0.5.0 bump alongside the streaming-trait `type Item: Encodable<Res>` change already on `main`.
