### PR TITLE
service: DeadlinePolicy for server-side timeout moderation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,38 @@ increment the patch version.
   build and return the owned message (or `MaybeBorrowed::Owned`) so the
   codec layer can skip the proto round-trip.
 
+- **`DeadlinePolicy`** — server-side moderation of client-asserted RPC
+  deadlines. Clients control the per-request timeout via
+  `Connect-Timeout-Ms` / `grpc-timeout`; without a policy the server
+  trusts that value verbatim. `DeadlinePolicy` clamps the asserted
+  timeout to a server-controlled `[min, max]` range, applies a default
+  when the client asserts nothing (or sends an unparseable header), and
+  optionally extends enforcement to streaming bodies.
+
+  Configure via `ConnectRpcService::with_deadline_policy(...)` (axum /
+  tower) or `Server::with_deadline_policy(...)`. `DeadlinePolicy::new()`
+  is a no-op policy that preserves the prior default behavior — no
+  clamping, no default, streaming bodies unbounded once the handler
+  returns. Existing services see no change without an explicit opt-in.
+  Recommended production starting point: set at least `with_max(...)` to
+  bound worker lifetime and `with_default_timeout(...)` to your SLA.
+
+  Two independent opt-in extensions, both off by default:
+  - `with_enforce_on_streams(true)` wraps server- and bidi-streaming
+    response bodies so the next item after the deadline is a
+    `deadline_exceeded` error and the stream ends. Unary and
+    client-streaming responses were already bounded by the handler
+    future timeout; this closes the streaming-body gap.
+  - `with_inter_message_timeout(d)` cuts off a stream that goes longer
+    than `d` between yielded items (a stalled handler waiting on a slow
+    upstream). Takes effect whenever set, with or without
+    `with_enforce_on_streams`.
+
+  When clamping changes a client value, a `tracing::debug!` event fires
+  on target `connectrpc::deadline` with the path and before/after
+  durations. Per-route deadline policy is a planned follow-up coupled
+  to the typed routing surface (#91).
+
 ### Breaking
 
 These are breaking under semver but the practical blast radius is

--- a/connectrpc/src/deadline.rs
+++ b/connectrpc/src/deadline.rs
@@ -1,0 +1,592 @@
+//! Server-side moderation and enforcement of client-asserted RPC deadlines.
+//!
+//! Connect and gRPC clients send a per-request timeout header
+//! (`Connect-Timeout-Ms` or `grpc-timeout`). Without moderation, a client
+//! controls server resource lifetime: a `Connect-Timeout-Ms: 1` request
+//! cancels the handler before it starts, while a `Connect-Timeout-Ms:
+//! 86400000` request holds a worker for 24 hours. [`DeadlinePolicy`] gives
+//! the server a place to clamp the asserted value to an operationally sane
+//! range, supply a default when the client asserts nothing, and (opt-in)
+//! extend enforcement to streaming response bodies.
+//!
+//! The stream-body deadline wrapper bounds work driven by polling the
+//! response stream. Handlers that `tokio::spawn` detached tasks must clean
+//! those up themselves; the wrapper drops the response stream future,
+//! which propagates cancellation to anything awaited inside it but not to
+//! spawned tasks.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::Stream;
+use pin_project::pin_project;
+use tokio::time::Sleep;
+
+use crate::error::ConnectError;
+use crate::handler::BoxStream;
+
+/// Server-side moderation of client-asserted RPC deadlines.
+///
+/// Clients send a `Connect-Timeout-Ms` (or `grpc-timeout`) header that the
+/// server uses to bound the request. Without moderation a client can
+/// assert an absurdly short timeout — forcing premature cancellation
+/// mid-write — or an absurdly long one — holding server resources for
+/// hours. `DeadlinePolicy` clamps the client value to a server-controlled
+/// range, applies a server-side default when the client asserts nothing,
+/// and can extend enforcement to streaming bodies (whose initial setup is
+/// already bounded by the server's `tokio::time::timeout`, but whose item
+/// stream is unbounded by default).
+///
+/// Construct via [`DeadlinePolicy::new`] and the `with_*` builders; the
+/// field set is `#[non_exhaustive]` so struct-literal construction is not
+/// available outside the crate.
+///
+/// ## Default behavior
+///
+/// [`DeadlinePolicy::new`] is a no-op policy: `min` is zero, `max` and
+/// `default` are unset, and `enforce_on_streams` and `inter_message_timeout`
+/// are off. Existing services that don't set a policy see no behavioral
+/// change relative to prior releases. Services expecting untrusted clients
+/// should set at least a [`with_max`] cap.
+///
+/// ## Combination matrix
+///
+/// With `min = 10ms`, `max = 100ms`, `default = 50ms`:
+///
+/// | Client asserts | Effective timeout | Why |
+/// |---|---|---|
+/// | `20ms` | `20ms` | in range, passthrough |
+/// | `1ms` | `10ms` | clamped up to `min` (debug log) |
+/// | `500ms` | `100ms` | clamped down to `max` (debug log) |
+/// | (none) | `50ms` | `default` applied |
+/// | `garbage` | `50ms` | unparseable header treated as absent |
+/// | (none, no `default`) | (none) | unbounded |
+///
+/// ## Example
+///
+/// ```rust
+/// use connectrpc::DeadlinePolicy;
+/// use std::time::Duration;
+///
+/// // A policy suitable for a low-latency online service: clamp client
+/// // values to 5ms–10s, default to 5s when the client asserts nothing,
+/// // and cut off any stream that runs past the deadline.
+/// let policy = DeadlinePolicy::new()
+///     .with_min(Duration::from_millis(5))
+///     .with_max(Duration::from_secs(10))
+///     .with_default_timeout(Duration::from_secs(5))
+///     .with_enforce_on_streams(true);
+/// assert_eq!(policy.max(), Some(Duration::from_secs(10)));
+/// ```
+///
+/// [`with_max`]: DeadlinePolicy::with_max
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub struct DeadlinePolicy {
+    /// Floor: client values below this are clamped up. Defaults to
+    /// `Duration::ZERO`, which is a no-op floor.
+    min: Duration,
+    /// Cap: client values above this are clamped down. `None` = no cap.
+    max: Option<Duration>,
+    /// Applied when the client asserts no timeout (or an unparseable one).
+    default: Option<Duration>,
+    /// Whether to wrap streaming bodies (server/bidi) in the absolute
+    /// deadline. `false` (the default) preserves the prior default
+    /// behavior: only the time-to-first-response is bounded. Independent
+    /// of [`inter_message_timeout`](Self::inter_message_timeout).
+    enforce_on_streams: bool,
+    /// Maximum gap between yielded items on a streaming body. Detects
+    /// stalled handlers waiting on slow upstreams. `None` = no per-item
+    /// bound. Independent of [`enforce_on_streams`](Self::enforce_on_streams):
+    /// setting this enables the per-item timer regardless of whether the
+    /// absolute deadline is enforced.
+    inter_message_timeout: Option<Duration>,
+}
+
+impl DeadlinePolicy {
+    /// Create a no-op policy — no clamping, no default timeout, no stream
+    /// enforcement. Preserves the prior default behavior.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the floor for client-asserted timeouts. Client values below
+    /// this are clamped up before enforcement.
+    ///
+    /// Protects against premature cancellation from a misbehaving or
+    /// adversarial client asserting a near-zero timeout. Defaults to
+    /// [`Duration::ZERO`], a no-op floor.
+    #[must_use]
+    pub fn with_min(mut self, min: Duration) -> Self {
+        self.min = min;
+        self
+    }
+
+    /// Set the cap for client-asserted timeouts. Client values above this
+    /// are clamped down before enforcement.
+    ///
+    /// Protects server resources against a client asserting an
+    /// unreasonably long timeout. There is no default cap — set one for
+    /// any service that accepts untrusted callers.
+    #[must_use]
+    pub fn with_max(mut self, max: Duration) -> Self {
+        self.max = Some(max);
+        self
+    }
+
+    /// Set the timeout applied when the client asserts none.
+    ///
+    /// Without a default, a request with no timeout header runs unbounded.
+    /// Setting this to your SLA is the cheapest hardening step a service
+    /// can take. The default is server-controlled and is not subject to
+    /// the `min`/`max` clamps — those guard against the *client*.
+    #[must_use]
+    pub fn with_default_timeout(mut self, default: Duration) -> Self {
+        self.default = Some(default);
+        self
+    }
+
+    /// Extend the absolute-deadline enforcement to streaming response
+    /// bodies.
+    ///
+    /// By default only the time-to-first-response is bounded by the
+    /// deadline: a server- or bidi-streaming handler that returns its
+    /// stream quickly can yield items unbounded thereafter. Setting this
+    /// to `true` wraps the response body so the next item after the
+    /// deadline is a [`deadline_exceeded`](ConnectError::deadline_exceeded)
+    /// error, after which the stream ends.
+    ///
+    /// On the wire: Connect emits `code: deadline_exceeded` in the
+    /// trailing `EndStreamResponse` JSON; gRPC emits `grpc-status: 4` in
+    /// trailing headers.
+    ///
+    /// Cancellation drops the inner stream at the next yield point — the
+    /// standard Rust idiom, no grace period. A handler that needs to
+    /// commit work after the client gives up should `tokio::spawn` the
+    /// commit-critical path off the request future, or leave this `false`.
+    ///
+    /// Independent of [`with_inter_message_timeout`](Self::with_inter_message_timeout):
+    /// this knob controls the *absolute* deadline; the inter-message timer
+    /// can be set with or without it.
+    #[must_use]
+    pub fn with_enforce_on_streams(mut self, enforce: bool) -> Self {
+        self.enforce_on_streams = enforce;
+        self
+    }
+
+    /// Set the maximum gap between yielded items on a streaming body.
+    ///
+    /// Detects stalled handlers — a stream that goes quiet for longer
+    /// than this errors with
+    /// [`deadline_exceeded`](ConnectError::deadline_exceeded) and ends.
+    /// Independent of [`with_enforce_on_streams`](Self::with_enforce_on_streams):
+    /// the per-item timer takes effect whenever this is set, regardless of
+    /// whether the absolute deadline is also enforced on the stream.
+    #[must_use]
+    pub fn with_inter_message_timeout(mut self, timeout: Duration) -> Self {
+        self.inter_message_timeout = Some(timeout);
+        self
+    }
+
+    /// The configured floor (defaults to [`Duration::ZERO`]).
+    #[must_use]
+    pub fn min(&self) -> Duration {
+        self.min
+    }
+
+    /// The configured cap, or `None` if none is set.
+    #[must_use]
+    pub fn max(&self) -> Option<Duration> {
+        self.max
+    }
+
+    /// The configured default timeout, or `None` if none is set.
+    #[must_use]
+    pub fn default_timeout(&self) -> Option<Duration> {
+        self.default
+    }
+
+    /// Whether streaming response bodies are wrapped in the absolute
+    /// deadline.
+    #[must_use]
+    pub fn enforce_on_streams(&self) -> bool {
+        self.enforce_on_streams
+    }
+
+    /// The configured inter-message timeout, or `None` if none is set.
+    #[must_use]
+    pub fn inter_message_timeout(&self) -> Option<Duration> {
+        self.inter_message_timeout
+    }
+
+    /// Apply the policy to a client-asserted timeout.
+    ///
+    /// Returns the *effective* timeout the server will enforce: `client`
+    /// clamped to `[min, max]`, or `default` when `client` is `None`
+    /// (the request had no timeout header or the header was unparseable).
+    /// Returns `None` when there is no effective bound.
+    ///
+    /// When clamping changes the client's value, emits a
+    /// `tracing::debug!` event (target `connectrpc::deadline`) with the
+    /// request path and the before/after durations so operators can spot
+    /// misbehaving clients.
+    pub(crate) fn moderate(&self, client: Option<Duration>, path: &str) -> Option<Duration> {
+        match client {
+            Some(asserted) => {
+                // `Ord::clamp` panics when `min > max`; if a misconfigured
+                // policy has `min > max`, treat `max` as the effective bound
+                // (the more conservative choice for server resource use).
+                let upper = self.max.unwrap_or(Duration::MAX);
+                let lower = self.min.min(upper);
+                let clamped = asserted.clamp(lower, upper);
+                if clamped != asserted {
+                    tracing::debug!(
+                        target: "connectrpc::deadline",
+                        path,
+                        client_timeout_ms =
+                            u64::try_from(asserted.as_millis()).unwrap_or(u64::MAX),
+                        effective_timeout_ms =
+                            u64::try_from(clamped.as_millis()).unwrap_or(u64::MAX),
+                        "client-asserted timeout clamped by server DeadlinePolicy",
+                    );
+                }
+                Some(clamped)
+            }
+            None => self.default,
+        }
+    }
+
+    /// Wrap a streaming response body with deadline enforcement, if the
+    /// policy calls for it.
+    ///
+    /// `remaining` is the time left in the request's absolute deadline
+    /// budget at the point the stream starts (`None` if the request has
+    /// no deadline). The wrapper is created when either
+    /// `enforce_on_streams` is `true` *and* a deadline is in effect, or
+    /// `inter_message_timeout` is set — the two are independent. When
+    /// neither applies, the stream is returned unchanged so the no-op
+    /// policy adds no overhead.
+    ///
+    /// Requires a tokio runtime; constructs `tokio::time::Sleep` internally.
+    pub(crate) fn enforce_on_response_stream(
+        &self,
+        stream: BoxStream<Result<Bytes, ConnectError>>,
+        remaining: Option<Duration>,
+    ) -> BoxStream<Result<Bytes, ConnectError>> {
+        let absolute = if self.enforce_on_streams {
+            remaining
+        } else {
+            None
+        };
+        // Independent of `enforce_on_streams` — a per-item timer is useful
+        // even on requests that have no absolute deadline.
+        let per_item = self.inter_message_timeout;
+        if absolute.is_none() && per_item.is_none() {
+            return stream;
+        }
+        Box::pin(DeadlineStream::new(stream, absolute, per_item))
+    }
+}
+
+/// A streaming body wrapper that enforces an absolute deadline and an
+/// optional inter-message timeout.
+///
+/// On either bound lapsing, yields a single
+/// [`deadline_exceeded`](ConnectError::deadline_exceeded) error and then
+/// ends. The inner stream is dropped on the first poll after the bound
+/// lapses.
+#[pin_project]
+struct DeadlineStream<S> {
+    #[pin]
+    inner: Option<S>,
+    /// Absolute deadline timer, armed once at construction.
+    #[pin]
+    absolute: Option<Sleep>,
+    /// Inter-message timer, re-armed after each yielded item.
+    #[pin]
+    per_item: Option<Sleep>,
+    inter_message: Option<Duration>,
+    finished: bool,
+}
+
+impl<S> DeadlineStream<S> {
+    fn new(inner: S, absolute: Option<Duration>, inter_message: Option<Duration>) -> Self {
+        Self {
+            inner: Some(inner),
+            absolute: absolute.map(tokio::time::sleep),
+            per_item: inter_message.map(tokio::time::sleep),
+            inter_message,
+            finished: false,
+        }
+    }
+}
+
+impl<S> Stream for DeadlineStream<S>
+where
+    S: Stream<Item = Result<Bytes, ConnectError>>,
+{
+    type Item = Result<Bytes, ConnectError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        if *this.finished {
+            return Poll::Ready(None);
+        }
+
+        // Check the absolute deadline first — once it lapses the whole
+        // request is over regardless of per-item progress.
+        if let Some(sleep) = this.absolute.as_mut().as_pin_mut()
+            && sleep.poll(cx).is_ready()
+        {
+            *this.finished = true;
+            this.inner.set(None);
+            return Poll::Ready(Some(Err(ConnectError::deadline_exceeded(
+                "request deadline exceeded while streaming",
+            ))));
+        }
+
+        // Then the inter-message timer — detects a stalled handler.
+        if let Some(sleep) = this.per_item.as_mut().as_pin_mut()
+            && sleep.poll(cx).is_ready()
+        {
+            *this.finished = true;
+            this.inner.set(None);
+            return Poll::Ready(Some(Err(ConnectError::deadline_exceeded(
+                "stream stalled past inter-message timeout",
+            ))));
+        }
+
+        // Poll the inner stream.
+        let Some(inner) = this.inner.as_mut().as_pin_mut() else {
+            *this.finished = true;
+            return Poll::Ready(None);
+        };
+        match inner.poll_next(cx) {
+            Poll::Ready(Some(item)) => {
+                // Re-arm the inter-message timer for the next gap.
+                if let Some(d) = this.inter_message {
+                    this.per_item.set(Some(tokio::time::sleep(*d)));
+                }
+                Poll::Ready(Some(item))
+            }
+            Poll::Ready(None) => {
+                *this.finished = true;
+                this.inner.set(None);
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn no_op_policy_is_passthrough() {
+        let p = DeadlinePolicy::new();
+        assert_eq!(p.moderate(Some(ms(5)), "/svc/m"), Some(ms(5)));
+        assert_eq!(p.moderate(None, "/svc/m"), None);
+    }
+
+    #[test]
+    fn min_clamps_up() {
+        let p = DeadlinePolicy::new().with_min(ms(10));
+        assert_eq!(p.moderate(Some(ms(1)), "/svc/m"), Some(ms(10)));
+        assert_eq!(p.moderate(Some(ms(50)), "/svc/m"), Some(ms(50)));
+    }
+
+    #[test]
+    fn max_clamps_down() {
+        let p = DeadlinePolicy::new().with_max(ms(100));
+        assert_eq!(p.moderate(Some(ms(500)), "/svc/m"), Some(ms(100)));
+        assert_eq!(p.moderate(Some(ms(50)), "/svc/m"), Some(ms(50)));
+    }
+
+    #[test]
+    fn default_applies_when_client_absent() {
+        let p = DeadlinePolicy::new().with_default_timeout(ms(200));
+        assert_eq!(p.moderate(None, "/svc/m"), Some(ms(200)));
+        // Default does NOT replace an asserted value.
+        assert_eq!(p.moderate(Some(ms(50)), "/svc/m"), Some(ms(50)));
+    }
+
+    #[test]
+    fn no_default_no_client_is_unbounded() {
+        let p = DeadlinePolicy::new().with_min(ms(1)).with_max(ms(100));
+        assert_eq!(p.moderate(None, "/svc/m"), None);
+    }
+
+    #[test]
+    fn misconfigured_min_above_max_does_not_panic() {
+        // `Ord::clamp` panics on `min > max`; the policy must not. The
+        // conservative choice (smallest server resource use) is to honor
+        // `max` as both bounds.
+        let p = DeadlinePolicy::new().with_min(ms(500)).with_max(ms(100));
+        assert_eq!(p.moderate(Some(ms(1)), "/svc/m"), Some(ms(100)));
+        assert_eq!(p.moderate(Some(ms(700)), "/svc/m"), Some(ms(100)));
+    }
+
+    #[test]
+    fn full_matrix() {
+        let p = DeadlinePolicy::new()
+            .with_min(ms(10))
+            .with_max(ms(100))
+            .with_default_timeout(ms(50));
+        // In range — passthrough.
+        assert_eq!(p.moderate(Some(ms(20)), "/svc/m"), Some(ms(20)));
+        // Below min — clamp up.
+        assert_eq!(p.moderate(Some(ms(1)), "/svc/m"), Some(ms(10)));
+        // Above max — clamp down.
+        assert_eq!(p.moderate(Some(ms(500)), "/svc/m"), Some(ms(100)));
+        // Absent — default.
+        assert_eq!(p.moderate(None, "/svc/m"), Some(ms(50)));
+        // Boundary.
+        assert_eq!(p.moderate(Some(ms(10)), "/svc/m"), Some(ms(10)));
+        assert_eq!(p.moderate(Some(ms(100)), "/svc/m"), Some(ms(100)));
+    }
+
+    #[test]
+    fn accessors_round_trip() {
+        let p = DeadlinePolicy::new()
+            .with_min(ms(1))
+            .with_max(ms(2))
+            .with_default_timeout(ms(3))
+            .with_enforce_on_streams(true)
+            .with_inter_message_timeout(ms(4));
+        assert_eq!(p.min(), ms(1));
+        assert_eq!(p.max(), Some(ms(2)));
+        assert_eq!(p.default_timeout(), Some(ms(3)));
+        assert!(p.enforce_on_streams());
+        assert_eq!(p.inter_message_timeout(), Some(ms(4)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn enforce_no_op_returns_original_stream() {
+        // With enforce_on_streams=false and no inter_message_timeout, the
+        // stream is returned unchanged (no allocation, no wrapper) and runs
+        // unbounded — even when a deadline is nominally in effect.
+        let p = DeadlinePolicy::new();
+        let inner: BoxStream<Result<Bytes, ConnectError>> = Box::pin(
+            futures::stream::iter([Ok(Bytes::from_static(b"a"))]).chain(futures::stream::pending()),
+        );
+        let mut wrapped = p.enforce_on_response_stream(inner, Some(ms(1)));
+        assert_eq!(
+            wrapped.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"a")
+        );
+        // Advance well past what would have been the deadline; the
+        // unwrapped stream stays pending rather than erroring.
+        tokio::time::advance(ms(10)).await;
+        let pending = futures::poll!(wrapped.next());
+        assert!(pending.is_pending());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fast_stream_completes_under_deadline() {
+        let p = DeadlinePolicy::new().with_enforce_on_streams(true);
+        let inner: BoxStream<Result<Bytes, ConnectError>> = Box::pin(futures::stream::iter([
+            Ok(Bytes::from_static(b"a")),
+            Ok(Bytes::from_static(b"b")),
+        ]));
+        let mut wrapped = p.enforce_on_response_stream(inner, Some(Duration::from_secs(60)));
+        assert_eq!(
+            wrapped.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"a")
+        );
+        assert_eq!(
+            wrapped.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"b")
+        );
+        assert!(wrapped.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn slow_stream_cut_off_at_deadline() {
+        let p = DeadlinePolicy::new().with_enforce_on_streams(true);
+        // A stream that yields one item then hangs forever.
+        let inner: BoxStream<Result<Bytes, ConnectError>> = Box::pin(
+            futures::stream::iter([Ok(Bytes::from_static(b"a"))]).chain(futures::stream::pending()),
+        );
+        let mut wrapped = p.enforce_on_response_stream(inner, Some(ms(100)));
+        assert_eq!(
+            wrapped.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"a")
+        );
+        // Advance past the deadline. With `start_paused`, the next poll
+        // sees the lapsed deadline.
+        tokio::time::advance(ms(200)).await;
+        let err = wrapped.next().await.unwrap().unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::DeadlineExceeded);
+        // After the error, the stream is finished.
+        assert!(wrapped.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inter_message_timeout_cuts_off_stalled_stream() {
+        let p = DeadlinePolicy::new()
+            .with_enforce_on_streams(true)
+            .with_inter_message_timeout(ms(50));
+        // Yields one item, then stalls forever — never reaches the
+        // (long) absolute deadline, but the inter-message timer fires.
+        let inner: BoxStream<Result<Bytes, ConnectError>> = Box::pin(
+            futures::stream::iter([Ok(Bytes::from_static(b"a"))]).chain(futures::stream::pending()),
+        );
+        let mut wrapped = p.enforce_on_response_stream(inner, Some(Duration::from_secs(3600)));
+        assert_eq!(
+            wrapped.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"a")
+        );
+        tokio::time::advance(ms(100)).await;
+        let err = wrapped.next().await.unwrap().unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::DeadlineExceeded);
+        assert!(err.message.as_deref().unwrap().contains("inter-message"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inter_message_timeout_independent_of_enforce_on_streams() {
+        // `inter_message_timeout` is independent of `enforce_on_streams`:
+        // the per-item timer takes effect even when the absolute deadline
+        // is not enforced on the stream.
+        let p = DeadlinePolicy::new().with_inter_message_timeout(ms(50));
+        assert!(!p.enforce_on_streams());
+        let inner: BoxStream<Result<Bytes, ConnectError>> = Box::pin(
+            futures::stream::iter([Ok(Bytes::from_static(b"a"))]).chain(futures::stream::pending()),
+        );
+        // No absolute deadline at all — only the per-item timer runs.
+        let mut wrapped = p.enforce_on_response_stream(inner, None);
+        assert_eq!(
+            wrapped.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"a")
+        );
+        tokio::time::advance(ms(100)).await;
+        let err = wrapped.next().await.unwrap().unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::DeadlineExceeded);
+        assert!(err.message.as_deref().unwrap().contains("inter-message"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn no_deadline_no_inter_message_streams_unbounded() {
+        // enforce_on_streams=true but no deadline (no client timeout, no
+        // default) and no inter_message_timeout — the wrapper is skipped.
+        let p = DeadlinePolicy::new().with_enforce_on_streams(true);
+        let inner: BoxStream<Result<Bytes, ConnectError>> =
+            Box::pin(futures::stream::iter([Ok(Bytes::from_static(b"a"))]));
+        let mut wrapped = p.enforce_on_response_stream(inner, None);
+        assert_eq!(
+            wrapped.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"a")
+        );
+        assert!(wrapped.next().await.is_none());
+    }
+}

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -181,6 +181,7 @@ where
 // Core modules (always available)
 pub mod codec;
 pub mod compression;
+pub mod deadline;
 pub mod dispatcher;
 pub mod envelope;
 pub mod error;
@@ -283,6 +284,12 @@ pub use compression::CompressionPolicy;
 pub use compression::CompressionProvider;
 pub use compression::CompressionRegistry;
 pub use compression::DEFAULT_COMPRESSION_MIN_SIZE;
+
+// ============================================================================
+// Deadline exports
+// ============================================================================
+
+pub use deadline::DeadlinePolicy;
 
 #[cfg(feature = "gzip")]
 pub use compression::GzipProvider;

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -39,6 +39,11 @@ pub struct RequestContext {
     pub headers: HeaderMap,
     /// Absolute request deadline parsed from the protocol's timeout header,
     /// if any. Propagate to downstream calls.
+    ///
+    /// If a [`DeadlinePolicy`](crate::DeadlinePolicy) is configured on the
+    /// service, this is the *moderated* value — clamped to the policy's
+    /// `[min, max]` range, or the policy default when the client asserted
+    /// nothing — not the raw client header.
     pub deadline: Option<Instant>,
     /// Request extensions carried from the underlying `http::Request`.
     ///

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -194,6 +194,20 @@ impl Server {
         self
     }
 
+    /// Configure server-side moderation of client-asserted RPC deadlines.
+    ///
+    /// Delegates to [`ConnectRpcService::with_deadline_policy`]. The
+    /// default [`DeadlinePolicy::new`](crate::DeadlinePolicy::new) is a
+    /// no-op: client timeout headers are honored verbatim and streaming
+    /// bodies are unbounded once the handler returns. Set a policy to
+    /// clamp, supply a default, or enforce on streams. See
+    /// [`DeadlinePolicy`](crate::DeadlinePolicy).
+    #[must_use]
+    pub fn with_deadline_policy(mut self, policy: crate::DeadlinePolicy) -> Self {
+        self.service = self.service.with_deadline_policy(policy);
+        self
+    }
+
     /// Get a reference to the underlying router.
     pub fn router(&self) -> &Router {
         self.service.dispatcher()

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -56,6 +56,7 @@ use crate::codec::content_type;
 use crate::codec::header as connect_header;
 use crate::compression::CompressionPolicy;
 use crate::compression::CompressionRegistry;
+use crate::deadline::DeadlinePolicy;
 use crate::dispatcher::Dispatcher;
 use crate::envelope::Envelope;
 use crate::error::ConnectError;
@@ -1097,6 +1098,7 @@ pub struct ConnectRpcService<D = Router> {
     /// op instead of the registry's three internal Arc fields.
     compression: Arc<CompressionRegistry>,
     compression_policy: CompressionPolicy,
+    deadline_policy: DeadlinePolicy,
 }
 
 // Manual Clone impl because `#[derive(Clone)]` would add a `D: Clone` bound,
@@ -1108,6 +1110,7 @@ impl<D> Clone for ConnectRpcService<D> {
             limits: self.limits.clone(),
             compression: Arc::clone(&self.compression),
             compression_policy: self.compression_policy,
+            deadline_policy: self.deadline_policy.clone(),
         }
     }
 }
@@ -1126,6 +1129,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
             limits: Limits::default(),
             compression: Arc::new(CompressionRegistry::default()),
             compression_policy: CompressionPolicy::default(),
+            deadline_policy: DeadlinePolicy::new(),
         }
     }
 
@@ -1136,6 +1140,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
             limits: Limits::default(),
             compression: Arc::new(CompressionRegistry::default()),
             compression_policy: CompressionPolicy::default(),
+            deadline_policy: DeadlinePolicy::new(),
         }
     }
 
@@ -1166,6 +1171,27 @@ impl<D: Dispatcher> ConnectRpcService<D> {
     pub fn with_compression_policy(mut self, policy: CompressionPolicy) -> Self {
         self.compression_policy = policy;
         self
+    }
+
+    /// Configure server-side moderation of client-asserted RPC deadlines.
+    ///
+    /// The default [`DeadlinePolicy::new`] is a no-op: the client's
+    /// `Connect-Timeout-Ms` / `grpc-timeout` header is honored verbatim
+    /// and streaming bodies are not bounded by it (only the time-to-
+    /// first-response is). Set a policy to clamp client values to an
+    /// operationally sane range, supply a default when the client
+    /// asserts nothing, or extend enforcement to streaming bodies. See
+    /// [`DeadlinePolicy`] for details and recommendations.
+    #[must_use]
+    pub fn with_deadline_policy(mut self, policy: DeadlinePolicy) -> Self {
+        self.deadline_policy = policy;
+        self
+    }
+
+    /// Get the current deadline policy.
+    #[must_use]
+    pub fn deadline_policy(&self) -> &DeadlinePolicy {
+        &self.deadline_policy
     }
 
     /// Get the current limits configuration.
@@ -1266,6 +1292,7 @@ where
         let limits = self.limits.clone();
         let compression = Arc::clone(&self.compression);
         let compression_policy = self.compression_policy;
+        let deadline_policy = self.deadline_policy.clone();
 
         // Only create and attach the tracing span when a subscriber would
         // actually observe it. For disabled-debug (the common production case),
@@ -1287,13 +1314,19 @@ where
         };
 
         let fut = async move {
-            let response =
-                match handle_request(dispatcher, req, limits, compression, &compression_policy)
-                    .await
-                {
-                    Ok(response) => response,
-                    Err(err) => error_response_either(err),
-                };
+            let response = match handle_request(
+                dispatcher,
+                req,
+                limits,
+                compression,
+                &compression_policy,
+                &deadline_policy,
+            )
+            .await
+            {
+                Ok(response) => response,
+                Err(err) => error_response_either(err),
+            };
             Ok(response)
         };
 
@@ -1311,6 +1344,7 @@ async fn handle_request<D, B>(
     limits: Limits,
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
+    deadline_policy: &DeadlinePolicy,
 ) -> Result<Response<ConnectRpcBody>, ConnectError>
 where
     D: Dispatcher,
@@ -1330,9 +1364,16 @@ where
     // detection returns None. Route GET requests directly to the unary handler
     // which handles Connect GET query parameter parsing.
     if req.method() == Method::GET {
-        return handle_unary_request(&*dispatcher, req, limits, compression, compression_policy)
-            .await
-            .map(|r| r.map(ConnectRpcBody::Full));
+        return handle_unary_request(
+            &*dispatcher,
+            req,
+            limits,
+            compression,
+            compression_policy,
+            deadline_policy,
+        )
+        .await
+        .map(|r| r.map(ConnectRpcBody::Full));
     }
 
     // Check for gRPC/gRPC-Web content type prefix with unsupported codec
@@ -1413,6 +1454,7 @@ where
                         limits,
                         compression,
                         compression_policy,
+                        deadline_policy,
                     )
                     .await;
                     return Ok(response.map(ConnectRpcBody::GrpcUnary));
@@ -1428,15 +1470,23 @@ where
                 limits,
                 compression,
                 compression_policy,
+                deadline_policy,
             )
             .await;
             Ok(response.map(ConnectRpcBody::Streaming))
         }
         Some(_) | None => {
             // Unary request (Connect unary) or unknown content type (for error reporting)
-            handle_unary_request(&*dispatcher, req, limits, compression, compression_policy)
-                .await
-                .map(|r| r.map(ConnectRpcBody::Full))
+            handle_unary_request(
+                &*dispatcher,
+                req,
+                limits,
+                compression,
+                compression_policy,
+                deadline_policy,
+            )
+            .await
+            .map(|r| r.map(ConnectRpcBody::Full))
         }
     }
 }
