### PR TITLE
interceptor: Interceptor trait, Next continuation, server registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio-stream = "0.1"
 tokio-util = "0.7"
 futures = "0.3"
 pin-project = "1"
+async-trait = "0.1"
 
 # Protobuf. The 0.6 floor matches the regen baseline for the checked-in
 # generated code: 0.6.0 adds `with_*` setters for explicit-presence fields,

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -28,6 +28,7 @@ tower = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "sync", "time"] }
 futures = { workspace = true }
 pin-project = { workspace = true }
+async-trait = { workspace = true }
 
 # Protobuf
 buffa = { workspace = true }

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -1,0 +1,640 @@
+//! RPC-level interceptors for unary calls.
+//!
+//! Interceptors are the typed equivalent of `tower` middleware: they wrap
+//! a single RPC *after* envelope decoding, decompression, and header
+//! parsing, and *before* the handler runs. Each interceptor sees a
+//! [`UnaryRequest`] (the [`Spec`](crate::Spec), headers, deadline,
+//! extensions, and a lazily-decoded [`Payload`]) and a [`Next`]
+//! continuation, and returns a [`UnaryResponse`].
+//!
+//! The first interceptor registered is the outermost: it runs first on
+//! the way in and last on the way out, exactly like wrapping a function
+//! call. This matches `connect-go`'s `WithInterceptors` ordering.
+//!
+//! ```text
+//! request ──▶ interceptor[0] ──▶ interceptor[1] ──▶ handler
+//!                  │                  │                 │
+//! response ◀───────┴──────────◀───────┴────────◀───────┘
+//! ```
+//!
+//! Register interceptors with
+//! [`ConnectRpcService::with_interceptor`](crate::ConnectRpcService::with_interceptor).
+//! When no interceptors are registered the dispatch path is byte-for-byte
+//! identical to a build without this module — there is no per-request
+//! cost for opting out.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::future::BoxFuture;
+
+use crate::codec::CodecFormat;
+use crate::error::ConnectError;
+use crate::payload::Payload;
+use crate::response::{EncodedResponse, RequestContext, Response};
+
+/// Re-export of [`async_trait::async_trait`] so interceptor authors don't
+/// need a direct `async-trait` dependency.
+///
+/// ```rust,ignore
+/// #[connectrpc::async_trait]
+/// impl connectrpc::Interceptor for MyInterceptor { /* ... */ }
+/// ```
+///
+/// The macro expansion references only `core` and the prelude — there is
+/// no runtime `async-trait` requirement.
+pub use async_trait::async_trait;
+
+/// A unary RPC interceptor.
+///
+/// Implement [`intercept_unary`](Interceptor::intercept_unary) to wrap a
+/// call. The default implementation is a passthrough — calling
+/// [`next.run(req)`](Next::run) — so an interceptor that only cares about
+/// (say) streaming RPCs in a future release is forwards-compatible.
+///
+/// Use [`unary_interceptor`] for a closure-shaped interceptor without a
+/// dedicated type.
+///
+/// `Interceptor` is an async trait. Annotate the impl with the
+/// [`connectrpc::async_trait`](crate::async_trait) re-export — there is
+/// no separate `async-trait` dependency to add.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// struct LoggingInterceptor;
+///
+/// #[connectrpc::async_trait]
+/// impl Interceptor for LoggingInterceptor {
+///     async fn intercept_unary(
+///         &self,
+///         req: UnaryRequest,
+///         next: Next<'_>,
+///     ) -> Result<UnaryResponse, ConnectError> {
+///         // `ctx.spec` is `None` for dynamic `Router` dispatch — only
+///         // generated `FooServiceServer<T>` dispatchers supply one.
+///         let proc = req.ctx.spec().map(|s| s.procedure).unwrap_or("<dynamic>");
+///         tracing::info!(%proc, "rpc start");
+///         let resp = next.run(req).await;
+///         tracing::info!(%proc, ok = resp.is_ok(), "rpc end");
+///         resp
+///     }
+/// }
+/// ```
+#[async_trait::async_trait]
+pub trait Interceptor: Send + Sync + 'static {
+    /// Wrap a unary RPC. The default is a passthrough.
+    ///
+    /// Call [`next.run(req)`](Next::run) to continue. Returning without
+    /// calling it short-circuits the chain — neither inner interceptors
+    /// nor the handler run.
+    ///
+    /// # Errors
+    ///
+    /// Forward errors from `next.run` (handler or inner-interceptor
+    /// failures), or return your own to short-circuit.
+    async fn intercept_unary(
+        &self,
+        req: UnaryRequest,
+        next: Next<'_>,
+    ) -> Result<UnaryResponse, ConnectError> {
+        next.run(req).await
+    }
+}
+
+/// Construct an [`Interceptor`] from a closure.
+///
+/// The closure must be a higher-ranked `Fn` over the [`Next`] lifetime
+/// that returns a boxed future. The boilerplate is unavoidable — the
+/// trait method returns a boxed future — but the closure body is what
+/// you'd write in an `impl Interceptor` block:
+///
+/// ```rust,ignore
+/// let timing = unary_interceptor(|req, next| Box::pin(async move {
+///     let started = std::time::Instant::now();
+///     let resp = next.run(req).await;
+///     tracing::debug!(elapsed = ?started.elapsed(), "rpc");
+///     resp
+/// }));
+/// ```
+pub fn unary_interceptor<F>(f: F) -> impl Interceptor
+where
+    F: for<'a> Fn(UnaryRequest, Next<'a>) -> BoxFuture<'a, Result<UnaryResponse, ConnectError>>
+        + Send
+        + Sync
+        + 'static,
+{
+    struct FnInterceptor<F>(F);
+
+    #[async_trait::async_trait]
+    impl<F> Interceptor for FnInterceptor<F>
+    where
+        F: for<'a> Fn(UnaryRequest, Next<'a>) -> BoxFuture<'a, Result<UnaryResponse, ConnectError>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        async fn intercept_unary(
+            &self,
+            req: UnaryRequest,
+            next: Next<'_>,
+        ) -> Result<UnaryResponse, ConnectError> {
+            (self.0)(req, next).await
+        }
+    }
+
+    FnInterceptor(f)
+}
+
+/// The continuation an [`Interceptor`] calls to run the rest of the chain.
+///
+/// `Next` holds the still-to-run interceptors and the terminal handler.
+/// [`run`](Next::run) consumes it: an interceptor can call `next.run(req)`
+/// at most once. Not calling it at all short-circuits the chain.
+pub struct Next<'a> {
+    rest: &'a [Arc<dyn Interceptor>],
+    terminal: &'a (dyn UnaryTerminal + 'a),
+}
+
+impl<'a> Next<'a> {
+    /// Construct the head of a chain.
+    pub(crate) fn new(
+        rest: &'a [Arc<dyn Interceptor>],
+        terminal: &'a (dyn UnaryTerminal + 'a),
+    ) -> Self {
+        Self { rest, terminal }
+    }
+
+    /// Run the rest of the chain — the next interceptor if any, otherwise
+    /// the terminal handler — and return its response.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever error the next interceptor or handler produced.
+    pub async fn run(self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError> {
+        match self.rest.split_first() {
+            Some((head, tail)) => {
+                head.intercept_unary(
+                    req,
+                    Next {
+                        rest: tail,
+                        terminal: self.terminal,
+                    },
+                )
+                .await
+            }
+            None => self.terminal.call(req).await,
+        }
+    }
+}
+
+impl std::fmt::Debug for Next<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Next")
+            .field("remaining", &self.rest.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// The terminal step of an interceptor chain: decode the request body,
+/// invoke the handler, encode the response.
+///
+/// `pub(crate)` because the only producer is the dispatch path. Tests
+/// inside the crate can supply mocks.
+#[async_trait::async_trait]
+pub(crate) trait UnaryTerminal: Send + Sync {
+    async fn call(&self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError>;
+}
+
+/// A unary RPC request as seen by an [`Interceptor`].
+///
+/// Carries the dispatch [`RequestContext`] (headers, deadline,
+/// extensions, [`Spec`](crate::Spec), negotiated protocol) and the
+/// lazily-decoded body. Both fields are public so an interceptor can
+/// rewrite headers, inject extensions, or replace the message and pass
+/// the mutated request to [`Next::run`].
+///
+/// `ctx.spec` is `Some(..)` for generated `FooServiceServer<T>`
+/// dispatchers and `None` for the dynamic [`Router`](crate::Router)
+/// (its method paths are owned `String`s, not `&'static str`).
+///
+/// `#[non_exhaustive]` so future fields can be added without a
+/// breaking change. Construct with [`UnaryRequest::new`]; destructure
+/// with a trailing `..`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct UnaryRequest {
+    /// The dispatch context. Mutating `ctx.headers` or `ctx.extensions`
+    /// before `next.run` propagates to the handler.
+    pub ctx: RequestContext,
+    /// The lazily-decoded request body. Call
+    /// [`set_message`](Payload::set_message) to replace it.
+    pub payload: Payload,
+}
+
+impl UnaryRequest {
+    /// Build a `UnaryRequest` from a dispatch context and wire-encoded
+    /// body. Used by the dispatch path and by test fixtures.
+    pub fn new(ctx: RequestContext, body: Bytes, format: CodecFormat) -> Self {
+        Self {
+            ctx,
+            payload: Payload::new(body, format),
+        }
+    }
+}
+
+/// A unary RPC response as seen by an [`Interceptor`].
+///
+/// Carries response metadata (headers, trailers, compression hint) and
+/// a lazily-decoded body, with the same shape as the handler-facing
+/// [`Response<B>`](crate::Response). All fields are public so an
+/// interceptor can read or rewrite the response on the way out.
+pub type UnaryResponse = Response<Payload>;
+
+impl UnaryResponse {
+    /// Build a `UnaryResponse` from an encoded handler response.
+    pub fn from_encoded(resp: EncodedResponse, format: CodecFormat) -> Self {
+        Response {
+            body: Payload::new(resp.body, format),
+            headers: resp.headers,
+            trailers: resp.trailers,
+            compress: resp.compress,
+        }
+    }
+
+    /// Convert back to the dispatch path's encoded form.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a replacement set with
+    /// [`Payload::set_message`] fails to re-encode.
+    pub fn into_encoded(self) -> Result<EncodedResponse, ConnectError> {
+        Ok(Response {
+            body: self.body.encoded()?,
+            headers: self.headers,
+            trailers: self.trailers,
+            compress: self.compress,
+        })
+    }
+}
+
+/// Run an interceptor chain against a closure terminal.
+///
+/// The dispatch path constructs [`Next`] internally; this helper is for
+/// **unit-testing** an [`Interceptor`] without spinning up a tower
+/// service or a TCP listener. The `terminal` closure stands in for the
+/// handler.
+///
+/// ```rust,ignore
+/// let trace = Arc::new(Mutex::new(Vec::new()));
+/// let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(MyInterceptor)];
+/// let resp = connectrpc::interceptor::run_chain(&chain, my_req, |req| async move {
+///     // assert what the handler would see
+///     Ok(UnaryResponse::from_encoded(EncodedResponse::new(Bytes::new()), CodecFormat::Proto))
+/// })
+/// .await?;
+/// ```
+///
+/// # Errors
+///
+/// Returns whatever error the chain or terminal produces.
+pub async fn run_chain<F, Fut>(
+    interceptors: &[Arc<dyn Interceptor>],
+    req: UnaryRequest,
+    terminal: F,
+) -> Result<UnaryResponse, ConnectError>
+where
+    F: Fn(UnaryRequest) -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = Result<UnaryResponse, ConnectError>> + Send,
+{
+    struct FnTerminal<F>(F);
+
+    #[async_trait::async_trait]
+    impl<F, Fut> UnaryTerminal for FnTerminal<F>
+    where
+        F: Fn(UnaryRequest) -> Fut + Send + Sync,
+        Fut: std::future::Future<Output = Result<UnaryResponse, ConnectError>> + Send,
+    {
+        async fn call(&self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError> {
+            (self.0)(req).await
+        }
+    }
+
+    let terminal = FnTerminal(terminal);
+    Next::new(interceptors, &terminal).run(req).await
+}
+
+/// Run a unary call through the interceptor chain, or skip straight to the
+/// dispatcher when there are no interceptors.
+///
+/// The empty-chain path makes a single `is_empty` check and delegates;
+/// it does not build a [`UnaryRequest`], a [`Next`], or any chain
+/// machinery. A service with no interceptors pays nothing.
+pub(crate) async fn call_unary_intercepted<D: crate::Dispatcher>(
+    dispatcher: &D,
+    interceptors: &[Arc<dyn Interceptor>],
+    path: &str,
+    ctx: RequestContext,
+    body: Bytes,
+    format: CodecFormat,
+) -> Result<EncodedResponse, ConnectError> {
+    if interceptors.is_empty() {
+        return dispatcher.call_unary(path, ctx, body, format).await;
+    }
+    let terminal = DispatchTerminal {
+        dispatcher,
+        path,
+        format,
+    };
+    let req = UnaryRequest::new(ctx, body, format);
+    let resp = Next::new(interceptors, &terminal).run(req).await?;
+    resp.into_encoded()
+}
+
+/// `UnaryTerminal` that hands off to the dispatcher's `call_unary`.
+struct DispatchTerminal<'a, D> {
+    dispatcher: &'a D,
+    path: &'a str,
+    format: CodecFormat,
+}
+
+#[async_trait::async_trait]
+impl<D: crate::Dispatcher> UnaryTerminal for DispatchTerminal<'_, D> {
+    async fn call(&self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError> {
+        let UnaryRequest { ctx, payload } = req;
+        let body = payload.encoded()?;
+        let resp = self
+            .dispatcher
+            .call_unary(self.path, ctx, body, self.format)
+            .await?;
+        Ok(UnaryResponse::from_encoded(resp, self.format))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::encode_proto;
+    use buffa_types::google::protobuf::StringValue;
+    use std::sync::Mutex;
+
+    /// A terminal that records whether it ran and returns a fixed body.
+    struct RecordingTerminal {
+        ran: Mutex<bool>,
+        respond_with: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl UnaryTerminal for RecordingTerminal {
+        async fn call(&self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError> {
+            *self.ran.lock().unwrap() = true;
+            // Echo the (possibly replaced) request body length in a header
+            // so tests can verify mutation reached the terminal.
+            let in_len = req.payload.encoded()?.len().to_string();
+            let body = encode_proto(&StringValue {
+                value: self.respond_with.into(),
+                ..Default::default()
+            })?;
+            let mut resp = EncodedResponse::new(body);
+            resp.headers.insert("x-in-len", in_len.parse().unwrap());
+            Ok(UnaryResponse::from_encoded(resp, CodecFormat::Proto))
+        }
+    }
+
+    fn req() -> UnaryRequest {
+        let body = encode_proto(&StringValue {
+            value: "hi".into(),
+            ..Default::default()
+        })
+        .unwrap();
+        UnaryRequest::new(RequestContext::default(), body, CodecFormat::Proto)
+    }
+
+    /// Interceptor that pushes a label into the request extensions on the
+    /// way in and prepends it to a response header on the way out, so the
+    /// test can assert nesting order.
+    struct Tagger(&'static str);
+
+    #[derive(Clone, Default)]
+    struct Trace(Arc<Mutex<Vec<&'static str>>>);
+
+    #[async_trait::async_trait]
+    impl Interceptor for Tagger {
+        async fn intercept_unary(
+            &self,
+            mut req: UnaryRequest,
+            next: Next<'_>,
+        ) -> Result<UnaryResponse, ConnectError> {
+            req.ctx
+                .extensions
+                .get_or_insert_default::<Trace>()
+                .0
+                .lock()
+                .unwrap()
+                .push(self.0);
+            let resp = next.run(req).await?;
+            Ok(resp.with_header("x-trace", format!("{}-out", self.0)))
+        }
+    }
+
+    #[tokio::test]
+    async fn ordering_first_registered_is_outermost() {
+        let trace = Trace::default();
+        let chain: Vec<Arc<dyn Interceptor>> = vec![
+            Arc::new(Tagger("a")),
+            Arc::new(Tagger("b")),
+            Arc::new(Tagger("c")),
+        ];
+        let terminal = RecordingTerminal {
+            ran: Mutex::new(false),
+            respond_with: "ok",
+        };
+        let mut request = req();
+        request.ctx.extensions.insert(trace.clone());
+        let resp = Next::new(&chain, &terminal).run(request).await.unwrap();
+        assert!(*terminal.ran.lock().unwrap(), "terminal should have run");
+        // Way in: outermost first.
+        assert_eq!(*trace.0.lock().unwrap(), vec!["a", "b", "c"]);
+        // Way out: innermost appends to headers first (HeaderMap::append
+        // preserves insertion order), so "c-out" is first and "a-out" last.
+        let outs: Vec<_> = resp
+            .headers
+            .get_all("x-trace")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_owned())
+            .collect();
+        assert_eq!(outs, vec!["c-out", "b-out", "a-out"]);
+    }
+
+    #[tokio::test]
+    async fn short_circuit_skips_terminal() {
+        struct Reject;
+        #[async_trait::async_trait]
+        impl Interceptor for Reject {
+            async fn intercept_unary(
+                &self,
+                _req: UnaryRequest,
+                _next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                Err(ConnectError::permission_denied("nope"))
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Reject), Arc::new(Tagger("never"))];
+        let terminal = RecordingTerminal {
+            ran: Mutex::new(false),
+            respond_with: "ok",
+        };
+        let err = Next::new(&chain, &terminal).run(req()).await.unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::PermissionDenied);
+        assert!(!*terminal.ran.lock().unwrap(), "terminal must not run");
+    }
+
+    #[tokio::test]
+    async fn mutation_replaces_request_body() {
+        struct Replace;
+        #[async_trait::async_trait]
+        impl Interceptor for Replace {
+            async fn intercept_unary(
+                &self,
+                mut req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                req.payload.set_message(StringValue {
+                    value: "rewritten by interceptor".into(),
+                    ..Default::default()
+                });
+                next.run(req).await
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Replace)];
+        let terminal = RecordingTerminal {
+            ran: Mutex::new(false),
+            respond_with: "ok",
+        };
+        let resp = Next::new(&chain, &terminal).run(req()).await.unwrap();
+        // The terminal re-encoded the replaced message; its length differs
+        // from the original ("hi" -> 4 bytes) and is recorded in the header.
+        let in_len: usize = resp
+            .headers
+            .get("x-in-len")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        let original_len = req().payload.encoded().unwrap().len();
+        assert_ne!(in_len, original_len, "terminal should see the replacement");
+    }
+
+    #[tokio::test]
+    async fn closure_interceptor_works() {
+        let i = unary_interceptor(|req, next| {
+            Box::pin(async move {
+                let resp = next.run(req).await?;
+                Ok(resp.with_header("x-fn", "1"))
+            })
+        });
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(i)];
+        // Exercise the public test helper that downstream crates use.
+        let resp = run_chain(&chain, req(), |_| async {
+            Ok(UnaryResponse::from_encoded(
+                EncodedResponse::new(Bytes::new()),
+                CodecFormat::Proto,
+            ))
+        })
+        .await
+        .unwrap();
+        assert_eq!(resp.headers.get("x-fn").unwrap(), "1");
+    }
+
+    /// Trailers and the compression hint must round-trip through a
+    /// passthrough chain — `into_encoded` preserves all `Response`
+    /// metadata, not just the body.
+    #[tokio::test]
+    async fn passthrough_chain_preserves_response_metadata() {
+        struct Passthrough;
+        #[async_trait::async_trait]
+        impl Interceptor for Passthrough {}
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
+        let resp = run_chain(&chain, req(), |_| async {
+            let mut r = EncodedResponse::new(Bytes::from_static(b"x"));
+            r.headers.insert("x-h", "1".parse().unwrap());
+            r.trailers.insert("x-t", "2".parse().unwrap());
+            r.compress = Some(true);
+            Ok(UnaryResponse::from_encoded(r, CodecFormat::Proto))
+        })
+        .await
+        .unwrap();
+        let encoded = resp.into_encoded().unwrap();
+        assert_eq!(encoded.headers.get("x-h").unwrap(), "1");
+        assert_eq!(encoded.trailers.get("x-t").unwrap(), "2");
+        assert_eq!(encoded.compress, Some(true));
+        assert_eq!(&*encoded.body, b"x");
+    }
+
+    #[tokio::test]
+    async fn empty_chain_is_no_op() {
+        // `call_unary_intercepted` with an empty slice delegates straight
+        // to the dispatcher. The response bytes must come straight from
+        // the dispatcher (refcount-shared with the request that the echo
+        // dispatcher returned). Note: a `Bytes` clone shares the backing
+        // pointer, so this test alone doesn't *uniquely* prove the
+        // `UnaryRequest`-free fast path — that property is guarded by the
+        // conformance suite, which only ever runs the empty chain.
+        struct Echo;
+        impl crate::Dispatcher for Echo {
+            fn lookup(&self, _: &str) -> Option<crate::dispatcher::MethodDescriptor> {
+                None
+            }
+            fn call_unary(
+                &self,
+                _: &str,
+                _: RequestContext,
+                request: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                Box::pin(async move { Ok(EncodedResponse::new(request)) })
+            }
+            fn call_server_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unimplemented!()
+            }
+            fn call_client_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unimplemented!()
+            }
+            fn call_bidi_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unimplemented!()
+            }
+        }
+        let body = Bytes::from_static(b"x");
+        let resp = call_unary_intercepted(
+            &Echo,
+            &[],
+            "p",
+            RequestContext::default(),
+            body.clone(),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        // Same backing storage — no copy through Payload.
+        assert!(std::ptr::eq(resp.body.as_ptr(), body.as_ptr()));
+    }
+}

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -71,12 +71,23 @@ pub use async_trait::async_trait;
 ///         req: UnaryRequest,
 ///         next: Next<'_>,
 ///     ) -> Result<UnaryResponse, ConnectError> {
-///         // `ctx.spec` is `None` for dynamic `Router` dispatch — only
-///         // generated `FooServiceServer<T>` dispatchers supply one.
-///         let proc = req.ctx.spec().map(|s| s.procedure).unwrap_or("<dynamic>");
-///         tracing::info!(%proc, "rpc start");
+///         // `ctx.path()` is the requested procedure path. The dispatch
+///         // path always sets it before an interceptor runs, including
+///         // for dynamic `Router` routes (which never carry a `Spec`) —
+///         // the `expect` documents that invariant rather than hiding a
+///         // default. Use `ctx.spec()` for the *resolved* method's static
+///         // metadata (`stream_type`, `idempotency`), not the name.
+///         //
+///         // `to_owned()` because `path()` borrows `req.ctx`, and `req`
+///         // is moved into `next.run` below.
+///         let path = req
+///             .ctx
+///             .path()
+///             .expect("dispatch sets path before interceptors run")
+///             .to_owned();
+///         tracing::info!(%path, "rpc start");
 ///         let resp = next.run(req).await;
-///         tracing::info!(%proc, ok = resp.is_ok(), "rpc end");
+///         tracing::info!(%path, ok = resp.is_ok(), "rpc end");
 ///         resp
 ///     }
 /// }
@@ -476,7 +487,12 @@ mod tests {
                 _req: UnaryRequest,
                 _next: Next<'_>,
             ) -> Result<UnaryResponse, ConnectError> {
-                Err(ConnectError::permission_denied("nope"))
+                // Auth interceptors attach diagnostic headers (e.g. an
+                // operator-facing "which policy denied" hint) to the deny
+                // error. Those must reach the wire response.
+                let mut headers = http::HeaderMap::new();
+                headers.insert("x-deny-policy", "p1".parse().unwrap());
+                Err(ConnectError::permission_denied("nope").with_headers(headers))
             }
         }
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Reject), Arc::new(Tagger("never"))];
@@ -487,6 +503,91 @@ mod tests {
         let err = Next::new(&chain, &terminal).run(req()).await.unwrap_err();
         assert_eq!(err.code, crate::ErrorCode::PermissionDenied);
         assert!(!*terminal.ran.lock().unwrap(), "terminal must not run");
+        // The chain must not strip response headers off a short-circuit
+        // error: they reach the dispatch path and the protocol-aware error
+        // renderers (`error_response`, `grpc_error_response`,
+        // `ConnectError::into_http_response`) walk `response_headers()`
+        // when building the wire response.
+        assert_eq!(
+            err.response_headers().get("x-deny-policy").unwrap(),
+            "p1",
+            "diagnostic headers on a short-circuit error must survive the chain"
+        );
+    }
+
+    /// `call_unary_intercepted` propagates a short-circuit error verbatim,
+    /// including response headers, so the caller's error renderer can put
+    /// them on the wire. Pinned because an auth interceptor relies on it.
+    #[tokio::test]
+    async fn call_unary_intercepted_propagates_error_headers() {
+        struct Reject;
+        #[async_trait::async_trait]
+        impl Interceptor for Reject {
+            async fn intercept_unary(
+                &self,
+                _req: UnaryRequest,
+                _next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                let mut headers = http::HeaderMap::new();
+                headers.insert("x-deny-policy", "p1".parse().unwrap());
+                Err(ConnectError::permission_denied("nope").with_headers(headers))
+            }
+        }
+        struct PanickyDispatcher;
+        impl crate::Dispatcher for PanickyDispatcher {
+            fn lookup(&self, _: &str) -> Option<crate::dispatcher::MethodDescriptor> {
+                None
+            }
+            fn call_unary(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!("dispatcher must not be reached when an interceptor short-circuits")
+            }
+            fn call_server_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+            fn call_client_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!()
+            }
+            fn call_bidi_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Reject)];
+        let err = call_unary_intercepted(
+            &PanickyDispatcher,
+            &chain,
+            "p",
+            RequestContext::default(),
+            Bytes::new(),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::PermissionDenied);
+        assert_eq!(err.response_headers().get("x-deny-policy").unwrap(), "p1");
     }
 
     #[tokio::test]

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -69,6 +69,7 @@
 //! - [`service`] - Tower service implementation (primary integration point)
 //! - [`spec`] - Static per-method metadata ([`Spec`], [`StreamType`])
 //! - [`payload`] - Lazily-decoded, type-erased message bodies ([`Payload`])
