### PR TITLE
docs: add doc(cfg) annotations for feature-gated APIs

### DIFF
--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -414,6 +414,7 @@ impl Http2Connection {
     /// Returns an error (surfaced from the first `poll_ready`) if the URI
     /// scheme is `http://` — use [`lazy_plaintext`](Self::lazy_plaintext).
     #[cfg(feature = "client-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
     pub fn lazy_tls(uri: Uri, tls_config: Arc<rustls::ClientConfig>) -> Self {
         Self {
             inner: Reconnect::new(MakeSendRequest::new_tls(tls_config), uri, true),
@@ -427,6 +428,7 @@ impl Http2Connection {
     /// Returns an error if the URI scheme is `http://`, if the TCP/TLS
     /// handshake fails, or if the server doesn't negotiate h2 via ALPN.
     #[cfg(feature = "client-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
     pub async fn connect_tls(
         uri: Uri,
         tls_config: Arc<rustls::ClientConfig>,
@@ -447,6 +449,7 @@ impl Http2Connection {
     /// first `poll_ready`. See [`lazy_tls`](Self::lazy_tls) for ALPN and
     /// cert rotation details.
     #[cfg(feature = "client-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
     pub fn with_builder_tls(
         uri: Uri,
         builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -231,8 +231,10 @@ where
 #[cfg(feature = "client")]
 mod http2;
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use http2::Http2Connection;
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use http2::SharedHttp2Connection;
 
 /// General-purpose HTTP client supporting both HTTP/1.1 and HTTP/2.
@@ -262,6 +264,7 @@ pub use http2::SharedHttp2Connection;
 ///
 /// Available when the `client` feature is enabled.
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 #[derive(Clone)]
 pub struct HttpClient {
     inner: HttpClientInner,
@@ -270,6 +273,7 @@ pub struct HttpClient {
 // Manual impl: hyper's `Client` doesn't impl `Debug`. Print the mode so
 // tests can identify which transport variant unexpectedly succeeded.
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 impl std::fmt::Debug for HttpClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mode = match self.inner {
@@ -308,6 +312,7 @@ enum HttpClientInner {
 }
 
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 impl HttpClient {
     /// Create a **plaintext** HTTP client. Only for `http://` URIs.
     ///
@@ -393,6 +398,7 @@ impl HttpClient {
     /// let client = GreetServiceClient::new(http, config);
     /// ```
     #[cfg(feature = "client-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
     pub fn with_tls(tls_config: std::sync::Arc<rustls::ClientConfig>) -> Self {
         use hyper_util::client::legacy::Client;
         use hyper_util::client::legacy::connect::HttpConnector;
@@ -434,6 +440,7 @@ impl HttpClient {
 // explicitly choose plaintext() or with_tls().
 
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 impl ClientTransport for HttpClient {
     type ResponseBody = hyper::body::Incoming;
     type Error = ConnectError;

--- a/connectrpc/src/compression.rs
+++ b/connectrpc/src/compression.rs
@@ -71,10 +71,12 @@ use crate::error::ConnectError;
 
 /// A boxed async reader for streaming compression/decompression.
 #[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub type BoxedAsyncRead = Pin<Box<dyn AsyncRead + Send>>;
 
 /// A boxed async buffered reader for streaming input.
 #[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub type BoxedAsyncBufRead = Pin<Box<dyn AsyncBufRead + Send>>;
 
 /// Trait for compression algorithm implementations.
@@ -151,6 +153,7 @@ pub trait CompressionProvider: Send + Sync + 'static {
 ///
 /// Available when the `streaming` feature is enabled (default).
 #[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub trait StreamingCompressionProvider: CompressionProvider {
     /// Create a streaming decompressor.
     ///
@@ -363,6 +366,7 @@ impl CompressionRegistry {
     ///
     /// Available when the `streaming` feature is enabled.
     #[cfg(feature = "streaming")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
     #[must_use]
     pub fn register_streaming<P: StreamingCompressionProvider>(mut self, provider: P) -> Self {
         let name = provider.name();
@@ -383,12 +387,14 @@ impl CompressionRegistry {
     ///
     /// Returns `None` if no streaming provider is registered for the given name.
     #[cfg(feature = "streaming")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
     pub fn get_streaming(&self, name: &str) -> Option<Arc<dyn StreamingCompressionProvider>> {
         self.streaming_providers.get(name).cloned()
     }
 
     /// Check if streaming compression is supported for the given encoding name.
     #[cfg(feature = "streaming")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
     pub fn supports_streaming(&self, name: &str) -> bool {
         self.streaming_providers.contains_key(name)
     }
@@ -398,6 +404,7 @@ impl CompressionRegistry {
     /// Returns an `AsyncRead` that decompresses data from the input reader.
     /// Returns an error if the encoding is not supported for streaming.
     #[cfg(feature = "streaming")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
     pub fn decompress_stream(
         &self,
         encoding: &str,
@@ -422,6 +429,7 @@ impl CompressionRegistry {
     /// Returns an `AsyncRead` that compresses data from the input reader.
     /// Returns an error if the encoding is not supported for streaming.
     #[cfg(feature = "streaming")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
     pub fn compress_stream(
         &self,
         encoding: &str,
@@ -593,6 +601,7 @@ impl Default for CompressionRegistry {
 ///
 /// Available when the `gzip` feature is enabled (default).
 #[cfg(feature = "gzip")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
 pub struct GzipProvider {
     /// Compression level (0-9, default is 1).
     level: u32,
@@ -601,6 +610,7 @@ pub struct GzipProvider {
 }
 
 #[cfg(feature = "gzip")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
 impl std::fmt::Debug for GzipProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GzipProvider")
@@ -618,6 +628,7 @@ impl std::fmt::Debug for GzipProvider {
 }
 
 #[cfg(feature = "gzip")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
 impl Default for GzipProvider {
     fn default() -> Self {
         Self::with_level(Self::DEFAULT_LEVEL)
@@ -625,6 +636,7 @@ impl Default for GzipProvider {
 }
 
 #[cfg(feature = "gzip")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
 impl GzipProvider {
     /// Default compression level: 1 (fastest).
     ///
@@ -868,6 +880,7 @@ fn gzip_header_len(data: &[u8]) -> Result<usize, ConnectError> {
 }
 
 #[cfg(feature = "gzip")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
 impl CompressionProvider for GzipProvider {
     fn name(&self) -> &'static str {
         "gzip"
@@ -896,6 +909,7 @@ impl CompressionProvider for GzipProvider {
 }
 
 #[cfg(all(feature = "gzip", feature = "streaming"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "gzip", feature = "streaming"))))]
 impl StreamingCompressionProvider for GzipProvider {
     fn decompress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead {
         Box::pin(async_compression::tokio::bufread::GzipDecoder::new(reader))
@@ -920,6 +934,7 @@ impl StreamingCompressionProvider for GzipProvider {
 ///
 /// Available when the `zstd` feature is enabled (default).
 #[cfg(feature = "zstd")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 pub struct ZstdProvider {
     /// Compression level (1-22, default is 3).
     level: i32,
@@ -927,6 +942,7 @@ pub struct ZstdProvider {
 }
 
 #[cfg(feature = "zstd")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 impl std::fmt::Debug for ZstdProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ZstdProvider")
@@ -940,6 +956,7 @@ impl std::fmt::Debug for ZstdProvider {
 }
 
 #[cfg(feature = "zstd")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 impl ZstdProvider {
     /// Default compression level: 3 (the zstd library default).
     pub const DEFAULT_LEVEL: i32 = 3;
@@ -962,6 +979,7 @@ impl ZstdProvider {
 }
 
 #[cfg(feature = "zstd")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 impl Default for ZstdProvider {
     fn default() -> Self {
         Self {
@@ -1044,6 +1062,7 @@ impl ZstdProvider {
 }
 
 #[cfg(feature = "zstd")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 impl CompressionProvider for ZstdProvider {
     fn name(&self) -> &'static str {
         "zstd"
@@ -1074,6 +1093,7 @@ impl CompressionProvider for ZstdProvider {
 }
 
 #[cfg(all(feature = "zstd", feature = "streaming"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "zstd", feature = "streaming"))))]
 impl StreamingCompressionProvider for ZstdProvider {
     fn decompress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead {
         Box::pin(async_compression::tokio::bufread::ZstdDecoder::new(reader))

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -197,6 +197,7 @@ pub mod client;
 
 // Optional: Standalone hyper-based server
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub mod server;
 
 // Optional: TLS-aware `axum::serve` counterpart with peer-identity passthrough.
@@ -292,18 +293,23 @@ pub use compression::DEFAULT_COMPRESSION_MIN_SIZE;
 pub use deadline::DeadlinePolicy;
 
 #[cfg(feature = "gzip")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
 pub use compression::GzipProvider;
 
 #[cfg(feature = "zstd")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 pub use compression::ZstdProvider;
 
 #[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub use compression::BoxedAsyncBufRead;
 
 #[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub use compression::BoxedAsyncRead;
 
 #[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub use compression::StreamingCompressionProvider;
 
 // ============================================================================
@@ -311,14 +317,18 @@ pub use compression::StreamingCompressionProvider;
 // ============================================================================
 
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use server::BoundServer;
 
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use server::Server;
 
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use server::PeerAddr;
 #[cfg(feature = "server-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
 pub use server::PeerCerts;
 
 /// Re-export of `rustls` for TLS configuration.
@@ -327,6 +337,7 @@ pub use server::PeerCerts;
 /// or a [`rustls::ClientConfig`] for [`HttpClient::with_tls`](client::HttpClient::with_tls)
 /// / [`Http2Connection::connect_tls`](client::Http2Connection::connect_tls).
 #[cfg(any(feature = "server-tls", feature = "client-tls"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "server-tls", feature = "client-tls"))))]
 pub use rustls;
 
 /// Include the generated ConnectRPC file from `$OUT_DIR`.

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -166,6 +166,7 @@ impl RequestContext {
     /// passes in unit tests, and panics in production behind a transport
     /// that didn't insert it.
     #[cfg(feature = "server")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
     pub fn peer_addr(&self) -> Option<std::net::SocketAddr> {
         self.extensions
             .get::<crate::server::PeerAddr>()
@@ -183,6 +184,7 @@ impl RequestContext {
     /// request extensions. Like [`peer_addr`](Self::peer_addr), prefer
     /// this over a raw `extensions().get()` + `unwrap()`.
     #[cfg(feature = "server-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
     pub fn peer_certs(&self) -> Option<&[rustls::pki_types::CertificateDer<'static>]> {
         self.extensions
             .get::<crate::server::PeerCerts>()

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -86,6 +86,7 @@ pub struct PeerAddr(pub SocketAddr);
 /// The `Arc` makes per-request insertion cheap: all requests on a
 /// connection share one chain, so this is a refcount bump, not a copy.
 #[cfg(feature = "server-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
 #[derive(Clone, Debug)]
 pub struct PeerCerts(pub Arc<[rustls::pki_types::CertificateDer<'static>]>);
 
@@ -121,6 +122,7 @@ impl PeerInfo {
 /// Override via [`Server::with_tls_handshake_timeout`] or
 /// [`BoundServer::with_tls_handshake_timeout`].
 #[cfg(feature = "server-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
 pub const DEFAULT_TLS_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// ConnectRPC server built on hyper.
@@ -179,6 +181,7 @@ impl Server {
     ///     .serve(addr).await?;
     /// ```
     #[cfg(feature = "server-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
     #[must_use]
     pub fn with_tls(mut self, config: Arc<rustls::ServerConfig>) -> Self {
         self.tls_config = Some(config);
@@ -191,6 +194,7 @@ impl Server {
     /// that connects via TCP but does not complete the TLS handshake within
     /// this duration is disconnected.
     #[cfg(feature = "server-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
     #[must_use]
     pub fn with_tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.tls_handshake_timeout = timeout;
@@ -361,6 +365,7 @@ impl BoundServer {
 
     /// Enable TLS with the given rustls server configuration.
     #[cfg(feature = "server-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
     #[must_use]
     pub fn with_tls(mut self, config: Arc<rustls::ServerConfig>) -> Self {
         self.tls_config = Some(config);
@@ -371,6 +376,7 @@ impl BoundServer {
     ///
     /// Defaults to [`DEFAULT_TLS_HANDSHAKE_TIMEOUT`] (10 seconds).
     #[cfg(feature = "server-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
     #[must_use]
     pub fn with_tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.tls_handshake_timeout = timeout;

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -2780,6 +2780,7 @@ impl ConnectError {
 ///
 /// Available when the `axum` feature is enabled.
 #[cfg(feature = "axum")]
+#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 pub mod axum_integration {
     use super::*;
     use axum::body::Body;


### PR DESCRIPTION
## Summary

- Add docs.rs `doc(cfg(...))` annotations to feature-gated public API items.
- Cover client, client TLS, server, server TLS, compression, streaming, axum, and TLS re-export surfaces.
- Preserve existing `#[cfg(...)]` gates and avoid generated files.

Fixes #102.

## Verification

- `rustfmt --edition 2024 --check connectrpc/src/lib.rs connectrpc/src/compression.rs connectrpc/src/client/mod.rs connectrpc/src/client/http2.rs connectrpc/src/response.rs connectrpc/src/server.rs connectrpc/src/service.rs`
- `cargo check -p connectrpc --all-features --all-targets`
- `cargo doc -p connectrpc --all-features --no-deps`

Workspace commands attempted but blocked locally because `protoc` is not installed/on PATH:

- `cargo check --workspace --all-features --all-targets`
- `cargo doc --workspace --all-features --no-deps`
