### PR TITLE
interceptor: streaming RPC support via Stream-shaped intercept_streaming

### DIFF
--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -1,11 +1,28 @@
-//! RPC-level interceptors for unary calls.
+//! RPC-level interceptors.
 //!
 //! Interceptors are the typed equivalent of `tower` middleware: they wrap
 //! a single RPC *after* envelope decoding, decompression, and header
-//! parsing, and *before* the handler runs. Each interceptor sees a
-//! [`UnaryRequest`] (the [`Spec`](crate::Spec), headers, deadline,
-//! extensions, and a lazily-decoded [`Payload`]) and a [`Next`]
-//! continuation, and returns a [`UnaryResponse`].
+//! parsing, and *before* the handler runs. Two surfaces:
+//!
+//! - **Unary** ([`Interceptor::intercept_unary`]): sees a [`UnaryRequest`]
+//!   (the [`Spec`](crate::Spec), headers, deadline, extensions, and a
+//!   lazily-decoded [`Payload`]) and a [`Next`] continuation, and returns
+//!   a [`UnaryResponse`].
+//! - **Streaming** ([`Interceptor::intercept_streaming`]): sees a
+//!   [`StreamRequest`], an inbound [`PayloadStream`], and a [`NextStream`]
+//!   continuation, and returns a [`StreamResponse`] carrying the outbound
+//!   [`PayloadStream`]. One method covers server-streaming,
+//!   client-streaming, and bidi by treating "one" as "stream of one".
+//!
+//! Streaming interceptors are **`Stream`-shaped, not connection-shaped.**
+//! `connect-go` exposes a `StreamingHandlerConn` with `Receive()`/`Send()`
+//! because Go handlers *push* — they call `stream.Send(res)`. Rust handlers
+//! *produce* — they return a [`Stream`](futures::Stream) the framework
+//! polls. There is no per-item `send()` call site to hook, so a conn
+//! wrapper would need a channel intermediary plus a pump task. Wrapping
+//! the inbound and outbound streams with adapters is the same expressive
+//! power without that cost, and matches the rest of the Rust ecosystem
+//! (`tower`, `tonic`, `axum` all work with `Stream`-shaped bodies).
 //!
 //! The first interceptor registered is the outermost: it runs first on
 //! the way in and last on the way out, exactly like wrapping a function
@@ -27,9 +44,12 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use futures::future::BoxFuture;
+use futures::stream::StreamExt;
 
 use crate::codec::CodecFormat;
+use crate::dispatcher::RequestStream;
 use crate::error::ConnectError;
+use crate::handler::BoxStream;
 use crate::payload::Payload;
 use crate::response::{EncodedResponse, RequestContext, Response};
 
@@ -110,6 +130,61 @@ pub trait Interceptor: Send + Sync + 'static {
         next: Next<'_>,
     ) -> Result<UnaryResponse, ConnectError> {
         next.run(req).await
+    }
+
+    /// Wrap a streaming RPC. The default is a passthrough.
+    ///
+    /// Called once at stream establishment, before any messages flow.
+    /// Wrap `inbound` with a [`Stream`](futures::Stream) adapter to
+    /// observe, mutate, or filter incoming messages; wrap the body of the
+    /// returned [`StreamResponse`] the same way. Returning without calling
+    /// `next.run()` short-circuits the chain — neither inner interceptors
+    /// nor the handler run. Returning `Err` aborts the stream with an
+    /// error rendered in the protocol's streaming error format
+    /// (`EndStreamResponse` envelope for Connect, `grpc-status` trailer
+    /// for gRPC/gRPC-Web).
+    ///
+    /// All three streaming shapes route through this method. For
+    /// server-streaming `inbound` yields exactly one item; for
+    /// client-streaming the returned outbound stream yields exactly one
+    /// item. Read [`Spec::stream_type`](crate::Spec::stream_type) (when
+    /// [`spec()`](RequestContext::spec) is present) to branch on
+    /// cardinality.
+    ///
+    /// Cross-stream coordination — making a decision on an outbound item
+    /// based on what was observed inbound — needs shared state between the
+    /// two stream adapters (e.g. an `Arc<Mutex<..>>` captured by both).
+    /// This is rare; most interceptors observe one direction or none.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// #[connectrpc::async_trait]
+    /// impl Interceptor for AuthInterceptor {
+    ///     async fn intercept_streaming(
+    ///         &self,
+    ///         req: StreamRequest,
+    ///         inbound: PayloadStream,
+    ///         next: NextStream<'_>,
+    ///     ) -> Result<StreamResponse, ConnectError> {
+    ///         // Auth runs once at establishment, not per message.
+    ///         let path = req.ctx.path().expect("dispatch sets path");
+    ///         self.authorize(path, req.ctx.headers()).await?;
+    ///         next.run(req, inbound).await
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Forward errors from `next.run`, or return your own to short-circuit.
+    async fn intercept_streaming(
+        &self,
+        req: StreamRequest,
+        inbound: PayloadStream,
+        next: NextStream<'_>,
+    ) -> Result<StreamResponse, ConnectError> {
+        next.run(req, inbound).await
     }
 }
 
@@ -286,6 +361,486 @@ impl UnaryResponse {
             trailers: self.trailers,
             compress: self.compress,
         })
