### PR TITLE
router: store Spec per route so dynamic dispatch carries it

### DIFF
--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -327,6 +327,7 @@ impl<S: BenchService> BenchServiceExt for S {
                     })
                 },
             )
+            .with_spec(BENCH_SERVICE_UNARY_SPEC)
             .route_view_server_stream::<
                 _,
                 _,
@@ -342,6 +343,7 @@ impl<S: BenchService> BenchServiceExt for S {
                     }
                 }),
             )
+            .with_spec(BENCH_SERVICE_SERVER_STREAM_SPEC)
             .route_view_client_stream(
                 BENCH_SERVICE_SERVICE_NAME,
                 "ClientStream",
@@ -357,6 +359,7 @@ impl<S: BenchService> BenchServiceExt for S {
                     }
                 }),
             )
+            .with_spec(BENCH_SERVICE_CLIENT_STREAM_SPEC)
             .route_view_bidi_stream::<
                 _,
                 _,
@@ -372,6 +375,7 @@ impl<S: BenchService> BenchServiceExt for S {
                     }
                 }),
             )
+            .with_spec(BENCH_SERVICE_BIDI_STREAM_SPEC)
             .route_view(
                 BENCH_SERVICE_SERVICE_NAME,
                 "LogUnary",
@@ -387,6 +391,7 @@ impl<S: BenchService> BenchServiceExt for S {
                     })
                 },
             )
+            .with_spec(BENCH_SERVICE_LOG_UNARY_SPEC)
             .route_view(
                 BENCH_SERVICE_SERVICE_NAME,
                 "LogUnaryOwned",
@@ -402,6 +407,7 @@ impl<S: BenchService> BenchServiceExt for S {
                     })
                 },
             )
+            .with_spec(BENCH_SERVICE_LOG_UNARY_OWNED_SPEC)
     }
 }
 /// Monomorphic dispatcher for `BenchService`.
@@ -1039,6 +1045,7 @@ impl<S: EchoService> EchoServiceExt for S {
                     })
                 },
             )
+            .with_spec(ECHO_SERVICE_ECHO_SPEC)
     }
 }
 /// Monomorphic dispatcher for `EchoService`.
@@ -1383,6 +1390,7 @@ impl<S: LogIngestService> LogIngestServiceExt for S {
                     })
                 },
             )
+            .with_spec(LOG_INGEST_SERVICE_INGEST_SPEC)
     }
 }
 /// Monomorphic dispatcher for `LogIngestService`.

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -134,6 +134,7 @@ impl<S: LogIngestService> LogIngestServiceExt for S {
                     })
                 },
             )
+            .with_spec(LOG_INGEST_SERVICE_INGEST_SPEC)
     }
 }
 /// Monomorphic dispatcher for `LogIngestService`.

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -133,6 +133,7 @@ impl<S: BloatEchoService> BloatEchoServiceExt for S {
                     })
                 },
             )
+            .with_spec(BLOAT_ECHO_SERVICE_ECHO_SPEC)
     }
 }
 /// Monomorphic dispatcher for `BloatEchoService`.

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -132,6 +132,7 @@ impl<S: FilterService> FilterServiceExt for S {
                     })
                 },
             )
+            .with_spec(FILTER_SERVICE_REDACT_SPEC)
     }
 }
 /// Monomorphic dispatcher for `FilterService`.

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -134,6 +134,7 @@ impl<S: FortuneService> FortuneServiceExt for S {
                     })
                 },
             )
+            .with_spec(FORTUNE_SERVICE_GET_FORTUNES_SPEC)
     }
 }
 /// Monomorphic dispatcher for `FortuneService`.

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -529,6 +529,7 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     })
                 },
             )
+            .with_spec(CONFORMANCE_SERVICE_UNARY_SPEC)
             .route_view_server_stream::<
                 _,
                 _,
@@ -544,6 +545,7 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     }
                 }),
             )
+            .with_spec(CONFORMANCE_SERVICE_SERVER_STREAM_SPEC)
             .route_view_client_stream(
                 CONFORMANCE_SERVICE_SERVICE_NAME,
                 "ClientStream",
@@ -561,6 +563,7 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     }
                 }),
             )
