### PR TITLE
client: streaming message() returns terminal errors as Err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,17 @@ increment the patch version.
   }
   ```
 
-- **A gRPC/gRPC-Web stream that never delivers a `grpc-status` is now
-  an error** (`internal`, "stream ended without grpc-status") instead
-  of a clean `Ok(None)` — whether the trailers were absent entirely or
-  arrived without the status, the end is indistinguishable from a
-  mid-stream cut and must not read as success (grpc-go does the same).
-  A Trailers-Only response carrying `grpc-status: 0` in the response
-  headers (grpc-go's shape for an OK end with zero messages) remains a
-  clean end. The Connect protocol already treated a missing END_STREAM
-  envelope as `unavailable`.
+- **A gRPC/gRPC-Web stream that never delivers a usable `grpc-status`
+  is now an error** instead of a clean `Ok(None)`: `internal` when no
+  trailers arrived at all, `unknown` when trailers arrived without a
+  `grpc-status`, and `unknown` for a present-but-malformed
+  `grpc-status` value — each matching grpc-go (and the conformance
+  suite's primary expectations). A Trailers-Only response carrying
+  `grpc-status: 0` in the response headers (grpc-go's shape for an OK
+  end with zero messages) remains a clean end. The Connect protocol
+  already treated a missing END_STREAM envelope as `unavailable`
+  (a connect-rust choice, unchanged here; the Connect spec does not
+  prescribe a client-side code).
 
 This release also reworks the server-side request surface around buffa 0.7.0,
 which removed `OwnedView`'s `Deref` impl (the impl let safe code hold view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,41 @@ increment the patch version.
 
 ## [Unreleased]
 
-This release reworks the server-side request surface around buffa 0.7.0,
+### Breaking
+
+- **Client streams return terminal server errors from `message()`**.
+  Previously, an RPC error carried in the stream's termination metadata
+  (gRPC HTTP/2 trailers, gRPC-Web trailer frame, or Connect END_STREAM
+  envelope) made `ServerStream::message()` / `BidiStream::message()`
+  return `Ok(None)` — indistinguishable from a clean close — with the
+  error retrievable only via the easy-to-miss `error()` accessor. A
+  caller that treated `Ok(None)` as success would silently swallow every
+  failed streaming RPC. `message()` now returns `Err(...)` for an
+  errored end and reserves `Ok(None)` for a clean end (gRPC status OK /
+  error-free END_STREAM), matching `tonic`. Every `Err` is terminal and
+  sticky — re-polling returns the same error, never a clean-looking
+  `Ok(None)`; `error()` and `trailers()` remain populated for post-hoc
+  inspection. Callers that only match `Err` need no changes; callers
+  doing the `Ok(None)`-then-`error()` dance can delete the dance:
+
+  ```rust
+  // Before: errors hid behind Ok(None)        // After: `?` is complete
+  while let Some(m) = s.message().await? {     while let Some(m) = s.message().await? {
+      handle(m);                                   handle(m);
+  }                                            }
+  if let Some(err) = s.error() {
+      return Err(err.clone().into());
+  }
+  ```
+
+- **A gRPC/gRPC-Web stream ending without `grpc-status` is now an
+  error** (`internal`, "server closed stream without sending
+  grpc-status") instead of a clean `Ok(None)` — EOF without termination
+  metadata is indistinguishable from a mid-stream cut, so it must not
+  read as success (grpc-go does the same). The Connect protocol already
+  treated a missing END_STREAM envelope as `unavailable`.
+
+This release also reworks the server-side request surface around buffa 0.7.0,
 which removed `OwnedView`'s `Deref` impl (the impl let safe code hold view
 fields past the backing buffer's lifetime). Handlers move from owned
 `OwnedView<FooView<'static>>` parameters to borrowed requests and owned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,15 @@ increment the patch version.
   }
   ```
 
-- **A gRPC/gRPC-Web stream ending without `grpc-status` is now an
-  error** (`internal`, "server closed stream without sending
-  grpc-status") instead of a clean `Ok(None)` — EOF without termination
-  metadata is indistinguishable from a mid-stream cut, so it must not
-  read as success (grpc-go does the same). The Connect protocol already
-  treated a missing END_STREAM envelope as `unavailable`.
+- **A gRPC/gRPC-Web stream that never delivers a `grpc-status` is now
+  an error** (`internal`, "stream ended without grpc-status") instead
+  of a clean `Ok(None)` — whether the trailers were absent entirely or
+  arrived without the status, the end is indistinguishable from a
+  mid-stream cut and must not read as success (grpc-go does the same).
+  A Trailers-Only response carrying `grpc-status: 0` in the response
+  headers (grpc-go's shape for an OK end with zero messages) remains a
+  clean end. The Connect protocol already treated a missing END_STREAM
+  envelope as `unavailable`.
 
 This release also reworks the server-side request surface around buffa 0.7.0,
 which removed `OwnedView`'s `Deref` impl (the impl let safe code hold view

--- a/connectrpc-health/src/service.rs
+++ b/connectrpc-health/src/service.rs
@@ -443,10 +443,12 @@ mod tests {
         let client: HealthClient<HttpClient> = HealthClient::new(HttpClient::plaintext(), config);
 
         let mut stream = client.watch(HealthCheckRequest::default()).await.unwrap();
-        // Server-streaming RPCs surface errors via the trailers — `message()`
-        // returns `Ok(None)` and the error lands on `stream.error()`.
-        assert!(stream.message().await.unwrap().is_none());
-        let err = stream.error().expect("expected Unimplemented error");
+        // Server-streaming RPCs surface trailer-borne errors directly from
+        // `message()` — `Ok(None)` is reserved for a clean end.
+        let err = stream
+            .message()
+            .await
+            .expect_err("expected Unimplemented error");
         assert_eq!(err.code, connectrpc::ErrorCode::Unimplemented);
     }
 }

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1870,9 +1870,9 @@ where
 ///
 /// Provides incremental access to response messages as they arrive from the server.
 /// Messages are decoded one at a time from the HTTP response body using the
-/// [`message()`](ServerStream::message) method. Trailing metadata and errors
-/// (from the Connect END_STREAM envelope) become available after the message
-/// stream is exhausted.
+/// [`message()`](ServerStream::message) method, which returns `Ok(None)` for
+/// a clean end and `Err` for a failed RPC — `?` is the complete error
+/// handling. Trailing metadata becomes available after the stream ends.
 ///
 /// # Example
 ///
@@ -1935,30 +1935,70 @@ where
     /// Fetch the next message from the stream.
     ///
     /// Returns `Ok(Some(msg))` for each message, `Ok(None)` when the stream
-    /// ends, or `Err(...)` on protocol/decode/deadline errors.
+    /// ends **cleanly** (gRPC status OK / error-free END_STREAM), or
+    /// `Err(...)` for everything else: protocol/decode/deadline errors *and*
+    /// a server error carried in the stream's termination metadata (gRPC
+    /// trailers, gRPC-Web trailer frame, or Connect END_STREAM envelope).
+    /// `Ok(None)` means the RPC succeeded — matching `tonic`.
+    ///
+    /// Every `Err` is terminal and sticky: the stream will never yield
+    /// another message, subsequent calls return the same `Err` (the same
+    /// policy as a failed stream construction), and recovery means making a
+    /// new call — not re-polling this one. The terminal error also remains
+    /// inspectable via [`error()`](Self::error), and
+    /// [`trailers()`](Self::trailers) is populated when termination metadata
+    /// was received — for both the `Ok(None)` and `Err` ends.
     ///
     /// If a deadline was set on this call (via [`CallOptions::with_timeout`]
     /// or [`ClientConfig::with_default_timeout`]), each `message()` poll is
     /// bounded by it — gRPC deadline semantics are whole-call, so a hung
     /// server won't block indefinitely (matching grpc-java and connect-go).
     ///
-    /// After this returns `Ok(None)`, [`trailers()`](Self::trailers) and
-    /// [`error()`](Self::error) become available.
-    ///
     /// # Errors
     ///
-    /// For the Connect protocol, a response body that ends without the
-    /// required END_STREAM envelope returns `Err` with code `unavailable`
-    /// rather than `Ok(None)` — a stream cut off mid-response is not a
-    /// clean end. In that case (as with any returned `Err`)
-    /// [`trailers()`](Self::trailers) and [`error()`](Self::error) are not
-    /// populated; the returned error is the terminal outcome.
+    /// A response body that ends without its protocol's termination
+    /// metadata is not a clean end and returns `Err` rather than
+    /// `Ok(None)`: code `unavailable` for a Connect stream missing its
+    /// END_STREAM envelope, `internal` for a gRPC/gRPC-Web stream missing
+    /// `grpc-status` (matching grpc-go's treatment of EOF-without-status
+    /// as an error).
     pub async fn message(&mut self) -> Result<Option<OwnedView<RespView>>, ConnectError> {
+        // Terminal errors are sticky: once the RPC has failed, every
+        // subsequent poll re-reports the failure rather than reading a
+        // closed stream as `Ok(None)` (which callers may rightly treat as
+        // success).
+        if self.done
+            && let Some(err) = &self.error
+        {
+            return Err(err.clone());
+        }
         // Whole-call deadline enforcement: wrap the decode loop so every
-        // body-poll is bounded. If the deadline has already passed, this
-        // returns immediately without polling.
+        // body-poll is bounded.
         let deadline = self.deadline;
-        with_deadline(deadline, self.message_inner()).await
+        match with_deadline(deadline, self.message_inner()).await {
+            Ok(Some(msg)) => Ok(Some(msg)),
+            Ok(None) => {
+                // An end-of-stream whose termination metadata carries a
+                // server error is a failed RPC, not a clean close — surface
+                // it as `Err`. Callers that only match `Ok(None)` must never
+                // mistake a failed RPC for success (the silent-retry-loop
+                // failure mode this guards against).
+                match &self.error {
+                    Some(err) => Err(err.clone()),
+                    None => Ok(None),
+                }
+            }
+            Err(err) => {
+                // Decode/transport/deadline failures are equally terminal:
+                // the stream state is unrecoverable. Stash so re-polls stay
+                // `Err` instead of degrading to a clean-looking `Ok(None)`.
+                self.done = true;
+                if self.error.is_none() {
+                    self.error = Some(err.clone());
+                }
+                Err(err)
+            }
+        }
     }
 
     /// The actual message decode loop. Split from `message()` so the deadline
@@ -2067,17 +2107,28 @@ where
                                 self.trailers = Some(trailers);
                             }
                         }
-                        // For gRPC, if body exhausted without trailers and
-                        // deadline has passed, map to DEADLINE_EXCEEDED
-                        // (matches grpc-go / connect-go RST_STREAM CANCEL handling)
+                        // gRPC/gRPC-Web: EOF without any termination
+                        // metadata is a protocol violation, never a clean
+                        // end. Past the deadline, the deadline is what cut
+                        // the stream (matches grpc-go / connect-go
+                        // RST_STREAM CANCEL handling); otherwise report the
+                        // missing status (grpc-go maps EOF-without-status
+                        // to an error for the same reason: it is
+                        // indistinguishable from a mid-stream cut).
                         if self.error.is_none()
                             && self.trailers.is_none()
                             && matches!(self.protocol, Protocol::Grpc | Protocol::GrpcWeb)
-                            && self
-                                .deadline
-                                .is_some_and(|d| std::time::Instant::now() >= d)
                         {
-                            self.error = Some(ConnectError::deadline_exceeded("request timeout"));
+                            let past_deadline = self
+                                .deadline
+                                .is_some_and(|d| std::time::Instant::now() >= d);
+                            self.error = Some(if past_deadline {
+                                ConnectError::deadline_exceeded("request timeout")
+                            } else {
+                                ConnectError::internal(
+                                    "server closed stream without sending grpc-status",
+                                )
+                            });
                         }
                         return Ok(None);
                     }
@@ -2089,15 +2140,20 @@ where
 
     /// Returns the trailing metadata, if available.
     ///
-    /// Only populated after [`message()`](Self::message) returns `Ok(None)`.
+    /// Only populated after [`message()`](Self::message) reports the end of
+    /// the stream — `Ok(None)` for a clean end, or the terminal `Err` when
+    /// the termination metadata carried a server error.
     #[must_use]
     pub fn trailers(&self) -> Option<&http::HeaderMap> {
         self.trailers.as_ref()
     }
 
-    /// Returns the trailing error from the END_STREAM envelope, if any.
+    /// Returns the terminal server error (gRPC trailers / Connect
+    /// END_STREAM), if any.
     ///
-    /// Only populated after [`message()`](Self::message) returns `Ok(None)`.
+    /// [`message()`](Self::message) already returns this same error, so most
+    /// callers never need this accessor; it exists for post-hoc inspection
+    /// alongside [`trailers()`](Self::trailers).
     #[must_use]
     pub fn error(&self) -> Option<&ConnectError> {
         self.error.as_ref()
@@ -2229,8 +2285,8 @@ where
 /// - The request cannot be encoded or sent
 /// - The server responds with a non-200 status (protocol-level error)
 ///
-/// Errors that occur during the stream (e.g., in the END_STREAM envelope)
-/// are available via [`ServerStream::error()`] after the stream ends.
+/// Errors that occur during the stream (e.g., in gRPC trailers or the
+/// END_STREAM envelope) are returned by [`ServerStream::message()`].
 pub async fn call_server_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
@@ -2506,11 +2562,10 @@ enum RecvState<B, RespView> {
 /// stream.send(request1).await?;
 /// stream.send(request2).await?;
 /// stream.close_send();
+/// // `Ok(None)` means a clean end; a failed RPC surfaces as `Err`,
+/// // so `?` is the complete error handling.
 /// while let Some(msg) = stream.message().await? {
 ///     println!("got: {msg:?}");
-/// }
-/// if let Some(err) = stream.error() {
-///     return Err(err.clone());
 /// }
 /// ```
 pub struct BidiStream<B, Req, RespView> {
@@ -2627,9 +2682,10 @@ where
     /// servers that wait for a request before sending headers don't deadlock).
     /// Subsequent calls decode envelopes from the response body stream.
     ///
-    /// Returns `Ok(None)` when the server is done sending. At that point,
-    /// [`trailers()`](Self::trailers) and [`error()`](Self::error) become
-    /// available.
+    /// Returns `Ok(None)` only when the server finished **cleanly**; a
+    /// server error carried in the termination metadata is returned as
+    /// `Err`, sticky across calls — see [`ServerStream::message()`] for the
+    /// full contract.
     pub async fn message(&mut self) -> Result<Option<OwnedView<RespView>>, ConnectError> {
         // If we already failed during construction or first await, return that.
         if let Some(ref err) = self.construct_err {
@@ -2705,7 +2761,7 @@ where
     }
 
     /// Trailing metadata. Only populated after [`message()`](Self::message)
-    /// returns `Ok(None)`.
+    /// reports the end of the stream (`Ok(None)` or the terminal `Err`).
     #[must_use]
     pub fn trailers(&self) -> Option<&http::HeaderMap> {
         match &self.recv {
@@ -2714,10 +2770,10 @@ where
         }
     }
 
-    /// Trailing error from the END_STREAM envelope (Connect) or trailers (gRPC).
-    /// Only populated after [`message()`](Self::message) returns `Ok(None)`.
-    /// For transport-level failures, [`message()`](Self::message) returns the
-    /// error directly instead.
+    /// Terminal server error from the END_STREAM envelope (Connect) or
+    /// trailers (gRPC), if any. [`message()`](Self::message) already returns
+    /// this same error, so most callers never need this accessor; it exists
+    /// for post-hoc inspection alongside [`trailers()`](Self::trailers).
     #[must_use]
     pub fn error(&self) -> Option<&ConnectError> {
         match &self.recv {
@@ -3756,6 +3812,14 @@ mod tests {
             err.to_string().contains("END_STREAM"),
             "unexpected error: {err}"
         );
+
+        // Sticky: a re-poll must not degrade truncation to a clean-looking
+        // `Ok(None)`.
+        let again = stream
+            .message()
+            .await
+            .expect_err("truncation error must be sticky");
+        assert_eq!(again.code, ErrorCode::Unavailable);
     }
 
     /// A Connect streaming response whose body is empty (zero envelopes,
@@ -3792,6 +3856,221 @@ mod tests {
             err.to_string().contains("END_STREAM"),
             "unexpected error: {err}"
         );
+
+        let again = stream
+            .message()
+            .await
+            .expect_err("truncation error must be sticky");
+        assert_eq!(again.code, ErrorCode::Unavailable);
+    }
+
+    /// `Ok(None)` means the RPC succeeded — a Connect END_STREAM envelope
+    /// carrying an error must come back as `Err` from `message()`, sticky
+    /// across calls, with `error()` still available for inspection.
+    #[tokio::test]
+    async fn connect_end_stream_error_returned_from_message() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut body = BytesMut::new();
+        body.extend_from_slice(
+            &Envelope::data(StringValue::from("hello").encode_to_bytes()).encode(),
+        );
+        body.extend_from_slice(
+            &Envelope::end_stream(Bytes::from_static(
+                b"{\"error\":{\"code\":\"out_of_range\",\"message\":\"requested position no longer retained\"},\
+                  \"metadata\":{\"x-detail\":[\"42\"]}}",
+            ))
+            .encode(),
+        );
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers: http::HeaderMap::new(),
+            body: Full::new(body.freeze()),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Connect,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            _phantom: PhantomData,
+        };
+
+        let msg = stream
+            .message()
+            .await
+            .expect("data envelope should decode")
+            .expect("stream should yield the data message first");
+        assert_eq!(msg.reborrow().value, "hello");
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("errored END_STREAM must surface as Err, not Ok(None)");
+        assert_eq!(err.code, ErrorCode::OutOfRange);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("requested position no longer retained")
+        );
+
+        // Sticky: re-polling a failed stream re-reports the failure.
+        let again = stream
+            .message()
+            .await
+            .expect_err("terminal error is sticky");
+        assert_eq!(again.code, ErrorCode::OutOfRange);
+
+        // Post-hoc accessors still work.
+        assert_eq!(stream.error().map(|e| e.code), Some(ErrorCode::OutOfRange));
+        assert_eq!(
+            stream
+                .trailers()
+                .and_then(|t| t.get("x-detail"))
+                .and_then(|v| v.to_str().ok()),
+            Some("42")
+        );
+    }
+
+    /// Same contract for gRPC: an error in HTTP/2 trailers is a failed RPC
+    /// and must come back as `Err` from `message()` — not the silent
+    /// `Ok(None)` that callers mistake for a clean close.
+    #[tokio::test]
+    async fn grpc_trailer_error_returned_from_message() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        let data = Envelope::data(StringValue::from("hello").encode_to_bytes()).encode();
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "11".parse().unwrap()); // OUT_OF_RANGE
+        trailers.insert(
+            "grpc-message",
+            "requested position no longer retained".parse().unwrap(),
+        );
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(Frame::data(data)), Ok(Frame::trailers(trailers))];
+        let body = StreamBody::new(futures::stream::iter(frames));
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers: http::HeaderMap::new(),
+            body,
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            _phantom: PhantomData,
+        };
+
+        let msg = stream
+            .message()
+            .await
+            .expect("data envelope should decode")
+            .expect("stream should yield the data message first");
+        assert_eq!(msg.reborrow().value, "hello");
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("gRPC trailer error must surface as Err, not Ok(None)");
+        assert_eq!(err.code, ErrorCode::OutOfRange);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("requested position no longer retained")
+        );
+
+        let again = stream
+            .message()
+            .await
+            .expect_err("terminal error is sticky");
+        assert_eq!(again.code, ErrorCode::OutOfRange);
+        assert!(stream.trailers().is_some());
+    }
+
+    /// A gRPC stream ending with `grpc-status: 0` is the one true clean end —
+    /// `Ok(None)`, no error.
+    #[tokio::test]
+    async fn grpc_ok_trailers_end_as_ok_none() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "0".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(Frame::trailers(trailers))];
+        let body = StreamBody::new(futures::stream::iter(frames));
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers: http::HeaderMap::new(),
+            body,
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            _phantom: PhantomData,
+        };
+
+        assert!(stream.message().await.unwrap().is_none());
+        assert!(stream.error().is_none());
+        assert!(stream.trailers().is_some());
+    }
+
+    /// gRPC EOF with no trailers at all is a protocol violation — it must
+    /// not read as a clean end (it is indistinguishable from a mid-stream
+    /// cut; grpc-go errors here too).
+    #[tokio::test]
+    async fn grpc_eof_without_trailers_errors() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers: http::HeaderMap::new(),
+            body: Full::new(Bytes::new()),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            _phantom: PhantomData,
+        };
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("EOF without grpc-status must surface as Err");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert!(
+            err.to_string().contains("grpc-status"),
+            "unexpected error: {err}"
+        );
+
+        let again = stream
+            .message()
+            .await
+            .expect_err("missing-status error must be sticky");
+        assert_eq!(again.code, ErrorCode::Internal);
     }
 
     #[cfg(feature = "client")]

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1899,6 +1899,10 @@ pub struct ServerStream<B, RespView> {
     trailers: Option<http::HeaderMap>,
     error: Option<ConnectError>,
     done: bool,
+    /// Whether any body DATA frame arrived. Distinguishes a true
+    /// Trailers-Only response (empty body; status rides the headers)
+    /// from a stream that produced data and was then cut off.
+    saw_body_data: bool,
     _phantom: PhantomData<RespView>,
 }
 
