### PR TITLE
examples/bazel: update to connectrpc 0.7.0 / buffa 0.7.0 and fix codegen rules

### DIFF
--- a/examples/bazel/BUILD.bazel
+++ b/examples/bazel/BUILD.bazel
@@ -26,21 +26,27 @@ buf_lint_test(
 #
 # Output naming is deterministic given the proto file path: a file at
 # `proto/anthropic/connectrpc/examples/greet/v1/greet.proto` becomes
-# `anthropic.connectrpc.examples.greet.v1.greet.rs`. The packaging plugin
-# emits a `mod.rs` that nests `pub mod` blocks matching the proto's
-# `package` declaration and `include!`s the per-file output as a sibling.
+# `anthropic.connectrpc.examples.greet.v1.greet.rs` (buffa message types)
+# plus the `....greet.__view.rs` companion (zero-copy views), and
+# `....greet.__connect.rs` (connectrpc service stubs). The packaging
+# plugin emits a per-package `<pkg>.mod.rs` stitcher that `include!`s the
+# per-file outputs as siblings, and a root `mod.rs` that nests `pub mod`
+# blocks matching the proto's `package` declaration.
 #
 # Two output trees are produced — one with buffa message types, one with
 # connectrpc service stubs — because the plugins emit colliding filenames
-# (both `mod.rs` and `<package>.rs`).
+# (both trees get `mod.rs` and `<pkg>.mod.rs`).
 genrule(
     name = "gen_code",
     srcs = ["proto/anthropic/connectrpc/examples/greet/v1/greet.proto"],
     outs = [
         "generated/buffa/mod.rs",
+        "generated/buffa/anthropic.connectrpc.examples.greet.v1.mod.rs",
         "generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        "generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.__view.rs",
         "generated/connect/mod.rs",
-        "generated/connect/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        "generated/connect/anthropic.connectrpc.examples.greet.v1.mod.rs",
+        "generated/connect/anthropic.connectrpc.examples.greet.v1.greet.__connect.rs",
     ],
     cmd = """
         mkdir -p $(@D)/generated/buffa $(@D)/generated/connect
@@ -81,9 +87,12 @@ genrule(
     ],
     outs = [
         "generated_buf/buffa/mod.rs",
+        "generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.mod.rs",
         "generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        "generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.greet.__view.rs",
         "generated_buf/connect/mod.rs",
-        "generated_buf/connect/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        "generated_buf/connect/anthropic.connectrpc.examples.greet.v1.mod.rs",
+        "generated_buf/connect/anthropic.connectrpc.examples.greet.v1.greet.__connect.rs",
     ],
     cmd = """
         mkdir -p $(@D)/generated_buf/buffa $(@D)/generated_buf/connect
@@ -126,22 +135,34 @@ sh_test(
     args = [
         "$(location :generated/buffa/mod.rs)",
         "$(location :generated_buf/buffa/mod.rs)",
+        "$(location :generated/buffa/anthropic.connectrpc.examples.greet.v1.mod.rs)",
+        "$(location :generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.mod.rs)",
         "$(location :generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.rs)",
         "$(location :generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.greet.rs)",
+        "$(location :generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.__view.rs)",
+        "$(location :generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.greet.__view.rs)",
         "$(location :generated/connect/mod.rs)",
         "$(location :generated_buf/connect/mod.rs)",
-        "$(location :generated/connect/anthropic.connectrpc.examples.greet.v1.greet.rs)",
-        "$(location :generated_buf/connect/anthropic.connectrpc.examples.greet.v1.greet.rs)",
+        "$(location :generated/connect/anthropic.connectrpc.examples.greet.v1.mod.rs)",
+        "$(location :generated_buf/connect/anthropic.connectrpc.examples.greet.v1.mod.rs)",
+        "$(location :generated/connect/anthropic.connectrpc.examples.greet.v1.greet.__connect.rs)",
+        "$(location :generated_buf/connect/anthropic.connectrpc.examples.greet.v1.greet.__connect.rs)",
     ],
     data = [
         ":generated/buffa/mod.rs",
+        ":generated/buffa/anthropic.connectrpc.examples.greet.v1.mod.rs",
         ":generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        ":generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.__view.rs",
         ":generated/connect/mod.rs",
-        ":generated/connect/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        ":generated/connect/anthropic.connectrpc.examples.greet.v1.mod.rs",
+        ":generated/connect/anthropic.connectrpc.examples.greet.v1.greet.__connect.rs",
         ":generated_buf/buffa/mod.rs",
+        ":generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.mod.rs",
         ":generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        ":generated_buf/buffa/anthropic.connectrpc.examples.greet.v1.greet.__view.rs",
         ":generated_buf/connect/mod.rs",
-        ":generated_buf/connect/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        ":generated_buf/connect/anthropic.connectrpc.examples.greet.v1.mod.rs",
+        ":generated_buf/connect/anthropic.connectrpc.examples.greet.v1.greet.__connect.rs",
     ],
 )
 
@@ -152,9 +173,12 @@ rust_library(
     srcs = [
         "src/lib.rs",
         "generated/buffa/mod.rs",
+        "generated/buffa/anthropic.connectrpc.examples.greet.v1.mod.rs",
         "generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        "generated/buffa/anthropic.connectrpc.examples.greet.v1.greet.__view.rs",
         "generated/connect/mod.rs",
-        "generated/connect/anthropic.connectrpc.examples.greet.v1.greet.rs",
+        "generated/connect/anthropic.connectrpc.examples.greet.v1.mod.rs",
+        "generated/connect/anthropic.connectrpc.examples.greet.v1.greet.__connect.rs",
     ],
     crate_root = "src/lib.rs",
     edition = "2021",

--- a/examples/bazel/Cargo.lock
+++ b/examples/bazel/Cargo.lock
@@ -32,17 +32,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "buffa"
-version = "0.6.0"
+name = "borsh"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941c714734a660caa93a210c531dec553cc0ef417890409914d24032c94ab840"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "buffa"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6bfcf26f959599a1501e632486d1d5d9db5ecb18905c01b83061019b473e115"
 dependencies = [
  "base64",
  "bytes",
+ "compact_str",
+ "ecow",
  "hashbrown 0.15.5",
  "once_cell",
  "serde",
  "serde_json",
+ "smol_str",
  "thiserror",
 ]
 
@@ -62,16 +75,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "connectrpc"
-version = "0.6.0"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3382e121377f6c160bbbe56f5809637ccbabff7edbf56bb8e96cc64e65998045"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "connectrpc"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003fac88ace432fd8e6adbe13da8b20e90613b89e70c72186c505ad1bea307b2"
 dependencies = [
  "async-trait",
  "base64",
@@ -107,6 +150,15 @@ dependencies = [
  "http-body",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -451,6 +503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +582,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/examples/bazel/Cargo.toml
+++ b/examples/bazel/Cargo.toml
@@ -16,8 +16,8 @@ publish = false
 path = "stub.rs"
 
 [dependencies]
-buffa = { version = "0.6.0", features = ["json"] }
-connectrpc = { version = "0.6.1", default-features = false, features = ["server", "client"] }
+buffa = { version = "0.7.0", features = ["json"] }
+connectrpc = { version = "0.7.0", default-features = false, features = ["server", "client"] }
 futures = "0.3"
 http-body = "1"
 serde = { version = "1", features = ["derive"] }

--- a/examples/bazel/README.md
+++ b/examples/bazel/README.md
@@ -5,14 +5,14 @@ work cleanly under Bazel. A `bazel test //...` invocation:
 
 1. Runs `protoc` with all three plugins (`protoc-gen-buffa`,
    `protoc-gen-buffa-packaging`, `protoc-gen-connect-rust`) via a
-   `genrule`, producing four `.rs` files. A second `genrule` runs the
+   `genrule`, producing seven `.rs` files. A second `genrule` runs the
    same plugins through `buf generate` (driven by the `rules_buf`
    toolchain) and a `sh_test` proves the two output trees are
    byte-identical.
 2. Pulls `buffa`, `connectrpc`, and their transitive deps from crates.io
    via `rules_rust` + `crates_universe`.
 3. Compiles a `rust_library` whose srcs include `src/lib.rs` plus the
-   four generated files.
+   seven generated files.
 4. Runs three `rust_test`s that exercise the generated message types
    (construction, encode/decode round-trip via `buffa::Message`) and
    the connectrpc service-stub constants.
@@ -89,15 +89,20 @@ plugins and emit byte-identical output (verified by
 
 Output naming is deterministic from the proto file path: a file at
 `proto/anthropic/connectrpc/examples/greet/v1/greet.proto` becomes
-`anthropic.connectrpc.examples.greet.v1.greet.rs`. The packaging plugin
-emits a `mod.rs` that nests `pub mod` blocks matching the proto's
-`package` declaration and `include!`s the per-file output as a sibling.
+`anthropic.connectrpc.examples.greet.v1.greet.rs` (message types) plus
+the `....greet.__view.rs` companion (zero-copy views) from
+`protoc-gen-buffa`, and `....greet.__connect.rs` (service stubs) from
+`protoc-gen-connect-rust`. The packaging plugin emits a per-package
+`<pkg>.mod.rs` stitcher that `include!`s the per-file outputs as
+siblings, and a root `mod.rs` that nests `pub mod` blocks matching the
+proto's `package` declaration.
 
 Two output trees per genrule — one with buffa message types, one with
 connectrpc service stubs — because the plugins emit colliding filenames
-(both `mod.rs` and `<package>.rs`). The packaging plugin runs twice,
-once over each tree (the second invocation passes `filter=services` so
-files without services are skipped from the connect output).
+(both trees get `mod.rs` and `<pkg>.mod.rs`). The packaging plugin runs
+twice, once over each tree (the second invocation passes
+`filter=services` so files without services are skipped from the
+connect output).
 
 The generated `mod.rs` files use sibling-relative `include!("foo.rs")`,
 so consuming the output requires no `env!("OUT_DIR")` indirection.


### PR DESCRIPTION
## Summary

Post-release follow-up for 0.7.0: point the Bazel example at the published crates, and repair its codegen rules, which had silently drifted from the plugins' output layout.

### Dependency bump

- `examples/bazel/Cargo.toml`: `buffa` 0.6.0 → 0.7.0, `connectrpc` 0.6.1 → 0.7.0.
- `examples/bazel/Cargo.lock`: targeted `cargo update -p connectrpc -p buffa` (no blanket transitive refresh). buffa 0.7.0 pulls in its new transitive deps (`compact_str`, `ecow`, `smol_str`, `castaway`, `static_assertions`, `cfg_aliases`, `ryu`). The lockfile was still at connectrpc 0.6.0 — #142 (the 0.6.1 bump) was closed unmerged when the 0.7.0 cycle superseded it — so this catches the example up two releases.

### BUILD.bazel repair

Verifying the bump exposed that the example's genrules declare an output layout the plugins have not produced since 0.4.0 introduced companion files. Nothing in CI builds this example, and the interim release follow-ups (#124, #142) only touched the lockfile, so the breakage went unnoticed. Current plugin output per proto file:

- `protoc-gen-buffa`: `<pkg>.greet.rs` plus the `<pkg>.greet.__view.rs` companion
- `protoc-gen-connect-rust`: `<pkg>.greet.__connect.rs` (not `<pkg>.greet.rs`)
- `protoc-gen-buffa-packaging`: a per-package `<pkg>.mod.rs` stitcher in addition to the root `mod.rs`

Both genrules' `outs`, the byte-identical-output `sh_test` pairs, the `rust_library` srcs, and the README's output-naming section are updated to match (7 files per tree-pair instead of 4).

## Verification

- `cargo check` in `examples/bazel/` compiles the dependency stub against the published 0.7.0 crates with the example's feature set (`default-features = false, features = ["server", "client"]`).
- `bazel build //...` and `bazel test //...` pass with Bazel 8.3.1, using the v0.7.0-tagged buffa plugins and `protoc-gen-connect-rust` built from this repo: both codegen paths (protoc-direct and buf-driven) produce the declared outputs, the byte-identical diff test passes, and the generated-code unit tests compile and pass against the crates.io 0.7.0 dependencies resolved by crates_universe from the new lockfile.

## Not addressed here

The example pins no Bazel version, and Bazel 9 removes the built-in `sh_test` rule, so `bazel build //...` fails at package loading under a current bazelisk default. Verified with 8.3.1. A `.bazelversion` (or migrating to `rules_shell`) would close that off — happy to do it as a separate change.