+//! - [`interceptor`] - RPC-level interceptors ([`Interceptor`], [`Next`])
 //! - [`client`] - Tower-based HTTP client utilities (requires `client` feature)
 //! - [`server`] - Standalone hyper-based server (requires `server` feature)
 //!
@@ -189,6 +190,7 @@ pub mod envelope;
 pub mod error;
 pub(crate) mod grpc_status;
 pub mod handler;
+pub mod interceptor;
 pub mod payload;
 pub mod protocol;
 pub mod response;
@@ -280,8 +282,16 @@ pub use spec::SpecOrigin;
 pub use spec::StreamType;
 
 // Type-erased message bodies for interceptors
+pub use interceptor::async_trait;
 pub use payload::AnyMessage;
 pub use payload::Payload;
+
+// Unary RPC interceptors
+pub use interceptor::Interceptor;
+pub use interceptor::Next;
+pub use interceptor::UnaryRequest;
+pub use interceptor::UnaryResponse;
+pub use interceptor::unary_interceptor;
 
 // ============================================================================
 // Codec exports

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -105,9 +105,9 @@ where
 ///   sent: either the original `bytes` or the re-encoded replacement.
 ///
 /// `Payload` is normally constructed by the dispatch path and received
-/// by user code through `UnaryRequest`/`UnaryResponse` (a future
-/// addition). [`Payload::new`] is `pub` so test fixtures and custom
-/// transports can build one directly.
+/// by user code through [`UnaryRequest`](crate::UnaryRequest) and
+/// [`UnaryResponse`](crate::UnaryResponse). [`Payload::new`] is `pub`
+/// so test fixtures and custom transports can build one directly.
 ///
 /// `message` borrows the cached owned decode; `view` returns a fresh
 /// self-contained [`OwnedView`] (a [`Bytes`] refcount bump, not a copy)

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -61,6 +61,7 @@ use crate::dispatcher::Dispatcher;
 use crate::envelope::Envelope;
 use crate::error::ConnectError;
 use crate::handler::BoxStream;