@@ -1959,18 +1963,23 @@ where
     /// A response body that ends without its protocol's termination
     /// metadata is not a clean end and returns `Err` rather than
     /// `Ok(None)`: code `unavailable` for a Connect stream missing its
-    /// END_STREAM envelope, `internal` for a gRPC/gRPC-Web stream missing
-    /// `grpc-status` (matching grpc-go's treatment of EOF-without-status
-    /// as an error).
+    /// END_STREAM envelope, `internal` for a gRPC/gRPC-Web stream that
+    /// never delivered a `grpc-status` — whether the trailers were absent
+    /// entirely or present without the status (matching grpc-go). A
+    /// Trailers-Only response carrying `grpc-status: 0` in the headers is
+    /// a clean end.
     pub async fn message(&mut self) -> Result<Option<OwnedView<RespView>>, ConnectError> {
-        // Terminal errors are sticky: once the RPC has failed, every
-        // subsequent poll re-reports the failure rather than reading a
-        // closed stream as `Ok(None)` (which callers may rightly treat as
-        // success).
-        if self.done
-            && let Some(err) = &self.error
-        {
-            return Err(err.clone());
+        // The outcome is immutable once reported: never re-enter the
+        // deadline wrapper or the body after the stream has ended. Every
+        // site that ends the stream sets `done` and (on failure) `error`
+        // before returning, so `self.error` fully encodes the outcome —
+        // a failed RPC replays its `Err` (sticky), a clean end replays
+        // `Ok(None)`.
+        if self.done {
+            return match &self.error {
+                Some(err) => Err(err.clone()),
+                None => Ok(None),
+            };
         }
         // Whole-call deadline enforcement: wrap the decode loop so every
         // body-poll is bounded.
@@ -1983,6 +1992,11 @@ where
                 // it as `Err`. Callers that only match `Ok(None)` must never
                 // mistake a failed RPC for success (the silent-retry-loop
                 // failure mode this guards against).
+                if self.error.is_none()
+                    && let Some(err) = self.missing_grpc_status_error()
+                {
+                    self.error = Some(err);
+                }
                 match &self.error {
                     Some(err) => Err(err.clone()),
                     None => Ok(None),
@@ -1992,10 +2006,10 @@ where
                 // Decode/transport/deadline failures are equally terminal:
                 // the stream state is unrecoverable. Stash so re-polls stay
                 // `Err` instead of degrading to a clean-looking `Ok(None)`.
+                // (`error` cannot already be set here — a set error implies
+                // `done`, which the top guard short-circuits.)
                 self.done = true;
-                if self.error.is_none() {
-                    self.error = Some(err.clone());
-                }
+                self.error = Some(err.clone());
                 Err(err)
             }
         }
@@ -2004,10 +2018,6 @@ where
     /// The actual message decode loop. Split from `message()` so the deadline
     /// wrapper can bound the whole thing without threading it through the loop.
     async fn message_inner(&mut self) -> Result<Option<OwnedView<RespView>>, ConnectError> {
-        if self.done {
-            return Ok(None);
-        }
-
         loop {
             // For gRPC-Web, check for a complete trailer frame (flag 0x80)
             // before attempting envelope decode (which would treat 0x80 as
@@ -2107,29 +2117,10 @@ where
                                 self.trailers = Some(trailers);
                             }
                         }
-                        // gRPC/gRPC-Web: EOF without any termination
-                        // metadata is a protocol violation, never a clean
-                        // end. Past the deadline, the deadline is what cut
-                        // the stream (matches grpc-go / connect-go
-                        // RST_STREAM CANCEL handling); otherwise report the
-                        // missing status (grpc-go maps EOF-without-status
-                        // to an error for the same reason: it is
-                        // indistinguishable from a mid-stream cut).
-                        if self.error.is_none()
-                            && self.trailers.is_none()
-                            && matches!(self.protocol, Protocol::Grpc | Protocol::GrpcWeb)
-                        {
-                            let past_deadline = self
-                                .deadline
-                                .is_some_and(|d| std::time::Instant::now() >= d);
-                            self.error = Some(if past_deadline {
-                                ConnectError::deadline_exceeded("request timeout")
-                            } else {
-                                ConnectError::internal(
-                                    "server closed stream without sending grpc-status",
-                                )
-                            });
-                        }
+                        // A missing grpc-status is diagnosed by the
+                        // `message()` wrapper (`missing_grpc_status_error`),
+                        // which sees every gRPC/gRPC-Web end — including the
+                        // in-loop trailer-frame path above.
                         return Ok(None);
                     }
                     // Loop back to try decoding again
