### PR TITLE
connectrpc-build: add Config::emit_descriptor_set for gRPC server reflection

### DIFF
--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -62,6 +62,7 @@ pub struct Config {
     out_dir: Option<PathBuf>,
     descriptor_source: DescriptorSource,
     include_file: Option<String>,
+    emit_descriptor_set: Option<String>,
     emit_rerun_directives: bool,
     options: Options,
 }
@@ -75,6 +76,7 @@ impl Config {
             out_dir: None,
             descriptor_source: DescriptorSource::default(),
             include_file: None,
+            emit_descriptor_set: None,
             emit_rerun_directives: true,
             options: Options::default(),
         }
@@ -220,6 +222,35 @@ impl Config {
         self
     }
 
+    /// Also write the parsed `FileDescriptorSet` (the descriptors used for
+    /// codegen) to `<out_dir>/<name>` as wire-format bytes.
+    ///
+    /// The set carries the full transitive import closure for every descriptor
+    /// source (`protoc --include_imports`, `buf --as-file-descriptor-set`, or a
+    /// precompiled set), so it is ready to back `grpc.reflection.v1.ServerReflection`
+    /// for clients such as `grpcurl`. Pair it with `include_bytes!`:
+    ///
+    /// ```ignore
+    /// // build.rs
+    /// connectrpc_build::Config::new()
+    ///     .files(&["proto/svc.proto"])
+    ///     .includes(&["proto/"])
+    ///     .emit_descriptor_set("svc_descriptor.bin")
+    ///     .compile()?;
+    /// // src/lib.rs
+    /// pub const FILE_DESCRIPTOR_SET: &[u8] =
+    ///     include_bytes!(concat!(env!("OUT_DIR"), "/svc_descriptor.bin"));
+    /// ```
+    ///
+    /// The inverse of [`Config::descriptor_set`], which *reads* a precompiled
+    /// set; this *writes* the one connectrpc-build already computed, so build
+    /// scripts no longer need a second `protoc --descriptor_set_out` pass.
+    #[must_use]
+    pub fn emit_descriptor_set(mut self, name: impl Into<String>) -> Self {
+        self.emit_descriptor_set = Some(name.into());
+        self
+    }
+
     /// Emit an `include!`-based module tree file alongside the per-file
     /// `.rs` outputs.
     ///
@@ -304,6 +335,13 @@ impl Config {
         //    stitchers.
         std::fs::create_dir_all(&out_dir)
             .with_context(|| format!("failed to create out_dir '{}'", out_dir.display()))?;
+
+        // Emit the parsed descriptor set for gRPC server reflection, if requested.
+        // `descriptor_bytes` already carries the full import closure for every
+        // descriptor source, so the written set is reflection-ready as-is.
+        if let Some(name) = &self.emit_descriptor_set {
+            write_if_changed(&out_dir.join(name), &descriptor_bytes)?;
+        }
 
         let mut entries: Vec<(String, String)> = Vec::new();
         for file in &generated {
@@ -669,6 +707,48 @@ mod tests {
             Config::new().descriptor_set("x.bin").descriptor_source,
             DescriptorSource::Precompiled(_)
         ));
+    }
+
+    #[test]
+    fn config_emit_descriptor_set_toggle() {
+        let cfg = Config::new().emit_descriptor_set("d.bin");
+        assert_eq!(cfg.emit_descriptor_set.as_deref(), Some("d.bin"));
+    }
+
+    /// `emit_descriptor_set` writes the descriptor set used for codegen to
+    /// `<out_dir>/<name>` as a wire-format `FileDescriptorSet` ready for gRPC
+    /// server reflection. A precompiled source passes the bytes through
+    /// unchanged, so the emitted file round-trips the input set.
+    #[test]
+    fn emit_descriptor_set_writes_reflection_bin() {
+        let fixture = format!("{}/tests/fixtures/echo.fds.bin", env!("CARGO_MANIFEST_DIR"));
+        let out = tempfile::tempdir().unwrap();
+
+        Config::new()
+            .descriptor_set(&fixture)
+            .files(&["echo.proto"])
+            .out_dir(out.path())
+            .emit_descriptor_set("echo_descriptor.bin")
+            .compile()
+            .unwrap();
+
+        let emitted = out.path().join("echo_descriptor.bin");
+        assert!(emitted.exists(), "expected {emitted:?} to be written");
+
+        let bytes = std::fs::read(&emitted).unwrap();
+        let fds = FileDescriptorSet::decode_from_slice(&bytes)
+            .expect("emitted descriptor set must decode");
+        assert!(
+            !fds.file.is_empty(),
+            "emitted set should contain file descriptors"
+        );
+
+        // Precompiled source passes bytes through unchanged → exact round-trip.
+        let fixture_bytes = std::fs::read(&fixture).unwrap();
+        assert_eq!(
+            bytes, fixture_bytes,
+            "emitted bytes must equal the source set"
+        );
     }
 
     /// End-to-end: precompiled descriptor set → generated Rust in a tempdir.


