### PR TITLE
dispatcher: pass Payload to call_unary so handlers reuse the interceptor decode

### DIFF
--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -490,7 +490,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("bench.v1.BenchService/") else {
@@ -503,7 +503,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::BenchRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.unary(ctx, req)
                         .await?
                         .encode::<crate::proto::bench::v1::BenchResponse>(format)
@@ -514,7 +514,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::LogRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.log_unary(ctx, req)
                         .await?
                         .encode::<crate::proto::bench::v1::LogResponse>(format)
@@ -525,7 +525,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::LogRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.log_unary_owned(ctx, req)
                         .await?
                         .encode::<crate::proto::bench::v1::LogResponse>(format)
@@ -1097,7 +1097,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("bench.v1.EchoService/") else {
@@ -1110,7 +1110,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::EchoRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.echo(ctx, req)
                         .await?
                         .encode::<crate::proto::bench::v1::EchoResponse>(format)
@@ -1441,7 +1441,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("bench.v1.LogIngestService/") else {
@@ -1454,7 +1454,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::LogRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.ingest(ctx, req)
                         .await?
                         .encode::<crate::proto::bench::v1::LogIngestResponse>(format)

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -192,7 +192,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("bench.noutf8.v1.LogIngestService/") else {
@@ -205,7 +205,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::noutf8::v1::__buffa::view::LogRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.ingest(ctx, req)
                         .await?
                         .encode::<

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -191,7 +191,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("bench.v1.BloatEchoService/") else {
@@ -204,7 +204,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::bench::v1::__buffa::view::BloatEchoView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.echo(ctx, req)
                         .await?
                         .encode::<crate::proto::bench::v1::BloatEcho>(format)

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -190,7 +190,7 @@ impl<T: FilterService> ::connectrpc::Dispatcher for FilterServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path
@@ -204,7 +204,7 @@ impl<T: FilterService> ::connectrpc::Dispatcher for FilterServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::filter::v1::__buffa::view::RecordView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.redact(ctx, req)
                         .await?
                         .encode::<

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -192,7 +192,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("fortune.v1.FortuneService/") else {
@@ -205,7 +205,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::fortune::v1::__buffa::view::GetFortunesRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.get_fortunes(ctx, req)
                         .await?
                         .encode::<crate::proto::fortune::v1::GetFortunesResponse>(format)

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -698,7 +698,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path
@@ -712,7 +712,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::UnaryRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.unary(ctx, req)
                         .await?
                         .encode::<
@@ -725,7 +725,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::UnimplementedRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.unimplemented(ctx, req)
                         .await?
                         .encode::<
@@ -738,7 +738,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::conformance::v1::__buffa::view::IdempotentUnaryRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.idempotent_unary(ctx, req)
                         .await?
                         .encode::<

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1486,7 +1486,11 @@ fn generate_service_server(
                 #method_name => {
                     let svc = ::std::sync::Arc::clone(&self.inner);
                     Box::pin(async move {
-                        let req = ::connectrpc::dispatcher::codegen::decode_request_view::<#input_view>(request, format)?;
+                        // Generated handlers are view-based, so the owned-message
+                        // cache an interceptor may have populated cannot be reused.
+                        // `encoded()` returns the (post-replacement) wire bytes —
+                        // a cheap `Bytes` clone for the common no-replacement case.
+                        let req = ::connectrpc::dispatcher::codegen::decode_request_view::<#input_view>(request.encoded()?, format)?;
                         svc.#method_snake(ctx, req).await?.encode::<#output_type>(format)
                     })
                 }
@@ -1547,7 +1551,7 @@ fn generate_service_server(
                 &self,
                 path: &str,
                 ctx: ::connectrpc::RequestContext,
-                request: ::buffa::bytes::Bytes,
+                request: ::connectrpc::Payload,
                 format: ::connectrpc::CodecFormat,
             ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
                 let Some(method) = path.strip_prefix(#path_prefix) else {

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -23,6 +23,7 @@ use crate::codec::CodecFormat;
 use crate::error::ConnectError;
 use crate::handler::BoxFuture;
 use crate::handler::BoxStream;
+use crate::payload::Payload;
 use crate::response::{EncodedResponse, RequestContext};
 use crate::router::MethodKind;
 use crate::spec::Spec;
@@ -152,14 +153,24 @@ pub trait Dispatcher: Send + Sync + 'static {
 
     /// Dispatch a unary call.
     ///
-    /// The caller decodes the request body to raw bytes (after envelope
-    /// stripping / decompression), and the dispatcher decodes it to the
-    /// concrete request type, invokes the handler, and encodes the response.
+    /// The caller wraps the body bytes (after envelope stripping /
+    /// decompression) in a [`Payload`], and the dispatcher decodes it to
+    /// the concrete request type, invokes the handler, and encodes the
+    /// response.
+    ///
+    /// The `request` is a [`Payload`] rather than raw `Bytes` so a
+    /// dispatcher backing an owned-message handler can call
+    /// [`Payload::take_message`] and reuse the decode an interceptor may
+    /// already have cached, instead of decoding the same bytes twice.
+    /// Dispatchers backing zero-copy view handlers call
+    /// [`Payload::encoded`] to recover the (post-replacement) wire bytes
+    /// — the cache stores owned messages, not views, so it cannot help
+    /// the view path.
     fn call_unary(
         &self,
         path: &str,
         ctx: RequestContext,
-        request: Bytes,
+        request: Payload,
         format: CodecFormat,
     ) -> UnaryResult;
 
@@ -255,7 +266,7 @@ impl<A: Dispatcher, B: Dispatcher> Dispatcher for Chain<A, B> {
         &self,
         path: &str,
         ctx: RequestContext,
-        request: Bytes,
+        request: Payload,
         format: CodecFormat,
     ) -> UnaryResult {
         if self.0.lookup(path).is_some() {

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -89,11 +89,14 @@ where
 
 /// Type-erased unary handler for use in the router.
 pub(crate) trait ErasedHandler: Send + Sync {
-    /// Handle a request with raw bytes and specified codec format.
+    /// Handle a request, decoding the [`Payload`] to the concrete request
+    /// type. Owned-message handlers should call [`Payload::take_message`]
+    /// to reuse a decode an interceptor may already have cached; view
+    /// handlers should call [`Payload::encoded`] for the wire bytes.
     fn call_erased(
         &self,
         ctx: RequestContext,
-        request: Bytes,
+        request: crate::Payload,
         format: CodecFormat,
     ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>>;
 
@@ -241,12 +244,14 @@ where
     fn call_erased(
         &self,
         ctx: RequestContext,
-        request: Bytes,
+        request: crate::Payload,
         format: CodecFormat,
     ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>> {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let req: Req = decode_request(&request, format)?;
+            // `take_message` reuses an interceptor's decode when one ran
+            // and cached this `Req`, instead of decoding the bytes again.
+            let req: Req = request.take_message()?;
             handler.call(ctx, req).await?.encode::<Res>(format)
         })
     }
@@ -783,12 +788,16 @@ where
     fn call_erased(
         &self,
         ctx: RequestContext,
-        request: Bytes,
+        request: crate::Payload,
         format: CodecFormat,
     ) -> BoxFuture<'static, Result<EncodedResponse, ConnectError>> {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let req = decode_request_view::<ReqView>(request, format)?;
+            // The cache stores owned messages, not views, so it can't help
+            // here. `encoded()` is the wire bytes — a cheap `Bytes` clone
+            // unless an interceptor replaced the body, in which case it
+            // re-encodes the replacement.
+            let req = decode_request_view::<ReqView>(request.encoded()?, format)?;
             handler.call(ctx, req, format).await
         })
     }

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -340,7 +340,9 @@ where
 ///
 /// The empty-chain path makes a single `is_empty` check and delegates;
 /// it does not build a [`UnaryRequest`], a [`Next`], or any chain
-/// machinery. A service with no interceptors pays nothing.
+/// machinery. The [`Payload::new`] wrap is plain struct construction —
+/// no allocation, no decode — so a service with no interceptors pays
+/// nothing.
 pub(crate) async fn call_unary_intercepted<D: crate::Dispatcher>(
     dispatcher: &D,
     interceptors: &[Arc<dyn Interceptor>],
@@ -350,7 +352,9 @@ pub(crate) async fn call_unary_intercepted<D: crate::Dispatcher>(
     format: CodecFormat,
 ) -> Result<EncodedResponse, ConnectError> {
     if interceptors.is_empty() {
-        return dispatcher.call_unary(path, ctx, body, format).await;
+        return dispatcher
+            .call_unary(path, ctx, Payload::new(body, format), format)
+            .await;
     }
     let terminal = DispatchTerminal {
         dispatcher,
@@ -373,10 +377,11 @@ struct DispatchTerminal<'a, D> {
 impl<D: crate::Dispatcher> UnaryTerminal for DispatchTerminal<'_, D> {
     async fn call(&self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError> {
         let UnaryRequest { ctx, payload } = req;
-        let body = payload.encoded()?;
+        // Hand the Payload — not raw bytes — to the dispatcher, so an
+        // owned-message handler can reuse a decode an interceptor cached.
         let resp = self
             .dispatcher
-            .call_unary(self.path, ctx, body, self.format)
+            .call_unary(self.path, ctx, payload, self.format)
             .await?;
         Ok(UnaryResponse::from_encoded(resp, self.format))
     }
@@ -542,7 +547,7 @@ mod tests {
                 &self,
                 _: &str,
                 _: RequestContext,
-                _: Bytes,
+                _: Payload,
                 _: CodecFormat,
             ) -> crate::dispatcher::UnaryResult {
                 unreachable!("dispatcher must not be reached when an interceptor short-circuits")
@@ -691,10 +696,10 @@ mod tests {
                 &self,
                 _: &str,
                 _: RequestContext,
-                request: Bytes,
+                request: Payload,
                 _: CodecFormat,
             ) -> crate::dispatcher::UnaryResult {
-                Box::pin(async move { Ok(EncodedResponse::new(request)) })
+                Box::pin(async move { Ok(EncodedResponse::new(request.encoded()?)) })
             }
             fn call_server_streaming(
                 &self,
@@ -737,5 +742,107 @@ mod tests {
         .unwrap();
         // Same backing storage — no copy through Payload.
         assert!(std::ptr::eq(resp.body.as_ptr(), body.as_ptr()));
+    }
+
+    /// `DispatchTerminal` hands the `Payload` — not raw bytes — to the
+    /// dispatcher, so an owned-message handler can `take_message()` and
+    /// reuse the decode an interceptor cached.
+    ///
+    /// Pinned by handing the dispatcher a `Payload` whose wire bytes are
+    /// *garbage* but whose cache an interceptor populated by replacement.
+    /// If the terminal stripped the `Payload` to bytes (the pre-this-PR
+    /// behavior), the dispatcher's `take_message` would error on the
+    /// garbage; if it forwards the `Payload`, the dispatcher sees the
+    /// replacement.
+    #[tokio::test]
+    async fn dispatch_terminal_forwards_payload_to_handler() {
+        let captured = Arc::new(Mutex::new(None::<String>));
+
+        // A dispatcher that decodes via `take_message` — the path an
+        // owned-message `Router::route` handler takes.
+        struct Capture(Arc<Mutex<Option<String>>>);
+        impl crate::Dispatcher for Capture {
+            fn lookup(&self, _: &str) -> Option<crate::dispatcher::MethodDescriptor> {
+                None
+            }
+            fn call_unary(
+                &self,
+                _: &str,
+                _: RequestContext,
+                request: Payload,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                let captured = Arc::clone(&self.0);
+                Box::pin(async move {
+                    let m: StringValue = request.take_message()?;
+                    *captured.lock().unwrap() = Some(m.value);
+                    Ok(EncodedResponse::new(Bytes::new()))
+                })
+            }
+            fn call_server_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+            fn call_client_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!()
+            }
+            fn call_bidi_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+        }
+
+        // Interceptor that replaces the request body. The original wire
+        // bytes are garbage — only the replacement is valid.
+        struct Replace;
+        #[async_trait::async_trait]
+        impl Interceptor for Replace {
+            async fn intercept_unary(
+                &self,
+                mut req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                req.payload.set_message(StringValue {
+                    value: "from interceptor".into(),
+                    ..Default::default()
+                });
+                next.run(req).await
+            }
+        }
+
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Replace)];
+        call_unary_intercepted(
+            &Capture(Arc::clone(&captured)),
+            &chain,
+            "p",
+            RequestContext::default(),
+            // Garbage wire bytes: would error on a fresh decode.
+            Bytes::from_static(&[0xff, 0xff, 0xff]),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            captured.lock().unwrap().as_deref(),
+            Some("from interceptor"),
+            "the dispatcher must see the interceptor's replacement, not re-decode the wire bytes"
+        );
     }
 }

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -54,6 +54,11 @@ pub trait AnyMessage: Send + Sync + 'static {
     fn as_any(&self) -> &dyn Any;
     /// Mutably borrow the message as `dyn Any` for downcasting.
     fn as_any_mut(&mut self) -> &mut dyn Any;
+    /// Convert the boxed message into a `Box<dyn Any>` for owned downcasting.
+    ///
+    /// [`Payload::take_message`] uses this to move the cached decode out
+    /// of the `Payload` and into the handler without a clone.
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
     /// Serialize the message to wire bytes in the given format.
     ///
     /// # Errors
@@ -78,6 +83,9 @@ where
         self
     }
     fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
     fn encode(&self, format: CodecFormat) -> Result<Bytes, ConnectError> {
@@ -202,6 +210,75 @@ impl Payload {
                 std::any::type_name::<M>()
             ))
         })
+    }
+
+    /// Decode the body into an owned `M`, consuming `self`.
+    ///
+    /// If the body was already decoded — an interceptor called
+    /// [`message`](Payload::message) — and the cached value is an `M`,
+    /// it is moved out: no second decode, no clone. If a replacement was
+    /// set with [`set_message`](Payload::set_message), it is moved out
+    /// instead. Otherwise the wire bytes are decoded fresh.
+    ///
+    /// The dispatch path uses this to hand the request to the handler
+    /// without re-decoding bytes an interceptor already decoded. Because
+    /// it consumes the `Payload`, it must be the last access — call
+    /// [`message`](Payload::message) (which caches a borrow) for repeated
+    /// reads.
+    ///
+    /// # Errors
+    ///
+    /// The same error contract as [`message`](Payload::message), with one
+    /// behavioral difference worth noting: a wrong-typed cache that an
+    /// interceptor created is now an error *for the handler*. Before
+    /// `take_message`, the handler decoded the wire bytes independently
+    /// and never saw the interceptor's cache, so an interceptor that
+    /// decoded as the wrong `M` failed silently. Surfacing it loudly is
+    /// the intent — interceptors and handlers for the same RPC must agree
+    /// on the message types.
+    ///
+    /// - [`invalid_argument`](ConnectError::invalid_argument) if there is
+    ///   no cache and the wire bytes fail to decode as `M` — peer-supplied
+    ///   data, not a server bug.
+    /// - [`internal`](ConnectError::internal) if a cached decode or a
+    ///   replacement set with [`set_message`](Payload::set_message) is not
+    ///   an `M` — a server-side type bug.
+    pub fn take_message<M>(self) -> Result<M, ConnectError>
+    where
+        // Unlike `message()`, this never *populates* the cache, so it
+        // does not need `M: Serialize` (the bound `message()` carries to
+        // box `M` as `dyn AnyMessage`). It only reads the cache or
+        // decodes fresh.
+        M: Message + DeserializeOwned + 'static,
+    {
+        if let Some(replaced) = self.replaced {
+            let type_name = replaced.type_name();
+            return replaced
+                .into_any()
+                .downcast::<M>()
+                .map(|b| *b)
+                .map_err(|_| {
+                    ConnectError::internal(format!(
+                        "payload replacement is a {}, not a {}",
+                        type_name,
+                        std::any::type_name::<M>()
+                    ))
+                });
+        }
+        if let Some(cached) = self.decoded.into_inner() {
+            let type_name = cached.type_name();
+            return cached.into_any().downcast::<M>().map(|b| *b).map_err(|_| {
+                ConnectError::internal(format!(
+                    "payload was previously decoded as a {}, not a {}",
+                    type_name,
+                    std::any::type_name::<M>()
+                ))
+            });
+        }
+        match self.format {
+            CodecFormat::Proto => decode_proto(&self.bytes),
+            CodecFormat::Json => decode_json(&self.bytes),
+        }
     }
 
     /// Decode the body as a zero-copy [`OwnedView`].
@@ -488,6 +565,79 @@ mod tests {
         });
         let m: &StringValue = p.message().unwrap();
         assert_eq!(m.value, "second");
+    }
+
+    #[test]
+    fn take_message_decodes_fresh_when_no_cache() {
+        let p = proto_payload("fresh");
+        let m: StringValue = p.take_message().unwrap();
+        assert_eq!(m.value, "fresh");
+    }
+
+    #[test]
+    fn take_message_reuses_cache() {
+        let p = proto_payload("cached");
+        // Populate the cache (an interceptor would do this).
+        let _ = p.message::<StringValue>().unwrap();
+        // `take_message` reads the cache, not the wire bytes. The
+        // no-second-decode property has no observable proof in safe Rust
+        // (the cached value and a fresh decode are bitwise identical), so
+        // it's pinned indirectly by `take_message_returns_replacement` —
+        // if `take_message` decoded the bytes there, it would never see
+        // the replacement. The wrong-type test below pins the other
+        // direction (the cache, not the bytes, is the source of truth).
+        let m: StringValue = p.take_message().unwrap();
+        assert_eq!(m.value, "cached");
+    }
+
+    #[test]
+    fn take_message_returns_replacement() {
+        // Build a payload whose wire bytes are *garbage* — not a valid
+        // proto. If `take_message` decoded the bytes instead of moving
+        // the replacement out, this would error.
+        let mut p = Payload::new(Bytes::from_static(&[0xff, 0xff, 0xff]), CodecFormat::Proto);
+        p.set_message(StringValue {
+            value: "replaced".into(),
+            ..Default::default()
+        });
+        let m: StringValue = p.take_message().unwrap();
+        assert_eq!(m.value, "replaced");
+    }
+
+    #[test]
+    fn take_message_wrong_cached_type_errors() {
+        use buffa_types::google::protobuf::Int32Value;
+        let p = proto_payload("x");
+        // An interceptor cached the wrong type for this route. Before
+        // `take_message`, the handler would silently re-decode and never
+        // notice. Now the bug is loud.
+        let _: &StringValue = p.message().unwrap();
+        let err = p.take_message::<Int32Value>().unwrap_err();
+        let msg = err.message.as_deref().unwrap_or_default();
+        assert!(msg.contains("previously decoded as a"), "{err:?}");
+        assert!(msg.contains("StringValue"), "{err:?}");
+        assert!(msg.contains("Int32Value"), "{err:?}");
+    }
+
+    #[test]
+    fn take_message_wrong_replacement_type_errors() {
+        use buffa_types::google::protobuf::Int32Value;
+        let mut p = proto_payload("x");
+        p.set_message(Int32Value {
+            value: 7,
+            ..Default::default()
+        });
+        let err = p.take_message::<StringValue>().unwrap_err();
+        let msg = err.message.as_deref().unwrap_or_default();
+        assert!(msg.contains("replacement is a"), "{err:?}");
+    }
+
+    #[test]
+    fn take_message_decode_error_is_invalid_argument() {
+        use crate::ErrorCode;
+        let p = Payload::new(Bytes::from_static(&[0xff, 0xff, 0xff]), CodecFormat::Proto);
+        let err = p.take_message::<StringValue>().unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidArgument, "{err:?}");
     }
 
     #[test]

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -430,7 +430,7 @@ impl crate::dispatcher::Dispatcher for Router {
         &self,
         path: &str,
         ctx: crate::response::RequestContext,
-        request: bytes::Bytes,
+        request: crate::Payload,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::UnaryResult {
         match self.methods.get(path) {

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -344,7 +344,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("connectrpc.eliza.v1.ElizaService/") else {
@@ -357,7 +357,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::connectrpc::eliza::v1::__buffa::view::SayRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.say(ctx, req)
                         .await?
                         .encode::<

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -205,7 +205,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path
@@ -219,7 +219,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::greet::v1::__buffa::view::GreetRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.greet(ctx, req)
                         .await?
                         .encode::<

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -196,7 +196,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path.strip_prefix("anthropic.connectrpc.math.v1.MathService/")
@@ -210,7 +210,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::math::v1::__buffa::view::AddRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.add(ctx, req)
                         .await?
                         .encode::<

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -378,7 +378,7 @@ for WellKnownTypesServiceServer<T> {
         &self,
         path: &str,
         ctx: ::connectrpc::RequestContext,
-        request: ::buffa::bytes::Bytes,
+        request: ::connectrpc::Payload,
         format: ::connectrpc::CodecFormat,
     ) -> ::connectrpc::dispatcher::codegen::UnaryResult {
         let Some(method) = path
@@ -392,7 +392,7 @@ for WellKnownTypesServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::CreateEventRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.create_event(ctx, req)
                         .await?
                         .encode::<
@@ -405,7 +405,7 @@ for WellKnownTypesServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::CalculateDurationRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.calculate_duration(ctx, req)
                         .await?
                         .encode::<
@@ -418,7 +418,7 @@ for WellKnownTypesServiceServer<T> {
                 Box::pin(async move {
                     let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
                         crate::proto::anthropic::connectrpc::wkt::v1::__buffa::view::ProcessMetadataRequestView,
-                    >(request, format)?;
+                    >(request.encoded()?, format)?;
                     svc.process_metadata(ctx, req)
                         .await?
                         .encode::<


### PR DESCRIPTION
## Why

When an interceptor reads the request body via `Payload::message::<M>()`, the decode is cached in `Payload`'s `OnceLock`. `DispatchTerminal::call` then stripped the `Payload` back to raw `Bytes` (`payload.encoded()`) and handed them to `Dispatcher::call_unary`, which decoded the same bytes a second time for the handler. The interceptor's cache was discarded — every body-inspecting interceptor pays for the decode twice.

## What

Pass the `Payload` through the dispatcher contract so the handler's decode can reuse the interceptor's cache.

- **`Dispatcher::call_unary` takes `Payload`, not `Bytes`.** `ErasedHandler` and the `Router`/codegen impls follow. Pre-1.0 breaking change.
- **`Payload::take_message::<M>()`** consumes `self` and returns an owned `M`: the cached decode if one exists (no re-decode, the `Box<M>` is unboxed in place), the replacement if `set_message` was called, or a fresh decode otherwise. Owned-message handlers (`Router::route`) call this.
- **`AnyMessage::into_any(self: Box<Self>) -> Box<dyn Any>`** so a cached `Box<dyn AnyMessage>` can be downcast and moved out by value. Breaking for manual `AnyMessage` impls (the doc says "you will almost never" write one); the blanket impl covers every codegen message.
- **Generated dispatchers and zero-copy view handlers call `Payload::encoded()`** — the cache stores owned messages, not views, so it cannot help the view path. `encoded()` is a refcounted `Bytes` clone for the common no-replacement case, the same cost as before.
- **The empty-interceptor-chain fast path keeps its no-overhead invariant.** `Payload::new` is plain struct construction (no allocation, no decode).

### Behavioral change worth noting

Before this PR, an interceptor that decoded the body as the *wrong* message type failed silently: the handler decoded the wire bytes independently and never saw the interceptor's mistake. Now `Payload::take_message` surfaces the wrong-type cache as an `Internal` error at the handler. This is the intended behavior — interceptors and handlers for the same RPC must agree on the message types — but it's a change. The `take_message_wrong_cached_type_errors` test pins it.

## Confidence

- 6 new `Payload::take_message` unit tests (fresh decode, cache reuse, replacement, wrong cache type, wrong replacement type, decode error code).
- New `dispatch_terminal_forwards_payload_to_handler` interceptor test: hands the dispatcher a `Payload` whose wire bytes are garbage but whose cache holds a replacement — if the terminal stripped the `Payload` to bytes (the old behavior), the dispatcher's decode would error; if it forwards the `Payload`, the dispatcher sees the replacement.
- 336 `connectrpc` lib tests, 20 `streaming-test` e2e tests pass. `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt` clean. `cargo doc` introduces no new warnings.
- `task generate:all` regenerated all checked-in `*.__connect.rs` files; the diff there is just the `request: Payload` signature change and the `request.encoded()?` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