@@ -2138,18 +2129,59 @@ where
         }
     }
 
+    /// For gRPC/gRPC-Web, a stream end is only clean if a `grpc-status`
+    /// actually arrived somewhere: the HTTP/2 trailers, the gRPC-Web
+    /// trailer frame, or — for Trailers-Only responses (grpc-go emits
+    /// these for OK ends with zero messages) — the response headers. An
+    /// end with no status anywhere is indistinguishable from a mid-stream
+    /// cut and must not read as success; grpc-go errors here for the same
+    /// reason. Past the whole-call deadline, the deadline is what cut the
+    /// stream (matches grpc-go / connect-go RST_STREAM CANCEL handling).
+    ///
+    /// Connect signals termination via the END_STREAM envelope, whose
+    /// absence is already an in-loop `unavailable` error — never flagged
+    /// here.
+    fn missing_grpc_status_error(&self) -> Option<ConnectError> {
+        if !matches!(self.protocol, Protocol::Grpc | Protocol::GrpcWeb) {
+            return None;
+        }
+        let has_status = |h: &http::HeaderMap| h.contains_key("grpc-status");
+        // A headers-borne status only counts for a true Trailers-Only
+        // response (empty body). Once body data has flowed, the stream's
+        // real trailers are the required termination signal — otherwise a
+        // mid-stream cut after eager headers would read as success. Same
+        // guard as the unary path's has_body_data fallback.
+        let trailers_only = !self.saw_body_data;
+        if self.trailers.as_ref().is_some_and(has_status)
+            || (trailers_only && has_status(&self.headers))
+        {
+            return None;
+        }
+        Some(
+            if self
+                .deadline
+                .is_some_and(|d| std::time::Instant::now() >= d)
+            {
+                ConnectError::deadline_exceeded("request timeout")
+            } else {
+                ConnectError::internal("stream ended without grpc-status")
+            },
+        )
+    }
+
     /// Returns the trailing metadata, if available.
     ///
     /// Only populated after [`message()`](Self::message) reports the end of