+use crate::interceptor::{Interceptor, call_unary_intercepted};
 use crate::protocol::Protocol;
 use crate::response::{EncodedResponse, RequestContext};
 use crate::router::MethodKind;
@@ -1099,6 +1100,9 @@ pub struct ConnectRpcService<D = Router> {
     compression: Arc<CompressionRegistry>,
     compression_policy: CompressionPolicy,
     deadline_policy: DeadlinePolicy,
+    /// Unary interceptor chain, outermost first. The `Arc<[..]>` is one
+    /// pointer to clone per request regardless of chain length.
+    interceptors: Arc<[Arc<dyn Interceptor>]>,
 }
 
 // Manual Clone impl because `#[derive(Clone)]` would add a `D: Clone` bound,
@@ -1111,6 +1115,7 @@ impl<D> Clone for ConnectRpcService<D> {
             compression: Arc::clone(&self.compression),
             compression_policy: self.compression_policy,
             deadline_policy: self.deadline_policy.clone(),
+            interceptors: Arc::clone(&self.interceptors),
         }
     }
 }
@@ -1124,13 +1129,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
     /// - a code-generated `FooServiceServer<T>` struct for monomorphic
     ///   dispatch with no HashMap lookup or trait-object indirection.
     pub fn new(dispatcher: D) -> Self {
-        Self {
-            dispatcher: Arc::new(dispatcher),
-            limits: Limits::default(),
-            compression: Arc::new(CompressionRegistry::default()),
-            compression_policy: CompressionPolicy::default(),
-            deadline_policy: DeadlinePolicy::new(),
-        }
+        Self::from_arc(Arc::new(dispatcher))
     }
 
     /// Create a new ConnectRPC service from an Arc'd dispatcher.