+            .with_spec(CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC)
             .route_view_bidi_stream::<
                 _,
                 _,
@@ -576,6 +579,7 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     }
                 }),
             )
+            .with_spec(CONFORMANCE_SERVICE_BIDI_STREAM_SPEC)
             .route_view(
                 CONFORMANCE_SERVICE_SERVICE_NAME,
                 "Unimplemented",
@@ -593,6 +597,7 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     })
                 },
             )
+            .with_spec(CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC)
             .route_view_idempotent(
                 CONFORMANCE_SERVICE_SERVICE_NAME,
                 "IdempotentUnary",
@@ -610,6 +615,7 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                     })
                 },
             )
+            .with_spec(CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC)
     }
 }
 /// Monomorphic dispatcher for `ConformanceService`.

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1046,11 +1046,15 @@ fn generate_service(
         .map(|m| {
             let method_name = m.name.as_deref().unwrap_or("");
             let method_snake = make_field_ident(&method_name.to_snake_case());
+            // Attach the per-method `Spec` const so the dynamic `Router`
+            // surfaces `RequestContext::spec()` exactly like the
+            // monomorphic `FooServiceServer<T>` dispatcher does.
+            let spec_const = method_spec_const_ident(service, method_name);
 
             let client_streaming = m.client_streaming.unwrap_or(false);
             let server_streaming = m.server_streaming.unwrap_or(false);
 
-            if server_streaming && !client_streaming {
+            let route_call = if server_streaming && !client_streaming {
                 // Server streaming method. The trait method returns
                 // `ServiceStream<impl Encodable<Out>>`; `Res = Out` is no
                 // longer derivable from the opaque item type, so it must
@@ -1142,6 +1146,11 @@ fn generate_service(
                         },
                     )
                 }
+            };
+
+            quote! {
+                #route_call
+                .with_spec(#spec_const)
             }
         })
         .collect();

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -31,6 +31,8 @@ use crate::handler::ViewBidiStreamingHandler;
 use crate::handler::ViewClientStreamingHandler;
 use crate::handler::ViewHandler;
 use crate::handler::ViewStreamingHandler;
+use crate::spec::IdempotencyLevel;
+use crate::spec::Spec;
 
 /// The kind of RPC method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,22 +79,42 @@ enum Method {
     BidiStreaming(BidiStreamingMethod),
 }
 
+/// A registered method plus its optional static [`Spec`].
+///
+/// `spec` is `None` until [`Router::with_spec`] runs for the route. The
+/// generated `FooServiceExt::register` always chains `.with_spec(...)`
+/// after the `route_*` call; hand-written registrations may omit it
+/// (their paths are usually owned `String`s, not `&'static str`s, so
+/// they cannot construct a [`Spec`] anyway).
+struct RegisteredMethod {
+    method: Method,
+    spec: Option<Spec>,
+}
+
+impl From<Method> for RegisteredMethod {
+    fn from(method: Method) -> Self {
+        Self { method, spec: None }
+    }
+}
+
 /// Router for ConnectRPC services.
 ///
 /// The router maps service/method paths to their handlers and manages
 /// request dispatching.
 ///
 /// `Router` is the *dynamic* dispatch path: method paths are owned `String`
-/// keys, so it cannot supply [`Spec::procedure`](crate::Spec::procedure)'s
-/// `&'static str` and handlers receive [`RequestContext::spec`] as `None`.
-/// Code that needs `Spec` (interceptors, OTel labels) should use the
-/// generated `FooServiceServer<T>` dispatcher instead.
+/// keys. It can still carry a [`Spec`] when one is attached with
+/// [`with_spec`](Self::with_spec) — the generated
+/// `FooServiceExt::register` does this for every method, so a `Router`
+/// built through codegen surfaces [`RequestContext::spec`] just like the
+/// monomorphic `FooServiceServer<T>` dispatcher does. Hand-written
+/// `route_*` registrations without a `Spec` surface `None`.
 ///
 /// [`RequestContext::spec`]: crate::RequestContext::spec
 #[derive(Default)]
 pub struct Router {
     /// Map from "service_name/method_name" to handler.
-    methods: HashMap<String, Method>,
+    methods: HashMap<String, RegisteredMethod>,
 }
 
 impl Router {
@@ -180,7 +202,8 @@ impl Router {
             Method::Unary(UnaryMethod {
                 handler: Arc::new(wrapper),
                 idempotent,
-            }),
+            })
+            .into(),
         );
         self
     }