@@ -1448,6 +1498,7 @@ async fn handle_unary_request<D, B>(
     limits: Limits,
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
+    deadline_policy: &DeadlinePolicy,
 ) -> Result<Response<Full<Bytes>>, ConnectError>
 where
     D: Dispatcher,
@@ -1461,7 +1512,8 @@ where
     let method = req.method().clone();
 
     // Extract metadata from headers using the Connect protocol (unary is always Connect)
-    let metadata = RequestMetadata::from_headers(req.headers(), Protocol::Connect);
+    let mut metadata = RequestMetadata::from_headers(req.headers(), Protocol::Connect);
+    metadata.timeout = deadline_policy.moderate(metadata.timeout, &path);
 
     // Split request to consume the body
     let (parts, body) = req.into_parts();
@@ -1647,6 +1699,7 @@ async fn handle_grpc_unary_request<D, B>(
     limits: Limits,
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
+    deadline_policy: &DeadlinePolicy,
 ) -> Response<GrpcUnaryBody>
 where
     D: Dispatcher,
@@ -1704,7 +1757,8 @@ where
     }
 
     // Extract metadata
-    let metadata = RequestMetadata::from_headers(req.headers(), protocol);
+    let mut metadata = RequestMetadata::from_headers(req.headers(), protocol);
+    metadata.timeout = deadline_policy.moderate(metadata.timeout, path);
 
     // Validate request compression
     if let Some(ref encoding) = metadata.streaming_encoding
