### PR TITLE
ci: pass repo-token to setup-protoc to avoid anonymous rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
         with:
           version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo check --workspace --all-features --all-targets
 
   msrv-check:
@@ -40,6 +41,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
         with:
           version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo check --workspace --all-features --all-targets
 
   test:
@@ -53,6 +55,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
         with:
           version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo test --workspace --all-features
 
   clippy:
@@ -68,6 +71,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
         with:
           version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
   fmt:
@@ -94,6 +98,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
         with:
           version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo doc --workspace --all-features --no-deps
 
   # Integration test: start server, run client, verify RPCs work end-to-end
@@ -153,6 +158,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
         with:
           version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: cargo check -p connectrpc --no-default-features --target wasm32-unknown-unknown
       - run: cargo check -p connectrpc --no-default-features --features gzip --target wasm32-unknown-unknown


### PR DESCRIPTION
Adds `repo-token: ${{ secrets.GITHUB_TOKEN }}` to all 6 `arduino/setup-protoc` steps in `ci.yml`.

The action queries the GitHub API to resolve `protocolbuffers/protobuf` releases. Without a token it uses the anonymous per-IP quota (60 req/hr) which the shared GitHub-hosted runner egress IPs exhaust quickly — especially with 6 jobs × N concurrent PRs. Passing `GITHUB_TOKEN` moves the calls to the workflow token's authenticated quota (1,000 req/hr).

No `permissions:` change needed: the action only reads a public repo's releases, which the default token scope (`contents: read`) already allows.

Fixes #106
