### PR TITLE
response: add RequestContext::path() — the requested procedure path

### DIFF
--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -58,6 +58,8 @@ pub struct RequestContext {
     pub(crate) spec: Option<crate::spec::Spec>,
     /// The wire protocol negotiated for this request, when known.
     pub(crate) protocol: Option<crate::Protocol>,
+    /// The procedure path the client requested, with a leading slash.
+    pub(crate) path: Option<String>,
 }
 
 impl RequestContext {
@@ -69,6 +71,7 @@ impl RequestContext {
             extensions: http::Extensions::new(),
             spec: None,
             protocol: None,
+            path: None,
         }
     }
 
@@ -97,6 +100,17 @@ impl RequestContext {
     #[must_use]
     pub fn with_protocol(mut self, protocol: Option<crate::Protocol>) -> Self {
         self.protocol = protocol;
+        self
+    }
+
+    /// Attach the procedure path the client requested. The dispatch path
+    /// always supplies the leading-slash form (`"/package.Service/Method"`),
+    /// matching [`Spec::procedure`](crate::Spec::procedure); custom
+    /// dispatch shims and test fixtures should do the same so consumers
+    /// of [`path()`](Self::path) see a consistent shape.
+    #[must_use]
+    pub fn with_path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
         self
     }
 
@@ -179,6 +193,7 @@ impl RequestContext {
     /// `None` when the dynamic [`Router`](crate::Router) handled dispatch
     /// (its method paths are owned `String`s and can't supply
     /// [`Spec::procedure`](crate::Spec::procedure)'s `&'static str`).
+    /// See [`path`](Self::path) for the always-present procedure path.
     pub fn spec(&self) -> Option<crate::spec::Spec> {
         self.spec
     }
@@ -189,6 +204,35 @@ impl RequestContext {
     /// path (e.g. unit tests calling handlers directly).
     pub fn protocol(&self) -> Option<crate::Protocol> {
         self.protocol
+    }
+
+    /// The procedure path the client requested, `"/package.Service/Method"`.
+    ///
+    /// Always present when constructed by the dispatch path: it is taken
+    /// from the request URI, so it is populated whenever a handler is
+    /// dispatched — including dispatch through the dynamic
+    /// [`Router`](crate::Router), which does not supply a
+    /// [`Spec`](crate::Spec). `None` only for hand-built contexts (unit
+    /// tests calling handlers directly, custom dispatch shims). Code that
+    /// must label or gate every request — auth interceptors, span
+    /// builders, rate limiters — should read `path()`, not `spec()`, and
+    /// treat `None` as a misconfigured or synthetic context rather than a
+    /// real RPC.
+    ///
+    /// Compare [`spec()`](Self::spec): that is the registered method's
+    /// *static* metadata, populated only when a generated
+    /// `FooServiceServer<T>` dispatcher resolved the route, and
+    /// [`Spec::procedure`](crate::Spec::procedure) is its `&'static str`
+    /// procedure name. When both are present they are identical strings;
+    /// `path()` exists for the cases where `spec()` cannot be.
+    ///
+    /// The leading slash is included to match `Spec::procedure`, the
+    /// `connect-go` `Spec.Procedure` convention, and `http::Uri::path()`
+    /// for any HTTP request that reached the dispatch layer. To compare
+    /// against [`Dispatcher::lookup`](crate::Dispatcher::lookup) keys
+    /// (which omit it), use `path.strip_prefix('/').unwrap_or(path)`.
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
     }
 
     /// Remote peer socket address, if the transport recorded one.
@@ -1310,5 +1354,30 @@ mod tests {
         let ctx = ctx.with_spec(None).with_protocol(None);
         assert_eq!(ctx.spec(), None);
         assert_eq!(ctx.protocol(), None);
+    }
+
+    #[test]
+    fn request_context_with_path() {
+        // Hand-built contexts (tests, custom dispatchers) have no path.
+        let ctx = RequestContext::new(HeaderMap::new());
+        assert_eq!(ctx.path(), None);
+
+        // Round-trips through the builder.
+        let ctx = RequestContext::new(HeaderMap::new()).with_path("/pkg.Svc/M");
+        assert_eq!(ctx.path(), Some("/pkg.Svc/M"));
+
+        // The builder takes ownership (Into<String>) so callers can pass
+        // borrowed or owned without an extra clone.
+        let owned = String::from("/pkg.Svc/Other");
+        let ctx = RequestContext::new(HeaderMap::new()).with_path(owned);
+        assert_eq!(ctx.path(), Some("/pkg.Svc/Other"));
+
+        // The builder does not normalize or validate — `Some("")` is
+        // preserved verbatim. The dispatch path always supplies a non-empty
+        // leading-slash form; `Some("")` only reaches consumers from a
+        // misconfigured custom dispatch shim, which is a wiring bug they
+        // should surface rather than silently coerce to `None`.
+        let ctx = RequestContext::new(HeaderMap::new()).with_path("");
+        assert_eq!(ctx.path(), Some(""));
     }
 }

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -1624,7 +1624,11 @@ where
         .with_deadline(deadline)
         .with_extensions(extensions)
         .with_spec(desc.spec)
