### PR TITLE
docs: drop rustdoc hidden-line markers from guide health example

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1001,12 +1001,10 @@ use connectrpc::Router;
 use connectrpc_health::{install_static, Status};
 
 // `install_static` registers every name with `Status::Serving`; use the
-// generated `*_SERVICE_NAME` constants so the registered name matches
-// exactly what clients ask for. The whole-process `""` entry is seeded
-// for you, so probes that don't pass a service name also work.
-# mod proto { pub mod greet { pub mod v1 {
-#     pub const GREET_SERVICE_SERVICE_NAME: &str = "greet.v1.GreetService";
-# } } }
+// generated `*_SERVICE_NAME` constants from your service stubs so the
+// registered name matches exactly what clients ask for. The
+// whole-process `""` entry is seeded for you, so probes that don't
+// pass a service name also work.
 let (router, health) = install_static(Router::new(), [
     proto::greet::v1::GREET_SERVICE_SERVICE_NAME,
 ]);
@@ -1021,7 +1019,6 @@ health
 // At shutdown, drain. `shutdown()` flips every registered service,
 // including the empty whole-process entry:
 health.shutdown();
-# drop(router);
 ```
 
 For custom logic (e.g. report `NotServing` while a database connection


### PR DESCRIPTION
docs/guide.md is rendered as plain markdown on GitHub and is not run through rustdoc, so the `# mod proto { ... }` hidden-line scaffolding in the new health-checking example (from #128) showed up as literal `#`-prefixed lines in the rendered guide. Replace the hidden module with a comment pointing at the generated service stubs, and drop the trailing `# drop(router);` line.

Doc-only change; no code affected.