@@ -1141,6 +1140,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
             compression: Arc::new(CompressionRegistry::default()),
             compression_policy: CompressionPolicy::default(),
             deadline_policy: DeadlinePolicy::new(),
+            interceptors: Arc::default(),
         }
     }
 
@@ -1192,6 +1192,29 @@ impl<D: Dispatcher> ConnectRpcService<D> {
     #[must_use]
     pub fn deadline_policy(&self) -> &DeadlinePolicy {
         &self.deadline_policy
+    }
+
+    /// Append a unary [`Interceptor`] to the chain.
+    ///
+    /// The first interceptor registered runs **outermost**: first on the
+    /// way in, last on the way out (matching `connect-go`'s
+    /// `WithInterceptors`). Interceptors run after envelope decoding,
+    /// decompression, and header parsing, and before the handler.
+    ///
+    /// When no interceptors are registered the dispatch path is identical
+    /// to a build without this call — there is no per-request allocation
+    /// or branch beyond a single `is_empty` check.
+    ///
+    /// Interceptors apply to **unary** calls only in this release.
+    /// Streaming calls bypass the chain.
+    #[must_use]
+    pub fn with_interceptor(mut self, interceptor: impl Interceptor) -> Self {
+        // The Arc<[..]> is shared across cloned service handles; rebuild
+        // it on registration. Registration is a cold path.
+        let mut v: Vec<Arc<dyn Interceptor>> = self.interceptors.to_vec();
+        v.push(Arc::new(interceptor));
+        self.interceptors = Arc::from(v);
+        self
     }
 
     /// Get the current limits configuration.
@@ -1293,6 +1316,7 @@ where
         let compression = Arc::clone(&self.compression);
         let compression_policy = self.compression_policy;
         let deadline_policy = self.deadline_policy.clone();
+        let interceptors = Arc::clone(&self.interceptors);
 
         // Only create and attach the tracing span when a subscriber would
         // actually observe it. For disabled-debug (the common production case),
@@ -1321,6 +1345,7 @@ where
                 compression,
                 &compression_policy,
                 &deadline_policy,
+                &interceptors,
             )
             .await
             {
@@ -1338,6 +1363,7 @@ where
 }
 
 /// Handle a ConnectRPC request (unary or streaming).