@@ -1895,6 +1949,7 @@ async fn handle_streaming_request<D, B>(
     limits: Limits,
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
+    deadline_policy: &DeadlinePolicy,
 ) -> Response<StreamingResponseBody>
 where
     D: Dispatcher,
@@ -1916,7 +1971,8 @@ where
     }
 
     // Extract metadata from headers using the detected protocol
-    let metadata = RequestMetadata::from_headers(req.headers(), protocol);
+    let mut metadata = RequestMetadata::from_headers(req.headers(), protocol);
+    metadata.timeout = deadline_policy.moderate(metadata.timeout, &path);
 
     // Validate request compression is supported (if specified)
     if let Some(ref encoding) = metadata.streaming_encoding
@@ -1951,6 +2007,7 @@ where
             limits,
             compression,
             compression_policy,
+            deadline_policy,
         )
         .await;
     }
@@ -2140,8 +2197,13 @@ where
 
     let stream_compression = response_encoding.map(|encoding| (compression, encoding));
     let effective_policy = compression_policy.with_override(resp.compress);
+    // Time remaining in the absolute deadline budget at the point the
+    // stream starts; the wrapper arms a `tokio::time::sleep` from this so
+    // the deadline does not shift relative to request arrival.
+    let remaining = deadline.map(|d| d.saturating_duration_since(std::time::Instant::now()));
+    let resp_body = deadline_policy.enforce_on_response_stream(resp.body, remaining);
     let body = StreamingResponseBody::new(
-        resp.body,
+        resp_body,
         resp.trailers,
         protocol,
         stream_compression,
@@ -2430,6 +2492,7 @@ async fn handle_bidi_streaming_request<D, B>(
     limits: Limits,
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
+    deadline_policy: &DeadlinePolicy,
 ) -> Response<StreamingResponseBody>
 where
     D: Dispatcher,
@@ -2509,8 +2572,13 @@ where
 
     let stream_compression = response_encoding.map(|encoding| (compression, encoding));
     let effective_policy = compression_policy.with_override(resp.compress);
+    // Time remaining in the absolute deadline budget at the point the
+    // stream starts; the wrapper arms a `tokio::time::sleep` from this so
+    // the deadline does not shift relative to request arrival.
+    let remaining = deadline.map(|d| d.saturating_duration_since(std::time::Instant::now()));
+    let resp_body = deadline_policy.enforce_on_response_stream(resp.body, remaining);
     let body = StreamingResponseBody::new(
-        resp.body,
+        resp_body,
         resp.trailers,
         protocol,
         stream_compression,
@@ -3420,6 +3488,7 @@ mod tests {
             Limits::default(),
             Arc::new(CompressionRegistry::new()),
             &CompressionPolicy::default(),
+            &DeadlinePolicy::new(),
         )
         .await
         .expect("dispatch should succeed");

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -704,6 +704,74 @@ mtls-identity example
 demonstrates `serve_tls` end-to-end with cert-SAN identity extraction
 and an ACL keyed on it.
 
+## Production hardening
+
+### Deadline policy
+
+Connect and gRPC clients send a per-request timeout header
+(`Connect-Timeout-Ms` or `grpc-timeout`). With no policy, the server
+trusts that value verbatim: a `Connect-Timeout-Ms: 1` request cancels
+the handler mid-write, while a `Connect-Timeout-Ms: 86400000` request
+holds a worker for 24 hours, and a request with no timeout header runs
+unbounded. `DeadlinePolicy` gives the server the say.
+
+```rust,ignore
+use connectrpc::{ConnectRpcService, DeadlinePolicy};
+use std::time::Duration;
+
+let policy = DeadlinePolicy::new()
+    .with_min(Duration::from_millis(5))           // floor: reject "cancel me instantly"
+    .with_max(Duration::from_secs(30))            // cap: bound worker lifetime
+    .with_default_timeout(Duration::from_secs(10)) // applied when client asserts nothing
+    .with_enforce_on_streams(true);               // also cut off streaming bodies
+
+let service = ConnectRpcService::new(router)
+    .with_deadline_policy(policy);
+// or: Server::new(router).with_deadline_policy(policy)
+```
+
+Why each knob:
+
+- **`with_max`** is the most important one for any service that accepts
+  untrusted callers — without it a client controls how long a worker
+  stays busy. Set it to your longest acceptable handler runtime.
+- **`with_default_timeout`** matters because the timeout header is
+  optional. A request that omits it has no bound at all unless you set
+  one. Set it to your SLA.
+- **`with_min`** protects against a misbehaving or adversarial client
+  cancelling the handler before it can do anything (e.g. mid-write on a
+  streaming response). A few milliseconds is usually enough.
+- **`with_enforce_on_streams(true)`** closes the streaming-body gap.
+  By default the deadline only bounds the time-to-first-response —
+  once a server- or bidi-streaming handler returns its stream, the
+  items flow unbounded. Enabling this wraps the response body so the
+  next item after the deadline is a `deadline_exceeded` error and the
+  stream ends. Cancellation drops the inner stream at the next yield
+  point with no grace period; spawn commit-critical work off the
+  request future if it must outlive the caller.
+- **`with_inter_message_timeout(d)`** detects stalled streams (a
+  handler waiting on a slow upstream). Independent of
+  `with_enforce_on_streams` — takes effect whenever set, with or
+  without the absolute deadline. Resets on each yielded item.
+
+`DeadlinePolicy::new()` with no `with_*` calls is a no-op that
+preserves the prior default behavior. Existing services see no change
+without opting in.
+
+When a client value is clamped, a `tracing::debug!` event fires on
+target `connectrpc::deadline` with the path and before/after
+durations. Enable `RUST_LOG=connectrpc::deadline=debug` to spot
+misbehaving clients.
+
+Inside a handler, `ctx.deadline` reflects the *moderated* value (after
+clamping), so the handler can budget downstream calls — propagate the
+remaining time minus a margin as the timeout for outbound RPCs:
+
+```rust,ignore
+use std::time::Instant;
+let remaining = ctx.deadline.map(|d| d.saturating_duration_since(Instant::now()));
+```
+
 ## Clients
 
 Enable the `client` feature for HTTP client support with connection


### PR DESCRIPTION
Fixes #92.

Adds `DeadlinePolicy` for server-side moderation of client-asserted RPC deadlines. A client controls the per-request timeout via `Connect-Timeout-Ms` / `grpc-timeout`; without a policy the server trusts that value verbatim — a 1ms request cancels the handler mid-write, a 24h request holds a worker indefinitely, no header means no bound, and once a streaming handler returns its stream the items flow unbounded regardless of the header.

`DeadlinePolicy` clamps the client value to a server-controlled `[min, max]`, supplies a default when the client asserts nothing (or sends garbage), and optionally extends enforcement to streaming response bodies and to the gap between yielded items.

```rust
let policy = DeadlinePolicy::new()
    .with_min(Duration::from_millis(5))
    .with_max(Duration::from_secs(30))
    .with_default(Duration::from_secs(10))
    .with_enforce_on_streams(true);
ConnectRpcService::new(router).with_deadline_policy(policy)
// or: Server::new(router).deadline_policy(policy)
```

`DeadlinePolicy::new()` is a strict no-op — no clamping, no default, no stream enforcement. **Existing services that don't set a policy see exactly the previous behavior**, so this is purely additive and safe in 0.5.0. The recommended production starting point is at least `with_max()` and `with_default()`.

`min` is `Duration` (not `Option`) because zero is a natural identity for a floor; `max`/`default` are `Option<Duration>` because there's no clean identity for them. The asymmetry is deliberate.

Stream-body enforcement (when `enforce_on_streams` is set) is a pin-projected wrapper applied to server- and bidi-streaming response bodies. Unary and client-streaming responses are already bounded by the existing `tokio::time::timeout` on the handler future. `inter_message_timeout` re-arms a per-item timer to detect stalled streams independent of the absolute deadline.

When a clamp changes the client value, a `tracing::debug!` event fires on target `connectrpc::deadline` with the path and before/after durations.

### Notes for reviewers

- `Server::with_deadline_policy()` is a new delegating builder (renamed from `deadline_policy()` after review to match `ConnectRpcService::with_deadline_policy` and avoid colliding with the same-named getter on `ConnectRpcService`). `Server` does not yet proxy `ConnectRpcService::with_compression()` / `with_compression_policy()` / `with_limits()` — that's a pre-existing gap; the `Server::from_service(ConnectRpcService::new(...).with_*(...))` path is the canonical way to set those today. Worth a follow-up to either add the missing proxies or document `from_service` as the configuration path.
- `enforce_on_streams` and `inter_message_timeout` are independent knobs — either alone wraps the stream. Both default off.
- `RequestContext.deadline` reflects the *moderated* value once a policy is set; the field doc cross-links `DeadlinePolicy`. PR #101 (issue #89) replaces the field with a `deadline()` accessor and adds `time_remaining()` — there will be a small merge conflict in `response.rs` between this PR and #101, expected and trivial.
- I have not run the conformance suite locally (the runner wasn't downloaded in the dev environment). Since `DeadlinePolicy::new()` is a strict identity (`moderate` returns the input unchanged; `enforce_on_response_stream` returns the stream unchanged), conformance behavior is provably unaffected without a configured policy. CI runs the full suite.
- Per-route deadline policy is deferred to a follow-up coupled to the typed routing surface (#91). A per-path string map now would be a second stringly-typed route surface that #91 wants to remove.
- Net change in `connectrpc/src/`: ~250 lines excluding tests and doc comments. The `deadline.rs` file is large because of doc-comment density on every public knob.