### PR DESCRIPTION
# connectrpc-build: add `Config::emit_descriptor_set` for gRPC Server Reflection

## Motivation

`Config::compile()` already parses the `.proto` inputs into a full `FileDescriptorSet` — `run_protoc` is invoked with `--include_imports`, `run_buf` with `--as-file-descriptor-set`, and the precompiled path is read as-is, so the `descriptor_bytes` it decodes for codegen always carry the **complete transitive import closure**.

Today that set can be *read in* (`Config::descriptor_set(path)`) but never *written out*. A build script that needs those bytes — to serve `grpc.reflection.v1.ServerReflection` to clients like `grpcurl` via `include_bytes!(concat!(env!("OUT_DIR"), "…"))` — has to invoke `protoc` a **second** time with `--descriptor_set_out --include_imports`, duplicating work connectrpc-build already did and re-requiring a `protoc` install even when generation used `buf` or a precompiled set.

This adds the symmetric `Config::emit_descriptor_set(name)`: write the descriptor set connectrpc-build already computed to `<out_dir>/<name>`.

This is the connectrpc-build counterpart of the [buffa#125 follow-up the maintainers invited](https://github.com/anthropics/buffa/issues/125#issuecomment-4514370502) — buffa-build went with the embedded `buffa-reflect` pool for in-process reflection, explicitly leaving open the "standalone `.bin` for tooling outside the Rust build" case. Emitting at the connectrpc-build layer is the natural home for that: the bytes are already in hand, with `--include_imports` guaranteed, for every descriptor source.

## API

```rust
/// Also write the parsed `FileDescriptorSet` (the descriptors used for
/// codegen) to `<out_dir>/<name>` as wire-format bytes.
///
/// The set carries the full transitive import closure for every descriptor
/// source (`protoc --include_imports`, `buf --as-file-descriptor-set`, or a
/// precompiled set), so it is ready to back `grpc.reflection.v1.ServerReflection`.
/// The inverse of [`Config::descriptor_set`], which *reads* a precompiled set.
#[must_use]
pub fn emit_descriptor_set(mut self, name: impl Into<String>) -> Self
```

```rust
// build.rs
connectrpc_build::Config::new()
    .files(&["proto/svc.proto"])
    .includes(&["proto/"])
    .emit_descriptor_set("svc_descriptor.bin")
    .compile()?;

// src/lib.rs
pub const FILE_DESCRIPTOR_SET: &[u8] =
    include_bytes!(concat!(env!("OUT_DIR"), "/svc_descriptor.bin"));
```

## Implementation (connectrpc-build/src/lib.rs)

Purely additive — no change to existing behavior; the field defaults to `None`.

1. `Config` struct — new field:
```rust
     include_file: Option<String>,
+    emit_descriptor_set: Option<String>,
     emit_rerun_directives: bool,
```
2. `Config::new()` — default:
```rust
             include_file: None,
+            emit_descriptor_set: None,
             emit_rerun_directives: true,
```
3. Builder method (next to `descriptor_set`):
```rust
+    #[must_use]
+    pub fn emit_descriptor_set(mut self, name: impl Into<String>) -> Self {
+        self.emit_descriptor_set = Some(name.into());
+        self
+    }
```
4. In `compile()`, right after `create_dir_all(&out_dir)` (with `descriptor_bytes` already in scope from the descriptor-source match):
```rust
+        // Emit the parsed descriptor set for reflection, if requested.
+        if let Some(name) = &self.emit_descriptor_set {
+            write_if_changed(&out_dir.join(name), &descriptor_bytes)?;
+        }
```

It reuses the existing `write_if_changed` (so it won't churn mtimes / trigger needless rebuilds), and works uniformly for the `Protoc`, `Buf`, and `Precompiled` sources because each already produces an import-complete `descriptor_bytes`.

## Tests (included)

Two tests added to the existing `mod tests`, mirroring `compile_precompiled_descriptor_set`:
- `config_emit_descriptor_set_toggle` — builder-state check.
- `emit_descriptor_set_writes_reflection_bin` — end-to-end against the `echo.fds.bin` fixture (hermetic, Precompiled source, no protoc): asserts the file is written, `FileDescriptorSet::decode_from_slice` succeeds with a non-empty file list, and the bytes round-trip the source set exactly.

Verified locally: `cargo build/clippy -p connectrpc-build` clean; `cargo test -p connectrpc-build` → **20 passed, 0 failed**.

## Notes
- Additive and backward-compatible; no existing API changes.
- Complements `buffa-reflect`'s in-process pool — this is the wire-bytes path for serving reflection v1 to external clients.

Follow-up to anthropics/buffa#125.