+#[allow(clippy::too_many_arguments)]
 async fn handle_request<D, B>(
     dispatcher: Arc<D>,
     req: Request<B>,
@@ -1345,6 +1371,7 @@ async fn handle_request<D, B>(
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
     deadline_policy: &DeadlinePolicy,
+    interceptors: &[Arc<dyn Interceptor>],
 ) -> Result<Response<ConnectRpcBody>, ConnectError>
 where
     D: Dispatcher,
@@ -1371,6 +1398,7 @@ where
             compression,
             compression_policy,
             deadline_policy,
+            interceptors,
         )
         .await
         .map(|r| r.map(ConnectRpcBody::Full));
@@ -1456,6 +1484,7 @@ where
                         compression,
                         compression_policy,
                         deadline_policy,
+                        interceptors,
                     )
                     .await;
                     return Ok(response.map(ConnectRpcBody::GrpcUnary));
@@ -1472,6 +1501,7 @@ where
                 compression,
                 compression_policy,
                 deadline_policy,
+                interceptors,
             )
             .await;
             Ok(response.map(ConnectRpcBody::Streaming))
@@ -1485,6 +1515,7 @@ where
                 compression,
                 compression_policy,
                 deadline_policy,
+                interceptors,
             )
             .await
             .map(|r| r.map(ConnectRpcBody::Full))
