### PR TITLE
server: with_* builder consistency + ConnectRpcService dispatch-config proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,21 @@ increment the patch version.
   durations. Per-route deadline policy is a planned follow-up coupled
   to the typed routing surface (#91).
 
+- **`Server` proxies for `ConnectRpcService` dispatch config** —
+  `Server::with_limits`, `Server::with_compression`, and
+  `Server::with_compression_policy` delegate to the same-named
+  `ConnectRpcService` builders, so a `Server::new(router)` user no longer
+  has to drop down to `Server::from_service(...)` to set request limits
+  or compression. (`Server` already held the inner `ConnectRpcService`;
+  the proxies just expose the existing surface.)
+
+- **`Server::with_http1_keep_alive`** — `Server` already had an
+  `http1_keep_alive` field (used by `serve`/`serve_with_graceful_shutdown`)
+  but no builder to set it; only `BoundServer` did. Adds the missing
+  builder so a one-step `Server::new(router).serve(addr)` user can disable
+  HTTP/1.1 keep-alive without switching to the `bind`/`from_listener`
+  two-step path.
+
 ### Breaking
 
 These are breaking under semver but the practical blast radius is
@@ -153,6 +168,15 @@ need a one-line edit.
   was supplied` on a `ClientConfig` builder call, you've hit the rename:
   the same-named read accessor now occupies the old name. Prefix the
   call with `with_` per the table above.
+
+- **`Server` / `BoundServer` / `ServeTls` builders renamed to `with_*`** —
+  `tls_handshake_timeout(...)` is now `with_tls_handshake_timeout(...)`
+  (on `Server`, `BoundServer`, and `axum::ServeTls`) and
+  `BoundServer::http1_keep_alive(...)` is now
+  `with_http1_keep_alive(...)`. This matches the `with_tls(...)` /
+  `with_graceful_shutdown(...)` siblings that were already `with_*` and
+  the `ConnectRpcService`/`ClientConfig` convention. Migration: prefix
+  the call with `with_`. `with_tls(...)` is unchanged.
 
 ## [0.4.2] - 2026-05-07
 

--- a/connectrpc/src/axum.rs
+++ b/connectrpc/src/axum.rs
@@ -84,7 +84,7 @@ use crate::server::{
 ///
 /// Like the standalone server, the TLS handshake is bounded by a
 /// [`DEFAULT_TLS_HANDSHAKE_TIMEOUT`] to prevent slowloris-style connection
-/// exhaustion; tune it with [`ServeTls::tls_handshake_timeout`].
+/// exhaustion; tune it with [`ServeTls::with_tls_handshake_timeout`].
 ///
 /// The returned [`ServeTls`] resolves once the listener stops accepting and
 /// in-flight connections drain (after [`ServeTls::with_graceful_shutdown`]'s
@@ -151,7 +151,7 @@ impl ServeTls {
     /// [`DEFAULT_TLS_HANDSHAKE_TIMEOUT`]). Set generously; clients on
     /// high-latency links need a few round trips to complete the handshake.
     #[must_use = "ServeTls does nothing unless `.await`ed"]
-    pub fn tls_handshake_timeout(mut self, timeout: Duration) -> Self {
+    pub fn with_tls_handshake_timeout(mut self, timeout: Duration) -> Self {
         self.tls_handshake_timeout = timeout;
         self
     }
@@ -446,7 +446,7 @@ mod tests {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let serve = tokio::spawn(
             serve_tls(listener, app, server_cfg)
-                .tls_handshake_timeout(Duration::from_millis(100))
+                .with_tls_handshake_timeout(Duration::from_millis(100))
                 .with_graceful_shutdown(async {
                     rx.await.ok();
                 })

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -115,8 +115,8 @@ impl PeerInfo {
 /// where a client opens a TCP connection and stalls the handshake indefinitely,
 /// holding a task and file descriptor per connection.
 ///
-/// Override via [`Server::tls_handshake_timeout`] or
-/// [`BoundServer::tls_handshake_timeout`].
+/// Override via [`Server::with_tls_handshake_timeout`] or
+/// [`BoundServer::with_tls_handshake_timeout`].
 #[cfg(feature = "server-tls")]
 pub const DEFAULT_TLS_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -189,8 +189,22 @@ impl Server {
     /// this duration is disconnected.
     #[cfg(feature = "server-tls")]
     #[must_use]
-    pub fn tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
+    pub fn with_tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.tls_handshake_timeout = timeout;
+        self
+    }
+
+    /// Enable or disable HTTP/1.1 keep-alive (default: enabled).
+    ///
+    /// When disabled, the server sends `Connection: close` and handles
+    /// only one request per TCP connection. This avoids stale-connection
+    /// races where the server closes an idle connection at the same time
+    /// the client sends a new request on it.
+    ///
+    /// HTTP/2 multiplexing is unaffected.
+    #[must_use]
+    pub fn with_http1_keep_alive(mut self, enabled: bool) -> Self {
+        self.http1_keep_alive = enabled;
         self
     }
 
@@ -205,6 +219,41 @@ impl Server {
     #[must_use]
     pub fn with_deadline_policy(mut self, policy: crate::DeadlinePolicy) -> Self {
         self.service = self.service.with_deadline_policy(policy);
+        self
+    }
+
+    /// Configure request limits on the underlying service.
+    ///
+    /// Delegates to [`ConnectRpcService::with_limits`]. See
+    /// [`Limits`](crate::Limits) for available options. Replaces any
+    /// previously configured limits.
+    #[must_use]
+    pub fn with_limits(mut self, limits: crate::Limits) -> Self {
+        self.service = self.service.with_limits(limits);
+        self
+    }
+
+    /// Configure the compression registry on the underlying service.
+    ///
+    /// Delegates to [`ConnectRpcService::with_compression`]. The
+    /// [`CompressionRegistry`](crate::CompressionRegistry) determines which
+    /// compression algorithms are available for request decompression and
+    /// response compression. Replaces any previously configured registry.
+    #[must_use]
+    pub fn with_compression(mut self, registry: crate::CompressionRegistry) -> Self {
+        self.service = self.service.with_compression(registry);
+        self
+    }
+
+    /// Configure the compression policy on the underlying service.
+    ///
+    /// Delegates to [`ConnectRpcService::with_compression_policy`]. The
+    /// [`CompressionPolicy`](crate::CompressionPolicy) controls when
+    /// compression is applied (e.g. minimum message size). Replaces any
+    /// previously configured policy.
+    #[must_use]
+    pub fn with_compression_policy(mut self, policy: crate::CompressionPolicy) -> Self {
+        self.service = self.service.with_compression_policy(policy);
         self
     }
 
@@ -320,12 +369,12 @@ impl BoundServer {
     /// Defaults to [`DEFAULT_TLS_HANDSHAKE_TIMEOUT`] (10 seconds).
     #[cfg(feature = "server-tls")]
     #[must_use]
-    pub fn tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
+    pub fn with_tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.tls_handshake_timeout = timeout;
         self
     }
 
-    /// Disable HTTP/1.1 keep-alive.
+    /// Enable or disable HTTP/1.1 keep-alive.
     ///
     /// When disabled, the server sends `Connection: close` and handles
     /// only one request per TCP connection. This avoids stale-connection
@@ -334,7 +383,7 @@ impl BoundServer {
     ///
     /// HTTP/2 multiplexing is unaffected.
     #[must_use]
-    pub fn http1_keep_alive(mut self, enabled: bool) -> Self {
+    pub fn with_http1_keep_alive(mut self, enabled: bool) -> Self {
         self.http1_keep_alive = enabled;
         self
     }
@@ -742,6 +791,32 @@ mod tests {
     fn test_server_creation() {
         let router = Router::new();
         let _server = Server::new(router);
+    }
+
+    /// `Server` proxies the dispatch-config builders so users don't have to
+    /// drop down to `Server::from_service(ConnectRpcService::new(...).with_*())`.
+    /// Exercises the chain and verifies the readable knobs (`limits()`, the
+    /// `http1_keep_alive` field) round-trip; the compression knobs have no
+    /// public read path so the test only confirms the builders compile and
+    /// chain.
+    #[test]
+    fn test_server_dispatch_config_proxies() {
+        use crate::service::Limits;
+        use crate::{CompressionPolicy, CompressionRegistry};
+
+        let limits = Limits {
+            max_request_body_size: 1024,
+            max_message_size: 512,
+        };
+        let server = Server::new(Router::new())
+            .with_limits(limits.clone())
+            .with_compression(CompressionRegistry::default())
+            .with_compression_policy(CompressionPolicy::default().min_size(8192))
+            .with_http1_keep_alive(false);
+
+        assert_eq!(server.service.limits().max_request_body_size, 1024);
+        assert_eq!(server.service.limits().max_message_size, 512);
+        assert!(!server.http1_keep_alive);
     }
 
     #[tokio::test]

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1072,7 +1072,7 @@ mod tests {
     }
 
     /// A client that opens a TCP connection to a TLS server but never sends a
-    /// ClientHello should be disconnected after `tls_handshake_timeout`.
+    /// ClientHello should be disconnected after `with_tls_handshake_timeout`.
     #[tokio::test]
     async fn tls_handshake_timeout_disconnects_stalled_client() {
         use connectrpc::Server;
@@ -1090,7 +1090,7 @@ mod tests {
             .await
             .expect("bind")
             .with_tls(server_cfg)
-            .tls_handshake_timeout(handshake_timeout);
+            .with_tls_handshake_timeout(handshake_timeout);
         let addr = bound.local_addr().expect("local_addr");
         let _server = tokio::spawn(async move {
             bound.serve(router).await.unwrap();


### PR DESCRIPTION
Fixes #104.

`Server` is the convenience wrapper around `ConnectRpcService`, but until now it only exposed connection-level knobs (`with_tls`, `tls_handshake_timeout`, HTTP/1.1 keep-alive). Setting request limits or compression required discovering `Server::from_service(...)` and threading config through `ConnectRpcService::new(...)` by hand. The compiler error doesn't point at `from_service`.

## Changes

**Renames (breaking):**

| Before | After |
|---|---|
| `Server::tls_handshake_timeout(d)` | `Server::with_tls_handshake_timeout(d)` |
| `BoundServer::tls_handshake_timeout(d)` | `BoundServer::with_tls_handshake_timeout(d)` |
| `BoundServer::http1_keep_alive(b)` | `BoundServer::with_http1_keep_alive(b)` |
| `axum::ServeTls::tls_handshake_timeout(d)` | `axum::ServeTls::with_tls_handshake_timeout(d)` |

Migration: prefix the call with `with_`. `with_tls(...)` and `with_graceful_shutdown(...)` are unchanged (already `with_*`). `ServeTls` is included because it has the same `with_graceful_shutdown` / bare-name `tls_handshake_timeout` split as `Server`; renaming all three at once keeps the crate consistent.

**New proxies (additive):** `Server::with_limits`, `Server::with_compression`, `Server::with_compression_policy` delegating to the same-named `ConnectRpcService` builders.

`BoundServer` doesn't get the dispatch proxies because it doesn't hold a `ConnectRpcService` — it takes one at `serve()` time. `Server` gets them because it constructs the service in `new()`.

## Sibling PRs

#103 adds `Server::with_deadline_policy()` — same `Server` impl block, so whichever lands second has a small merge conflict in `server.rs` (and `CHANGELOG.md`). Both are 0.5.0-bound.

## Verification

`task lint`, `task test`, `cargo check -p connectrpc --no-default-features`, `cargo check --workspace --all-features --all-targets`, and `RUSTDOCFLAGS="-D warnings" cargo doc -p connectrpc --all-features --no-deps` all clean. Net change ~71 lines excluding tests.