+    }
+}
+
+// ============================================================================
+// Streaming
+// ============================================================================
+
+/// A stream of lazily-decoded message bodies, as seen by an
+/// [`Interceptor::intercept_streaming`].
+///
+/// The same type is used for both the inbound (client → server) and
+/// outbound (server → client) directions. Each item is a [`Payload`] —
+/// lazy decode, so an interceptor that never inspects message bodies pays
+/// only the per-item struct construction (no decode, no allocation beyond
+/// the wire `Bytes` refcount the dispatch path already holds).
+pub type PayloadStream = BoxStream<Result<Payload, ConnectError>>;
+
+/// A streaming RPC request as seen by an [`Interceptor`].
+///
+/// Mirrors [`UnaryRequest`] minus the `Payload` — stream messages arrive
+/// through the `inbound` [`PayloadStream`] passed to
+/// [`Interceptor::intercept_streaming`].
+///
+/// `#[non_exhaustive]` so future fields can be added without a breaking
+/// change. Construct with [`StreamRequest::new`]; destructure with a
+/// trailing `..`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct StreamRequest {
+    /// The dispatch context. Mutating `ctx.headers` or `ctx.extensions`
+    /// before `next.run` propagates to the handler.
+    pub ctx: RequestContext,
+}
+
+impl StreamRequest {
+    /// Build a `StreamRequest` from a dispatch context. Used by the
+    /// dispatch path and by test fixtures.
+    pub fn new(ctx: RequestContext) -> Self {
+        Self { ctx }
+    }
+}
+
+/// A streaming RPC response as seen by an [`Interceptor`].
+///
+/// Carries response metadata (headers, trailers, compression hint) and
+/// the outbound [`PayloadStream`]. All fields are public so an interceptor
+/// can read or rewrite the response on the way out — wrap `body` with a
+/// [`Stream`](futures::Stream) adapter to observe or mutate outbound
+/// messages, or [`with_header`](Response::with_header) /
+/// [`with_trailer`](Response::with_trailer) to set metadata.
+///
+/// Note the trailers are set by the handler **before** the body stream is
+/// drained — an interceptor cannot delay setting a trailer until it has
+/// seen the last outbound item.
+pub type StreamResponse = Response<PayloadStream>;
+
+impl StreamResponse {
+    /// Build a `StreamResponse` from a dispatcher's encoded streaming
+    /// response by wrapping each body item in a [`Payload`].
+    pub fn from_encoded(
+        resp: Response<BoxStream<Result<Bytes, ConnectError>>>,
+        format: CodecFormat,
+    ) -> Self {
+        resp.map_body(move |stream| -> PayloadStream {
+            Box::pin(stream.map(move |item| item.map(|bytes| Payload::new(bytes, format))))
+        })
+    }
+
+    /// Convert back to the dispatch path's encoded form by re-encoding
+    /// each [`Payload`].
+    ///
+    /// Items whose [`Payload::encoded`] fails (a replacement that failed
+    /// to re-encode) become `Err` entries in the stream, which the
+    /// dispatch path renders as a streaming error and then ends the
+    /// stream. There is no fallible up-front conversion: stream items
+    /// haven't been produced yet.
+    pub fn into_encoded(self) -> Response<BoxStream<Result<Bytes, ConnectError>>> {
+        self.map_body(|stream| -> BoxStream<Result<Bytes, ConnectError>> {
+            Box::pin(stream.map(|item| item.and_then(|payload| payload.encoded())))
+        })
+    }
+}
+
+/// Construct an [`Interceptor`] from a streaming closure.
+///
+/// The streaming counterpart of [`unary_interceptor`]. The closure must be
+/// a higher-ranked `Fn` over the [`NextStream`] lifetime that returns a
+/// boxed future. The boilerplate is unavoidable — the trait method returns
+/// a boxed future — but the closure body is what you'd write in an
+/// `impl Interceptor` block:
+///
+/// ```rust,ignore
+/// let logging = streaming_interceptor(|req, inbound, next| Box::pin(async move {
+///     tracing::info!(path = req.ctx.path(), "stream open");
+///     next.run(req, inbound).await
+/// }));
+/// ```
+pub fn streaming_interceptor<F>(f: F) -> impl Interceptor
+where
+    F: for<'a> Fn(
+            StreamRequest,
+            PayloadStream,
+            NextStream<'a>,
+        ) -> BoxFuture<'a, Result<StreamResponse, ConnectError>>
+        + Send
+        + Sync
+        + 'static,
+{
+    struct FnInterceptor<F>(F);
+
+    #[async_trait::async_trait]
+    impl<F> Interceptor for FnInterceptor<F>
+    where
+        F: for<'a> Fn(
+                StreamRequest,
+                PayloadStream,
+                NextStream<'a>,
+            ) -> BoxFuture<'a, Result<StreamResponse, ConnectError>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        async fn intercept_streaming(
+            &self,
+            req: StreamRequest,
+            inbound: PayloadStream,
+            next: NextStream<'_>,
+        ) -> Result<StreamResponse, ConnectError> {
+            (self.0)(req, inbound, next).await
+        }
+    }
+
+    FnInterceptor(f)
+}
+
+/// The continuation an [`Interceptor`] calls to run the rest of a
+/// streaming chain.
+///
+/// `NextStream` holds the still-to-run interceptors and the terminal
+/// handler. [`run`](NextStream::run) consumes it: an interceptor can call
+/// `next.run(req, inbound)` at most once. Not calling it short-circuits.
+pub struct NextStream<'a> {
+    rest: &'a [Arc<dyn Interceptor>],
+    terminal: &'a (dyn StreamTerminal + 'a),
+}
+
+impl<'a> NextStream<'a> {
+    /// Construct the head of a chain.
+    pub(crate) fn new(
+        rest: &'a [Arc<dyn Interceptor>],
+        terminal: &'a (dyn StreamTerminal + 'a),
+    ) -> Self {
+        Self { rest, terminal }
+    }
+
+    /// Run the rest of the chain — the next interceptor if any, otherwise
+    /// the terminal handler — and return its response.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever error the next interceptor or handler produced.
+    pub async fn run(
+        self,
+        req: StreamRequest,
+        inbound: PayloadStream,
+    ) -> Result<StreamResponse, ConnectError> {
+        match self.rest.split_first() {
+            Some((head, tail)) => {
+                head.intercept_streaming(
+                    req,
+                    inbound,
+                    NextStream {
+                        rest: tail,
+                        terminal: self.terminal,
+                    },
+                )
+                .await
+            }
+            None => self.terminal.call(req, inbound).await,
+        }
+    }
+}
+
+impl std::fmt::Debug for NextStream<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NextStream")
+            .field("remaining", &self.rest.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// The terminal step of a streaming interceptor chain: hand the inbound
+/// stream to the dispatcher and wrap the outbound stream.
+///
+/// `pub(crate)` because the only producer is the dispatch path. Tests
+/// inside the crate can supply mocks.
+#[async_trait::async_trait]
+pub(crate) trait StreamTerminal: Send + Sync {
+    async fn call(
+        &self,
+        req: StreamRequest,
+        inbound: PayloadStream,
+    ) -> Result<StreamResponse, ConnectError>;
+}
+
+/// Run a streaming interceptor chain against a closure terminal.
+///
+/// The streaming counterpart of [`run_chain`]. For **unit-testing** an
+/// [`Interceptor`] without a tower service or TCP listener.
+///
+/// ```rust,ignore
+/// let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(MyInterceptor)];
+/// let resp = connectrpc::interceptor::run_chain_streaming(
+///     &chain,
+///     my_req,
+///     my_inbound_stream,
+///     |req, inbound| async move {
+///         // assert what the handler would see
+///         Ok(StreamResponse::from_encoded(/* ... */, CodecFormat::Proto))
+///     },
+/// )
+/// .await?;
+/// ```
+///
+/// # Errors
+///
+/// Returns whatever error the chain or terminal produces.
+pub async fn run_chain_streaming<F, Fut>(
+    interceptors: &[Arc<dyn Interceptor>],
+    req: StreamRequest,
+    inbound: PayloadStream,
+    terminal: F,
+) -> Result<StreamResponse, ConnectError>
+where
+    F: Fn(StreamRequest, PayloadStream) -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = Result<StreamResponse, ConnectError>> + Send,
+{
+    struct FnTerminal<F>(F);
+
+    #[async_trait::async_trait]
+    impl<F, Fut> StreamTerminal for FnTerminal<F>
+    where
+        F: Fn(StreamRequest, PayloadStream) -> Fut + Send + Sync,
+        Fut: std::future::Future<Output = Result<StreamResponse, ConnectError>> + Send,
+    {
+        async fn call(
+            &self,
+            req: StreamRequest,
+            inbound: PayloadStream,
+        ) -> Result<StreamResponse, ConnectError> {
+            (self.0)(req, inbound).await
+        }
+    }
+
+    let terminal = FnTerminal(terminal);
+    NextStream::new(interceptors, &terminal)
+        .run(req, inbound)
+        .await
+}
+
+// ============================================================================
+// Streaming dispatch glue
+// ============================================================================
+
+/// Convert a [`PayloadStream`] back to the dispatcher's `RequestStream`
+/// (raw `Bytes`) by re-encoding each [`Payload`].
+fn payload_stream_to_request_stream(stream: PayloadStream) -> RequestStream {
+    Box::pin(stream.map(|item| item.and_then(|payload| payload.encoded())))
+}
+
+/// Wrap a dispatcher inbound `RequestStream` (raw `Bytes`) as a
+/// [`PayloadStream`] for the interceptor chain.
+fn request_stream_to_payload_stream(stream: RequestStream, format: CodecFormat) -> PayloadStream {
+    Box::pin(stream.map(move |item| item.map(|bytes| Payload::new(bytes, format))))
+}
+
+/// Run a server-streaming call through the interceptor chain, or skip
+/// straight to the dispatcher when there are no interceptors.
+///
+/// Server-streaming has a single request `Bytes`, presented to the
+/// interceptor as a 1-item inbound stream. The terminal pulls the single
+/// item back out and hands it to [`Dispatcher::call_server_streaming`].
+pub(crate) async fn call_server_streaming_intercepted<D: crate::Dispatcher>(
+    dispatcher: &D,
+    interceptors: &[Arc<dyn Interceptor>],
+    path: &str,
+    ctx: RequestContext,
+    body: Bytes,
+    format: CodecFormat,
+) -> Result<Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError> {
+    if interceptors.is_empty() {
+        return dispatcher
+            .call_server_streaming(path, ctx, body, format)
+            .await;
+    }
+    let terminal = ServerStreamingTerminal {
+        dispatcher,
+        path,
+        format,
+    };
+    let req = StreamRequest::new(ctx);
+    let inbound: PayloadStream = Box::pin(futures::stream::once(async move {
+        Ok(Payload::new(body, format))
+    }));
+    let resp = NextStream::new(interceptors, &terminal)
+        .run(req, inbound)
+        .await?;
+    Ok(resp.into_encoded())
+}
+
+/// Run a client-streaming call through the interceptor chain.
+///
+/// Client-streaming has an inbound stream and a single response, presented
+/// to the chain as a 1-item outbound stream. `call_client_streaming_intercepted`
+/// pulls the single item back out for the dispatch path.
+pub(crate) async fn call_client_streaming_intercepted<D: crate::Dispatcher>(
+    dispatcher: &D,
+    interceptors: &[Arc<dyn Interceptor>],
+    path: &str,
+    ctx: RequestContext,
+    requests: RequestStream,
+    format: CodecFormat,
+) -> Result<EncodedResponse, ConnectError> {
+    if interceptors.is_empty() {
+        return dispatcher
+            .call_client_streaming(path, ctx, requests, format)
+            .await;
+    }
+    let terminal = ClientStreamingTerminal {
+        dispatcher,
+        path,
+        format,
+    };
+    let req = StreamRequest::new(ctx);
+    let inbound = request_stream_to_payload_stream(requests, format);
+    let resp = NextStream::new(interceptors, &terminal)
+        .run(req, inbound)
+        .await?;
+    // The terminal produced a 1-item outbound stream; collapse it. The
+    // single item carries the (possibly replaced) response body. An
+    // interceptor that filtered the item away is a programming error;
+    // fail with `Internal` rather than send an empty response.
+    let Response {
+        body: mut stream,
+        headers,
+        trailers,
+        compress,
+    } = resp;
+    let body = match stream.next().await {
+        Some(Ok(payload)) => payload.encoded()?,
+        Some(Err(e)) => return Err(e),
+        None => {
+            return Err(ConnectError::internal(
+                "client-streaming interceptor consumed the response without replacing it",
+            ));
+        }
+    };
+    Ok(Response {
+        body,
+        headers,
+        trailers,
+        compress,
+    })
+}
+
+/// Run a bidi-streaming call through the interceptor chain.
+pub(crate) async fn call_bidi_streaming_intercepted<D: crate::Dispatcher>(
+    dispatcher: &D,
+    interceptors: &[Arc<dyn Interceptor>],
+    path: &str,
+    ctx: RequestContext,
+    requests: RequestStream,
+    format: CodecFormat,
+) -> Result<Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError> {
+    if interceptors.is_empty() {
+        return dispatcher
+            .call_bidi_streaming(path, ctx, requests, format)
+            .await;
+    }
+    let terminal = BidiStreamingTerminal {
+        dispatcher,
+        path,
+        format,
+    };
+    let req = StreamRequest::new(ctx);
+    let inbound = request_stream_to_payload_stream(requests, format);
+    let resp = NextStream::new(interceptors, &terminal)
+        .run(req, inbound)
+        .await?;
+    Ok(resp.into_encoded())
+}
+
+/// `StreamTerminal` that hands off to the dispatcher's
+/// `call_server_streaming`.
+struct ServerStreamingTerminal<'a, D> {
+    dispatcher: &'a D,
+    path: &'a str,
+    format: CodecFormat,
+}
+
+#[async_trait::async_trait]
+impl<D: crate::Dispatcher> StreamTerminal for ServerStreamingTerminal<'_, D> {
+    async fn call(
+        &self,
+        req: StreamRequest,
+        mut inbound: PayloadStream,
+    ) -> Result<StreamResponse, ConnectError> {
+        // The dispatch path provided a 1-item inbound stream. An
+        // interceptor that filtered it away is a programming error;
+        // fail rather than dispatch with no body.
+        let body = match inbound.next().await {
+            Some(Ok(payload)) => payload.encoded()?,
+            Some(Err(e)) => return Err(e),
+            None => {
+                return Err(ConnectError::internal(
+                    "server-streaming interceptor consumed the request without replacing it",
+                ));
+            }
+        };
+        let resp = self
+            .dispatcher
+            .call_server_streaming(self.path, req.ctx, body, self.format)
+            .await?;
+        Ok(StreamResponse::from_encoded(resp, self.format))
+    }
+}
+
+/// `StreamTerminal` that hands off to the dispatcher's
+/// `call_client_streaming`.
+struct ClientStreamingTerminal<'a, D> {
+    dispatcher: &'a D,
+    path: &'a str,
+    format: CodecFormat,
+}
+
+#[async_trait::async_trait]
+impl<D: crate::Dispatcher> StreamTerminal for ClientStreamingTerminal<'_, D> {
+    async fn call(
+        &self,
+        req: StreamRequest,
+        inbound: PayloadStream,
+    ) -> Result<StreamResponse, ConnectError> {
+        let requests = payload_stream_to_request_stream(inbound);
+        let resp = self
+            .dispatcher
+            .call_client_streaming(self.path, req.ctx, requests, self.format)
+            .await?;
+        let format = self.format;
+        // Wrap the single response in a 1-item outbound stream so the
+        // chain has a uniform type. `call_client_streaming_intercepted`
+        // pulls it back out for the dispatch path.
+        Ok(resp.map_body(move |bytes| -> PayloadStream {
+            Box::pin(futures::stream::once(async move {
+                Ok(Payload::new(bytes, format))
+            }))
+        }))
+    }
+}
+
+/// `StreamTerminal` that hands off to the dispatcher's
+/// `call_bidi_streaming`.
+struct BidiStreamingTerminal<'a, D> {
+    dispatcher: &'a D,
+    path: &'a str,
+    format: CodecFormat,
+}
+
+#[async_trait::async_trait]
+impl<D: crate::Dispatcher> StreamTerminal for BidiStreamingTerminal<'_, D> {
+    async fn call(
+        &self,
+        req: StreamRequest,
+        inbound: PayloadStream,
+    ) -> Result<StreamResponse, ConnectError> {
+        let requests = payload_stream_to_request_stream(inbound);
+        let resp = self
+            .dispatcher
+            .call_bidi_streaming(self.path, req.ctx, requests, self.format)
+            .await?;
+        Ok(StreamResponse::from_encoded(resp, self.format))
     }
 }
 