@@ -1493,6 +1524,7 @@ where
 }
 
 /// Handle a unary ConnectRPC request.
+#[allow(clippy::too_many_arguments)]
 async fn handle_unary_request<D, B>(
     dispatcher: &D,
     req: Request<B>,
@@ -1500,6 +1532,7 @@ async fn handle_unary_request<D, B>(
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
     deadline_policy: &DeadlinePolicy,
+    interceptors: &[Arc<dyn Interceptor>],
 ) -> Result<Response<Full<Bytes>>, ConnectError>
 where
     D: Dispatcher,
@@ -1634,12 +1667,12 @@ where
     let resp: EncodedResponse = if let Some(timeout) = metadata.timeout {
         tokio::time::timeout(
             timeout,
-            dispatcher.call_unary(&path, ctx, body, codec_format),
+            call_unary_intercepted(dispatcher, interceptors, &path, ctx, body, codec_format),
         )
         .await
         .map_err(|_| ConnectError::deadline_exceeded("request timeout"))?
     } else {
-        dispatcher.call_unary(&path, ctx, body, codec_format).await
+        call_unary_intercepted(dispatcher, interceptors, &path, ctx, body, codec_format).await
     }?;
 
     // Negotiate response compression
@@ -1708,6 +1741,7 @@ async fn handle_grpc_unary_request<D, B>(
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
     deadline_policy: &DeadlinePolicy,
+    interceptors: &[Arc<dyn Interceptor>],
 ) -> Response<GrpcUnaryBody>
 where
     D: Dispatcher,
@@ -1852,7 +1886,14 @@ where
     let handler_result = if let Some(timeout) = metadata.timeout {
         match tokio::time::timeout(
             timeout,
-            dispatcher.call_unary(path, ctx, request_body, codec_format),
+            call_unary_intercepted(
+                dispatcher,
+                interceptors,
+                path,
+                ctx,
+                request_body,
+                codec_format,
+            ),
         )
         .await
         {
@@ -1863,9 +1904,15 @@ where
             }
         }
     } else {
-        dispatcher
-            .call_unary(path, ctx, request_body, codec_format)
-            .await
+        call_unary_intercepted(
+            dispatcher,
+            interceptors,
+            path,
+            ctx,
+            request_body,
+            codec_format,
+        )
+        .await
     };
 
     let resp = match handler_result {
@@ -1961,6 +2008,7 @@ async fn handle_streaming_request<D, B>(
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
     deadline_policy: &DeadlinePolicy,
+    interceptors: &[Arc<dyn Interceptor>],
 ) -> Response<StreamingResponseBody>
 where
     D: Dispatcher,
@@ -2162,7 +2210,14 @@ where
             }
         }
         StreamingDispatchKind::Unary => {
-            let fut = dispatcher.call_unary(&path, ctx, request_body, codec_format);
+            let fut = call_unary_intercepted(
+                dispatcher,
+                interceptors,
+                &path,
+                ctx,
+                request_body,
+                codec_format,
+            );
             let handler_result = if let Some(timeout) = metadata.timeout {
                 match tokio::time::timeout(timeout, fut).await {
                     Ok(result) => result,
@@ -3573,6 +3628,7 @@ mod tests {
             Arc::new(CompressionRegistry::new()),
             &CompressionPolicy::default(),
             &DeadlinePolicy::new(),
+            &[],
         )
         .await
         .expect("dispatch should succeed");
@@ -3625,6 +3681,7 @@ mod tests {
             Arc::new(CompressionRegistry::new()),
             &CompressionPolicy::default(),
             &DeadlinePolicy::new(),
+            &[],
         )
         .await
         .expect("dispatch should succeed");

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -3698,6 +3698,81 @@ mod tests {
         );
     }
 
+    /// Interceptors must run on the Connect GET path. An idempotent unary
+    /// RPC accessed via HTTP GET must not bypass an authz interceptor —
+    /// every dispatch shape (Connect POST, Connect GET, gRPC fast path,
+    /// gRPC streaming-frame unary) routes through `call_unary_intercepted`.
+    /// A regression in any one of them is silent until a client uses that
+    /// shape, which for GET only happens for `idempotency_level =
+    /// NO_SIDE_EFFECTS` methods.
+    #[tokio::test]
+    async fn interceptor_runs_on_connect_get_request() {
+        use crate::interceptor::{Interceptor, Next, UnaryRequest, UnaryResponse};
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let intercepted = Arc::new(AtomicBool::new(false));
+        let handler_ran = Arc::new(Mutex::new(false));
+
+        let handler_ran_inner = Arc::clone(&handler_ran);
+        let router = Router::new().route_idempotent(
+            "svc",
+            "Get",
+            crate::handler_fn(move |_ctx: RequestContext, _req: buffa_types::Empty| {
+                let h = Arc::clone(&handler_ran_inner);
+                async move {
+                    *h.lock().unwrap() = true;
+                    crate::Response::ok(buffa_types::Empty::default())
+                }
+            }),
+        );
+
+        struct Recorder(Arc<AtomicBool>);
+        #[async_trait::async_trait]
+        impl Interceptor for Recorder {
+            async fn intercept_unary(
+                &self,
+                req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                self.0.store(true, Ordering::SeqCst);
+                next.run(req).await
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Recorder(Arc::clone(&intercepted)))];
+
+        // A Connect GET request: empty proto message, base64-encoded
+        // (empty), encoding declared. Idempotent methods opt into GET so
+        // CDNs and browsers can cache them — those requests must still be
+        // intercepted.
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/svc/Get?message=&encoding=proto&base64=1&connect=v1")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        handle_unary_request(
+            &router,
+            req,
+            Limits::default(),
+            Arc::new(CompressionRegistry::new()),
+            &CompressionPolicy::default(),
+            &DeadlinePolicy::new(),
+            &chain,
+        )
+        .await
+        .expect("dispatch should succeed");
+
+        assert!(
+            intercepted.load(Ordering::SeqCst),
+            "interceptor must run on Connect GET requests"
+        );
+        assert!(
+            *handler_ran.lock().unwrap(),
+            "handler must run after the interceptor passes through"
+        );
+    }
+
     // ========================================================================
     // ConnectError::into_http_response tests
     // ========================================================================

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1193,6 +1193,64 @@ mod tests {
         }
     }
 