@@ -219,7 +242,8 @@ impl Router {
             Method::Streaming(StreamingMethod {
                 handler: Arc::new(wrapper),
                 kind: MethodKind::ServerStreaming,
-            }),
+            })
+            .into(),
         );
         self
     }
@@ -244,7 +268,8 @@ impl Router {
             path,
             Method::ClientStreaming(ClientStreamingMethod {
                 handler: Arc::new(wrapper),
-            }),
+            })
+            .into(),
         );
         self
     }
@@ -269,7 +294,8 @@ impl Router {
             path,
             Method::BidiStreaming(BidiStreamingMethod {
                 handler: Arc::new(wrapper),
-            }),
+            })
+            .into(),
         );
         self
     }
@@ -323,7 +349,8 @@ impl Router {
             Method::Unary(UnaryMethod {
                 handler: Arc::new(wrapper),
                 idempotent,
-            }),
+            })
+            .into(),
         );
         self
     }
@@ -348,7 +375,8 @@ impl Router {
             Method::Streaming(StreamingMethod {
                 handler: Arc::new(wrapper),
                 kind: MethodKind::ServerStreaming,
-            }),
+            })
+            .into(),
         );
         self
     }
@@ -371,7 +399,8 @@ impl Router {
             path,
             Method::ClientStreaming(ClientStreamingMethod {
                 handler: Arc::new(wrapper),
-            }),
+            })
+            .into(),
         );
         self
     }
@@ -395,8 +424,61 @@ impl Router {
             path,
             Method::BidiStreaming(BidiStreamingMethod {
                 handler: Arc::new(wrapper),
-            }),
+            })
+            .into(),
         );
+        self
+    }
+
+    /// Attach a [`Spec`] to the route registered at `spec.procedure`.
+    ///
+    /// The route must already exist — [`Spec::procedure`] is the lookup
+    /// key (with the leading slash stripped, matching the `route_*`
+    /// methods' `format!("{service}/{method}")` keying). Generated
+    /// `FooServiceExt::register` chains this after each `route_view*`
+    /// call so the dynamic `Router` carries the same per-method
+    /// metadata as the monomorphic `FooServiceServer<T>`. Hand-written
+    /// registrations may call it too when they have a `&'static`
+    /// procedure path:
+    ///
+    /// ```rust,ignore
+    /// const SAY_SPEC: Spec = Spec::server("/eliza.v1.Eliza/Say", StreamType::Unary);
+    /// let router = Router::new()
+    ///     .route_view_idempotent("eliza.v1.Eliza", "Say", handler)
+    ///     .with_spec(SAY_SPEC);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Debug builds panic if no route is registered at `spec.procedure`,
+    /// or if the route is unary and `spec.idempotency_level` disagrees
+    /// with the `route` / `route_idempotent` choice. Both indicate a
+    /// programming error in `register()` (a typo, or calling `with_spec`
+    /// before the matching `route_*`); release builds skip the check and
+    /// silently drop the `Spec`.
+    #[must_use]
+    pub fn with_spec(mut self, spec: Spec) -> Self {
+        let key = spec.procedure.strip_prefix('/').unwrap_or(spec.procedure);
+        match self.methods.get_mut(key) {
+            Some(m) => {
+                if let Method::Unary(u) = &m.method {
+                    debug_assert_eq!(
+                        u.idempotent,
+                        spec.idempotency_level == IdempotencyLevel::NoSideEffects,
+                        "route {key:?} idempotency disagrees with Spec::idempotency_level — \
+                         pick `route` vs `route_idempotent` to match the Spec"
+                    );
+                }
+                m.spec = Some(spec);
+            }
+            None => {
+                debug_assert!(
+                    false,
+                    "Router::with_spec: no route registered at {key:?} — \
+                     call the matching `route_*` first"
+                );
+            }
+        }
         self
     }
 
