### PR TITLE
examples/bazel: regenerate Cargo.lock against connectrpc 0.6.1

### DIFF
--- a/examples/bazel/Cargo.lock
+++ b/examples/bazel/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "connectrpc"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3382e121377f6c160bbbe56f5809637ccbabff7edbf56bb8e96cc64e65998045"
+checksum = "1da5e4adde184f69e64ef112c6f8b645afe9ff82466761f8fc348dbd36aaee7e"
 dependencies = [
  "async-trait",
  "base64",


### PR DESCRIPTION
Updates the bazel example's lockfile to the published connectrpc 0.6.1 (the dependency requirement was already bumped in #134). buffa stays at 0.6.0. Same post-release follow-up as #124 was for 0.6.0.