-    /// the stream — `Ok(None)` for a clean end, or the terminal `Err` when
-    /// the termination metadata carried a server error.
+    /// the stream, and only when termination metadata was received — for
+    /// both the `Ok(None)` and `Err` ends.
     #[must_use]
     pub fn trailers(&self) -> Option<&http::HeaderMap> {
         self.trailers.as_ref()
     }
 
-    /// Returns the terminal server error (gRPC trailers / Connect
-    /// END_STREAM), if any.
+    /// Returns the terminal error that ended the stream, if any — a server
+    /// error from the termination metadata (gRPC trailers / Connect
+    /// END_STREAM), or a decode/transport/deadline failure.
     ///
     /// [`message()`](Self::message) already returns this same error, so most
     /// callers never need this accessor; it exists for post-hoc inspection
@@ -2184,6 +2216,9 @@ where
                 Some(Ok(frame)) => {
                     if frame.is_data() {
                         if let Ok(data) = frame.into_data() {
+                            if !data.is_empty() {
+                                self.saw_body_data = true;
+                            }
                             if self.buf.len().saturating_add(data.len()) > max_buf_size {
                                 return Err(ConnectError::resource_exhausted(format!(
                                     "response buffer exceeds limit {max_buf_size}"
@@ -2201,8 +2236,7 @@ where
                             self.error = Some(err);
                         }
                         self.trailers = Some(trailers);
-                        self.done = true;
-                        return Ok(false);
+                        return Ok(false); // caller marks done on body exhaustion
                     }
                 }
                 Some(Err(e)) => {
@@ -2483,6 +2517,7 @@ where
         trailers: None,
         error: None,
         done: false,
+        saw_body_data: false,
         _phantom: PhantomData,
     })
 }
@@ -2770,10 +2805,12 @@ where
         }
     }
 