@@ -418,12 +500,17 @@ impl Router {
 impl crate::dispatcher::Dispatcher for Router {
     fn lookup(&self, path: &str) -> Option<crate::dispatcher::MethodDescriptor> {
         use crate::dispatcher::MethodDescriptor;
-        match self.methods.get(path)? {
-            Method::Unary(m) => Some(MethodDescriptor::unary(m.idempotent)),
-            Method::Streaming(m) => Some(MethodDescriptor::from_kind(m.kind)),
-            Method::ClientStreaming(_) => Some(MethodDescriptor::client_streaming()),
-            Method::BidiStreaming(_) => Some(MethodDescriptor::bidi_streaming()),
+        let m = self.methods.get(path)?;
+        let mut desc = match &m.method {
+            Method::Unary(u) => MethodDescriptor::unary(u.idempotent),
+            Method::Streaming(s) => MethodDescriptor::from_kind(s.kind),
+            Method::ClientStreaming(_) => MethodDescriptor::client_streaming(),
+            Method::BidiStreaming(_) => MethodDescriptor::bidi_streaming(),
+        };
+        if let Some(spec) = m.spec {
+            desc = desc.with_spec(spec);
         }
+        Some(desc)
     }
 
     fn call_unary(
@@ -433,7 +520,7 @@ impl crate::dispatcher::Dispatcher for Router {
         request: bytes::Bytes,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::UnaryResult {
-        match self.methods.get(path) {
+        match self.methods.get(path).map(|m| &m.method) {
             Some(Method::Unary(m)) => m.handler.call_erased(ctx, request, format),
             _ => crate::dispatcher::unimplemented_unary(path),
         }
@@ -446,7 +533,7 @@ impl crate::dispatcher::Dispatcher for Router {
         request: bytes::Bytes,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::StreamingResult {
-        match self.methods.get(path) {
+        match self.methods.get(path).map(|m| &m.method) {
             Some(Method::Streaming(m)) => m.handler.call_erased(ctx, request, format),
             _ => crate::dispatcher::unimplemented_streaming(path),
         }
@@ -459,7 +546,7 @@ impl crate::dispatcher::Dispatcher for Router {
         requests: crate::dispatcher::RequestStream,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::UnaryResult {
-        match self.methods.get(path) {
+        match self.methods.get(path).map(|m| &m.method) {
             Some(Method::ClientStreaming(m)) => m.handler.call_erased(ctx, requests, format),
             _ => crate::dispatcher::unimplemented_unary(path),
         }
@@ -472,7 +559,7 @@ impl crate::dispatcher::Dispatcher for Router {
         requests: crate::dispatcher::RequestStream,
         format: crate::codec::CodecFormat,
     ) -> crate::dispatcher::StreamingResult {
-        match self.methods.get(path) {
+        match self.methods.get(path).map(|m| &m.method) {
             Some(Method::BidiStreaming(m)) => m.handler.call_erased(ctx, requests, format),
             _ => crate::dispatcher::unimplemented_streaming(path),
         }
@@ -491,6 +578,10 @@ pub fn merge_routers(routers: impl IntoIterator<Item = Router>) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dispatcher::Dispatcher;
+    use crate::handler_fn;
+    use crate::spec::StreamType;
+    use buffa_types::Empty;
 
     #[test]
     fn test_router_registration() {
@@ -498,5 +589,81 @@ mod tests {
         // Full testing requires actual proto types
         let router = Router::new();
         assert!(!router.has_method("test.Service/Method"));
+    }
+
+    fn unary_handler() -> impl Handler<Empty, Empty> {
+        handler_fn(|_ctx, _req: Empty| async { crate::Response::ok(Empty::default()) })
+    }
+
+    /// `with_spec` attaches the `Spec` and `lookup` returns it. This is
+    /// the property the codegen relies on: a `Router` built through
+    /// `register()` should surface `RequestContext::spec` exactly like
+    /// the monomorphic `FooServiceServer<T>` dispatcher.
+    #[test]
+    fn with_spec_round_trips_through_lookup() {
+        const SPEC: Spec = Spec::server("/test.Svc/Method", StreamType::Unary);
+        let router = Router::new()
+            .route("test.Svc", "Method", unary_handler())
+            .with_spec(SPEC);
+
+        let desc = router.lookup("test.Svc/Method").expect("route exists");
+        assert_eq!(
+            desc.spec,
+            Some(SPEC),
+            "lookup must return the attached Spec"
+        );
+        assert_eq!(desc.kind, MethodKind::Unary);
+        assert!(!desc.idempotent);
+    }
+
+    /// A route registered without `with_spec` keeps the pre-existing
+    /// `spec: None` behavior — back-compat.
+    #[test]
+    fn route_without_with_spec_is_unchanged() {
+        let router = Router::new().route("test.Svc", "Method", unary_handler());
+        let desc = router.lookup("test.Svc/Method").expect("route exists");
+        assert_eq!(desc.spec, None);
+    }
+
+    /// `merge_routers` carries each route's `Spec` across the merge.
+    #[test]
+    fn merge_routers_preserves_specs() {
+        const A: Spec = Spec::server("/svc.A/M", StreamType::Unary);
+        const B: Spec = Spec::server("/svc.B/N", StreamType::Unary);
+        let merged = merge_routers([
+            Router::new()
+                .route("svc.A", "M", unary_handler())
+                .with_spec(A),
+            Router::new()
+                .route("svc.B", "N", unary_handler())
+                .with_spec(B),
+        ]);
+        assert_eq!(merged.lookup("svc.A/M").unwrap().spec, Some(A));
+        assert_eq!(merged.lookup("svc.B/N").unwrap().spec, Some(B));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "no route registered")]
+    fn with_spec_unknown_route_panics_in_debug() {
+        const SPEC: Spec = Spec::server("/test.Svc/Nope", StreamType::Unary);
+        let _ = Router::new()
+            .route("test.Svc", "Method", unary_handler())
+            .with_spec(SPEC);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "idempotency disagrees")]
+    fn with_spec_idempotency_mismatch_panics_in_debug() {
+        // Spec declares NoSideEffects but the route was registered via
+        // `route` (idempotent: false). The `idempotent` flag is what the
+        // dispatch path consults to allow Connect GET, so a mismatch
+        // here would silently disable GET for an idempotent method.
+        const SPEC: Spec = Spec::server("/test.Svc/Method", StreamType::Unary)
+            .with_idempotency_level(IdempotencyLevel::NoSideEffects);
+        let _ = Router::new()
+            .route("test.Svc", "Method", unary_handler())
+            .with_spec(SPEC);
     }
 }

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -3640,19 +3640,16 @@ mod tests {
         );
     }
 
-    /// Prove that `RequestContext::path()` carries the request URI path
-    /// through the dispatch path, in the leading-slash form, *even when*
-    /// `RequestContext::spec()` is `None`.
-    ///
-    /// This test deliberately uses the dynamic [`Router`], which never
-    /// supplies a [`Spec`](crate::spec::Spec) — `path()` is the only
-    /// reliable source for the procedure name in that case, and it's the
-    /// one an auth interceptor or span builder must read.
-    #[tokio::test]
-    async fn path_flows_to_handler_context() {
+    /// Register a `svc/Method` handler that captures
+    /// `(ctx.path(), ctx.spec())`, apply `finalize` (e.g. `with_spec`),
+    /// drive a request through `handle_unary_request`, and return the
+    /// captured tuple.
+    async fn capture_path_and_spec(
+        finalize: impl FnOnce(Router) -> Router,
+    ) -> (Option<String>, Option<crate::spec::Spec>) {
         use std::sync::Mutex;
 
-        let captured = Arc::new(Mutex::new(None::<(Option<String>, bool)>));
+        let captured = Arc::new(Mutex::new(None));
         let handler_captured = Arc::clone(&captured);
         let router = Router::new().route(
             "svc",
@@ -3660,12 +3657,12 @@ mod tests {
             crate::handler_fn(move |ctx: RequestContext, _req: buffa_types::Empty| {
                 let cap = Arc::clone(&handler_captured);
                 async move {
-                    *cap.lock().unwrap() =
-                        Some((ctx.path().map(str::to_owned), ctx.spec().is_some()));
+                    *cap.lock().unwrap() = Some((ctx.path().map(str::to_owned), ctx.spec()));
                     crate::Response::ok(buffa_types::Empty::default())
                 }
             }),
         );
+        let router = finalize(router);
 
         let req = Request::builder()
             .method(Method::POST)
@@ -3686,15 +3683,52 @@ mod tests {
         .await
         .expect("dispatch should succeed");
 
-        let (path, spec_present) = captured.lock().unwrap().take().expect("handler ran");
+        captured.lock().unwrap().take().expect("handler ran")
+    }
+
+    /// Prove that `RequestContext::path()` carries the request URI path
+    /// through the dispatch path, in the leading-slash form, *even when*
+    /// `RequestContext::spec()` is `None`.
+    ///
+    /// A `Router` route registered without [`Router::with_spec`] supplies
+    /// no [`Spec`](crate::spec::Spec) — `path()` is the only source for
+    /// the procedure name in that case, and it's the one an auth
+    /// interceptor or span builder must read.
+    #[tokio::test]
+    async fn path_flows_to_handler_context() {
+        let (path, spec) = capture_path_and_spec(|r| r).await;
         assert_eq!(
             path.as_deref(),
             Some("/svc/Method"),
             "path() must carry the leading-slash request URI path"
         );
         assert!(
-            !spec_present,
-            "dynamic Router supplies no Spec — path() must still be populated"
+            spec.is_none(),
+            "Router route without with_spec supplies no Spec — path() must still be populated"
+        );
+    }
+
+    /// `Router::with_spec` flows through the dispatch path to
+    /// `RequestContext::spec()`. A `Router` built through the generated
+    /// `register()` (which chains `.with_spec(...)` after every
+    /// `route_view*`) surfaces `Spec` to handlers and interceptors
+    /// exactly like the monomorphic `FooServiceServer<T>` dispatcher.
+    /// `path()` and `spec().procedure` must agree when both are present.
+    #[tokio::test]
+    async fn spec_flows_to_handler_context() {
+        use crate::spec::{Spec, StreamType};
+        const SPEC: Spec = Spec::server("/svc/Method", StreamType::Unary);
+
+        let (path, spec) = capture_path_and_spec(|r| r.with_spec(SPEC)).await;
+        assert_eq!(
+            spec,
+            Some(SPEC),
+            "Router::with_spec must flow to ctx.spec()"
+        );
+        assert_eq!(
+            path.as_deref(),
+            spec.map(|s| s.procedure),
+            "path() and spec().procedure must agree when both are present"
         );
     }
 

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -244,6 +244,7 @@ impl<S: ElizaService> ElizaServiceExt for S {
                     })
                 },
             )
+            .with_spec(ELIZA_SERVICE_SAY_SPEC)
             .route_view_bidi_stream::<
                 _,
                 _,
@@ -259,6 +260,7 @@ impl<S: ElizaService> ElizaServiceExt for S {
                     }
                 }),
             )
+            .with_spec(ELIZA_SERVICE_CONVERSE_SPEC)
             .route_view_server_stream::<
                 _,
                 _,
@@ -274,6 +276,7 @@ impl<S: ElizaService> ElizaServiceExt for S {
                     }
                 }),
             )
+            .with_spec(ELIZA_SERVICE_INTRODUCE_SPEC)
     }
 }
 /// Monomorphic dispatcher for `ElizaService`.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -147,6 +147,7 @@ impl<S: GreetService> GreetServiceExt for S {
                     })
                 },
             )
