### PR TITLE
release: 0.6.1 (streaming reader and decompression robustness fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ with the [Rust 0.x convention](https://doc.rust-lang.org/cargo/reference/semver.
 breaking changes increment the minor version (0.2 → 0.3), additive changes
 increment the patch version.
 
+## [0.6.1] - 2026-05-27
+
+A patch release focused on the robustness of the streaming request and
+response paths and of decompression. There are no API changes; the only
+dependency-facing change is that the minimum supported `bytes` version is
+now 1.6.
+
+### Fixed
+
+- **The streaming request body reader treats the Connect END_STREAM
+  envelope as terminal** ([#130]). Request body bytes that arrive after
+  END_STREAM are now drained (bounded) and ignored with a warning instead
+  of being buffered, the decode buffer is released as soon as the decoder
+  finishes, and transport-level body errors are logged at debug level
+  instead of being silently discarded.
+- **Gzip decompression returns an error for truncated deflate streams**
+  ([#131]). A gzip payload whose deflate stream ends without an
+  end-of-stream marker is rejected with
+  `"gzip decompression stalled: truncated or invalid deflate stream"`
+  instead of never completing.
+- **Decompression output buffers are sized from the compressed input, not
+  from `max_message_size`** ([#132]). Previously every decompressed
+  message was backed by a limit-sized allocation (4 MiB by default) for as
+  long as the message was held; the backing allocation now tracks the
+  actual message size, with the same limits enforced as the buffer grows.
+- **The Connect client-streaming response parser stops at END_STREAM and
+  enforces the single-message rule before decompressing** ([#133]). A
+  second data envelope is rejected before its payload is touched, and
+  bytes after the END_STREAM envelope are ignored.
+
+### Changed
+
+- The minimum supported `bytes` version is now 1.6 ([#132]).
+
+[#130]: https://github.com/anthropics/connect-rust/pull/130
+[#131]: https://github.com/anthropics/connect-rust/pull/131
+[#132]: https://github.com/anthropics/connect-rust/pull/132
+[#133]: https://github.com/anthropics/connect-rust/pull/133
+
 ## [0.6.0] - 2026-05-20
 
 The headline feature is **server-side interceptors** ([#114], [#121]) —

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ ship Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows
 (`.sig` + `.pem`), and a GitHub-native build provenance attestation.
 
 ```sh
-VERSION=v0.6.0
+VERSION=v0.6.1
 PLATFORM=linux-x86_64        # or darwin-aarch64, etc.
 BASE=https://github.com/anthropics/connect-rust/releases/download/${VERSION}
 BIN=protoc-gen-connect-rust-${VERSION}-${PLATFORM}

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-build"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-codegen"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/examples/bazel/Cargo.toml
+++ b/examples/bazel/Cargo.toml
@@ -17,7 +17,7 @@ path = "stub.rs"
 
 [dependencies]
 buffa = { version = "0.6.0", features = ["json"] }
-connectrpc = { version = "0.6.0", default-features = false, features = ["server", "client"] }
+connectrpc = { version = "0.6.1", default-features = false, features = ["server", "client"] }
 futures = "0.3"
 http-body = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Prepares the 0.6.1 patch release:

- Bumps `connectrpc`, `connectrpc-build`, and `connectrpc-codegen` to 0.6.1, plus the bazel example's dependency version and the README plugin-download snippet.
- Adds the 0.6.1 CHANGELOG entry covering #130, #131, #132, and #133, and the `bytes` >= 1.6 note. All link refs in the new entry resolve.

No crate code changes are included in this PR. After it merges and `v0.6.1` is tagged/published, the bazel example's `Cargo.lock` needs a regeneration against the published crates (same follow-up as #124 for 0.6.0).