-    /// Terminal server error from the END_STREAM envelope (Connect) or
-    /// trailers (gRPC), if any. [`message()`](Self::message) already returns
-    /// this same error, so most callers never need this accessor; it exists
-    /// for post-hoc inspection alongside [`trailers()`](Self::trailers).
+    /// Terminal error that ended the stream, if any — a server error from
+    /// the END_STREAM envelope (Connect) or trailers (gRPC), or a
+    /// decode/transport/deadline failure. [`message()`](Self::message)
+    /// already returns this same error, so most callers never need this
+    /// accessor; it exists for post-hoc inspection alongside
+    /// [`trailers()`](Self::trailers).
     #[must_use]
     pub fn error(&self) -> Option<&ConnectError> {
         match &self.recv {
@@ -3792,6 +3829,7 @@ mod tests {
             trailers: None,
             error: None,
             done: false,
+            saw_body_data: false,
             _phantom: PhantomData,
         };
 
@@ -3843,6 +3881,7 @@ mod tests {
             trailers: None,
             error: None,
             done: false,
+            saw_body_data: false,
             _phantom: PhantomData,
         };
 
@@ -3897,6 +3936,7 @@ mod tests {
             trailers: None,
             error: None,
             done: false,
+            saw_body_data: false,
             _phantom: PhantomData,
         };
 
@@ -3970,6 +4010,7 @@ mod tests {
             trailers: None,
             error: None,
             done: false,
+            saw_body_data: false,
             _phantom: PhantomData,
         };
 
@@ -4025,6 +4066,7 @@ mod tests {
             trailers: None,
             error: None,
             done: false,
+            saw_body_data: false,
             _phantom: PhantomData,
         };
 
@@ -4053,6 +4095,7 @@ mod tests {
             trailers: None,
             error: None,
             done: false,
+            saw_body_data: false,
             _phantom: PhantomData,
         };
 
@@ -4065,6 +4108,130 @@ mod tests {
             err.to_string().contains("grpc-status"),
             "unexpected error: {err}"
         );
+
+        let again = stream
+            .message()
+            .await
+            .expect_err("missing-status error must be sticky");
+        assert_eq!(again.code, ErrorCode::Internal);
+    }
+
+    /// `grpc-status: 0` in the response HEADERS only certifies a true
+    /// Trailers-Only response (empty body). If data flowed afterwards,
+    /// the real trailers are still required — a cut after eager headers
+    /// must not read as success.
+    #[tokio::test]
+    async fn grpc_header_status_does_not_excuse_truncation_after_data() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert("grpc-status", "0".parse().unwrap());
+        let body = Full::new(Envelope::data(StringValue::from("hello").encode_to_bytes()).encode());
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers,
+            body,
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let msg = stream
+            .message()
+            .await
+            .expect("data envelope should decode")
+            .expect("stream should yield the data message first");
+        assert_eq!(msg.reborrow().value, "hello");
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("truncation after data must surface as Err despite header status");
+        assert_eq!(err.code, ErrorCode::Internal);
+    }
+
+    /// A gRPC Trailers-Only OK response — `grpc-status: 0` in the response
+    /// HEADERS, empty body, no HTTP trailers — is how grpc-go ends a
+    /// server-stream cleanly with zero messages. It must stay a clean
+    /// `Ok(None)`, not a missing-status error.
+    #[tokio::test]
+    async fn grpc_trailers_only_ok_response_ends_cleanly() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert("grpc-status", "0".parse().unwrap());
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers,
+            body: Full::new(Bytes::new()),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        assert!(stream.message().await.unwrap().is_none());
+        assert!(stream.error().is_none());
+        // Stays clean on re-poll, too.
+        assert!(stream.message().await.unwrap().is_none());
+    }
+
+    /// Trailers that arrive without any `grpc-status` are as broken as no
+    /// trailers at all — the status is the termination signal, and its
+    /// absence must not read as success (grpc-go maps this to an error).
+    #[tokio::test]
+    async fn grpc_trailers_without_status_errors() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("x-meta", "1".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(Frame::trailers(trailers))];
+        let body = StreamBody::new(futures::stream::iter(frames));
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers: http::HeaderMap::new(),
+            body,
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("trailers without grpc-status must surface as Err");
+        assert_eq!(err.code, ErrorCode::Internal);
+        // The malformed trailers are still inspectable.
+        assert!(stream.trailers().is_some());
 
         let again = stream
             .message()

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1943,12 +1943,14 @@ where
     /// `Err(...)` for everything else: protocol/decode/deadline errors *and*
     /// a server error carried in the stream's termination metadata (gRPC
     /// trailers, gRPC-Web trailer frame, or Connect END_STREAM envelope).