-        .with_protocol(Some(Protocol::Connect));
+        .with_protocol(Some(Protocol::Connect))
+        // The leading slash was stripped for the Dispatcher::lookup key;
+        // restore it so RequestContext::path() matches http::Uri::path()
+        // and Spec::procedure.
+        .with_path(format!("/{path}"));
 
     // Call the handler with the appropriate codec format, applying timeout if specified
     let resp: EncodedResponse = if let Some(timeout) = metadata.timeout {
@@ -1841,7 +1845,8 @@ where
         .with_deadline(deadline)
         .with_extensions(extensions)
         .with_spec(spec)
-        .with_protocol(Some(protocol));
+        .with_protocol(Some(protocol))
+        .with_path(format!("/{path}"));
 
     // Call the handler with timeout if configured
     let handler_result = if let Some(timeout) = metadata.timeout {
@@ -2132,7 +2137,8 @@ where
         .with_deadline(deadline)
         .with_extensions(extensions)
         .with_spec(method_desc.and_then(|d| d.spec))
-        .with_protocol(Some(protocol));
+        .with_protocol(Some(protocol))
+        .with_path(format!("/{path}"));
 
     // Call the handler with the appropriate codec format.
     // For gRPC unary handlers, we wrap the single response in a one-item stream.
@@ -2276,7 +2282,8 @@ where
         .with_deadline(deadline)
         .with_extensions(extensions)
         .with_spec(spec)
-        .with_protocol(Some(protocol));
+        .with_protocol(Some(protocol))
+        .with_path(format!("/{path}"));
 
     // Call the handler. On error paths, the reader task is left running
     // (detached) so it can finish draining the request body — aborting it
@@ -2528,7 +2535,8 @@ where
         .with_deadline(deadline)
         .with_extensions(extensions)
         .with_spec(spec)
-        .with_protocol(Some(protocol));
+        .with_protocol(Some(protocol))
+        .with_path(format!("/{path}"));
 
     // Call the handler with timeout if configured
     let handler_result = if let Some(timeout) = metadata.timeout {
@@ -3573,6 +3581,63 @@ mod tests {
             captured.lock().unwrap().take(),
             Some(PeerTag("10.0.0.1:54321")),
             "extension inserted on the http::Request must reach Context.extensions"
+        );
+    }
+
+    /// Prove that `RequestContext::path()` carries the request URI path
+    /// through the dispatch path, in the leading-slash form, *even when*
+    /// `RequestContext::spec()` is `None`.
+    ///
+    /// This test deliberately uses the dynamic [`Router`], which never
+    /// supplies a [`Spec`](crate::spec::Spec) — `path()` is the only
+    /// reliable source for the procedure name in that case, and it's the
+    /// one an auth interceptor or span builder must read.
+    #[tokio::test]
+    async fn path_flows_to_handler_context() {
+        use std::sync::Mutex;
+
+        let captured = Arc::new(Mutex::new(None::<(Option<String>, bool)>));
+        let handler_captured = Arc::clone(&captured);
+        let router = Router::new().route(
+            "svc",
+            "Method",
+            crate::handler_fn(move |ctx: RequestContext, _req: buffa_types::Empty| {
+                let cap = Arc::clone(&handler_captured);
+                async move {
+                    *cap.lock().unwrap() =
+                        Some((ctx.path().map(str::to_owned), ctx.spec().is_some()));
+                    crate::Response::ok(buffa_types::Empty::default())
+                }
+            }),
+        );
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/svc/Method")
+            .header(header::CONTENT_TYPE, "application/proto")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        handle_unary_request(
+            &router,
+            req,
+            Limits::default(),
+            Arc::new(CompressionRegistry::new()),
+            &CompressionPolicy::default(),
+            &DeadlinePolicy::new(),
+        )
+        .await
+        .expect("dispatch should succeed");
+
+        let (path, spec_present) = captured.lock().unwrap().take().expect("handler ran");
+        assert_eq!(
+            path.as_deref(),
+            Some("/svc/Method"),
+            "path() must carry the leading-slash request URI path"
+        );
+        assert!(
+            !spec_present,
+            "dynamic Router supplies no Spec — path() must still be populated"
         );
     }
 


### PR DESCRIPTION
## Why

`Spec` (#112) gives interceptors and span builders the resolved method's static metadata, but only when a generated `FooServiceServer<T>` dispatcher matched the route — `Spec.procedure` is `&'static str`, and the dynamic `Router` can't supply one because its keys are owned `String`s. By the time an interceptor (#114) runs, `handle_*_request` has already consumed the `http::Request`, so there is no way back to the request URI. An interceptor that must label or gate *every* request — an auth boundary, a span builder, a rate limiter — therefore has no reliable source for the method name on the dynamic-`Router` path.

## What

`RequestContext::path()` carries the requested procedure path (`/package.Service/Method`) unconditionally — populated at every dispatch site from the request URI. It is the *wire truth*; `spec()` remains the source of *resolved* static metadata (stream type, idempotency level). When both are present they're identical strings; `path()` exists for the cases where `spec()` cannot be.

Storage is `Option<String>` (matching `spec()`/`protocol()`), `None` only for hand-built contexts. The leading slash matches `Spec::procedure`, connect-go's `Spec.Procedure`, and `http::Uri::path()`.

The five `RequestContext::new(...)` call sites already have the stripped lookup-key form (`pkg.Service/Method`) in scope; the leading slash is reconstructed via `format!("/{path}")`. `strip_prefix('/')` removes at most one leading slash, so the round-trip is exact for any HTTP request that reaches the dispatch layer.

## Confidence

- `request_context_with_path` (response.rs) — builder round-trips, `None` for hand-built contexts, `Some("")` preserved verbatim.
- `path_flows_to_handler_context` (service.rs) — dispatches a request to `/svc/Method` through the dynamic `Router` and asserts the handler sees `path() == Some("/svc/Method")` *and* `spec() == None` — the case `path()` exists for.
- `cargo test` (306 pass), `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo doc` all clean. `cargo check --all-features` clean.
- No wire-format change (the new field is consumed only by handler code).

## Possible follow-ups (not blocking)

- Each request currently allocates twice on the dispatch path: once for the stripped lookup key (pre-existing) and once for `format!("/{path}")`. They can be collapsed to one by capturing the un-stripped URI path first and slicing it for the lookup key, at the cost of restructuring borrow scopes. ~30-byte alloc per request is noise next to the body buffer and `HeaderMap` clone on the same path; worth it if `benches/rpc/` shows a difference.
- Test coverage exercises `handle_unary_request`; the gRPC-fast-path and streaming entry points use the same `format!("/{path}")` recipe but aren't independently covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
