### PR TITLE
Bump CLA action to v3.1.0; run workflow on reopened PRs

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -3,7 +3,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, closed, reopened, synchronize]
 
 permissions:
   actions: write
@@ -24,7 +24,7 @@ jobs:
         # co-author of at least one commit), Co-authored-by trailer support,
         # email-based allowlist matching, automatic retry of transient
         # GitHub 5xx errors, and actionable unlinked-email guidance.
-        uses: iainmcgin/cla-github-action@3e58ace6af840f66fcd80f68c08d76559140df5e # v3.0.0 (sha-pinned)
+        uses: iainmcgin/cla-github-action@b2654283c3d541393bf2c6efa1e0097537186313 # v3.1.0 (sha-pinned)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Bumps the CLA Assistant action pin to v3.1.0 and adds `reopened` to the `pull_request_target` trigger types.

## Why

v3.0.0 locked the PR conversation on *any* `closed` event when `lock-pullrequest-aftermerge` was enabled (the default), including PRs that a contributor closed without merging. If such a PR was later reopened, the stale lock prevented the bot from commenting, so the CLA check could never complete. This happened on anthropics/buffa#172, which had to be unlocked manually.

## What changed

- Pin bumped to `b2654283c3d541393bf2c6efa1e0097537186313` (v3.1.0, [changelog](https://github.com/iainmcgin/cla-github-action/blob/master/CHANGELOG.md)). The action now only locks PRs that were actually merged, and removes a stale conversation lock when a PR is reopened.
- `reopened` added to the workflow trigger types — without it the workflow never runs on reopen, so the automatic unlock (and the CLA re-check) would not fire.
