### PR TITLE
server: proxy with_interceptor / with_interceptor_arc to ConnectRpcService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,17 @@ increment the patch version.
   switch to the generated dispatcher if you need `Spec` in handlers or
   middleware.
 
+- **`Server::with_interceptor` and `Server::with_interceptor_arc`**
+  ([#123]). Proxies to the same methods on `ConnectRpcService`, completing
+  the proxy set started in [#105]. Standalone `Server` users can now
+  register interceptors without dropping down to
+  `Server::from_service(ConnectRpcService::new(...).with_interceptor(...))`.
+
 [#87]: https://github.com/anthropics/connect-rust/issues/87
+[#105]: https://github.com/anthropics/connect-rust/pull/105
 [#110]: https://github.com/anthropics/connect-rust/issues/110
 [#112]: https://github.com/anthropics/connect-rust/pull/112
+[#123]: https://github.com/anthropics/connect-rust/pull/123
 [`Router`]: https://docs.rs/connectrpc/latest/connectrpc/struct.Router.html
 
 ## [0.5.0] - 2026-05-18

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -264,6 +264,35 @@ impl Server {
         self
     }
 
+    /// Append an [`Interceptor`](crate::Interceptor) to the chain on the
+    /// underlying service.
+    ///
+    /// Delegates to [`ConnectRpcService::with_interceptor`]. Interceptors
+    /// run after envelope decoding, decompression, and protocol header
+    /// parsing, and before the handler — they see the parsed request, not
+    /// the wire bytes. The first interceptor registered runs **outermost**:
+    /// first on the way in, last on the way out. To share one interceptor
+    /// instance across several `Server`s, use
+    /// [`with_interceptor_arc`](Self::with_interceptor_arc).
+    #[must_use]
+    pub fn with_interceptor(mut self, interceptor: impl crate::Interceptor) -> Self {
+        self.service = self.service.with_interceptor(interceptor);
+        self
+    }
+
+    /// Append an already-`Arc`'d [`Interceptor`](crate::Interceptor) to the
+    /// chain on the underlying service.
+    ///
+    /// Delegates to [`ConnectRpcService::with_interceptor_arc`]. Same
+    /// ordering and semantics as [`with_interceptor`](Self::with_interceptor);
+    /// use this when one interceptor instance is shared across multiple
+    /// services or `Server`s.
+    #[must_use]
+    pub fn with_interceptor_arc(mut self, interceptor: Arc<dyn crate::Interceptor>) -> Self {
+        self.service = self.service.with_interceptor_arc(interceptor);
+        self
+    }
+
     /// Get a reference to the underlying router.
     pub fn router(&self) -> &Router {
         self.service.dispatcher()
@@ -826,6 +855,37 @@ mod tests {
         assert_eq!(server.service.limits().max_request_body_size, 1024);
         assert_eq!(server.service.limits().max_message_size, 512);
         assert!(!server.http1_keep_alive);
+    }
+
+    /// `Server::with_interceptor` / `with_interceptor_arc` must reach the
+    /// underlying `ConnectRpcService` chain. The interceptor list has no
+    /// public read path, so the test pins delegation through `Arc` strong
+    /// counts: registering a shared `Arc<dyn Interceptor>` on the `Server`
+    /// must bump the count exactly as registering it on the service
+    /// directly would, and dropping the `Server` must release it.
+    #[test]
+    fn test_server_interceptor_proxies() {
+        struct Noop;
+        #[async_trait::async_trait]
+        impl crate::Interceptor for Noop {}
+
+        let shared: Arc<dyn crate::Interceptor> = Arc::new(Noop);
+        assert_eq!(Arc::strong_count(&shared), 1);
+
+        let server = Server::new(Router::new())
+            // `with_interceptor` Arc::new()s internally; only proves the
+            // proxy compiles and chains.
+            .with_interceptor(Noop)
+            // `with_interceptor_arc` must store a clone of `shared`.
+            .with_interceptor_arc(Arc::clone(&shared));
+        assert_eq!(
+            Arc::strong_count(&shared),
+            2,
+            "Server::with_interceptor_arc must reach the underlying service"
+        );
+
+        drop(server);
+        assert_eq!(Arc::strong_count(&shared), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

#105 added `Server` proxy methods for the `ConnectRpcService` dispatch-config builders (`with_deadline_policy`, `with_limits`, `with_compression`, `with_compression_policy`) so users of the standalone `Server` don't have to drop down to `Server::from_service(ConnectRpcService::new(...).with_*(...))`. But `with_interceptor` (#114) and `with_interceptor_arc` (#118) landed after #105, so the proxy set is incomplete: `Server` users currently have no way to register interceptors.

## What

`Server::with_interceptor` and `Server::with_interceptor_arc`, delegating to the matching `ConnectRpcService` methods. Same `#[must_use]` and doc-comment shape as the existing proxies; no feature gate beyond `server` (the same gate `Server` itself sits behind, and the delegate is ungated on `ConnectRpcService`).

## Confidence

`test_server_interceptor_proxies` registers a shared `Arc<dyn Interceptor>` via `Server::with_interceptor_arc` and pins delegation through `Arc::strong_count` (the interceptor list has no public read path, same constraint as the compression knobs in `test_server_dispatch_config_proxies`). `cargo test`, `task lint` (clippy + fmt), `cargo doc --all-features` all clean.