+    /// End-to-end: a registered interceptor wraps the unary call. The
+    /// interceptor sees `Spec`, the request payload, and can rewrite the
+    /// response before it hits the wire.
+    #[tokio::test]
+    async fn interceptor_wraps_unary_call() {
+        use connectrpc::{Interceptor, Next, UnaryRequest, UnaryResponse};
+
+        /// Reads the request `Spec`, echoes the procedure and request
+        /// `data` field through a response header, and increments the
+        /// response message's `sequence` field.
+        struct SpecAndBodyInterceptor;
+
+        #[connectrpc::async_trait]
+        impl Interceptor for SpecAndBodyInterceptor {
+            async fn intercept_unary(
+                &self,
+                req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                let proc = req
+                    .ctx
+                    .spec()
+                    .map(|s| s.procedure.to_owned())
+                    .unwrap_or_default();
+                let body = req.payload.message::<EchoRequest>()?.data.clone();
+                let mut resp = next.run(req).await?;
+                let mut msg = resp.body.message::<EchoResponse>()?.clone();
+                msg.sequence += 1000;
+                resp.body.set_message(msg);
+                Ok(resp
+                    .with_header("x-proc", proc)
+                    .with_header("x-req-data", body))
+            }
+        }
+
+        let server = EchoServiceServer::new(TestEchoService);
+        let service = ConnectRpcService::new(server).with_interceptor(SpecAndBodyInterceptor);
+        let app = axum::Router::new().fallback_service(service);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _h = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let resp = make_client(addr)
+            .echo(EchoRequest {
+                sequence: 7,
+                data: "ping".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.headers().get("x-proc").unwrap(),
+            "/test.echo.v1.EchoService/Echo"
+        );
+        assert_eq!(resp.headers().get("x-req-data").unwrap(), "ping");
+        // The handler echoes `sequence`; the interceptor adds 1000.
+        assert_eq!(resp.into_view().sequence, 1007);
+    }
+
     /// End-to-end: the codegen dispatcher surfaces `Spec` and `Protocol` on
     /// `RequestContext`, and the dynamic `Router` does not (no `'static` path).
     #[tokio::test]

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1194,15 +1194,17 @@ mod tests {
     }
 
     /// End-to-end: a registered interceptor wraps the unary call. The
-    /// interceptor sees `Spec`, the request payload, and can rewrite the
-    /// response before it hits the wire.
+    /// interceptor sees `path()`, `Spec`, the request payload, and can
+    /// rewrite the response before it hits the wire. Also pins the
+    /// invariant that `path()` and `spec().procedure` agree when both are
+    /// present (codegen dispatch is the only path where both are).
     #[tokio::test]
     async fn interceptor_wraps_unary_call() {
         use connectrpc::{Interceptor, Next, UnaryRequest, UnaryResponse};
 
-        /// Reads the request `Spec`, echoes the procedure and request
-        /// `data` field through a response header, and increments the
-        /// response message's `sequence` field.
+        /// Reads `path()` and `Spec`, echoes the path and request `data`
+        /// field through response headers, and increments the response
+        /// message's `sequence` field.
         struct SpecAndBodyInterceptor;
 
         #[connectrpc::async_trait]
@@ -1212,18 +1214,27 @@ mod tests {
                 req: UnaryRequest,
                 next: Next<'_>,
             ) -> Result<UnaryResponse, ConnectError> {
-                let proc = req
+                // `path()` is the wire truth; `spec().procedure` is the
+                // resolved registration. The codegen dispatcher supplies
+                // both and they must agree — pin that invariant here, since
+                // this is the only test where both are present.
+                let path = req
                     .ctx
-                    .spec()
-                    .map(|s| s.procedure.to_owned())
-                    .unwrap_or_default();
+                    .path()
+                    .expect("dispatch sets path before interceptors run")
+                    .to_owned();
+                assert_eq!(
+                    req.ctx.spec().map(|s| s.procedure),
+                    Some(path.as_str()),
+                    "Spec::procedure and RequestContext::path() must agree"
+                );
                 let body = req.payload.message::<EchoRequest>()?.data.clone();
                 let mut resp = next.run(req).await?;
                 let mut msg = resp.body.message::<EchoResponse>()?.clone();
                 msg.sequence += 1000;
                 resp.body.set_message(msg);
                 Ok(resp
-                    .with_header("x-proc", proc)
+                    .with_header("x-path", path)
                     .with_header("x-req-data", body))
             }
         }
@@ -1243,7 +1254,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            resp.headers().get("x-proc").unwrap(),
+            resp.headers().get("x-path").unwrap(),
             "/test.echo.v1.EchoService/Echo"
         );
         assert_eq!(resp.headers().get("x-req-data").unwrap(), "ping");


