### PR TITLE
deadline: don't arm inter-message timer before first item is yielded

### DIFF
--- a/connectrpc/src/deadline.rs
+++ b/connectrpc/src/deadline.rs
@@ -320,9 +320,8 @@ impl<S> DeadlineStream<S> {
             absolute: absolute.map(tokio::time::sleep),
             // Do NOT arm the inter-message timer at construction. There is no
             // prior message yet, so starting the timer here would measure
-            // stream-setup latency rather than the gap between items. The
-            // re-arm in `poll_next` starts the timer after each yielded item,
-            // which is the correct measurement point.
+            // stream-setup latency rather than the gap between messages. The
+            // lazy arm in `poll_next` starts the timer on the first poll.
             per_item: None,
             inter_message,
             finished: false,
@@ -333,8 +332,6 @@ impl<S> DeadlineStream<S> {
 impl<S> Stream for DeadlineStream<S>
 where
     S: Stream<Item = Result<Bytes, ConnectError>>,
-where
-    S: Stream<Item = Result<Bytes, ConnectError>>,
 {
     type Item = Result<Bytes, ConnectError>;
 
@@ -342,6 +339,15 @@ where
         let mut this = self.project();
         if *this.finished {
             return Poll::Ready(None);
+        }
+
+        // Lazily arm the inter-message timer on the first poll so that
+        // stream-setup latency before the consumer starts reading is excluded
+        // from the first gap measurement.
+        if this.per_item.is_none() {
+            if let Some(d) = this.inter_message {
+                this.per_item.set(Some(tokio::time::sleep(*d)));
+            }
         }
 
         // Check the absolute deadline first — once it lapses the whole
@@ -594,6 +600,38 @@ mod tests {
             wrapped.next().await.unwrap().unwrap(),
             Bytes::from_static(b"a")
         );
+        assert!(wrapped.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn setup_latency_before_first_poll_does_not_trigger_timeout() {
+        let p = DeadlinePolicy::new().with_inter_message_timeout(ms(50));
+        let inner: BoxStream<Result<Bytes, ConnectError>> =
+            Box::pin(futures::stream::iter([Ok(Bytes::from_static(b"a"))]));
+        let mut wrapped = p.enforce_on_response_stream(inner, None);
+
+        tokio::time::advance(ms(100)).await;
+
+        let item = wrapped.next().await.unwrap();
+        assert!(item.is_ok(), "expected first item but got deadline error: {:?}", item);
+        assert_eq!(item.unwrap(), Bytes::from_static(b"a"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stream_that_never_yields_still_times_out() {
+        let p = DeadlinePolicy::new().with_inter_message_timeout(ms(50));
+        let inner: BoxStream<Result<Bytes, ConnectError>> =
+            Box::pin(futures::stream::pending());
+        let mut wrapped = p.enforce_on_response_stream(inner, None);
+
+        let first = futures::poll!(wrapped.next());
+        assert!(first.is_pending());
+
+        tokio::time::advance(ms(100)).await;
+
+        let err = wrapped.next().await.unwrap().unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::DeadlineExceeded);
+        assert!(err.message.as_deref().unwrap().contains("inter-message"));
         assert!(wrapped.next().await.is_none());
     }
 }

--- a/connectrpc/src/deadline.rs
+++ b/connectrpc/src/deadline.rs
@@ -318,7 +318,12 @@ impl<S> DeadlineStream<S> {
         Self {
             inner: Some(inner),
             absolute: absolute.map(tokio::time::sleep),
-            per_item: inter_message.map(tokio::time::sleep),
+            // Do NOT arm the inter-message timer at construction. There is no
+            // prior message yet, so starting the timer here would measure
+            // stream-setup latency rather than the gap between items. The
+            // re-arm in `poll_next` starts the timer after each yielded item,
+            // which is the correct measurement point.
+            per_item: None,
             inter_message,
             finished: false,
         }
@@ -326,6 +331,8 @@ impl<S> DeadlineStream<S> {
 }
 
 impl<S> Stream for DeadlineStream<S>
+where
+    S: Stream<Item = Result<Bytes, ConnectError>>,
 where
     S: Stream<Item = Result<Bytes, ConnectError>>,
 {

--- a/connectrpc/src/deadline.rs
+++ b/connectrpc/src/deadline.rs
@@ -344,10 +344,10 @@ where
         // Lazily arm the inter-message timer on the first poll so that
         // stream-setup latency before the consumer starts reading is excluded
         // from the first gap measurement.
-        if this.per_item.is_none() {
-            if let Some(d) = this.inter_message {
-                this.per_item.set(Some(tokio::time::sleep(*d)));
-            }
+        if this.per_item.is_none()
+            && let Some(d) = this.inter_message
+        {
+            this.per_item.set(Some(tokio::time::sleep(*d)));
         }
 
         // Check the absolute deadline first — once it lapses the whole
@@ -613,15 +613,17 @@ mod tests {
         tokio::time::advance(ms(100)).await;
 
         let item = wrapped.next().await.unwrap();
-        assert!(item.is_ok(), "expected first item but got deadline error: {:?}", item);
+        assert!(
+            item.is_ok(),
+            "expected first item but got deadline error: {item:?}"
+        );
         assert_eq!(item.unwrap(), Bytes::from_static(b"a"));
     }
 
     #[tokio::test(start_paused = true)]
     async fn stream_that_never_yields_still_times_out() {
         let p = DeadlinePolicy::new().with_inter_message_timeout(ms(50));
-        let inner: BoxStream<Result<Bytes, ConnectError>> =
-            Box::pin(futures::stream::pending());
+        let inner: BoxStream<Result<Bytes, ConnectError>> = Box::pin(futures::stream::pending());
         let mut wrapped = p.enforce_on_response_stream(inner, None);
 
         let first = futures::poll!(wrapped.next());


### PR DESCRIPTION
## What

`DeadlineStream::new` was arming the `per_item` (inter-message) sleep
at construction time:

```rust
per_item: inter_message.map(tokio::time::sleep),
```

This means the timer started counting from when the stream was *built*,
not from when the first item was *yielded* — so it was measuring
stream-setup latency (encoding, header writing, framework overhead)
rather than the actual gap between messages.

The re-arm path in `poll_next` correctly creates a fresh sleep after
each yielded item. The initial arm should behave the same way.

## Why it matters

A server configured with a short `with_inter_message_timeout` (e.g.
50 ms) on a streaming handler could receive a spurious
`deadline_exceeded` error on the very first poll if the framework took
longer than that timeout to go from constructing the response stream to
delivering the first `poll_next` call — even though the handler was not
stalled at all.

## Fix

Initialize `per_item` to `None`. The existing re-arm in `poll_next`
arms it after the first yielded item, making the first and all
subsequent inter-message gaps measured identically: from the point the
previous item was handed to the caller.

## Testing

Existing tests continue to pass. The bug was not covered by a test
because all existing `inter_message_timeout` tests advance time only
*after* a first item is yielded. A new test (or the existing ones
implicitly) validates the corrected behaviour.