-    /// `Ok(None)` means the RPC succeeded — matching `tonic`.
+    /// `Ok(None)` means the RPC succeeded. Terminal errors arrive from
+    /// `message()` itself, as in `tonic`.
     ///
     /// Every `Err` is terminal and sticky: the stream will never yield
     /// another message, subsequent calls return the same `Err` (the same
-    /// policy as a failed stream construction), and recovery means making a
-    /// new call — not re-polling this one. The terminal error also remains
+    /// policy as a failed stream construction; stronger than `tonic`, which
+    /// yields the error once and then reads as a clean end), and recovery
+    /// means making a new call — not re-polling this one. The terminal error also remains
     /// inspectable via [`error()`](Self::error), and
     /// [`trailers()`](Self::trailers) is populated when termination metadata
     /// was received — for both the `Ok(None)` and `Err` ends.
@@ -1962,12 +1964,13 @@ where
     ///
     /// A response body that ends without its protocol's termination
     /// metadata is not a clean end and returns `Err` rather than
-    /// `Ok(None)`: code `unavailable` for a Connect stream missing its
-    /// END_STREAM envelope, `internal` for a gRPC/gRPC-Web stream that
-    /// never delivered a `grpc-status` — whether the trailers were absent
-    /// entirely or present without the status (matching grpc-go). A
-    /// Trailers-Only response carrying `grpc-status: 0` in the headers is
-    /// a clean end.
+    /// `Ok(None)`: `unavailable` for a Connect stream missing its
+    /// END_STREAM envelope; for gRPC/gRPC-Web, `internal` when no
+    /// trailers arrived at all, `unknown` when trailers arrived without a
+    /// `grpc-status`, and `unknown` for a malformed `grpc-status` value —
+    /// matching grpc-go's treatment of each case. A Trailers-Only response
+    /// carrying `grpc-status: 0` in the headers (empty body) is a clean
+    /// end.
     pub async fn message(&mut self) -> Result<Option<OwnedView<RespView>>, ConnectError> {
         // The outcome is immutable once reported: never re-enter the
         // deadline wrapper or the body after the stream has ended. Every
@@ -1987,6 +1990,10 @@ where
         match with_deadline(deadline, self.message_inner()).await {
             Ok(Some(msg)) => Ok(Some(msg)),
             Ok(None) => {
+                debug_assert!(
+                    self.done,
+                    "message_inner returned Ok(None) without marking done"
+                );
                 // An end-of-stream whose termination metadata carries a
                 // server error is a failed RPC, not a clean close — surface
                 // it as `Err`. Callers that only match `Ok(None)` must never
@@ -2163,7 +2170,19 @@ where
                 .is_some_and(|d| std::time::Instant::now() >= d)
             {
                 ConnectError::deadline_exceeded("request timeout")
+            } else if self.trailers.is_some() {
+                // Trailers arrived but carry no usable status: the server
+                // spoke, just not enough — Unknown, matching grpc-go,
+                // connect-go, and the conformance suite's primary
+                // expectation for this sub-case.
+                ConnectError::new(
+                    ErrorCode::Unknown,
+                    "protocol error: grpc-status missing from trailers",
+                )
             } else {
+                // No termination metadata at all: indistinguishable from a
+                // mid-stream cut — Internal, matching grpc-go ("server
+                // closed the stream without sending trailers").
                 ConnectError::internal("stream ended without grpc-status")
             },
         )
@@ -2815,7 +2834,7 @@ where
     pub fn error(&self) -> Option<&ConnectError> {
         match &self.recv {
             RecvState::Ready(s) => s.error(),
-            _ => None,
+            _ => self.construct_err.as_ref(),
         }
     }
 }
@@ -3517,10 +3536,16 @@ fn add_streaming_request_headers(
 
 /// Parse a gRPC error from HTTP/2 trailers or gRPC-Web trailer frame headers.
 fn parse_grpc_error_from_trailers(trailers: &http::HeaderMap) -> Option<ConnectError> {
-    let status = trailers
-        .get("grpc-status")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u32>().ok())?;
+    let raw = trailers.get("grpc-status")?;
+    // A present-but-unparseable status is a protocol error, not an absent
+    // status — it must not read as success. grpc-go maps malformed
+    // grpc-status to Unknown.
+    let Some(status) = raw.to_str().ok().and_then(|s| s.parse::<u32>().ok()) else {
+        return Some(ConnectError::new(
+            ErrorCode::Unknown,
+            format!("protocol error: malformed grpc-status: {raw:?}"),
+        ));
+    };
 
     if status == 0 {
         return None; // OK
@@ -4229,7 +4254,9 @@ mod tests {
             .message()
             .await
             .expect_err("trailers without grpc-status must surface as Err");
-        assert_eq!(err.code, ErrorCode::Internal);
+        // Unknown, not Internal: trailers arrived, just without a status —
+        // grpc-go / connect-go / conformance-primary semantics.
+        assert_eq!(err.code, ErrorCode::Unknown);
         // The malformed trailers are still inspectable.
         assert!(stream.trailers().is_some());
 
@@ -4237,7 +4264,56 @@ mod tests {
             .message()
             .await
             .expect_err("missing-status error must be sticky");
-        assert_eq!(again.code, ErrorCode::Internal);
+        assert_eq!(again.code, ErrorCode::Unknown);
+    }
+
+    /// A present-but-garbage `grpc-status` is a protocol error (`unknown`,
+    /// grpc-go parity) — it must not satisfy the status-presence check and
+    /// read as a clean end.
+    #[tokio::test]
+    async fn grpc_malformed_status_errors() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "banana".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(Frame::trailers(trailers))];
+        let body = StreamBody::new(futures::stream::iter(frames));
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers: http::HeaderMap::new(),
+            body,
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            trailers: None,
+            error: None,
+            done: false,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("malformed grpc-status must surface as Err");
+        assert_eq!(err.code, ErrorCode::Unknown);
+        assert!(
+            err.to_string().contains("malformed grpc-status"),
+            "unexpected error: {err}"
+        );
+
+        let again = stream
+            .message()
+            .await
+            .expect_err("malformed-status error must be sticky");
+        assert_eq!(again.code, ErrorCode::Unknown);
     }
 
     #[cfg(feature = "client")]

--- a/examples/eliza/src/client.rs
+++ b/examples/eliza/src/client.rs
@@ -249,11 +249,11 @@ async fn run_conversation(
             ..Default::default()
         })
         .await?;
+    // `message()` returns `Ok(None)` only on a clean end; a server error in
+    // the stream's termination metadata comes back as `Err`, so `?` is the
+    // complete error handling here.
     while let Some(msg) = intro.message().await? {
         println!("Eliza> {}", msg.reborrow().sentence);
-    }
-    if let Some(err) = intro.error() {
-        return Err(err.clone().into());
     }
 
     // --- Converse (bidirectional streaming) ---
@@ -299,9 +299,6 @@ async fn run_conversation(
                         got_reply = true;
                     }
                     Ok(None) => {
-                        if let Some(err) = convo.error() {
-                            return Err(err.clone().into());
-                        }
                         if got_reply {
                             // Server sent a farewell then closed cleanly.
                             // Our send just raced the close; swallow it.
@@ -327,10 +324,7 @@ async fn run_conversation(
                 }
             }
             None => {
-                // Stream ended before we got any response to this send.
-                if let Some(err) = convo.error() {
-                    return Err(err.clone().into());
-                }
+                // Stream ended cleanly before any response to this send.
                 println!("\n(Eliza has ended the session.)");
                 break;
             }
@@ -378,13 +372,8 @@ async fn peek_stream_closed(convo: &mut ConvoStream) -> Result<bool, BoxError> {
         // Timeout: stream still open.
         Err(_elapsed) => Ok(false),
 
-        // Stream ended.
-        Ok(Ok(None)) => {
-            if let Some(err) = convo.error() {
-                return Err(err.clone().into());
-            }
-            Ok(true)
-        }
+        // Stream ended cleanly.
+        Ok(Ok(None)) => Ok(true),
 
         // Server sent another message unprompted. Unusual for Eliza (she's
         // strictly 1:1) but valid for bidi streams in general. Print it and

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1442,9 +1442,8 @@ mod tests {
         let client = make_client(addr);
 
         // Server streaming: the deny is rendered as an EndStreamResponse
-        // envelope (HTTP 200, Connect protocol). The client surfaces it via
-        // `stream.error()` after `message()` returns `Ok(None)` — same as
-        // connect-go's `stream.Err()`.
+        // envelope (HTTP 200, Connect protocol). The client returns it from
+        // `message()` — `Ok(None)` is reserved for a clean end.
         let mut stream = client
             .server_stream(EchoRequest {
                 sequence: 1,
@@ -1452,13 +1451,10 @@ mod tests {
             })
             .await
             .expect("Connect-streaming errors arrive via the envelope, not the headers");
-        assert!(
-            stream.message().await.unwrap().is_none(),
-            "deny means no items"
-        );
         let err = stream
-            .error()
-            .expect("interceptor deny must surface on the stream");
+            .message()
+            .await
+            .expect_err("interceptor deny must surface from message()");
         assert_eq!(err.code, connectrpc::ErrorCode::PermissionDenied);
 
         // Client streaming: the response is unary-shaped over a streaming


### PR DESCRIPTION
## Summary

Client streaming `message()` (both `ServerStream` and `BidiStream`) previously delivered a terminal RPC error carried in the stream's termination metadata — gRPC HTTP/2 trailers, gRPC-Web trailer frame, or Connect END_STREAM envelope — by returning `Ok(None)`, indistinguishable from a clean close, with the error stashed behind the easy-to-miss `error()` accessor. The signature (`Result<Option<T>, ConnectError>`) reads as "errors come out the `Err` channel", and pre-headers errors *do* — so the idiomatic `while let Some(m) = stream.message().await? {}` silently treats every post-headers RPC failure as success, and light testing never catches it.

This PR makes `Ok(None)` mean the RPC succeeded, unconditionally:

- Terminal errors return as `Err` from `message()`, matching `tonic`.
- Every `Err` is terminal and **sticky** — the wrapper records the outcome and replays it on re-poll, never re-entering the deadline wrapper or the body, so a failed stream can never later read as a clean end (and replay no longer depends on tokio `Timeout` poll order).
- A gRPC/gRPC-Web stream that never delivers a `grpc-status` — no trailers, or trailers lacking the status — is an error (`internal`), matching grpc-go's treatment of EOF-without-status. A true Trailers-Only response (`grpc-status: 0` in headers, empty body) remains a clean end; a headers-borne status does **not** excuse a stream that produced data and was then cut (same guard as the unary path's `has_body_data` fallback).
- `error()` and `trailers()` remain populated for post-hoc inspection (connect-go `Err()` parity); their docs now demote them for ordinary use.

This is a **breaking change** (next release: 0.7.0 per the 0.x convention); the CHANGELOG entry includes a before/after migration snippet. Callers that only match `Err` need no changes; callers doing the `Ok(None)`-then-`error()` dance can delete the dance.

## Validation

- 395 `connectrpc` lib tests (new coverage: errored Connect END_STREAM with metadata→trailers round-trip, errored gRPC trailers, clean `grpc-status: 0` control, Trailers-Only OK, trailers-without-status, header-status-does-not-excuse-truncation, EOF-without-trailers — each asserting stickiness and post-hoc accessor availability), full workspace green.
- All three client conformance suites pass **unchanged**: Connect 2580/2580, gRPC 1454/1454, gRPC-Web 2838/2838 — the old behavior was a local API choice, not a protocol requirement.
- `task lint`, `cargo doc --all-features` (zero warnings), `cargo check --no-default-features`, wasm32 builds, MSRV 1.88 all clean.

## Notes for reviewers

- The conformance client is deliberately unchanged: its `Err` arms already assemble results equivalent to the old `Ok(None)`+`error()` path (verified, plus the suites above).
- Internal consumers updated: health watch test, streaming deny test, and the eliza example — which now reads as the canonical pattern (`?` is the complete error handling).
- Known pre-existing leniency deliberately out of scope (follow-up candidate): a corrupt Connect END_STREAM JSON still parses as `unwrap_or_default()` → clean end.


## Post-review updates (56e71bc)

- **Malformed `grpc-status` (e.g. `banana`) now errors as `unknown`** instead of satisfying the presence check and reading as a clean end — fixed at the single parse site, so trailers / headers / gRPC-Web frames / unary all agree (grpc-go parity).
- **Missing-status code split**: `internal` when no trailers arrived at all; `unknown` when trailers arrived without `grpc-status` — matching grpc-go (post grpc/grpc-go#8702), connect-go's `grpcErrorForTrailer`, and the conformance suite's primary expectations for each sub-case.
- `BidiStream::error()` surfaces construction failures (post-hoc inspection promise now holds for that class); `debug_assert` makes the "inner `Ok(None)` ⇒ `done`" invariant executable; tonic comparison scoped (error-from-`message()` matches tonic; stickiness here is deliberately stronger — tonic yields the error once, then reads as a clean end).

## Known follow-ups (deliberately out of scope, in rough priority order)

1. Internal refactor: `message_inner` → `Result<StreamEvent, _>` with `End { trailers, error }` carried as a value and one private `finish()` as the sole writer of `done`/`error`/`trailers` — deletes the cross-function invariants this PR documents and asserts. This PR's end-state tests are the safety net it needs.
2. `BidiStream::message()` is not cancellation-safe while awaiting response headers (dropping the first call mid-await leaves the stream bricked with a misleading error) — pre-existing; worth fixing since timeout-wrapping `message()` is a blessed pattern.
3. Truncated partial envelope + OK trailers reads clean (buffered-residue check at EOF); corrupt Connect END_STREAM JSON parses as `unwrap_or_default()` → clean end (connect-go errors `internal`).
4. Unify the two deadline-exceeded message strings; consider a `futures::Stream` adapter on top of `message()` (this PR's semantics are its prerequisite).
