### PR TITLE
release: 0.7.0

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -98,3 +98,9 @@ jobs:
 
       - name: Publish connectrpc-build
         run: /tmp/publish.sh connectrpc-build $DRY_RUN_FLAG
+
+      - name: Publish connectrpc-health
+        run: /tmp/publish.sh connectrpc-health $DRY_RUN_FLAG
+
+      - name: Publish connectrpc-reflection
+        run: /tmp/publish.sh connectrpc-reflection $DRY_RUN_FLAG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,63 +8,22 @@ with the [Rust 0.x convention](https://doc.rust-lang.org/cargo/reference/semver.
 breaking changes increment the minor version (0.2 → 0.3), additive changes
 increment the patch version.
 
-## [Unreleased]
+## [0.7.0] - 2026-06-10
 
-### Breaking
+A breaking release that reworks both ends of the message surface:
+handlers take borrowed request views built on buffa 0.7.0, and client
+streams surface terminal RPC errors from `message()` instead of hiding
+them behind `Ok(None)`. It is also the first release of two new crates
+that join the lockstep versioning scheme at 0.7.0: `connectrpc-health`
+(the standard gRPC health-checking service) and `connectrpc-reflection`
+(gRPC server reflection).
 
-- **Client streams return terminal server errors from `message()`**.
-  Previously, an RPC error carried in the stream's termination metadata
-  (gRPC HTTP/2 trailers, gRPC-Web trailer frame, or Connect END_STREAM
-  envelope) made `ServerStream::message()` / `BidiStream::message()`
-  return `Ok(None)` — indistinguishable from a clean close — with the
-  error retrievable only via the easy-to-miss `error()` accessor. A
-  caller that treated `Ok(None)` as success would silently swallow every
-  failed streaming RPC. `message()` now returns `Err(...)` for an
-  errored end and reserves `Ok(None)` for a clean end (gRPC status OK /
-  error-free END_STREAM), matching `tonic`. Every `Err` is terminal and
-  sticky — re-polling returns the same error, never a clean-looking
-  `Ok(None)`; `error()` and `trailers()` remain populated for post-hoc
-  inspection. Callers that only match `Err` need no changes; callers
-  doing the `Ok(None)`-then-`error()` dance can delete the dance:
-
-  ```rust
-  // Before: errors hid behind Ok(None)        // After: `?` is complete
-  while let Some(m) = s.message().await? {     while let Some(m) = s.message().await? {
-      handle(m);                                   handle(m);
-  }                                            }
-  if let Some(err) = s.error() {
-      return Err(err.clone().into());
-  }
-  ```
-
-- **A gRPC/gRPC-Web stream that never delivers a usable `grpc-status`
-  is now an error** instead of a clean `Ok(None)`: `internal` when no
-  trailers arrived at all, `unknown` when trailers arrived without a
-  `grpc-status`, and `unknown` for a present-but-malformed
-  `grpc-status` value — each matching grpc-go (and the conformance
-  suite's primary expectations). A Trailers-Only response carrying
-  `grpc-status: 0` in the response headers (grpc-go's shape for an OK
-  end with zero messages) remains a clean end. The Connect protocol
-  already treated a missing END_STREAM envelope as `unavailable`
-  (a connect-rust choice, unchanged here; the Connect spec does not
-  prescribe a client-side code).
-
-### Internal
-
-- The client streaming receive path is restructured so the contract
-  above is enforced by construction rather than convention (the
-  terminal outcome is recorded exactly once, and ending the stream
-  without recording why is unrepresentable). No public-API or intended
-  behavior change; the streaming contract tests' assertions are
-  unchanged.
-
-This release also reworks the server-side request surface around buffa 0.7.0,
-which removed `OwnedView`'s `Deref` impl (the impl let safe code hold view
-fields past the backing buffer's lifetime). Handlers move from owned
-`OwnedView<FooView<'static>>` parameters to borrowed requests and owned
-stream items with per-field accessors. **Consumers with checked-in
-`protoc-gen-connect-rust` output must regenerate with this release's
-toolchain and buffa ≥ 0.7.0.**
+On the server side, buffa 0.7.0 removed `OwnedView`'s `Deref` impl (the
+impl let safe code hold view fields past the backing buffer's lifetime),
+and handlers move from owned `OwnedView<FooView<'static>>` parameters to
+borrowed requests and owned stream items with per-field accessors.
+**Consumers with checked-in `protoc-gen-connect-rust` output must
+regenerate with this release's toolchain and buffa ≥ 0.7.0.**
 
 ### Breaking
 
@@ -77,7 +36,16 @@ toolchain and buffa ≥ 0.7.0.**
   points; the response — and anything moved into `tokio::spawn` — cannot
   borrow from it (enforced by the compiler). Existing handler impls must
   update their signatures; bodies that already started with
-  `.to_owned_message()` work unchanged.
+  `.to_owned_message()` work unchanged:
+
+  ```rust
+  // before (0.6)
+  async fn greet(&self, ctx: RequestContext, request: OwnedView<GreetRequestView<'static>>)
+      -> ServiceResult<GreetResponse>
+  // after (0.7)
+  async fn greet(&self, ctx: RequestContext, request: ServiceRequest<'_, GreetRequest>)
+      -> ServiceResult<GreetResponse>
+  ```
 - **Client-streaming and bidi inbound items are `StreamMessage<Req>`**
   ([#143]). Each item owns its decoded buffer, is `Send + 'static`, Derefs
   to the buffa-generated `FooOwnedView` wrapper for per-field accessor
@@ -99,9 +67,56 @@ toolchain and buffa ≥ 0.7.0.**
   output types — return the owned message for those.
 - **The workspace requires `buffa`/`buffa-types`/`buffa-codegen` 0.7**
   ([#143]), which is also the regen baseline for checked-in generated code.
+- **Client streams return terminal server errors from `message()`**
+  ([#159]). Previously, an RPC error carried in the stream's termination
+  metadata (gRPC HTTP/2 trailers, gRPC-Web trailer frame, or Connect
+  END_STREAM envelope) made `ServerStream::message()` /
+  `BidiStream::message()` return `Ok(None)` — indistinguishable from a
+  clean close — with the error retrievable only via the easy-to-miss
+  `error()` accessor. A caller that treated `Ok(None)` as success would
+  silently swallow every failed streaming RPC. `message()` now returns
+  `Err(...)` for an errored end and reserves `Ok(None)` for a clean end
+  (gRPC status OK / error-free END_STREAM), matching `tonic`. Every
+  `Err` is terminal and sticky — re-polling returns the same error,
+  never a clean-looking `Ok(None)`; `error()` and `trailers()` remain
+  populated for post-hoc inspection. Callers that only match `Err` need
+  no changes; callers doing the `Ok(None)`-then-`error()` dance can
+  delete the dance:
+
+  ```rust
+  // Before: errors hid behind Ok(None)        // After: `?` is complete
+  while let Some(m) = s.message().await? {     while let Some(m) = s.message().await? {
+      handle(m);                                   handle(m);
+  }                                            }
+  if let Some(err) = s.error() {
+      return Err(err.clone().into());
+  }
+  ```
+
+- **A gRPC/gRPC-Web stream that never delivers a usable `grpc-status`
+  is now an error** instead of a clean `Ok(None)` ([#159]): `internal`
+  when no trailers arrived at all, `unknown` when trailers arrived
+  without a `grpc-status`, and `unknown` for a present-but-malformed
+  `grpc-status` value — each matching grpc-go (and the conformance
+  suite's primary expectations). A Trailers-Only response carrying
+  `grpc-status: 0` in the response headers (grpc-go's shape for an OK
+  end with zero messages) remains a clean end. The Connect-protocol
+  equivalent — a missing END_STREAM envelope reported as `unavailable` —
+  ships in this release as [#140] (see Fixed below); this entry covers
+  only the gRPC and gRPC-Web protocols.
 
 ### Added
 
+- **New `connectrpc-health` crate** ([#128]) — the standard
+  `grpc.health.v1.Health` service for connectrpc routers, wire-compatible
+  with `grpc_health_probe`, kubelet `grpc:` probes, and gRPC-aware service
+  meshes (Linkerd, Istio). `install_static(router, [names])` mounts a
+  `StaticChecker`-backed service in one call; implement the `Checker`
+  trait for custom logic (e.g. reporting `NotServing` while a dependency
+  is down). The generated `HealthClient` re-export is gated on the
+  default-on `client` feature so server-only deployments can drop the
+  client transport stack. See the
+  [health checking](docs/guide.md#health-checking) section of the guide.
 - **`ServiceRequest<'a, Req>` and `StreamMessage<M>`** ([#143]) — the
   request wrappers described above, exported from the crate root.
 - The multiservice example gains a `Heartbeat(google.protobuf.Empty) →
@@ -114,7 +129,7 @@ toolchain and buffa ≥ 0.7.0.**
   `grpc.reflection.v1.ServerReflection` (e.g. for `grpcurl`). The inverse
   of `Config::descriptor_set`, which reads a precompiled set; build
   scripts no longer need a second `protoc --descriptor_set_out` pass.
-- **New `connectrpc-reflection` crate** ([#129]) — gRPC server reflection,
+- **New `connectrpc-reflection` crate** ([#157]) — gRPC server reflection,
   wire-compatible with `grpc.reflection.v1.ServerReflection` and its
   `v1alpha` predecessor, so `grpcurl`, `buf curl`, Postman, and `grpcui`
   work against connectrpc servers over gRPC, gRPC-Web, and Connect alike.
@@ -150,6 +165,16 @@ toolchain and buffa ≥ 0.7.0.**
   to drain cleanly against a known-good server may now error — if you see
   this, suspect an intermediary (proxy or load balancer) stripping the
   trailing envelope.
+- **The inter-message timeout no longer starts at response-stream
+  construction** ([#127]). `DeadlinePolicy::with_inter_message_timeout`
+  armed its timer when the response stream was built, so the first
+  measurement covered stream-setup latency (encoding, header writing,
+  framework overhead) rather than the gap between messages, and a short
+  timeout could fail the stream with `deadline_exceeded` before the
+  consumer ever polled it. The timer now arms when the stream is first
+  polled and re-arms after each yielded item, so setup latency before
+  the first poll is excluded while a handler that stalls before its
+  first item still times out.
 
 ### Changed
 
@@ -161,7 +186,11 @@ toolchain and buffa ≥ 0.7.0.**
   the error is remapped to `data_loss` so callers are not told their
   request was invalid. The client-side remap deliberately diverges from
   connect-go, which reports `invalid_argument` in both directions;
-  `data_loss` is more descriptive of what actually happened.
+  `data_loss` is more descriptive of what actually happened. The default
+  `CompressionProvider::decompress_with_limit` implementation (used by
+  custom providers that only implement `decompressor`) follows the same
+  convention: read failures now map to `invalid_argument` instead of
+  `internal`.
 - **Client-streaming and bidi handlers see request body failures as
   stream errors** ([#150]). A request body that fails mid-upload
   (truncated or broken transport) now yields `Err(internal)` from the
@@ -184,13 +213,27 @@ toolchain and buffa ≥ 0.7.0.**
   Client- and bidi-streaming RPCs are unchanged — their bodies are
   consumed inside the handler, already within the handler deadline.
 
-[#129]: https://github.com/anthropics/connect-rust/issues/129
+### Internal
+
+- The client streaming receive path is restructured so the terminal
+  contract above is enforced by construction rather than convention
+  ([#160]): the terminal outcome is recorded exactly once, and ending
+  the stream without recording why is unrepresentable. No public-API or
+  intended behavior change beyond [#159]; the streaming contract tests'
+  assertions are unchanged.
+
+[#127]: https://github.com/anthropics/connect-rust/pull/127
+[#128]: https://github.com/anthropics/connect-rust/pull/128
 [#136]: https://github.com/anthropics/connect-rust/issues/136
+[#139]: https://github.com/anthropics/connect-rust/issues/139
 [#140]: https://github.com/anthropics/connect-rust/issues/140
 [#141]: https://github.com/anthropics/connect-rust/pull/141
 [#143]: https://github.com/anthropics/connect-rust/pull/143
 [#147]: https://github.com/anthropics/connect-rust/pull/147
 [#150]: https://github.com/anthropics/connect-rust/pull/150
+[#157]: https://github.com/anthropics/connect-rust/pull/157
+[#159]: https://github.com/anthropics/connect-rust/pull/159
+[#160]: https://github.com/anthropics/connect-rust/pull/160
 
 ## [0.6.1] - 2026-05-27
 
@@ -230,7 +273,6 @@ now 1.6.
 [#131]: https://github.com/anthropics/connect-rust/pull/131
 [#132]: https://github.com/anthropics/connect-rust/pull/132
 [#133]: https://github.com/anthropics/connect-rust/pull/133
-[#139]: https://github.com/anthropics/connect-rust/issues/139
 
 ## [0.6.0] - 2026-05-20
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ship Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows
 (`.sig` + `.pem`), and a GitHub-native build provenance attestation.
 
 ```sh
-VERSION=v0.6.1
+VERSION=v0.7.0
 PLATFORM=linux-x86_64        # or darwin-aarch64, etc.
 BASE=https://github.com/anthropics/connect-rust/releases/download/${VERSION}
 BIN=protoc-gen-connect-rust-${VERSION}-${PLATFORM}
@@ -170,7 +170,7 @@ assembled via a single `include!`. No plugin binaries required at build time.
 
 ```toml
 [build-dependencies]
-connectrpc-build = "0.6"
+connectrpc-build = "0.7"
 ```
 
 ```rust
@@ -196,7 +196,6 @@ pub mod proto {
 
 ```rust
 use connectrpc::{RequestContext, Response, ServiceRequest, ServiceResult};
-use std::sync::Arc;
 
 struct MyGreetService;
 

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-build"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -10,7 +10,7 @@ keywords = ["connectrpc", "grpc", "protobuf", "build", "codegen"]
 categories = ["development-tools::build-utils"]
 
 [dependencies]
-connectrpc-codegen = { path = "../connectrpc-codegen", version = "0.6" }
+connectrpc-codegen = { path = "../connectrpc-codegen", version = "0.7" }
 buffa = { workspace = true }
 buffa-codegen = { workspace = true }
 tempfile = { workspace = true }

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -30,6 +30,9 @@
 //! Requires `protoc` on `PATH` (or set via `PROTOC`). To use `buf` instead,
 //! call [`Config::use_buf`]. To avoid both, precompile a `FileDescriptorSet`
 //! once and ship it alongside your source via [`Config::descriptor_set`].
+//!
+//! To embed the compiled `FileDescriptorSet` in your binary — for example
+//! to back gRPC server reflection — see [`Config::emit_descriptor_set`].
 
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-codegen"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc-health/Cargo.toml
+++ b/connectrpc-health/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-health"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -9,6 +9,10 @@ readme = "../README.md"
 description = "gRPC health-checking service for connectrpc (wire-compatible with grpc_health_v1)"
 keywords = ["connectrpc", "grpc", "health", "rpc"]
 categories = ["network-programming", "web-programming::http-server"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["client"]
@@ -20,7 +24,7 @@ default = ["client"]
 client = ["connectrpc/client"]
 
 [dependencies]
-connectrpc = { path = "../connectrpc", version = "0.6", features = ["server"] }
+connectrpc = { path = "../connectrpc", version = "0.7", features = ["server"] }
 
 # Protobuf + serde (pulled in by the generated module paths)
 buffa = { workspace = true }

--- a/connectrpc-health/src/lib.rs
+++ b/connectrpc-health/src/lib.rs
@@ -16,7 +16,7 @@
 //!   `HealthClient` for in-process probes, integration tests, and
 //!   sidecar tooling. Pulls in `connectrpc`'s `client` feature (the
 //!   HTTP/2 transport stack). Server-only deployments drop it with
-//!   `connectrpc-health = { version = "0.6", default-features = false }`;
+//!   `connectrpc-health = { version = "0.7", default-features = false }`;
 //!   `use connectrpc_health::HealthClient` then becomes an unresolved
 //!   import (the type is gone), but the dependency graph loses
 //!   `connectrpc/client`.
@@ -61,6 +61,7 @@
 //! / [`HealthService::from_arc`].
 //!
 //! [`grpc.health.v1.Health`]: https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod checker;
 mod service;
@@ -83,6 +84,7 @@ pub use status::Status;
 /// deployments turn off default features to drop the `connectrpc/client`
 /// transport stack from their dependency graph.
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use connect::grpc::health::v1::HealthClient;
 
 /// Generated extension trait that adds `.register(router)` to any

--- a/connectrpc-reflection/Cargo.toml
+++ b/connectrpc-reflection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-reflection"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -9,6 +9,10 @@ readme = "../README.md"
 description = "gRPC server reflection service for connectrpc (wire-compatible with grpc.reflection.v1 and v1alpha)"
 keywords = ["connectrpc", "grpc", "reflection", "rpc"]
 categories = ["network-programming", "web-programming::http-server"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["client"]
@@ -20,7 +24,7 @@ default = ["client"]
 client = ["connectrpc/client"]
 
 [dependencies]
-connectrpc = { path = "../connectrpc", version = "0.6", features = ["server"] }
+connectrpc = { path = "../connectrpc", version = "0.7", features = ["server"] }
 
 # Protobuf + serde (pulled in by the generated module paths)
 buffa = { workspace = true }

--- a/connectrpc-reflection/src/lib.rs
+++ b/connectrpc-reflection/src/lib.rs
@@ -13,8 +13,10 @@
 //! ```ignore
 //! // build.rs
 //! connectrpc_build::Config::new()
+//!     .files(&["proto/app.proto"])
+//!     .includes(&["proto/"])
 //!     .emit_descriptor_set("app.fds.bin")
-//!     .compile(&["proto/app.proto"], &["proto"])
+//!     .compile()
 //!     .unwrap();
 //! ```
 //!
@@ -78,6 +80,7 @@
 //!   `default-features = false`.
 //!
 //! [`grpc.reflection.v1.ServerReflection`]: https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod reflector;
 mod service;
@@ -134,6 +137,7 @@ pub use connect::grpc::reflection::v1alpha::{
 /// Generated client for querying a `grpc.reflection.v1.ServerReflection`
 /// server.
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use connect::grpc::reflection::v1::ServerReflectionClient;
 
 /// Re-exports of the generated `grpc.reflection.*` wire types — request

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1910,8 +1910,6 @@ enum BodyPoll {
 
 /// Response from a server-streaming RPC.
 ///
-/// A server-streaming RPC response.
-///
 /// Provides incremental access to response messages as they arrive from the server.
 /// Messages are decoded one at a time from the HTTP response body using the
 /// [`message()`](ServerStream::message) method, which returns `Ok(None)` for

--- a/connectrpc/src/compression.rs
+++ b/connectrpc/src/compression.rs
@@ -129,6 +129,14 @@ pub trait CompressionProvider: Send + Sync + 'static {
     /// reader from [`decompressor`](Self::decompressor) to structurally
     /// bound memory — custom providers are safe without any extra work.
     /// Built-in providers override this for performance.
+    ///
+    /// # Error codes
+    ///
+    /// Malformed or truncated input surfaces as
+    /// [`ConnectError::invalid_argument`] — the client sent a payload that
+    /// cannot be decoded. The default implementation maps read failures to
+    /// this code, matching the built-in gzip and zstd providers; custom
+    /// overrides should follow the same convention.
     fn decompress_with_limit(&self, data: &[u8], max_size: usize) -> Result<Bytes, ConnectError> {
         use std::io::Read;
         let reader = self.decompressor(data)?;
@@ -137,7 +145,7 @@ pub trait CompressionProvider: Send + Sync + 'static {
         reader
             .take((max_size as u64).saturating_add(1))
             .read_to_end(&mut buf)
-            .map_err(|e| ConnectError::internal(format!("decompression failed: {e}")))?;
+            .map_err(|e| ConnectError::invalid_argument(format!("decompression failed: {e}")))?;
         if buf.len() > max_size {
             return Err(ConnectError::resource_exhausted(format!(
                 "decompressed size exceeds limit {max_size}"
@@ -1853,6 +1861,46 @@ mod tests {
             let reversed: Vec<u8> = data.iter().rev().copied().collect();
             Ok(Box::new(std::io::Cursor::new(reversed)))
         }
+    }
+
+    /// Provider whose reader fails mid-read, exercising the default
+    /// `decompress_with_limit` error path for malformed input.
+    struct FailingReadProvider;
+
+    impl CompressionProvider for FailingReadProvider {
+        fn name(&self) -> &'static str {
+            "failing"
+        }
+
+        fn compress(&self, data: &[u8]) -> Result<Bytes, ConnectError> {
+            Ok(Bytes::copy_from_slice(data))
+        }
+
+        fn decompressor<'a>(
+            &self,
+            _data: &'a [u8],
+        ) -> Result<Box<dyn std::io::Read + 'a>, ConnectError> {
+            struct FailingReader;
+            impl std::io::Read for FailingReader {
+                fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "corrupt stream",
+                    ))
+                }
+            }
+            Ok(Box::new(FailingReader))
+        }
+    }
+
+    /// The default `decompress_with_limit` reports malformed input as
+    /// `invalid_argument`, matching the built-in gzip/zstd providers.
+    #[test]
+    fn test_default_trait_decompress_malformed_is_invalid_argument() {
+        let err = FailingReadProvider
+            .decompress_with_limit(b"whatever", usize::MAX)
+            .unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
     #[test]

--- a/connectrpc/src/deadline.rs
+++ b/connectrpc/src/deadline.rs
@@ -104,7 +104,8 @@ pub struct DeadlinePolicy {
     /// stalled handlers waiting on slow upstreams. `None` = no per-item
     /// bound. Independent of [`enforce_on_streams`](Self::enforce_on_streams):
     /// setting this enables the per-item timer regardless of whether the
-    /// absolute deadline is enforced.
+    /// absolute deadline is enforced. First armed when the stream is
+    /// first polled; re-armed after each yielded item.
     inter_message_timeout: Option<Duration>,
 }
 
@@ -194,6 +195,12 @@ impl DeadlinePolicy {
     /// Independent of [`with_enforce_on_streams`](Self::with_enforce_on_streams):
     /// the per-item timer takes effect whenever this is set, regardless of
     /// whether the absolute deadline is also enforced on the stream.
+    ///
+    /// The timer first arms when the consumer first polls the stream and
+    /// re-arms after each yielded item, so stream-setup latency before
+    /// the first poll (encoding, header writing, framework overhead) is
+    /// not counted against the first gap — but a handler that stalls
+    /// before producing its first item still times out.
     #[must_use]
     pub fn with_inter_message_timeout(mut self, timeout: Duration) -> Self {
         self.inter_message_timeout = Some(timeout);

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -65,23 +65,34 @@
 //! - [`envelope`] - Streaming message framing (5-byte header + payload)
 //! - [`error`] - ConnectRPC error types and HTTP status mapping
 //! - [`handler`] - Async handler traits for implementing RPC methods
+//! - [`request`] - Borrowed single-message request views ([`ServiceRequest`])
+//! - [`stream_message`] - Owned per-item streaming message wrapper ([`StreamMessage`])
+//! - [`response`] - Handler response types and [`RequestContext`]
 //! - [`router`] - Request routing and service registration
 //! - [`service`] - Tower service implementation (primary integration point)
+//! - [`dispatcher`] - Method dispatch glue between router and generated code
 //! - [`spec`] - Static per-method metadata ([`Spec`], [`StreamType`])
 //! - [`payload`] - Lazily-decoded, type-erased message bodies ([`Payload`])
 //! - [`interceptor`] - RPC-level interceptors ([`Interceptor`], [`Next`])
-//! - [`client`] - Tower-based HTTP client utilities (requires `client` feature)
+//! - [`deadline`] - Server-side deadline moderation ([`DeadlinePolicy`])
+//! - [`protocol`] - Protocol detection ([`Protocol`]: Connect, gRPC, gRPC-Web)
+//! - [`client`] - Tower-based HTTP client utilities (transports require the `client` feature)
 //! - [`server`] - Standalone hyper-based server (requires `server` feature)
 //!
 //! # Protocol Support
 //!
-//! This implementation follows the ConnectRPC protocol specification:
-//! - Unary RPC calls (request-response)
+//! Servers speak the [Connect protocol](https://connectrpc.com/docs/protocol),
+//! gRPC, and gRPC-Web from a single registration; clients can be configured
+//! for any of the three:
+//! - All four RPC shapes: unary, server-streaming, client-streaming, bidi
+//!   (full-duplex bidi requires HTTP/2; browsers additionally cannot
+//!   stream request bodies, regardless of protocol)
 //! - Proto and JSON message encoding
 //! - Compression negotiation (gzip, zstd) with streaming support
 //! - Error handling with proper HTTP status mapping
 //! - Trailers via `trailer-` prefixed headers
 //! - Envelope framing for streaming messages
+//! - Deadline propagation and server-side deadline moderation
 //!
 //! # Client
 //!

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -219,10 +219,10 @@ impl Server {
     ///
     /// Delegates to [`ConnectRpcService::with_deadline_policy`]. The
     /// default [`DeadlinePolicy::new`](crate::DeadlinePolicy::new) is a
-    /// no-op: client timeout headers are honored verbatim and streaming
-    /// bodies are unbounded once the handler returns. Set a policy to
-    /// clamp, supply a default, or enforce on streams. See
-    /// [`DeadlinePolicy`](crate::DeadlinePolicy).
+    /// no-op: client timeout headers are honored verbatim for request
+    /// receipt and handler execution, but streaming response bodies are
+    /// not bounded by them. Set a policy to clamp, supply a default, or
+    /// enforce on streams. See [`DeadlinePolicy`](crate::DeadlinePolicy).
     #[must_use]
     pub fn with_deadline_policy(mut self, policy: crate::DeadlinePolicy) -> Self {
         self.service = self.service.with_deadline_policy(policy);

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,6 +18,8 @@ with the [README quick start](../README.md#quick-start) and the
 - [Interceptors](#interceptors)
 - [Hosting](#hosting)
 - [Health checking](#health-checking)
+- [Server reflection](#server-reflection)
+- [Production hardening](#production-hardening)
 - [Clients](#clients)
 - [Errors and status codes](#errors-and-status-codes)
 - [Compression](#compression)
@@ -25,7 +27,7 @@ with the [README quick start](../README.md#quick-start) and the
 
 ## Installation
 
-`connectrpc` ships as three crates:
+`connectrpc` ships as five crates:
 
 | Crate | Purpose |
 |---|---|
@@ -33,12 +35,13 @@ with the [README quick start](../README.md#quick-start) and the
 | `protoc-gen-connect-rust` (binary, in `connectrpc-codegen`) | `protoc` plugin that generates service stubs |
 | `connectrpc-build` | `build.rs` integration that runs the codegen at build time |
 | `connectrpc-health` | The standard `grpc.health.v1.Health` service for liveness / readiness probes ([Health checking](#health-checking)) |
+| `connectrpc-reflection` | The standard gRPC server reflection service (`grpc.reflection.v1` + `v1alpha`) for `grpcurl` / `buf curl` / Postman / `grpcui` ([Server reflection](#server-reflection)) |
 
 Add the runtime to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-connectrpc = "0.5"
+connectrpc = "0.7"
 ```
 
 The runtime depends on [`buffa`](https://github.com/anthropics/buffa)
@@ -72,16 +75,16 @@ Common combinations:
 
 ```toml
 # Just the server, behind axum
-connectrpc = { version = "0.5", features = ["axum"] }
+connectrpc = { version = "0.7", features = ["axum"] }
 
 # Server + client, both with TLS
-connectrpc = { version = "0.5", features = ["axum", "client", "tls"] }
+connectrpc = { version = "0.7", features = ["axum", "client", "tls"] }
 
 # Built-in server (no axum)
-connectrpc = { version = "0.5", features = ["server"] }
+connectrpc = { version = "0.7", features = ["server"] }
 
 # Minimal (wasm-friendly: no networking, no native compression)
-connectrpc = { version = "0.5", default-features = false }
+connectrpc = { version = "0.7", default-features = false }
 ```
 
 ## Quick start
@@ -105,7 +108,7 @@ Generate code with `connectrpc-build` in `build.rs`:
 
 ```toml
 [build-dependencies]
-connectrpc-build = "0.5"
+connectrpc-build = "0.7"
 ```
 
 ```rust
@@ -194,6 +197,15 @@ fn main() {
 Output is unified: message types and service stubs in one file per
 proto, included into your crate with `connectrpc::include_generated!()`.
 Best for simple projects.
+
+If you need the compiled `FileDescriptorSet` at runtime — most commonly
+to feed the [`connectrpc-reflection`](#server-reflection) crate — chain
+`.emit_descriptor_set("svc_descriptor.bin")` before `.compile()`. The
+name must be a bare file name (no path separators). The set (including
+the full transitive import closure) is written to `OUT_DIR` and can be
+embedded with
+`include_bytes!(concat!(env!("OUT_DIR"), "/svc_descriptor.bin"))`. See
+the `Config::emit_descriptor_set` rustdoc for details.
 
 ### `buf generate` (checked-in code, production-grade)
 
@@ -299,7 +311,7 @@ methods (new request-scoped metadata can then be added in minor releases):
 |---|---|
 | `ctx.header(name)` / `ctx.headers()` | Caller-supplied headers (after protocol-prefix stripping) |
 | `ctx.deadline()` | Absolute `Instant` if the caller set a timeout |
-| `ctx.time_remaining()` | Saturating `Duration` until the deadline — budget downstream calls with this |
+| `ctx.time_remaining()` | Saturating `Option<Duration>` until the deadline (`None` when no deadline is set) — budget downstream calls with this |
 | `ctx.extensions()` | `http::Extensions` carried from the underlying `http::Request` |
 | `ctx.path()` | Requested procedure path (`/package.Service/Method`) from the request URI |
 | `ctx.spec()` | Static metadata for the dispatched RPC method ([`Spec`](#static-method-metadata-spec)); `None` only for `route_*` registrations without `with_spec` |
@@ -584,12 +596,20 @@ while let Some(msg) = stream.message().await? {
 // Client streaming - takes a Vec
 let resp = client.sum(vec![req1, req2, req3]).await?;
 
-// Bidi - received items are `OwnedView`s too: `reply.reborrow().total`
+// Bidi - received items are `OwnedView`s too, read via `.reborrow()`
 let mut bidi = client.running_sum().await?;
 bidi.send(req).await?;
-let reply = bidi.message().await?;
+if let Some(reply) = bidi.message().await? {
+    println!("{}", reply.reborrow().total.unwrap_or_default());
+}
 bidi.close_send();
 ```
+
+`?` on `message()` is the complete error handling: `Ok(None)` means the
+server finished cleanly, and a terminal RPC error — including a
+gRPC/gRPC-Web stream that ends without a usable `grpc-status` — comes
+back as `Err`, sticky across calls. The `error()` and `trailers()`
+accessors remain available afterwards for post-hoc inspection.
 
 Both `streaming-tour/src/client.rs` and the eliza example show these
 patterns end-to-end.
@@ -1010,8 +1030,8 @@ route for `httpGet:` probes; add the gRPC service for `grpc:` probes.
 
 ```toml
 [dependencies]
-connectrpc = { version = "0.6", features = ["server"] }
-connectrpc-health = "0.6"
+connectrpc = { version = "0.7", features = ["server"] }
+connectrpc-health = "0.7"
 ```
 
 ```rust,no_run
@@ -1051,8 +1071,8 @@ Server-only deployments turn it off:
 
 ```toml
 [dependencies]
-connectrpc = { version = "0.6", features = ["server"] }
-connectrpc-health = { version = "0.6", default-features = false }
+connectrpc = { version = "0.7", features = ["server"] }
+connectrpc-health = { version = "0.7", default-features = false }
 ```
 
 That drops `connectrpc/client` (the HTTP/2 transport stack) from the
@@ -1069,6 +1089,63 @@ reference. Every probe that treats any error as a failure — kubelet's
 `grpc:` probe, `grpc_health_probe`, Linkerd, Istio — works unchanged.
 See `HealthService`'s `# Unknown services` section in the crate docs
 for the full context.
+
+## Server reflection
+
+The `connectrpc-reflection` crate implements the standard gRPC server
+reflection service (`grpc.reflection.v1` and its `v1alpha` predecessor),
+so schema-aware clients — `grpcurl`, `buf curl`, Postman, `grpcui` —
+can discover and call your services without local proto files, over
+gRPC, gRPC-Web, and the Connect protocol alike.
+
+```toml
+[dependencies]
+connectrpc = { version = "0.7", features = ["server"] }
+connectrpc-reflection = "0.7"
+```
+
+Emit a descriptor set from your build script (see
+[Code generation](#code-generation)), embed it, and mount the service:
+
+```rust,ignore
+// build.rs: .emit_descriptor_set("app.fds.bin") before .compile()
+use connectrpc::Router;
+use connectrpc_reflection::{Reflector, install};
+
+let bytes: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/app.fds.bin"));
+let reflector = Reflector::from_descriptor_set_bytes(bytes)?;
+// `router` is your service router from `register()`.
+let router = install(router, reflector); // mounts v1 + v1alpha
+```
+
+Alternatively, when your buffa codegen has reflection enabled, serve
+straight from the generated package's descriptor pool with
+`Reflector::from_descriptor_pool(proto::descriptor_pool().clone())` —
+no build-script step. The bytes path answers with the compiler's
+original per-file descriptor bytes; the pool path re-encodes
+(semantically faithful, unknown fields preserved). See the `Reflector`
+crate docs for the trade-off.
+
+> **Reflection intentionally publishes your schema.** Everything in
+> the descriptor set is exposed — all files, their transitive imports,
+> and every compiled service, whether or not its handlers are mounted.
+> Gate or omit the service on deployments where that is not wanted.
+
+Two more behaviors worth knowing before deploying:
+
+- **`Reflector::with_services` curates the advertised list** (the
+  override is verbatim, like Go `grpcreflect`'s `Namer`) — use it when
+  the descriptor set compiles in more services than you want to
+  advertise; `Reflector::service_names` inspects the current list.
+- **The service is self-describing**: queries about `grpc.reflection.*`
+  fall back to the crate's own descriptors and `ListServices` includes
+  the reflection services, matching grpc-go. Schema-free callers like
+  `buf curl` need this to invoke `ServerReflectionInfo` at all.
+
+The [multiservice example](../examples/multiservice) mounts reflection
+with both descriptor sources (selectable via `REFLECTION_SOURCE=fds|pool`),
+and [`reflection-demo.sh`](../examples/multiservice/reflection-demo.sh)
+walks through discovery and schema-free calls with `buf curl`.
 
 ## Production hardening
 
@@ -1122,7 +1199,9 @@ Why each knob:
 - **`with_inter_message_timeout(d)`** detects stalled streams (a
   handler waiting on a slow upstream). Independent of
   `with_enforce_on_streams` — takes effect whenever set, with or
-  without the absolute deadline. Resets on each yielded item.
+  without the absolute deadline. Arms when the response stream is
+  first polled (stream-setup latency before that is not counted) and
+  resets on each yielded item.
 
 `DeadlinePolicy::new()` with no `with_*` calls is a no-op that
 preserves the prior default behavior. Existing services see no change
@@ -1133,13 +1212,16 @@ target `connectrpc::deadline` with the path and before/after
 durations. Enable `RUST_LOG=connectrpc::deadline=debug` to spot
 misbehaving clients.
 
-Inside a handler, `ctx.deadline` reflects the *moderated* value (after
-clamping), so the handler can budget downstream calls — propagate the
-remaining time minus a margin as the timeout for outbound RPCs:
+Inside a handler, `ctx.deadline()` reflects the *moderated* value
+(after clamping), so the handler can budget downstream calls —
+propagate the remaining time minus a margin as the timeout for
+outbound RPCs. `ctx.time_remaining()` does the subtraction for you
+(`None` when the request has no deadline):
 
 ```rust,ignore
-use std::time::Instant;
-let remaining = ctx.deadline.map(|d| d.saturating_duration_since(Instant::now()));
+if let Some(remaining) = ctx.time_remaining() {
+    options = options.with_timeout(remaining.saturating_sub(margin));
+}
 ```
 
 ## Clients
@@ -1267,9 +1349,8 @@ pub struct ConnectError {
     pub code: ErrorCode,
     pub message: Option<String>,
     pub details: Vec<ErrorDetail>,
-    pub headers: http::HeaderMap,
-    pub trailers: http::HeaderMap,
-    // ...
+    // response headers and trailers: private, exposed via the
+    // response_headers()/trailers() accessors and their _mut variants
 }
 ```
 
@@ -1365,8 +1446,9 @@ let service = ConnectRpcService::new(router).with_compression(registry);
 | [`middleware/`](../examples/middleware) | Server-side tower middleware composition: an `axum::middleware::from_fn` bearer-token auth, identity passthrough via `RequestContext::extensions()`, response trailers via `Response::with_trailer`. Client demos `ClientConfig::with_default_header` and `CallOptions::with_timeout`. |
 | [`mtls-identity/`](../examples/mtls-identity) | mTLS twin of `middleware/`: axum hosted behind `connectrpc::axum::serve_tls`, identity from the client cert's DNS SAN via `PeerCerts` instead of a bearer token, ACL keyed on the cert-derived identity. In-memory `rcgen` PKI; no PEM files. |
 | [`eliza/`](../examples/eliza) | Production-shaped streaming app: a port of the `connectrpc/examples-go` ELIZA demo. Server-streaming Introduce + bidi-streaming Converse, TLS, mTLS, CORS, IPv6, both server and client binaries, interoperates with the hosted Go reference at `demo.connectrpc.com`. |
-| [`multiservice/`](../examples/multiservice) | Multiple proto packages compiled together with `buf generate`, multiple services on one server, well-known type usage. |
+| [`multiservice/`](../examples/multiservice) | Multiple proto packages compiled together with `buf generate`, multiple services on one server, well-known type usage, and server reflection mounted from both descriptor sources (`REFLECTION_SOURCE=fds\|pool`; see `reflection-demo.sh`). |
 | [`wasm-client/`](../examples/wasm-client) | Browser fetch transport: same generated client used from `wasm32-unknown-unknown` with a custom `ClientTransport` backed by `web-sys::fetch`. |
 | [`bazel/`](../examples/bazel) | Bazel build integration via custom rules. |
 
-Each example has its own README with run instructions.
+Most examples have their own README with run instructions; the rest
+document themselves through their `test.sh` / demo scripts.


### PR DESCRIPTION
## Summary

Prepares the 0.7.0 release: lockstep version bumps for five crates, changelog restructuring and finalization, a documentation accuracy pass across README / guide / rustdoc, and one small behavior fix surfaced by the pre-release audit.

### Release mechanics

- All five crates bump to 0.7.0: `connectrpc`, `connectrpc-codegen`, `connectrpc-build`, plus `connectrpc-health` (#128) and `connectrpc-reflection` (#157), which both join the lockstep scheme with this as their first published version. Inter-crate version requirements move to `0.7`.
- `publish-crates.yml` gains publish steps for `connectrpc-health` and `connectrpc-reflection` — the workflow previously published only three crates, so a tag push would have silently skipped both new crates.
- Both new crates gain docs.rs metadata (`all-features` + `--cfg docsrs`) and feature badges on their `client`-gated re-exports, matching the `connectrpc` pattern.

### Changelog

The `[Unreleased]` section accumulated two stacked fragments (the #143 conversion plus the #159/#160 entries appended above it). Restructured into one coherent `[0.7.0] - 2026-06-10` entry:

- Single intro and Breaking section covering both breaking fronts: the server-side request rework (`ServiceRequest`/`StreamMessage` on buffa 0.7.0) and the client streaming terminal-error contract, with a before/after handler-signature snippet and PR references on the streaming entries.
- Previously missing entries added: `connectrpc-health` (#128) and the inter-message timer fix (#127, including the corrected first-poll arming semantics).
- The #159 gRPC entry now cross-references #140 instead of implying the Connect `unavailable` behavior predates this release.

### Documentation accuracy pass

- Guide: new **Server reflection** section (dependency snippet, both descriptor sources, schema-exposure callout, demo pointers), fifth crate-table row, streaming-client section now states the #159 `Err`-on-terminal-error contract, bidi snippet fixed to unwrap the `Option` before `.reborrow()`, inter-message timeout wording updated for #127, `ctx.deadline` field access replaced with the real accessors, `ConnectError` sketch corrected, stale `0.5`/`0.6` version snippets bumped.
- Rustdoc: `connectrpc-reflection`'s build.rs quick-start used the prost-style `compile(&files, &includes)` signature that doesn't exist — fixed to the real `Config` API; `with_inter_message_timeout` now documents when the timer arms; `connectrpc` crate-doc module index and Protocol Support section refreshed; duplicated `ServerStream` summary line removed.

### Behavior fix

The default `CompressionProvider::decompress_with_limit` implementation mapped read failures to `internal`, while #144 moved the built-in providers to `invalid_argument` — a custom provider relying on the default would silently keep the old 5xx behavior the changelog says was fixed. The default now maps read failures to `invalid_argument`, with a documented convention and a regression test.

## Verification

- `task lint` (clippy all targets `-D warnings` + nightly fmt) clean
- `task test` passes
- `task doc` (broken intra-doc links denied) clean

## After merge

Tag `v0.7.0` on the merge commit to trigger crates.io publish (now five crates) and the binary release. Post-release follow-up: regenerate `examples/bazel/Cargo.lock` against the published 0.7.0 crates (its pins cannot resolve before publish). Optional: pick up buffa 0.7.1 in lockfiles when it ships — the `0.7` floor needs no change.
