### PR TITLE
RequestContext: #[non_exhaustive] + accessor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,27 @@ need a one-line edit.
   directly need to turbofish `encode_response_stream::<Res, _, _>(s,
   format)`. We are not aware of any.
 
+- **`RequestContext` is now `#[non_exhaustive]` with `pub(crate)` fields
+  and accessor methods.** Direct field reads — `ctx.headers`,
+  `ctx.deadline`, `ctx.extensions` — must move to `ctx.headers()`,
+  `ctx.deadline()`, `ctx.extensions()`. Construction via
+  `RequestContext::new(headers)` and the `with_*` builders is unchanged.
+  Locking the contract now lets future request-scoped metadata (method
+  name, RPC kind, negotiated protocol — wanted by interceptor and
+  observability work) ship as non-breaking additions instead of one
+  semver bump per field.
+
+  New (additive) accessors landed alongside the change:
+  - `ctx.time_remaining()` — saturating `Duration` until the deadline,
+    for budgeting downstream calls.
+  - `ctx.extensions_mut()` — mutable extensions, for tower middleware
+    that builds a `RequestContext` directly.
+  - `ctx.peer_addr()` (`server` feature) and `ctx.peer_certs()`
+    (`server-tls` feature) — typed extension lookups for the well-known
+    peer types. They return `None` when the transport didn't insert the
+    value, replacing the panic-prone
+    `ctx.extensions.get::<PeerAddr>().unwrap()` pattern.
+
 ### Changed
 
 - **`ClientConfig` and `CallOptions` fields are now `pub(crate)`.**

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -85,7 +85,7 @@ fn build_request_info(
     // Collect header values by name, merging duplicates into a single Header
     let mut header_map: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
-    for (name, value) in ctx.headers.iter() {
+    for (name, value) in ctx.headers().iter() {
         header_map
             .entry(name.to_string())
             .or_default()
@@ -105,12 +105,12 @@ fn build_request_info(
     // Connect uses connect-timeout-ms (value in milliseconds).
     // gRPC/gRPC-Web uses grpc-timeout (value with unit suffix, e.g., "5000m").
     let timeout_ms = ctx
-        .headers
+        .headers()
         .get("connect-timeout-ms")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<i64>().ok())
         .or_else(|| {
-            ctx.headers
+            ctx.headers()
                 .get("grpc-timeout")
                 .and_then(|v| v.to_str().ok())
                 .and_then(grpc_timeout_to_ms)
@@ -449,7 +449,7 @@ impl ConformanceService for ConformanceServiceImpl {
         let request_headers: Vec<_> = {
             let mut header_map: std::collections::HashMap<String, Vec<String>> =
                 std::collections::HashMap::new();
-            for (name, value) in ctx.headers.iter() {
+            for (name, value) in ctx.headers().iter() {
                 header_map
                     .entry(name.to_string())
                     .or_default()
@@ -466,12 +466,12 @@ impl ConformanceService for ConformanceServiceImpl {
         };
 
         let timeout_ms = ctx
-            .headers
+            .headers()
             .get("connect-timeout-ms")
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<i64>().ok())
             .or_else(|| {
-                ctx.headers
+                ctx.headers()
                     .get("grpc-timeout")
                     .and_then(|v| v.to_str().ok())
                     .and_then(grpc_timeout_to_ms)
@@ -595,7 +595,7 @@ impl ConformanceService for ConformanceServiceImpl {
         let request_headers: Vec<_> = {
             let mut header_map: std::collections::HashMap<String, Vec<String>> =
                 std::collections::HashMap::new();
-            for (name, value) in ctx.headers.iter() {
+            for (name, value) in ctx.headers().iter() {
                 header_map
                     .entry(name.to_string())
                     .or_default()
@@ -612,12 +612,12 @@ impl ConformanceService for ConformanceServiceImpl {
         };
 
         let timeout_ms = ctx
-            .headers
+            .headers()
             .get("connect-timeout-ms")
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<i64>().ok())
             .or_else(|| {
-                ctx.headers
+                ctx.headers()
                     .get("grpc-timeout")
                     .and_then(|v| v.to_str().ok())
                     .and_then(grpc_timeout_to_ms)

--- a/connectrpc/src/axum.rs
+++ b/connectrpc/src/axum.rs
@@ -9,15 +9,15 @@
 //! terminating TLS. The standalone [`Server`](crate::Server), by contrast,
 //! owns the rustls accept loop and so can capture [`PeerAddr`]/[`PeerCerts`]
 //! once per connection and inject them into every request's extensions for
-//! handlers to read via `ctx.extensions.get::<T>()`. Without help, an axum +
-//! mTLS deployment has to reimplement that accept loop and per-connection
-//! plumbing by hand for handlers to get the same view.
+//! handlers to read via `ctx.peer_addr()` / `ctx.peer_certs()`. Without
+//! help, an axum + mTLS deployment has to reimplement that accept loop and
+//! per-connection plumbing by hand for handlers to get the same view.
 //!
 //! [`serve_tls`] is that help: it serves an `axum::Router`, terminates TLS,
 //! captures peer identity, and stamps it into request extensions. Handler
-//! code that reads `ctx.extensions.get::<PeerCerts>()` is then portable
-//! between the standalone `Server` and an axum app — the hosting choice no
-//! longer leaks into your authorization logic.
+//! code that reads `ctx.peer_certs()` is then portable between the
+//! standalone `Server` and an axum app — the hosting choice no longer
+//! leaks into your authorization logic.
 //!
 //! ```rust,ignore
 //! // Plaintext: axum's built-in serve.
@@ -42,8 +42,7 @@
 //!   [`rustls::ServerConfig`] requests client authentication *and* the peer
 //!   presents a chain rustls verifies. With `with_no_client_auth()` (or a
 //!   permissive verifier and a client that sends no cert), only [`PeerAddr`]
-//!   is present. Handlers must treat `ctx.extensions.get::<PeerCerts>()` as
-//!   optional.
+//!   is present. Handlers must treat `ctx.peer_certs()` as optional.
 //! - **ALPN.** The TLS terminator speaks the protocol ALPN selects. To allow
 //!   HTTP/2 (required for gRPC; preferred for Connect streaming), set
 //!   `server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()]`
@@ -366,8 +365,10 @@ mod tests {
     async fn serve_tls_injects_peer_identity() {
         let (server_cfg, client_cfg, expected_client_der) = pki();
 
-        // The handler stashes whatever PeerAddr/PeerCerts it sees.
-        type Captured = Arc<Mutex<Option<(PeerAddr, Option<PeerCerts>)>>>;
+        // The handler stashes whatever peer identity it sees via the typed
+        // `RequestContext` accessors.
+        type CapturedCerts = Vec<rustls::pki_types::CertificateDer<'static>>;
+        type Captured = Arc<Mutex<Option<(std::net::SocketAddr, Option<CapturedCerts>)>>>;
         let captured: Captured = Arc::new(Mutex::new(None));
         let handler_captured = Arc::clone(&captured);
         let connect = ConnectRouter::new().route(
@@ -378,8 +379,8 @@ mod tests {
                     let cap = Arc::clone(&handler_captured);
                     async move {
                         *cap.lock().unwrap() = Some((
-                            ctx.extensions.get::<PeerAddr>().cloned().unwrap(),
-                            ctx.extensions.get::<PeerCerts>().cloned(),
+                            ctx.peer_addr().expect("serve_tls inserts PeerAddr"),
+                            ctx.peer_certs().map(<[_]>::to_vec),
                         ));
                         ConnectResponse::ok(buffa_types::Empty::default())
                     }
@@ -415,10 +416,10 @@ mod tests {
             .unwrap();
 
         let (peer_addr, peer_certs) = captured.lock().unwrap().take().expect("handler ran");
-        assert_eq!(peer_addr.0.ip(), addr.ip());
+        assert_eq!(peer_addr.ip(), addr.ip());
         let certs = peer_certs.expect("mTLS client should present a cert chain");
-        assert_eq!(certs.0.len(), 1);
-        assert_eq!(certs.0[0].as_ref(), expected_client_der.as_ref());
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0].as_ref(), expected_client_der.as_ref());
     }
 
     /// Open a TLS+HTTP/1.1 connection, send `ECHO_REQ`, and return the raw

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -10,7 +10,7 @@
 
 use std::marker::PhantomData;
 use std::pin::Pin;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use buffa::Message;
 use buffa::view::{MessageView, ViewEncode};
@@ -33,10 +33,17 @@ use crate::error::ConnectError;
 /// connection-scoped extensions (peer address, TLS certs, auth context)
 /// inserted by a tower layer in front of the service. Handlers do *not*
 /// return this; response-side metadata lives on [`Response`].
+///
+/// `RequestContext` is `#[non_exhaustive]`: construct it with
+/// [`RequestContext::new`] and the `with_*` builders, and read fields
+/// through the accessor methods (`headers()`, `deadline()`,
+/// `extensions()`, …). New request-scoped metadata can be added in minor
+/// releases without breaking downstream code.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct RequestContext {
     /// Request headers (after protocol-prefix stripping).
-    pub headers: HeaderMap,
+    pub(crate) headers: HeaderMap,
     /// Absolute request deadline parsed from the protocol's timeout header,
     /// if any. Propagate to downstream calls.
     ///
@@ -44,15 +51,9 @@ pub struct RequestContext {
     /// service, this is the *moderated* value — clamped to the policy's
     /// `[min, max]` range, or the policy default when the client asserted
     /// nothing — not the raw client header.
-    pub deadline: Option<Instant>,
+    pub(crate) deadline: Option<Instant>,
     /// Request extensions carried from the underlying `http::Request`.
-    ///
-    /// This is the passthrough for connection-scoped metadata that a
-    /// tower layer in front of the service can attach — TLS peer
-    /// certificates, remote socket address, auth context, etc. The
-    /// dispatch path moves `parts.extensions` here verbatim; handlers
-    /// read it with `ctx.extensions.get::<T>()`.
-    pub extensions: http::Extensions,
+    pub(crate) extensions: http::Extensions,
 }
 
 impl RequestContext {
@@ -79,9 +80,113 @@ impl RequestContext {
         self
     }
 
+    /// Request headers (after protocol-prefix stripping).
+    ///
+    /// For a single header lookup, [`header`](Self::header) is simpler.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
     /// Get a request header value.
     pub fn header(&self, key: impl http::header::AsHeaderName) -> Option<&HeaderValue> {
         self.headers.get(key)
+    }
+
+    /// Absolute request deadline parsed from the protocol's timeout header
+    /// (`Connect-Timeout-Ms` or `grpc-timeout`), if the client asserted one.
+    ///
+    /// Propagate this to downstream calls so the whole call chain shares a
+    /// single budget. For the remaining budget as a `Duration`, see
+    /// [`time_remaining`](Self::time_remaining).
+    ///
+    /// If a [`DeadlinePolicy`](crate::DeadlinePolicy) is configured on the
+    /// service, this is the *moderated* value — clamped to the policy's
+    /// `[min, max]` range, or the policy default when the client asserted
+    /// nothing — not the raw client header.
+    pub fn deadline(&self) -> Option<Instant> {
+        self.deadline
+    }
+
+    /// Time remaining until the request deadline, saturating at zero.
+    ///
+    /// `None` if the client did not assert a timeout. Use this to budget
+    /// downstream calls — for example, subtract a margin before passing the
+    /// remainder as a downstream RPC's per-call timeout. See also issue
+    /// [#92](https://github.com/anthropics/connect-rust/issues/92) for
+    /// server-side deadline enforcement.
+    pub fn time_remaining(&self) -> Option<Duration> {
+        self.deadline
+            .map(|d| d.saturating_duration_since(Instant::now()))
+    }
+
+    /// Request extensions carried from the underlying `http::Request`.
+    ///
+    /// This is the passthrough for connection-scoped metadata that a tower
+    /// layer in front of the service can attach — TLS peer certificates,
+    /// remote socket address, auth context, etc. The dispatch path moves
+    /// `parts.extensions` here verbatim; handlers read it with
+    /// `ctx.extensions().get::<T>()`. For the well-known peer types, prefer
+    /// the typed accessors `peer_addr()` and `peer_certs()` (gated on the
+    /// `server` and `server-tls` features respectively) — they return
+    /// `None` instead of panicking when the transport didn't insert the
+    /// extension.
+    pub fn extensions(&self) -> &http::Extensions {
+        &self.extensions
+    }
+
+    /// Mutable access to the request extensions.
+    ///
+    /// Useful for code that constructs a `RequestContext` directly — e.g.
+    /// a custom dispatch shim or test fixture — and needs to insert
+    /// connection-scoped values before calling a handler.
+    ///
+    /// # Note
+    ///
+    /// Handlers receive `RequestContext` **by value**, so calling
+    /// `ctx.extensions_mut().insert(...)` inside a handler mutates a local
+    /// copy that the framework never sees again — it has no effect on the
+    /// dispatch path or on downstream layers. To pass values *into* a
+    /// handler from middleware, mutate `http::Request::extensions_mut()`
+    /// in the layer instead; the dispatcher moves request extensions into
+    /// `RequestContext` automatically before dispatch.
+    pub fn extensions_mut(&mut self) -> &mut http::Extensions {
+        &mut self.extensions
+    }
+
+    /// Remote peer socket address, if the transport recorded one.
+    ///
+    /// Present when the request arrived through
+    /// [`Server::serve`](crate::server::Server::serve) (plain) or
+    /// `Server::with_tls(...)` (TLS), or any integration that inserts
+    /// [`PeerAddr`](crate::server::PeerAddr) into the request extensions
+    /// (`connectrpc::axum::serve_tls` does).
+    /// Returns `None` otherwise (e.g. an axum app without a layer that
+    /// captures the connect info), so prefer this over
+    /// `ctx.extensions().get::<PeerAddr>().unwrap()` — the latter compiles,
+    /// passes in unit tests, and panics in production behind a transport
+    /// that didn't insert it.
+    #[cfg(feature = "server")]
+    pub fn peer_addr(&self) -> Option<std::net::SocketAddr> {
+        self.extensions
+            .get::<crate::server::PeerAddr>()
+            .map(|p| p.0)
+    }
+
+    /// TLS client certificate chain presented by the peer (leaf first), if any.
+    ///
+    /// Present only when the request arrived over a TLS listener that
+    /// requested a client certificate and the client presented one — see
+    /// [`Server::with_tls`](crate::server::Server::with_tls) and
+    /// `connectrpc::axum::serve_tls`. Returns `None` for plaintext
+    /// transports, for TLS without mutual auth, and for integrations that
+    /// don't insert [`PeerCerts`](crate::server::PeerCerts) into the
+    /// request extensions. Like [`peer_addr`](Self::peer_addr), prefer
+    /// this over a raw `extensions().get()` + `unwrap()`.
+    #[cfg(feature = "server-tls")]
+    pub fn peer_certs(&self) -> Option<&[rustls::pki_types::CertificateDer<'static>]> {
+        self.extensions
+            .get::<crate::server::PeerCerts>()
+            .map(|p| &p.0[..])
     }
 }
 
@@ -813,14 +918,73 @@ mod tests {
             ctx.header(HeaderName::from_static("x-custom")).unwrap(),
             "v"
         );
-        assert!(ctx.deadline.is_none());
+        assert_eq!(ctx.headers().get("x-custom").unwrap(), "v");
+        assert!(ctx.deadline().is_none());
+        assert!(ctx.time_remaining().is_none());
+        assert!(ctx.extensions().is_empty());
     }
 
     #[test]
     fn request_context_with_deadline() {
         let d = Instant::now();
         let ctx = RequestContext::new(HeaderMap::new()).with_deadline(Some(d));
-        assert_eq!(ctx.deadline, Some(d));
+        assert_eq!(ctx.deadline(), Some(d));
+    }
+
+    #[test]
+    fn request_context_time_remaining_saturates_at_zero() {
+        // Deadline in the past — `time_remaining()` should clamp to zero,
+        // not underflow.
+        let past = Instant::now() - Duration::from_secs(60);
+        let ctx = RequestContext::new(HeaderMap::new()).with_deadline(Some(past));
+        assert_eq!(ctx.time_remaining(), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn request_context_time_remaining_future() {
+        let future = Instant::now() + Duration::from_secs(60);
+        let ctx = RequestContext::new(HeaderMap::new()).with_deadline(Some(future));
+        let remaining = ctx.time_remaining().unwrap();
+        // Some elapsed time between `with_deadline` and the assertion is
+        // expected; just bound it.
+        assert!(remaining > Duration::from_secs(55));
+        assert!(remaining <= Duration::from_secs(60));
+    }
+
+    #[test]
+    fn request_context_extensions_mut() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct Tag(u8);
+        let mut ctx = RequestContext::new(HeaderMap::new());
+        ctx.extensions_mut().insert(Tag(1));
+        assert_eq!(ctx.extensions().get::<Tag>(), Some(&Tag(1)));
+    }
+
+    #[cfg(feature = "server")]
+    #[test]
+    fn request_context_peer_addr_absent() {
+        // No transport inserted `PeerAddr`; the typed accessor returns
+        // `None` rather than panicking.
+        let ctx = RequestContext::new(HeaderMap::new());
+        assert_eq!(ctx.peer_addr(), None);
+    }
+
+    #[cfg(feature = "server")]
+    #[test]
+    fn request_context_peer_addr_present() {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let mut ext = http::Extensions::new();
+        ext.insert(crate::server::PeerAddr(addr));
+        let ctx = RequestContext::new(HeaderMap::new()).with_extensions(ext);
+        assert_eq!(ctx.peer_addr(), Some(addr));
+    }
+
+    #[cfg(feature = "server-tls")]
+    #[test]
+    fn request_context_peer_certs_absent() {
+        let ctx = RequestContext::new(HeaderMap::new());
+        assert!(ctx.peer_certs().is_none());
     }
 
     #[test]
@@ -1082,6 +1246,6 @@ mod tests {
         let mut ext = http::Extensions::new();
         ext.insert(Peer(7));
         let ctx = RequestContext::new(HeaderMap::new()).with_extensions(ext);
-        assert_eq!(ctx.extensions.get::<Peer>(), Some(&Peer(7)));
+        assert_eq!(ctx.extensions().get::<Peer>(), Some(&Peer(7)));
     }
 }

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -64,7 +64,8 @@ use crate::service::ConnectRpcService;
 ///
 /// Inserted into every request's extensions by the built-in [`Server`]'s
 /// accept loop and by `connectrpc::axum::serve_tls`. Handlers read it via
-/// `ctx.extensions.get::<PeerAddr>()`.
+/// [`RequestContext::peer_addr`](crate::RequestContext::peer_addr) (or
+/// `ctx.extensions().get::<PeerAddr>()`).
 ///
 /// Callers using a different HTTP stack (axum, raw hyper) in front of
 /// [`ConnectRpcService`] can insert this same type
@@ -78,7 +79,9 @@ pub struct PeerAddr(pub SocketAddr);
 /// `connectrpc::axum::serve_tls` when the [`rustls::ServerConfig`] requests
 /// client authentication and the peer presents a valid chain. Absent on
 /// plaintext connections or when the client presents no certificate.
-/// Handlers read it via `ctx.extensions.get::<PeerCerts>()`.
+/// Handlers read it via
+/// [`RequestContext::peer_certs`](crate::RequestContext::peer_certs) (or
+/// `ctx.extensions().get::<PeerCerts>()`).
 ///
 /// The `Arc` makes per-request insertion cheap: all requests on a
 /// connection share one chain, so this is a refcount bump, not a copy.
@@ -98,7 +101,7 @@ struct PeerInfo {
 impl PeerInfo {
     /// Insert this connection's peer info as public extension types
     /// ([`PeerAddr`], [`PeerCerts`]) so handlers can read them via
-    /// `ctx.extensions.get::<T>()`.
+    /// `ctx.peer_addr()` / `ctx.peer_certs()`.
     fn insert_into(&self, ext: &mut http::Extensions) {
         ext.insert(PeerAddr(self.addr));
         #[cfg(feature = "server-tls")]
@@ -467,7 +470,7 @@ type WrappedService<D> = tower_http::catch_panic::CatchPanic<
 ///
 /// `peer` is inserted into every request's extensions so handlers can read
 /// the remote address (and TLS client cert chain, if any) via
-/// `ctx.extensions.get::<PeerAddr>()` / `get::<PeerCerts>()`.
+/// `ctx.peer_addr()` / `ctx.peer_certs()`.
 async fn serve_accepted_stream<D, S>(
     io: S,
     peer: PeerInfo,
@@ -962,7 +965,7 @@ mod tests {
     #[tokio::test]
     async fn peer_addr_reaches_handler() {
         // Handler stashes the PeerAddr it sees into a shared slot.
-        let captured: Arc<Mutex<Option<PeerAddr>>> = Arc::new(Mutex::new(None));
+        let captured: Arc<Mutex<Option<std::net::SocketAddr>>> = Arc::new(Mutex::new(None));
         let handler_captured = Arc::clone(&captured);
         let router = Router::new().route(
             "svc",
@@ -971,7 +974,7 @@ mod tests {
                 move |ctx: crate::RequestContext, _req: buffa_types::Empty| {
                     let cap = Arc::clone(&handler_captured);
                     async move {
-                        *cap.lock().unwrap() = ctx.extensions.get::<PeerAddr>().cloned();
+                        *cap.lock().unwrap() = ctx.peer_addr();
                         crate::Response::ok(buffa_types::Empty::default())
                     }
                 },
@@ -1017,11 +1020,11 @@ mod tests {
             .take()
             .expect("handler should have captured PeerAddr");
         // The server sees the client's local_addr() as the remote peer.
-        assert_eq!(peer.0, client_local);
+        assert_eq!(peer, client_local);
     }
 
     /// End-to-end mTLS: client presents a cert; handler reads it from
-    /// `ctx.extensions.get::<PeerCerts>()` and the DER bytes round-trip.
+    /// `ctx.peer_certs()` and the DER bytes round-trip.
     #[cfg(feature = "server-tls")]
     #[tokio::test]
     async fn peer_certs_reach_handler() {
@@ -1079,7 +1082,8 @@ mod tests {
 
         let (server_cfg, client_cfg, expected_client_der) = pki();
 
-        let captured: Arc<Mutex<Option<PeerCerts>>> = Arc::new(Mutex::new(None));
+        type CapturedCerts = Vec<rustls::pki_types::CertificateDer<'static>>;
+        let captured: Arc<Mutex<Option<CapturedCerts>>> = Arc::new(Mutex::new(None));
         let handler_captured = Arc::clone(&captured);
         let router = Router::new().route(
             "svc",
@@ -1088,7 +1092,7 @@ mod tests {
                 move |ctx: crate::RequestContext, _req: buffa_types::Empty| {
                     let cap = Arc::clone(&handler_captured);
                     async move {
-                        *cap.lock().unwrap() = ctx.extensions.get::<PeerCerts>().cloned();
+                        *cap.lock().unwrap() = ctx.peer_certs().map(<[_]>::to_vec);
                         crate::Response::ok(buffa_types::Empty::default())
                     }
                 },
@@ -1136,7 +1140,7 @@ mod tests {
             .take()
             .expect("handler should have captured PeerCerts");
         // The exact DER bytes the client presented.
-        assert_eq!(certs.0.len(), 1);
-        assert_eq!(certs.0[0].as_ref(), expected_client_der.as_ref());
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0].as_ref(), expected_client_der.as_ref());
     }
 }

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -3468,7 +3468,7 @@ mod tests {
             crate::handler_fn(move |ctx: RequestContext, _req: buffa_types::Empty| {
                 let cap = Arc::clone(&handler_captured);
                 async move {
-                    *cap.lock().unwrap() = ctx.extensions.get::<PeerTag>().cloned();
+                    *cap.lock().unwrap() = ctx.extensions().get::<PeerTag>().cloned();
                     crate::Response::ok(buffa_types::Empty::default())
                 }
             }),

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -288,11 +288,35 @@ you need it.
 Request-side metadata lives on `RequestContext` (passed in);
 response-side metadata lives on `Response<B>` (returned):
 
-| `RequestContext` field | Purpose |
+`RequestContext` is `#[non_exhaustive]`; read it through the accessor
+methods (new request-scoped metadata can then be added in minor releases):
+
+| `RequestContext` accessor | Purpose |
 |---|---|
-| `headers` | Caller-supplied headers (read with `ctx.header(name)` or `ctx.headers.get(...)`) |
-| `deadline` | Absolute `Instant` if the caller set a timeout |
-| `extensions` | `http::Extensions` carried from the underlying `http::Request` |
+| `ctx.header(name)` / `ctx.headers()` | Caller-supplied headers (after protocol-prefix stripping) |
+| `ctx.deadline()` | Absolute `Instant` if the caller set a timeout |
+| `ctx.time_remaining()` | Saturating `Duration` until the deadline — budget downstream calls with this |
+| `ctx.extensions()` | `http::Extensions` carried from the underlying `http::Request` |
+| `ctx.peer_addr()` | Remote socket address (requires the `server` feature; `None` when the transport didn't insert it) |
+| `ctx.peer_certs()` | TLS client cert chain (requires the `server-tls` feature; `None` for plaintext or no client cert) |
+
+For example, propagating the caller's deadline to a downstream RPC and
+reading the peer cert chain:
+
+```rust,ignore
+// Budget downstream calls from the remaining time, leaving a margin
+// for response encoding and network round-trips.
+if let Some(remaining) = ctx.time_remaining() {
+    let budget = remaining.saturating_sub(Duration::from_millis(50));
+    options = options.with_timeout(budget);
+}
+
+// Typed peer lookup — returns None instead of panicking when the
+// request didn't arrive over mTLS.
+if let Some(certs) = ctx.peer_certs() {
+    authorize(certs)?;
+}
+```
 
 | `Response<B>` field | Purpose |
 |---|---|
@@ -317,12 +341,14 @@ async fn greet(
 }
 ```
 
-`RequestContext::extensions` is the passthrough channel for tower-layer state:
-a custom auth layer can stamp a `UserId` into the request's
-`http::Extensions`, and the dispatcher forwards that map verbatim into
-`RequestContext::extensions` for the handler to read with
-`ctx.extensions.get::<UserId>()`. See [Tower middleware](#tower-middleware)
-for the full pattern.
+`RequestContext::extensions()` is the passthrough channel for tower-layer
+state: a custom auth layer can stamp a `UserId` into the request's
+`http::Extensions`, and the dispatcher forwards that map verbatim into the
+request context for the handler to read with
+`ctx.extensions().get::<UserId>()`. For the well-known peer types, prefer
+the typed `ctx.peer_addr()` / `ctx.peer_certs()` accessors — they return
+`None` rather than panicking when the transport didn't insert them. See
+[Tower middleware](#tower-middleware) for the full pattern.
 
 ### What you see vs. what you write
 
@@ -592,12 +618,12 @@ ServiceBuilder accepts.
 
 ### Passing data from a layer to a handler
 
-The dispatch path moves the request's `http::Extensions` into
-`RequestContext::extensions` verbatim. So a middleware that inserts a value
-via `req.extensions_mut().insert(value)` makes that value available to
-the handler via `ctx.extensions.get::<T>()`. This is the canonical way
-to pass per-request state from middleware (auth identity, trace IDs,
-remote addr, TLS peer info) into the handler.
+The dispatch path moves the request's `http::Extensions` into the
+request context verbatim. So a middleware that inserts a value via
+`req.extensions_mut().insert(value)` makes that value available to the
+handler via `ctx.extensions().get::<T>()`. This is the canonical way to
+pass per-request state from middleware (auth identity, trace IDs, remote
+addr, TLS peer info) into the handler.
 
 The middleware example does exactly this with a `UserId`:
 
@@ -607,7 +633,7 @@ req.extensions_mut().insert(UserId(user.into()));
 next.run(req).await
 
 // In the handler:
-let user = ctx.extensions.get::<UserId>().unwrap();
+let user = ctx.extensions().get::<UserId>().unwrap();
 ```
 
 ### Short-circuit responses
@@ -680,8 +706,8 @@ For the axum path, `connectrpc::axum::serve_tls` (requires both the
 `axum` and `server-tls` features) is a drop-in replacement for
 `axum::serve` that owns the rustls accept loop and stamps `PeerAddr` /
 `PeerCerts` into request extensions exactly as the standalone `Server`
-does, so handler code that reads `ctx.extensions.get::<PeerCerts>()`
-is portable across both hosting paths:
+does, so handler code that reads `ctx.peer_certs()` is portable across
+both hosting paths:
 
 ```rust
 let app = axum::Router::new()
@@ -991,7 +1017,7 @@ let service = ConnectRpcService::new(router).with_compression(registry);
 | Example | What it covers |
 |---|---|
 | [`streaming-tour/`](../examples/streaming-tour) | All four RPC types (unary, server stream, client stream, bidi) on a trivial NumberService. Smallest demo of handler signatures and client invocation patterns. |
-| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions`, response trailers via `Response::with_trailer`. Client demos `ClientConfig::with_default_header` and `CallOptions::with_timeout`. |
+| [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions()`, response trailers via `Response::with_trailer`. Client demos `ClientConfig::with_default_header` and `CallOptions::with_timeout`. |
 | [`mtls-identity/`](../examples/mtls-identity) | mTLS twin of `middleware/`: axum hosted behind `connectrpc::axum::serve_tls`, identity from the client cert's DNS SAN via `PeerCerts` instead of a bearer token, ACL keyed on the cert-derived identity. In-memory `rcgen` PKI; no PEM files. |
 | [`eliza/`](../examples/eliza) | Production-shaped streaming app: a port of the `connectrpc/examples-go` ELIZA demo. Server-streaming Introduce + bidi-streaming Converse, TLS, mTLS, CORS, IPv6, both server and client binaries, interoperates with the hosted Go reference at `demo.connectrpc.com`. |
 | [`multiservice/`](../examples/multiservice) | Multiple proto packages compiled together with `buf generate`, multiple services on one server, well-known type usage. |

--- a/examples/middleware/README.md
+++ b/examples/middleware/README.md
@@ -74,7 +74,7 @@ address.
 
 - **Handler reading from `Context`** - the dispatch path moves the
   request's `http::Extensions` into `Context::extensions`. The handler
-  reads `UserId` via `ctx.extensions.get::<UserId>()`, performs its own
+  reads `UserId` via `ctx.extensions().get::<UserId>()`, performs its own
   permission check against the secret store, and writes the
   `x-served-by` response trailer via `ctx.set_trailer(...)`.
 

--- a/examples/middleware/src/server.rs
+++ b/examples/middleware/src/server.rs
@@ -103,9 +103,9 @@ async fn auth_middleware(
         return unauthorized("invalid Bearer token");
     };
 
-    // The connect dispatcher forwards req.extensions() into
-    // Context::extensions verbatim, so the handler reads the UserId via
-    // ctx.extensions.get::<UserId>().
+    // The connect dispatcher forwards req.extensions() into the request
+    // context verbatim, so the handler reads the UserId via
+    // ctx.extensions().get::<UserId>().
     req.extensions_mut().insert(user);
     next.run(req).await
 }
@@ -140,9 +140,9 @@ impl SecretService for SecretServiceImpl {
         request: OwnedView<GetSecretRequestView<'static>>,
     ) -> ServiceResult<GetSecretResponse> {
         // The auth layer stamped UserId into the http::Request extensions,
-        // which the connect dispatcher then forwarded into ctx.extensions.
+        // which the connect dispatcher then forwarded into ctx.extensions().
         let user = ctx
-            .extensions
+            .extensions()
             .get::<UserId>()
             .ok_or_else(|| {
                 ConnectError::new(

--- a/examples/middleware/tests/e2e.rs
+++ b/examples/middleware/tests/e2e.rs
@@ -101,7 +101,7 @@ impl SecretService for SecretServiceImpl {
         request: OwnedView<GetSecretRequestView<'static>>,
     ) -> ServiceResult<GetSecretResponse> {
         let user = ctx
-            .extensions
+            .extensions()
             .get::<UserId>()
             .ok_or_else(|| ConnectError::new(ErrorCode::Internal, "auth layer misconfigured"))?
             .clone();

--- a/examples/mtls-identity/README.md
+++ b/examples/mtls-identity/README.md
@@ -12,7 +12,7 @@ and enforces an ACL against it.
 This is the mTLS twin of [`examples/middleware/`](../middleware): same
 secret-store-with-ACL shape, but the credential is a client certificate
 instead of a `Bearer` token. The handler-side code that reads
-`ctx.extensions.get::<T>()` is unchanged; only what the layer/accept
+`ctx.peer_certs()` is unchanged; only what the layer/accept
 loop puts into extensions differs.
 
 ## Run it
@@ -57,8 +57,8 @@ connectrpc::axum::serve_tls(listener, app, server_config)
     .await?;
 ```
 
-Handler code that reads `ctx.extensions.get::<PeerCerts>()` is then
-portable between the standalone `Server::with_tls` and an axum app.
+Handler code that reads `ctx.peer_certs()` is then portable
+between the standalone `Server::with_tls` and an axum app.
 
 ### Cert-SAN identity (`src/lib.rs::extract_identity`)
 

--- a/examples/mtls-identity/src/lib.rs
+++ b/examples/mtls-identity/src/lib.rs
@@ -4,21 +4,21 @@
 //! instead of an `axum::middleware::from_fn` reading an `Authorization`
 //! header, identity comes from the verified client certificate that
 //! `connectrpc::axum::serve_tls` captures during the TLS handshake and
-//! stamps into request extensions as [`PeerCerts`]. The handler parses
-//! the leaf cert's DNS SAN to derive a workload identity, then enforces
-//! an ACL against it.
+//! stamps into request extensions as [`connectrpc::PeerCerts`]. The
+//! handler reads it via [`RequestContext::peer_certs`], parses the leaf
+//! cert's DNS SAN to derive a workload identity, then enforces an ACL
+//! against it.
 //!
 //! The same handler code works unchanged on the standalone
-//! [`connectrpc::Server::with_tls`], which populates [`PeerCerts`] the
-//! same way — the hosting choice doesn't leak into authorization logic.
+//! [`connectrpc::Server::with_tls`], which populates
+//! [`connectrpc::PeerCerts`] the same way — the hosting choice doesn't
+//! leak into authorization logic.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use buffa::view::OwnedView;
-use connectrpc::{
-    ConnectError, ErrorCode, PeerAddr, PeerCerts, RequestContext, Router, ServiceResult,
-};
+use connectrpc::{ConnectError, ErrorCode, RequestContext, Router, ServiceResult};
 
 pub mod proto {
     connectrpc::include_generated!();
@@ -54,12 +54,15 @@ pub struct Identity {
 /// In a real deployment you'd typically match a SPIFFE ID
 /// (`spiffe://trust-domain/path`, a URI SAN) instead of a DNS SAN, or
 /// delegate this whole step to an authorization framework. The shape is
-/// the same: read [`PeerCerts`], parse the leaf, derive an identity.
-pub fn extract_identity(certs: Option<&PeerCerts>) -> Result<Identity, ConnectError> {
+/// the same: read [`RequestContext::peer_certs`], parse the leaf, derive
+/// an identity.
+pub fn extract_identity(
+    certs: Option<&[rustls_pki_types::CertificateDer<'static>]>,
+) -> Result<Identity, ConnectError> {
     use x509_parser::extensions::GeneralName;
     use x509_parser::prelude::{FromDer, X509Certificate};
 
-    let leaf = certs.and_then(|c| c.0.first()).ok_or_else(|| {
+    let leaf = certs.and_then(<[_]>::first).ok_or_else(|| {
         ConnectError::new(ErrorCode::Unauthenticated, "client certificate required")
     })?;
 
@@ -129,13 +132,11 @@ impl IdentityService for IdentityServiceImpl {
     ) -> ServiceResult<WhoAmIResponse> {
         // Both PeerCerts and PeerAddr are stamped per connection by
         // serve_tls; the dispatcher copies request extensions verbatim
-        // into ctx.extensions.
-        let id = extract_identity(ctx.extensions.get::<PeerCerts>())?;
-        let remote = ctx
-            .extensions
-            .get::<PeerAddr>()
-            .map(|a| a.0.to_string())
-            .unwrap_or_default();
+        // into the request context. Use the typed accessors rather than
+        // raw extension lookups so a missing transport insert is a clean
+        // `None` instead of a panic.
+        let id = extract_identity(ctx.peer_certs())?;
+        let remote = ctx.peer_addr().map(|a| a.to_string()).unwrap_or_default();
         connectrpc::Response::ok(WhoAmIResponse {
             identity: Some(id.name),
             san: Some(id.san),
@@ -149,7 +150,7 @@ impl IdentityService for IdentityServiceImpl {
         ctx: RequestContext,
         request: OwnedView<GetSecretRequestView<'static>>,
     ) -> ServiceResult<GetSecretResponse> {
-        let id = extract_identity(ctx.extensions.get::<PeerCerts>())?;
+        let id = extract_identity(ctx.peer_certs())?;
         let name = request.name.unwrap_or("").to_owned();
         let (value, allowed) = self.store.get(&name).ok_or_else(|| {
             ConnectError::new(ErrorCode::NotFound, format!("no secret named {name:?}"))
@@ -315,8 +316,8 @@ mod tests {
     use rcgen::{CertificateParams, KeyPair, SanType};
     use rustls_pki_types::CertificateDer;
 
-    /// Self-signed leaf with arbitrary DNS SANs, wrapped as PeerCerts.
-    fn peer_certs_with_dns_sans(sans: &[&str]) -> PeerCerts {
+    /// Self-signed leaf with arbitrary DNS SANs, as a chain.
+    fn peer_certs_with_dns_sans(sans: &[&str]) -> Vec<CertificateDer<'static>> {
         let key = KeyPair::generate().unwrap();
         let mut params = CertificateParams::default();
         params.subject_alt_names = sans
@@ -324,7 +325,7 @@ mod tests {
             .map(|s| SanType::DnsName((*s).try_into().unwrap()))
             .collect();
         let cert = params.self_signed(&key).unwrap();
-        PeerCerts(Arc::from(vec![CertificateDer::from(cert.der().to_vec())]))
+        vec![CertificateDer::from(cert.der().to_vec())]
     }
 
     #[test]


### PR DESCRIPTION
Fixes #89

`RequestContext` was a `pub`-fields struct without `#[non_exhaustive]`, so any new field is a SemVer break. We've already grown it once (mTLS routed connection-scoped data through `extensions` precisely to avoid a new field), and the post-0.4.0 ergonomics review identified several more candidate fields — service name, method name, RPC kind, negotiated protocol — all wanted by generic middleware and interceptors. This PR locks the contract before any of them land under pressure.

### What changed

`RequestContext` is now `#[non_exhaustive]` with `pub(crate)` fields. Fields are read through accessors:

| Old | New |
|---|---|
| `ctx.headers` | `ctx.headers()` (`ctx.header(name)` for a single lookup is unchanged) |
| `ctx.deadline` | `ctx.deadline()` |
| `ctx.extensions` | `ctx.extensions()` |

Construction (`RequestContext::new(headers)`, `.with_deadline()`, `.with_extensions()`) is unchanged, so dispatch code and test setup don't move.

### Additive accessors

- `time_remaining()` — saturating `Duration` until the deadline. Lets handlers budget downstream calls without doing the `deadline - Instant::now()` arithmetic and underflow check themselves. This is the read side of the deadline-enforcement work in #92.
- `extensions_mut()` — for tower middleware or test shims that construct a `RequestContext` directly and need to insert connection-scoped values before dispatch.
- `peer_addr()` (`server` feature) and `peer_certs()` (`server-tls` feature) — typed extension lookups for the well-known peer types. They return `None` when the transport didn't insert the value, replacing the `ctx.extensions.get::<PeerAddr>().unwrap()` pattern that compiles, passes in unit tests, and panics in production behind a transport that didn't insert it.

### Migration

Mechanical for almost everyone: add parentheses. The mtls-identity example, conformance server, middleware example, and the user guide are updated in this PR as the model migration. The mtls-identity `extract_identity` signature changes from `Option<&PeerCerts>` to `Option<&[CertificateDer<'static>]>` to match what `ctx.peer_certs()` returns — that's the one non-trivial change.

### Verification

`task lint`, `task test`, `cargo check -p connectrpc --no-default-features`, `cargo check -p connectrpc --all-features`, and `cargo doc -p connectrpc --all-features` (intra-doc-link check) are all clean. Net change excluding tests: ~180 lines.