@@ -844,5 +1399,623 @@ mod tests {
             Some("from interceptor"),
             "the dispatcher must see the interceptor's replacement, not re-decode the wire bytes"
         );
+    }
+
+    // ========================================================================
+    // Streaming interceptor tests
+    // ========================================================================
+
+    /// Build a `PayloadStream` from string values.
+    fn payload_stream(values: &[&'static str]) -> PayloadStream {
+        let items: Vec<Result<Payload, ConnectError>> = values
+            .iter()
+            .map(|v| {
+                let bytes = encode_proto(&StringValue {
+                    value: (*v).into(),
+                    ..Default::default()
+                })
+                .unwrap();
+                Ok(Payload::new(bytes, CodecFormat::Proto))
+            })
+            .collect();
+        Box::pin(futures::stream::iter(items))
+    }
+
+    /// Drain a `PayloadStream` to decoded `StringValue`s.
+    async fn collect_strings(stream: PayloadStream) -> Vec<String> {
+        stream
+            .map(|item| {
+                item.unwrap()
+                    .message::<StringValue>()
+                    .unwrap()
+                    .value
+                    .clone()
+            })
+            .collect()
+            .await
+    }
+
+    /// Streaming counterpart of `Tagger`: pushes a label into request
+    /// extensions inbound, appends to a header outbound.
+    struct StreamTagger(&'static str);
+
+    #[async_trait::async_trait]
+    impl Interceptor for StreamTagger {
+        async fn intercept_streaming(
+            &self,
+            mut req: StreamRequest,
+            inbound: PayloadStream,
+            next: NextStream<'_>,
+        ) -> Result<StreamResponse, ConnectError> {
+            req.ctx
+                .extensions
+                .get_or_insert_default::<Trace>()
+                .0
+                .lock()
+                .unwrap()
+                .push(self.0);
+            let resp = next.run(req, inbound).await?;
+            Ok(resp.with_header("x-trace", format!("{}-out", self.0)))
+        }
+    }
+
+    /// A streaming terminal that records whether it ran, drains the
+    /// inbound stream into a header, and produces a fixed outbound stream.
+    struct RecordingStreamTerminal {
+        ran: Mutex<bool>,
+        respond_with: Vec<&'static str>,
+    }
+
+    #[async_trait::async_trait]
+    impl StreamTerminal for RecordingStreamTerminal {
+        async fn call(
+            &self,
+            _req: StreamRequest,
+            inbound: PayloadStream,
+        ) -> Result<StreamResponse, ConnectError> {
+            *self.ran.lock().unwrap() = true;
+            let inbound_values = collect_strings(inbound).await;
+            let body: PayloadStream = payload_stream(&self.respond_with);
+            let resp = Response {
+                body,
+                headers: http::HeaderMap::new(),
+                trailers: http::HeaderMap::new(),
+                compress: None,
+            };
+            Ok(resp.with_header("x-inbound", inbound_values.join(",")))
+        }
+    }
+
+    fn stream_req() -> StreamRequest {
+        StreamRequest::new(RequestContext::default())
+    }
+
+    #[tokio::test]
+    async fn streaming_ordering_first_registered_is_outermost() {
+        let trace = Trace::default();
+        let chain: Vec<Arc<dyn Interceptor>> = vec![
+            Arc::new(StreamTagger("a")),
+            Arc::new(StreamTagger("b")),
+            Arc::new(StreamTagger("c")),
+        ];
+        let terminal = RecordingStreamTerminal {
+            ran: Mutex::new(false),
+            respond_with: vec!["ok"],
+        };
+        let mut request = stream_req();
+        request.ctx.extensions.insert(trace.clone());
+        let resp = NextStream::new(&chain, &terminal)
+            .run(request, payload_stream(&["x"]))
+            .await
+            .unwrap();
+        assert!(*terminal.ran.lock().unwrap(), "terminal should have run");
+        // Way in: outermost first.
+        assert_eq!(*trace.0.lock().unwrap(), vec!["a", "b", "c"]);
+        // Way out: innermost appends first.
+        let outs: Vec<_> = resp
+            .headers
+            .get_all("x-trace")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_owned())
+            .collect();
+        assert_eq!(outs, vec!["c-out", "b-out", "a-out"]);
+    }
+
+    #[tokio::test]
+    async fn streaming_short_circuit_skips_terminal() {
+        struct Reject;
+        #[async_trait::async_trait]
+        impl Interceptor for Reject {
+            async fn intercept_streaming(
+                &self,
+                _req: StreamRequest,
+                _inbound: PayloadStream,
+                _next: NextStream<'_>,
+            ) -> Result<StreamResponse, ConnectError> {
+                let mut headers = http::HeaderMap::new();
+                headers.insert("x-deny-policy", "p1".parse().unwrap());
+                Err(ConnectError::permission_denied("nope").with_headers(headers))
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> =
+            vec![Arc::new(Reject), Arc::new(StreamTagger("never"))];
+        let terminal = RecordingStreamTerminal {
+            ran: Mutex::new(false),
+            respond_with: vec!["ok"],
+        };
+        let err = match NextStream::new(&chain, &terminal)
+            .run(stream_req(), payload_stream(&["x"]))
+            .await
+        {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code, crate::ErrorCode::PermissionDenied);
+        assert!(!*terminal.ran.lock().unwrap(), "terminal must not run");
+        // Diagnostic headers on a short-circuit error must survive the
+        // chain so the dispatch path's streaming error renderer can put
+        // them on the wire.
+        assert_eq!(
+            err.response_headers().get("x-deny-policy").unwrap(),
+            "p1",
+            "diagnostic headers must survive a streaming short-circuit"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_passthrough_preserves_items_and_metadata() {
+        struct Passthrough;
+        #[async_trait::async_trait]
+        impl Interceptor for Passthrough {}
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
+        let resp = run_chain_streaming(
+            &chain,
+            stream_req(),
+            payload_stream(&["a", "b"]),
+            |_req, inbound| async move {
+                let inbound_values = collect_strings(inbound).await;
+                let body: PayloadStream = payload_stream(&["x", "y", "z"]);
+                let mut r = Response {
+                    body,
+                    headers: http::HeaderMap::new(),
+                    trailers: http::HeaderMap::new(),
+                    compress: Some(true),
+                };
+                r.headers.insert("x-h", "1".parse().unwrap());
+                r.trailers.insert("x-t", "2".parse().unwrap());
+                r.headers
+                    .insert("x-inbound", inbound_values.join(",").parse().unwrap());
+                Ok(r)
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.headers.get("x-h").unwrap(), "1");
+        assert_eq!(resp.trailers.get("x-t").unwrap(), "2");
+        assert_eq!(resp.compress, Some(true));
+        assert_eq!(resp.headers.get("x-inbound").unwrap(), "a,b");
+        let out = collect_strings(resp.body).await;
+        assert_eq!(out, vec!["x", "y", "z"]);
+    }
+
+    #[tokio::test]
+    async fn streaming_interceptor_wraps_inbound() {
+        /// Replaces every inbound message with `"redacted"`.
+        struct RedactInbound;
+        #[async_trait::async_trait]
+        impl Interceptor for RedactInbound {
+            async fn intercept_streaming(
+                &self,
+                req: StreamRequest,
+                inbound: PayloadStream,
+                next: NextStream<'_>,
+            ) -> Result<StreamResponse, ConnectError> {
+                let wrapped: PayloadStream = Box::pin(inbound.map(|item| {
+                    item.map(|mut payload| {
+                        payload.set_message(StringValue {
+                            value: "redacted".into(),
+                            ..Default::default()
+                        });
+                        payload
+                    })
+                }));
+                next.run(req, wrapped).await
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(RedactInbound)];
+        let resp = run_chain_streaming(
+            &chain,
+            stream_req(),
+            payload_stream(&["secret-a", "secret-b"]),
+            |_req, inbound| async move {
+                let inbound_values = collect_strings(inbound).await;
+                let body: PayloadStream = payload_stream(&[]);
+                let resp = Response {
+                    body,
+                    headers: http::HeaderMap::new(),
+                    trailers: http::HeaderMap::new(),
+                    compress: None,
+                };
+                Ok(resp.with_header("x-inbound", inbound_values.join(",")))
+            },
+        )
+        .await
+        .unwrap();
+        // The terminal saw the wrapped inbound stream.
+        assert_eq!(resp.headers.get("x-inbound").unwrap(), "redacted,redacted");
+    }
+
+    #[tokio::test]
+    async fn streaming_interceptor_wraps_outbound() {
+        /// Replaces every outbound message with `"redacted"`.
+        struct RedactOutbound;
+        #[async_trait::async_trait]
+        impl Interceptor for RedactOutbound {
+            async fn intercept_streaming(
+                &self,
+                req: StreamRequest,
+                inbound: PayloadStream,
+                next: NextStream<'_>,
+            ) -> Result<StreamResponse, ConnectError> {
+                let resp = next.run(req, inbound).await?;
+                Ok(resp.map_body(|stream| -> PayloadStream {
+                    Box::pin(stream.map(|item| {
+                        item.map(|mut payload| {
+                            payload.set_message(StringValue {
+                                value: "redacted".into(),
+                                ..Default::default()
+                            });
+                            payload
+                        })
+                    }))
+                }))
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(RedactOutbound)];
+        let terminal = RecordingStreamTerminal {
+            ran: Mutex::new(false),
+            respond_with: vec!["secret-1", "secret-2"],
+        };
+        let resp = NextStream::new(&chain, &terminal)
+            .run(stream_req(), payload_stream(&["x"]))
+            .await
+            .unwrap();
+        let out = collect_strings(resp.body).await;
+        assert_eq!(out, vec!["redacted", "redacted"]);
+    }
+
+    #[tokio::test]
+    async fn streaming_closure_interceptor_works() {
+        let i = streaming_interceptor(|req, inbound, next| {
+            Box::pin(async move {
+                let resp = next.run(req, inbound).await?;
+                Ok(resp.with_header("x-fn", "1"))
+            })
+        });
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(i)];
+        let resp = run_chain_streaming(
+            &chain,
+            stream_req(),
+            payload_stream(&[]),
+            |_req, _in| async {
+                let body: PayloadStream = payload_stream(&[]);
+                Ok(Response {
+                    body,
+                    headers: http::HeaderMap::new(),
+                    trailers: http::HeaderMap::new(),
+                    compress: None,
+                })
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.headers.get("x-fn").unwrap(), "1");
+    }
+
+    /// A `Dispatcher` mock for testing the streaming dispatch glue.
+    /// Echoes the inbound items as the outbound stream.
+    struct StreamEcho;
+    impl crate::Dispatcher for StreamEcho {
+        fn lookup(&self, _: &str) -> Option<crate::dispatcher::MethodDescriptor> {
+            None
+        }
+        fn call_unary(
+            &self,
+            _: &str,
+            _: RequestContext,
+            _: Payload,
+            _: CodecFormat,
+        ) -> crate::dispatcher::UnaryResult {
+            unimplemented!()
+        }
+        fn call_server_streaming(
+            &self,
+            _: &str,
+            _: RequestContext,
+            request: Bytes,
+            _: CodecFormat,
+        ) -> crate::dispatcher::StreamingResult {
+            Box::pin(async move {
+                let body: BoxStream<Result<Bytes, ConnectError>> =
+                    Box::pin(futures::stream::once(async move { Ok(request) }));
+                Ok(Response {
+                    body,
+                    headers: http::HeaderMap::new(),
+                    trailers: http::HeaderMap::new(),
+                    compress: None,
+                })
+            })
+        }
+        fn call_client_streaming(
+            &self,
+            _: &str,
+            _: RequestContext,
+            requests: crate::dispatcher::RequestStream,
+            _: CodecFormat,
+        ) -> crate::dispatcher::UnaryResult {
+            Box::pin(async move {
+                let mut total = 0usize;
+                let mut requests = requests;
+                while let Some(item) = requests.next().await {
+                    total += item?.len();
+                }
+                Ok(EncodedResponse::new(Bytes::from(total.to_string())))
+            })
+        }
+        fn call_bidi_streaming(
+            &self,
+            _: &str,
+            _: RequestContext,
+            requests: crate::dispatcher::RequestStream,
+            _: CodecFormat,
+        ) -> crate::dispatcher::StreamingResult {
+            Box::pin(async move {
+                Ok(Response {
+                    body: requests,
+                    headers: http::HeaderMap::new(),
+                    trailers: http::HeaderMap::new(),
+                    compress: None,
+                })
+            })
+        }
+    }
+
+    /// All three `call_*_streaming_intercepted` empty-chain fast paths
+    /// delegate straight to the dispatcher with no `PayloadStream` /
+    /// `NextStream` overhead. Verified by pointer-equality on the
+    /// echoed body bytes.
+    #[tokio::test]
+    async fn streaming_empty_chain_is_no_op() {
+        // Server-streaming.
+        let body = Bytes::from_static(b"x");
+        let resp = call_server_streaming_intercepted(
+            &StreamEcho,
+            &[],
+            "p",
+            RequestContext::default(),
+            body.clone(),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        let out: Vec<_> = resp.body.collect().await;
+        assert_eq!(out.len(), 1);
+        assert!(std::ptr::eq(
+            out[0].as_ref().unwrap().as_ptr(),
+            body.as_ptr()
+        ));
+
+        // Client-streaming.
+        let inbound: RequestStream = Box::pin(futures::stream::iter(vec![
+            Ok(Bytes::from_static(b"ab")),
+            Ok(Bytes::from_static(b"cd")),
+        ]));
+        let resp = call_client_streaming_intercepted(
+            &StreamEcho,
+            &[],
+            "p",
+            RequestContext::default(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        assert_eq!(&*resp.body, b"4");
+
+        // Bidi-streaming.
+        let body = Bytes::from_static(b"z");
+        let inbound: RequestStream = Box::pin(futures::stream::once({
+            let body = body.clone();
+            async move { Ok(body) }
+        }));
+        let resp = call_bidi_streaming_intercepted(
+            &StreamEcho,
+            &[],
+            "p",
+            RequestContext::default(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        let out: Vec<_> = resp.body.collect().await;
+        assert_eq!(out.len(), 1);
+        assert!(std::ptr::eq(
+            out[0].as_ref().unwrap().as_ptr(),
+            body.as_ptr()
+        ));
+    }
+
+    /// `call_*_streaming_intercepted` propagates a short-circuit error
+    /// verbatim, including response headers, without invoking the
+    /// dispatcher. Pinned because an auth interceptor relies on it.
+    #[tokio::test]
+    async fn call_streaming_intercepted_propagates_error_headers() {
+        struct Reject;
+        #[async_trait::async_trait]
+        impl Interceptor for Reject {
+            async fn intercept_streaming(
+                &self,
+                _req: StreamRequest,
+                _inbound: PayloadStream,
+                _next: NextStream<'_>,
+            ) -> Result<StreamResponse, ConnectError> {
+                let mut headers = http::HeaderMap::new();
+                headers.insert("x-deny-policy", "p1".parse().unwrap());
+                Err(ConnectError::permission_denied("nope").with_headers(headers))
+            }
+        }
+        struct PanickyDispatcher;
+        impl crate::Dispatcher for PanickyDispatcher {
+            fn lookup(&self, _: &str) -> Option<crate::dispatcher::MethodDescriptor> {
+                None
+            }
+            fn call_unary(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Payload,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!()
+            }
+            fn call_server_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!("dispatcher must not run when an interceptor short-circuits")
+            }
+            fn call_client_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!("dispatcher must not run when an interceptor short-circuits")
+            }
+            fn call_bidi_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!("dispatcher must not run when an interceptor short-circuits")
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Reject)];
+
+        let err = match call_server_streaming_intercepted(
+            &PanickyDispatcher,
+            &chain,
+            "p",
+            RequestContext::default(),
+            Bytes::new(),
+            CodecFormat::Proto,
+        )
+        .await
+        {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code, crate::ErrorCode::PermissionDenied);
+        assert_eq!(err.response_headers().get("x-deny-policy").unwrap(), "p1");
+
+        let err = call_client_streaming_intercepted(
+            &PanickyDispatcher,
+            &chain,
+            "p",
+            RequestContext::default(),
+            Box::pin(futures::stream::empty()),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::PermissionDenied);
+
+        let err = match call_bidi_streaming_intercepted(
+            &PanickyDispatcher,
+            &chain,
+            "p",
+            RequestContext::default(),
+            Box::pin(futures::stream::empty()),
+            CodecFormat::Proto,
+        )
+        .await
+        {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code, crate::ErrorCode::PermissionDenied);
+    }
+
+    /// The three `call_*_streaming_intercepted` un-unify correctly —
+    /// server-streaming pulls a 1-item inbound stream, client-streaming
+    /// collapses a 1-item outbound stream — through a passthrough chain.
+    #[tokio::test]
+    async fn streaming_intercepted_un_unifies_through_passthrough_chain() {
+        struct Passthrough;
+        #[async_trait::async_trait]
+        impl Interceptor for Passthrough {}
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
+
+        // Server-streaming: single body in → 1-item inbound stream → terminal
+        // pulls it → echo dispatcher returns a 1-item outbound stream.
+        let body = Bytes::from_static(b"ss");
+        let resp = call_server_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            RequestContext::default(),
+            body.clone(),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        let out: Vec<_> = resp.body.collect().await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].as_ref().unwrap(), &body);
+
+        // Client-streaming: 2-item inbound stream → terminal hands stream
+        // to dispatcher → dispatcher's single response collapses to body.
+        let inbound: RequestStream = Box::pin(futures::stream::iter(vec![
+            Ok(Bytes::from_static(b"abc")),
+            Ok(Bytes::from_static(b"de")),
+        ]));
+        let resp = call_client_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            RequestContext::default(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        assert_eq!(&*resp.body, b"5");
+
+        // Bidi: 2-item inbound → echo dispatcher returns it as outbound.
+        let inbound: RequestStream = Box::pin(futures::stream::iter(vec![
+            Ok(Bytes::from_static(b"1")),
+            Ok(Bytes::from_static(b"2")),
+        ]));
+        let resp = call_bidi_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            RequestContext::default(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        let out: Vec<_> = resp.body.collect().await;
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].as_ref().unwrap(), &Bytes::from_static(b"1"));
+        assert_eq!(out[1].as_ref().unwrap(), &Bytes::from_static(b"2"));
     }
 }

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -286,11 +286,16 @@ pub use interceptor::async_trait;
 pub use payload::AnyMessage;
 pub use payload::Payload;
 
-// Unary RPC interceptors
+// RPC interceptors (unary and streaming)
 pub use interceptor::Interceptor;
 pub use interceptor::Next;
+pub use interceptor::NextStream;
+pub use interceptor::PayloadStream;
+pub use interceptor::StreamRequest;
+pub use interceptor::StreamResponse;
 pub use interceptor::UnaryRequest;
 pub use interceptor::UnaryResponse;
+pub use interceptor::streaming_interceptor;
 pub use interceptor::unary_interceptor;
 
 // ============================================================================

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -61,7 +61,10 @@ use crate::dispatcher::Dispatcher;
 use crate::envelope::Envelope;
 use crate::error::ConnectError;
 use crate::handler::BoxStream;
-use crate::interceptor::{Interceptor, call_unary_intercepted};
+use crate::interceptor::{
+    Interceptor, call_bidi_streaming_intercepted, call_client_streaming_intercepted,
+    call_server_streaming_intercepted, call_unary_intercepted,
+};
 use crate::protocol::Protocol;
 use crate::response::{EncodedResponse, RequestContext};
 use crate::router::MethodKind;
@@ -1205,8 +1208,10 @@ impl<D: Dispatcher> ConnectRpcService<D> {
     /// to a build without this call — there is no per-request allocation
     /// or branch beyond a single `is_empty` check.
     ///
-    /// Interceptors apply to **unary** calls only in this release.
-    /// Streaming calls bypass the chain.
+    /// Interceptors run for unary and streaming calls alike. The unary
+    /// surface is [`Interceptor::intercept_unary`]; the streaming surface
+    /// (covering server-streaming, client-streaming, and bidi) is
+    /// [`Interceptor::intercept_streaming`].
     ///
     /// To share one interceptor instance across multiple services, use
     /// [`with_interceptor_arc`](Self::with_interceptor_arc).
@@ -2085,6 +2090,7 @@ where
             compression,
             compression_policy,
             deadline_policy,
+            interceptors,
         )
         .await;
     }
@@ -2103,6 +2109,7 @@ where
             limits,
             compression,
             compression_policy,
+            interceptors,
         )
         .await;
     }
@@ -2209,7 +2216,14 @@ where
     // For gRPC unary handlers, we wrap the single response in a one-item stream.
     let resp = match dispatch_kind {
         StreamingDispatchKind::ServerStreaming => {
-            let fut = dispatcher.call_server_streaming(&path, ctx, request_body, codec_format);
+            let fut = call_server_streaming_intercepted(
+                dispatcher,
+                interceptors,
+                &path,
+                ctx,
+                request_body,
+                codec_format,
+            );
             let handler_result = if let Some(timeout) = metadata.timeout {
                 match tokio::time::timeout(timeout, fut).await {
                     Ok(result) => result,
@@ -2334,6 +2348,7 @@ async fn handle_client_streaming_request<D, B>(
     limits: Limits,
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
+    interceptors: &[Arc<dyn Interceptor>],
 ) -> Response<StreamingResponseBody>
 where
     D: Dispatcher,
@@ -2364,7 +2379,14 @@ where
     let handler_result = if let Some(timeout) = metadata.timeout {
         match tokio::time::timeout(
             timeout,
-            dispatcher.call_client_streaming(path, ctx, request_stream, codec_format),
+            call_client_streaming_intercepted(
+                dispatcher,
+                interceptors,
+                path,
+                ctx,
+                request_stream,
+                codec_format,
+            ),
         )
         .await
         {
@@ -2376,9 +2398,15 @@ where
             }
         }
     } else {
-        dispatcher
-            .call_client_streaming(path, ctx, request_stream, codec_format)
-            .await
+        call_client_streaming_intercepted(
+            dispatcher,
+            interceptors,
+            path,
+            ctx,
+            request_stream,
+            codec_format,
+        )
+        .await
     };
 
     let resp = match handler_result {
@@ -2586,6 +2614,7 @@ async fn handle_bidi_streaming_request<D, B>(
     compression: Arc<CompressionRegistry>,
     compression_policy: &CompressionPolicy,
     deadline_policy: &DeadlinePolicy,
+    interceptors: &[Arc<dyn Interceptor>],
 ) -> Response<StreamingResponseBody>
 where
     D: Dispatcher,
@@ -2614,7 +2643,14 @@ where
     let handler_result = if let Some(timeout) = metadata.timeout {
         match tokio::time::timeout(
             timeout,
-            dispatcher.call_bidi_streaming(path, ctx, request_stream, codec_format),
+            call_bidi_streaming_intercepted(
+                dispatcher,
+                interceptors,
+                path,
+                ctx,
+                request_stream,
+                codec_format,
+            ),
         )
         .await
         {
@@ -2626,9 +2662,15 @@ where
             }
         }
     } else {
-        dispatcher
-            .call_bidi_streaming(path, ctx, request_stream, codec_format)
-            .await
+        call_bidi_streaming_intercepted(
+            dispatcher,
+            interceptors,
+            path,
+            ctx,
+            request_stream,
+            codec_format,
+        )
+        .await
     };
 
     let resp = match handler_result {

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1262,6 +1262,188 @@ mod tests {
         assert_eq!(resp.into_view().sequence, 1007);
     }
 
+    /// End-to-end: a registered streaming interceptor wraps server-streaming,
+    /// client-streaming, and bidi calls. Each shape routes through
+    /// `intercept_streaming` exactly once at stream establishment, sees
+    /// `path()`, and can attach response metadata. An auth interceptor
+    /// running this hook is the security boundary for streaming RPCs — a
+    /// bypassed shape is a vulnerability, not a gap.
+    #[tokio::test]
+    async fn interceptor_wraps_streaming_calls() {
+        use connectrpc::{Interceptor, NextStream, PayloadStream, StreamRequest, StreamResponse};
+        use std::sync::Mutex;
+
+        /// Records the path of every streaming RPC it sees and stamps a
+        /// response header so the client can assert the interceptor ran.
+        #[derive(Clone)]
+        struct StreamRecorder(Arc<Mutex<Vec<String>>>);
+
+        #[connectrpc::async_trait]
+        impl Interceptor for StreamRecorder {
+            async fn intercept_streaming(
+                &self,
+                req: StreamRequest,
+                inbound: PayloadStream,
+                next: NextStream<'_>,
+            ) -> Result<StreamResponse, ConnectError> {
+                let path = req
+                    .ctx
+                    .path()
+                    .expect("dispatch sets path before interceptors run")
+                    .to_owned();
+                self.0.lock().unwrap().push(path.clone());
+                let resp = next.run(req, inbound).await?;
+                Ok(resp.with_header("x-stream-intercepted", path))
+            }
+        }
+
+        let recorder = StreamRecorder(Arc::new(Mutex::new(Vec::new())));
+        let server = EchoServiceServer::new(TestEchoService);
+        let service = ConnectRpcService::new(server).with_interceptor(recorder.clone());
+        let app = axum::Router::new().fallback_service(service);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _h = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = make_client(addr);
+
+        // Server streaming: 1 request → N responses.
+        let mut stream = client
+            .server_stream(EchoRequest {
+                sequence: 3,
+                data: "ss".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            stream.headers().get("x-stream-intercepted").unwrap(),
+            "/test.echo.v1.EchoService/ServerStream"
+        );
+        let mut received = 0;
+        while stream.message().await.unwrap().is_some() {
+            received += 1;
+        }
+        assert_eq!(
+            received, 3,
+            "stream items must flow through the interceptor"
+        );
+
+        // Client streaming: N requests → 1 response.
+        let messages: Vec<EchoRequest> = (0..2)
+            .map(|i| EchoRequest {
+                sequence: i,
+                data: format!("cs-{i}"),
+                ..Default::default()
+            })
+            .collect();
+        let resp = client.client_stream(messages).await.unwrap();
+        assert_eq!(
+            resp.headers().get("x-stream-intercepted").unwrap(),
+            "/test.echo.v1.EchoService/ClientStream"
+        );
+        assert_eq!(
+            resp.into_view().sequence,
+            2,
+            "all items must reach the handler"
+        );
+
+        // Bidi streaming: N requests ↔ N responses (gRPC, full duplex).
+        {
+            use connectrpc::Protocol;
+            use connectrpc::client::Http2Connection;
+            let uri: http::Uri = format!("http://{addr}").parse().unwrap();
+            let conn = Http2Connection::connect_plaintext(uri.clone())
+                .await
+                .unwrap()
+                .shared(8);
+            let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
+            let bidi_client = EchoServiceClient::new(conn, config);
+            let mut bidi = bidi_client.bidi_stream().await.unwrap();
+            bidi.send(EchoRequest {
+                sequence: 1,
+                data: "bidi".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+            bidi.close_send();
+            let mut received = 0;
+            while bidi.message().await.unwrap().is_some() {
+                received += 1;
+            }
+            assert_eq!(received, 1);
+        }
+
+        // The interceptor saw all three streaming RPCs.
+        let seen = recorder.0.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![
+                "/test.echo.v1.EchoService/ServerStream",
+                "/test.echo.v1.EchoService/ClientStream",
+                "/test.echo.v1.EchoService/BidiStream",
+            ]
+        );
+    }
+
+    /// A streaming interceptor that returns `Err` at establishment must
+    /// short-circuit before the handler runs, and the client must receive a
+    /// structured error in the streaming wire format — not a transport
+    /// failure.
+    #[tokio::test]
+    async fn streaming_interceptor_short_circuit_reaches_client() {
+        use connectrpc::{Interceptor, NextStream, PayloadStream, StreamRequest, StreamResponse};
+
+        struct DenyAll;
+        #[connectrpc::async_trait]
+        impl Interceptor for DenyAll {
+            async fn intercept_streaming(
+                &self,
+                _req: StreamRequest,
+                _inbound: PayloadStream,
+                _next: NextStream<'_>,
+            ) -> Result<StreamResponse, ConnectError> {
+                Err(ConnectError::permission_denied("not authorized"))
+            }
+        }
+
+        let server = EchoServiceServer::new(TestEchoService);
+        let service = ConnectRpcService::new(server).with_interceptor(DenyAll);
+        let app = axum::Router::new().fallback_service(service);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _h = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = make_client(addr);
+
+        // Server streaming: the deny is rendered as an EndStreamResponse
+        // envelope (HTTP 200, Connect protocol). The client surfaces it via
+        // `stream.error()` after `message()` returns `Ok(None)` — same as
+        // connect-go's `stream.Err()`.
+        let mut stream = client
+            .server_stream(EchoRequest {
+                sequence: 1,
+                ..Default::default()
+            })
+            .await
+            .expect("Connect-streaming errors arrive via the envelope, not the headers");
+        assert!(
+            stream.message().await.unwrap().is_none(),
+            "deny means no items"
+        );
+        let err = stream
+            .error()
+            .expect("interceptor deny must surface on the stream");
+        assert_eq!(err.code, connectrpc::ErrorCode::PermissionDenied);
+
+        // Client streaming: the response is unary-shaped over a streaming
+        // wire, so the error surfaces from the call itself.
+        let err = client
+            .client_stream(vec![EchoRequest::default()])
+            .await
+            .expect_err("expected deny");
+        assert_eq!(err.code, connectrpc::ErrorCode::PermissionDenied);
+    }
+
     /// End-to-end: both dispatch paths surface `Spec` and `Protocol` on
     /// `RequestContext`. The codegen `FooServiceServer<T>` always did;
     /// the dynamic `Router` now does too because the generated


### PR DESCRIPTION
## Why

`Interceptor::intercept_unary` (#114) covers only unary RPCs. Server-streaming, client-streaming, and bidi-streaming bypass the chain. For an auth interceptor that's a vulnerability — a streaming RPC that skips authorization — not a gap. This adds `Interceptor::intercept_streaming` covering all three streaming shapes.

## Design: `Stream`-shaped, not connection-shaped

connect-go exposes a `StreamingHandlerConn` with `Receive()`/`Send()` methods because Go handlers *push*: they call `stream.Send(res)` for each item. There's a per-item `Send()` call site for the interceptor's wrapper to hook.

connect-rust handlers *produce*: they return a `Stream` the framework polls. There is no per-item `send()` call site anywhere in the dispatch path. To synthesize one — to make the framework "call" `conn.send(item)` for each polled item so a conn wrapper could hook it — would require an `mpsc` channel between the handler's stream and the wire encoder, plus a pump task that drains it. A per-stream allocation, a task spawn, a buffer-size knob, and changed backpressure semantics, for the privilege of looking like Go.

The Rust-idiomatic shape against a `Stream`-producing handler is a `Stream` adapter: the interceptor wraps the inbound `Stream`, calls `next.run`, wraps the outbound `Stream`, returns. No channel, no pump task — `.map()` is one closure call per item when the closure does something and zero when it doesn't. This matches how `tower`, `tonic`, and `axum` all do `Stream`-shaped body interception.

Cross-stream coordination (deciding on an outbound item based on what was observed inbound) needs shared state between the two adapters — `Arc<Mutex<..>>` captured by both closures. This is rare; documented in the trait.

## Unification: one method, three shapes

`intercept_streaming(req: StreamRequest, inbound: PayloadStream, next: NextStream<'_>) -> Result<StreamResponse, ConnectError>` covers server-streaming, client-streaming, and bidi by treating "one" as "stream of one." The terminal does the un-unification:

- **Server-streaming**: terminal pulls the single item out of the (1-item) inbound stream and calls `dispatcher.call_server_streaming(path, ctx, body, format)`. The dispatcher's outbound `Stream` is the response.
- **Client-streaming**: terminal passes the inbound stream straight to `dispatcher.call_client_streaming(...)` and wraps the single `EncodedResponse` as a 1-item outbound stream; `call_client_streaming_intercepted` collapses it back.
- **Bidi**: passthrough both directions.

The `Dispatcher` trait, codegen, and handler signatures are **unchanged** — the unify/un-unify lives entirely in the new `call_*_streaming_intercepted` wrappers, the same way `call_unary_intercepted` slots into the existing `call_unary` contract.

`StreamResponse = Response<PayloadStream>` carries response headers, trailers, and the compression hint alongside the body stream — same as `UnaryResponse = Response<Payload>` does for unary. The interceptor can set or rewrite all of them.

## Cost

Each `call_*_streaming_intercepted` has the same `is_empty()` fast path as `call_unary_intercepted`: a service with no interceptors pays one branch, no `PayloadStream`, no `NextStream`, no per-item `Payload` construction.

For a registered chain, each stream item is wrapped in `Payload::new(bytes, format)` — one struct construction (a `Bytes` move + an empty `OnceLock`, no allocation). An interceptor that never reads message bodies pays only that. An interceptor that does read calls `payload.message::<M>()` per item, which decodes once and caches.

## Public surface

- `Interceptor::intercept_streaming` (default passthrough).
- `StreamRequest`, `StreamResponse`, `PayloadStream`, `NextStream` — streaming counterparts of `UnaryRequest`/`UnaryResponse`/`Next`.
- `streaming_interceptor` closure helper, `run_chain_streaming` test helper.
- `with_interceptor` doc updated to drop the "Streaming calls bypass the chain" caveat.

## Confidence

- 9 unit tests in `interceptor.rs`: ordering (outermost-first), short-circuit with diagnostic headers, passthrough preserves items + metadata, inbound `Stream` adapter wrapping, outbound `Stream` adapter wrapping, closure helper, empty-chain fast path (pointer-equality on the echoed bytes), error-header propagation through `call_*_streaming_intercepted` without invoking the dispatcher, and the un-unification round trip through a passthrough chain.
- 2 e2e tests in `tests/streaming/`: a recording interceptor wrapping all three streaming shapes through axum + the typed client (asserting it sees `path()` and stamps response headers), and a denying interceptor whose error reaches the client as a structured `permission_denied` (via `stream.error()` for server-streaming, via the call result for client-streaming).
- 338 lib + 22 e2e tests, `cargo fmt`, `cargo clippy --all-targets -- -D warnings` (lib + test crate), `cargo doc` clean (no new warnings). The conformance suite runs zero interceptors and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