+            .with_spec(GREET_SERVICE_GREET_SPEC)
     }
 }
 /// Monomorphic dispatcher for `GreetService`.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -138,6 +138,7 @@ impl<S: MathService> MathServiceExt for S {
                     })
                 },
             )
+            .with_spec(MATH_SERVICE_ADD_SPEC)
     }
 }
 /// Monomorphic dispatcher for `MathService`.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -272,6 +272,7 @@ impl<S: WellKnownTypesService> WellKnownTypesServiceExt for S {
                     })
                 },
             )
+            .with_spec(WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC)
             .route_view(
                 WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME,
                 "CalculateDuration",
@@ -289,6 +290,7 @@ impl<S: WellKnownTypesService> WellKnownTypesServiceExt for S {
                     })
                 },
             )
+            .with_spec(WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC)
             .route_view(
                 WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME,
                 "ProcessMetadata",
@@ -306,6 +308,7 @@ impl<S: WellKnownTypesService> WellKnownTypesServiceExt for S {
                     })
                 },
             )
+            .with_spec(WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC)
     }
 }
 /// Monomorphic dispatcher for `WellKnownTypesService`.

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1262,8 +1262,12 @@ mod tests {
         assert_eq!(resp.into_view().sequence, 1007);
     }
 
-    /// End-to-end: the codegen dispatcher surfaces `Spec` and `Protocol` on
-    /// `RequestContext`, and the dynamic `Router` does not (no `'static` path).
+    /// End-to-end: both dispatch paths surface `Spec` and `Protocol` on
+    /// `RequestContext`. The codegen `FooServiceServer<T>` always did;
+    /// the dynamic `Router` now does too because the generated
+    /// `register()` chains `.with_spec(...)` after every route. Handlers
+    /// and interceptors should see identical metadata regardless of which
+    /// dispatch path the host wired up.
     #[tokio::test]
     async fn handler_sees_spec_and_protocol() {
         async fn round_trip(addr: std::net::SocketAddr) -> String {
@@ -1279,6 +1283,7 @@ mod tests {
                 .data
                 .to_owned()
         }
+        const EXPECT: &str = "/test.echo.v1.EchoService/Echo|Unary|Connect|Unknown|Server";
 
         // Codegen dispatcher path → spec is populated.
         let server = EchoServiceServer::new(SpecReflectingService);
@@ -1287,23 +1292,26 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let _h = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-        assert_eq!(
-            round_trip(addr).await,
-            "/test.echo.v1.EchoService/Echo|Unary|Connect|Unknown|Server"
-        );
+        assert_eq!(round_trip(addr).await, EXPECT);
 
-        // Dynamic Router path → spec is None, protocol is still populated.
+        // Dynamic Router path → spec is also populated (same Spec const,
+        // attached via `Router::with_spec` in the generated `register()`).
         let router = Arc::new(SpecReflectingService).register(Router::new());
         let app = router.into_axum_router();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let _h = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-        assert_eq!(round_trip(addr).await, "<none>|Connect");
+        assert_eq!(
+            round_trip(addr).await,
+            EXPECT,
+            "Router path must surface the same Spec as the codegen dispatcher"
+        );
     }
 
-    /// Codegen emits a per-method `Spec` const and the generated dispatcher
-    /// surfaces it through `Dispatcher::lookup`. The dynamic `Router` cannot
-    /// (its keys are owned `String`s), so it must return `spec: None`.
+    /// Codegen emits a per-method `Spec` const and *both* generated
+    /// dispatch paths surface it through `Dispatcher::lookup`: the
+    /// monomorphic `FooServiceServer<T>` and the dynamic `Router` (which
+    /// gets it via `Router::with_spec` chained in `register()`).
     #[test]
     fn codegen_specs_thread_through_lookup() {
         use connectrpc::{Dispatcher, IdempotencyLevel, MethodKind, SpecOrigin, StreamType};
@@ -1334,9 +1342,10 @@ mod tests {
             StreamType::ServerStream
         );
 
-        // The codegen dispatcher's `lookup` returns the spec; the spec's
-        // procedure round-trips through the route the dispatcher matched.
+        // Both dispatchers' `lookup` return the same spec; the spec's
+        // procedure round-trips through the route they matched.
         let server = EchoServiceServer::new(TestEchoService);
+        let router = Arc::new(TestEchoService).register(Router::new());
         for (method, spec) in [
             ("Echo", ECHO_SERVICE_ECHO_SPEC),
             ("ServerStream", ECHO_SERVICE_SERVER_STREAM_SPEC),
@@ -1344,18 +1353,21 @@ mod tests {
             ("BidiStream", ECHO_SERVICE_BIDI_STREAM_SPEC),
         ] {
             let path = format!("test.echo.v1.EchoService/{method}");
-            let desc = server.lookup(&path).expect("registered method");
-            assert_eq!(desc.spec, Some(spec), "lookup({path}) spec mismatch");
-            assert_eq!(MethodKind::from(spec.stream_type), desc.kind);
-            assert_eq!(spec.procedure.trim_start_matches('/'), path);
+            for (label, dispatcher) in [
+                ("FooServiceServer", &server as &dyn Dispatcher),
+                ("Router", &router as &dyn Dispatcher),
+            ] {
+                let desc = dispatcher.lookup(&path).expect("registered method");
+                assert_eq!(
+                    desc.spec,
+                    Some(spec),
+                    "{label}::lookup({path}) spec mismatch"
+                );
+                assert_eq!(MethodKind::from(spec.stream_type), desc.kind);
+                assert_eq!(spec.procedure.trim_start_matches('/'), path);
+            }
         }
         assert!(server.lookup("test.echo.v1.EchoService/Nope").is_none());
-
-        // The dynamic `Router` returns no spec.
-        let router = Arc::new(TestEchoService).register(Router::new());
-        let desc = router
-            .lookup("test.echo.v1.EchoService/Echo")
-            .expect("registered method");
-        assert!(desc.spec.is_none());
+        assert!(router.lookup("test.echo.v1.EchoService/Nope").is_none());
     }
 }


### PR DESCRIPTION
## Why

The dynamic `Router` returned `spec: None` from `lookup()` because its registration API had nowhere to put a `Spec`. The codegen-emitted `register(Router)` has the static `*_SPEC` consts in scope (#112) but `route()` never accepted them — so a `Router` built through `register()` was metadata-blind: `RequestContext::spec()` was always `None` for handlers and interceptors, even though the monomorphic `FooServiceServer<T>` dispatcher for the *same service* supplies a `Spec` for every method. `RequestContext::path()` (#116) papers over the procedure name; `stream_type` and `idempotency` were just lost. An interceptor or span builder behaves differently depending on which dispatch path the host wired up — for the same proto.

## What

Each registered route now carries an `Option<Spec>`, set after the fact by `Router::with_spec(spec)`. The `Spec` keys the route by `spec.procedure` (leading slash stripped, matching the `route_*` methods' `format!("{service}/{method}")` keying), so the codegen chains `.with_spec(SPEC_CONST)` after each `route_view*` call without touching the `route_*` signatures. `lookup()` returns the stored `Spec`.

- `Router::with_spec` is the one new public method. `route_*` signatures and behavior are unchanged — a registration without `with_spec` behaves exactly as before (`spec: None`).
- Debug builds assert `with_spec` finds a registered route, and that the route's `idempotent` flag agrees with `spec.idempotency_level` — a mismatch would silently disable Connect GET for an idempotent method, which is a hard-to-find bug.
- The generated `register()` now emits `.with_spec(SPEC_CONST)` per method. Checked-in generated code in `benches/`, `examples/`, and `conformance/` regenerated.
- `merge_routers` carries each route's `Spec` across the merge (the storage moves with the entry).

## Confidence

- 5 new `router.rs` tests: round-trip through `lookup()`, back-compat without `with_spec`, `merge_routers` preserves specs, debug-assert panics on unknown route and on idempotency mismatch.
- 1 new `service.rs` test (`spec_flows_to_handler_context`): drives a request through `handle_unary_request` with a `with_spec`-attached `Router` and asserts the handler sees the `Spec` *and* that `path()` agrees with `spec().procedure`.
- 2 streaming-test e2e tests updated to assert the `Router` path now surfaces the same `Spec` as the codegen dispatcher (they previously asserted the *opposite* — that's the behavior change this PR is for).
- 335 lib + 37 codegen + 20 e2e tests pass. `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo doc` all clean (no new warnings).
- Regenerated all checked-in `*.__connect.rs` via `buf generate` with the workspace's `protoc-gen-connect-rust` build; only `connect/` outputs changed (`buffa/` outputs unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