### PR DESCRIPTION
> **Stacked on #113** (`aknott/interceptors-pr2-payload`), which is stacked
> on #112.
>
> This PR targets `main`, so its diff currently also includes the #112 and
> #113 commits. **Review only the top commit** — _"interceptor: Interceptor
> trait, Next continuation, server registration"_. Once #112 and #113 merge,
> this branch will be rebased and the diff will reduce to just that commit.
> Kept as a draft until #112 and #113 land.

## Summary

PR 3 of the interceptor series — the user-facing surface. Adds a
connect-go-style typed unary interceptor. Interceptors wrap a single RPC
after envelope decoding, decompression, and header parsing, and before the
handler — they see the parsed `Spec`, headers, deadline, extensions, and a
lazily-decoded `Payload`, and can rewrite the request and response messages.

- **`Interceptor`** async trait with a default-passthrough `intercept_unary`.
  Annotate impls with the re-exported `#[connectrpc::async_trait]` — there is
  no separate `async-trait` dependency for downstream crates.
- **`Next<'a>`** continuation: holds the rest of the chain and a
  `pub(crate)` terminal. `run(self, req)` consumes it; an interceptor can
  call it at most once (enforced by the type system), and not calling it
  short-circuits the chain.
- **`UnaryRequest { ctx, payload }`** (`#[non_exhaustive]`) and
  **`UnaryResponse = Response<Payload>`** so `with_header` / `with_trailer` /
  `compress` / `map_body` are inherited.
- **`unary_interceptor(closure)`** for closure-shaped interceptors, and
  `interceptor::run_chain(chain, req, terminal_fn)` so interceptor authors
  can unit-test without a tower service or TCP listener.
- **`ConnectRpcService::with_interceptor`** builder; chain stored as
  `Arc<[Arc<dyn Interceptor>]>` for one Arc bump per request.
- **`call_unary_intercepted`** with an `is_empty()` fast path that delegates
  straight to `dispatcher.call_unary` — when no interceptors are registered
  the dispatch path is byte-identical to before.

Threaded through the five `call_unary` sites in `service.rs` (Connect unary,
Connect GET, gRPC fast-path, gRPC streaming-frame unary, and the generic
fallback). Streaming RPCs bypass the chain in this release.

## Interceptor series

1. #112 — `Spec` / `StreamType` / `IdempotencyLevel`
2. #113 — `AnyMessage` / `Payload`
3. **(this PR)** — `Interceptor` trait, `Next`, server registration

## Verification

Run on the rebased branch (buffa 0.6.0):

- `task generate:all` — no generated-code drift
- `task lint` — pass
- `task test` — pass, 0 failed
- Conformance: 3600/3600 (the suite runs with zero interceptors)
