### PR TITLE
ci: check generated code freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
     name: Check generated code
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Note: the workspace has no committed Cargo.lock, so `cargo
+    # generate-lockfile` below resolves buffa and prettyplease (which formats
+    # the generated code) to the latest compatible releases at run time. A new
+    # release of either can therefore make this job fail on PRs that did not
+    # touch the protos or codegen — the fix is to run `task generate:all` on
+    # main and commit the resulting diff.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -100,6 +106,10 @@ jobs:
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1 (sha-pinned)
         with:
           setup_only: true
+          # Pinned so the job's behaviour does not drift with new buf
+          # releases; keep in sync with the version used for local
+          # regeneration when bumping.
+          version: 1.69.0
       - uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2 (sha-pinned)
       - name: Generate lockfile
         run: cargo generate-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,64 @@ jobs:
           components: rustfmt
       - run: cargo +nightly fmt --all -- --check
 
+  check-generated-code:
+    name: Check generated code
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 (sha-pinned)
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1 (sha-pinned)
+        with:
+          setup_only: true
+      - uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2 (sha-pinned)
+      - name: Generate lockfile
+        run: cargo generate-lockfile
+      - name: Resolve locked buffa version
+        id: buffa-version
+        shell: bash
+        run: |
+          version="$(awk '
+            $0 == "[[package]]" { in_buffa = 0 }
+            $0 == "name = \"buffa\"" { in_buffa = 1 }
+            in_buffa && $1 == "version" {
+              gsub(/"/, "", $3)
+              print $3
+              exit
+            }
+          ' Cargo.lock)"
+
+          if [ -z "$version" ]; then
+            echo "::error::Could not find the buffa package version in Cargo.lock"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          repository: anthropics/buffa
+          ref: v${{ steps.buffa-version.outputs.version }}
+          path: buffa
+      - name: Link buffa sibling checkout
+        shell: bash
+        run: ln -sfn "$PWD/buffa" ../buffa
+      - run: task generate:all
+      - name: Verify checked-in generated code is current
+        run: |
+          if ! git diff --exit-code -- \
+            conformance/src/generated \
+            examples/eliza/src/generated \
+            examples/multiservice/src/generated \
+            benches/rpc/src/generated; then
+            echo "::error::Checked-in generated code is stale. Run 'task generate:all' and commit the diff."
+            exit 1
+          fi
+
   doc:
     name: Documentation
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,8 +104,8 @@ task generate:all
 
 This rebuilds `protoc-gen-connect-rust` (and the sibling buffa plugins
 from `../buffa`) in release mode, then runs `buf generate` in each
-directory. CI does not have a separate stale-check job — stale generated
-code surfaces as compile errors in `Check`/`Test` instead.
+directory. CI runs a separate generated-code check that fails when these
+checked-in files are stale.
 
 ## Building Against a Local buffa Checkout
 
@@ -128,6 +128,8 @@ GitHub Actions CI (`.github/workflows/ci.yml`) runs on every push to
 - **Test** — `cargo test --workspace`
 - **Clippy** — workspace, all targets, `-D warnings`
 - **Format** — nightly `cargo fmt --check`
+- **Check generated code** — runs `task generate:all` and verifies the
+  checked-in generated directories have no diff
 - **Documentation** — `cargo doc` with broken-intra-doc-links denied
 - **MSRV (1.88)** — `cargo check` on the pinned minimum toolchain
 - **Examples** — builds and runs the example crates


### PR DESCRIPTION
## Summary

- Add a `check-generated-code` CI job that runs `task generate:all`
- Resolve the sibling `buffa` checkout from the version locked in `Cargo.lock`
- Fail CI when checked-in generated code is stale
- Update contributing docs to mention the generated-code CI check

Closes #95.

## Verification

Environment:

- `task 3.50.0`
- `buf 1.69.0`
- `protoc libprotoc 33.5`
- sibling `../buffa` checked out at `v0.6.0`

Commands:

- `task generate:all`
- `git diff --exit-code -- conformance/src/generated examples/eliza/src/generated examples/multiservice/src/generated benches/rpc/src/generated`
- `git diff --check`