### PR TITLE
client: require END_STREAM for Connect client-streaming responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ with the [Rust 0.x convention](https://doc.rust-lang.org/cargo/reference/semver.
 breaking changes increment the minor version (0.2 → 0.3), additive changes
 increment the patch version.
 
+## [Unreleased]
+
+### Fixed
+
+- **Connect client-streaming responses require the END_STREAM envelope**
+  ([#163]). A response that ended after its single data message but before
+  the END_STREAM envelope was accepted as a success with empty trailers, so
+  a truncated response was indistinguishable from a complete one. It now
+  returns `Err(unavailable)`, matching the `ServerStream` Connect EOF path
+  ([#140]); complete responses are unchanged.
+
+[#163]: https://github.com/anthropics/connect-rust/pull/163
+
 ## [0.7.0] - 2026-06-10
 
 A breaking release that reworks both ends of the message surface:

--- a/benches/rpc/src/generated/buffa/bench.__view.rs
+++ b/benches/rpc/src/generated/buffa/bench.__view.rs
@@ -1480,6 +1480,7 @@ impl<'a> PayloadView<'a> {
                 13u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.scores.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.scores.push(::buffa::types::decode_int32(&mut pcur)?);

--- a/conformance/src/generated/buffa/connectrpc.conformance.v1.config.__view.rs
+++ b/conformance/src/generated/buffa/connectrpc.conformance.v1.config.__view.rs
@@ -657,6 +657,7 @@ impl<'a> FeaturesView<'a> {
                 1u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.versions.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.versions
@@ -684,6 +685,7 @@ impl<'a> FeaturesView<'a> {
                 2u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.protocols.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.protocols
@@ -711,6 +713,7 @@ impl<'a> FeaturesView<'a> {
                 3u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.codecs.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.codecs
@@ -738,6 +741,7 @@ impl<'a> FeaturesView<'a> {
                 4u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.compressions.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.compressions
@@ -765,6 +769,7 @@ impl<'a> FeaturesView<'a> {
                 5u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.stream_types.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.stream_types

--- a/conformance/src/generated/buffa/connectrpc.conformance.v1.suite.__view.rs
+++ b/conformance/src/generated/buffa/connectrpc.conformance.v1.suite.__view.rs
@@ -228,6 +228,7 @@ impl<'a> TestSuiteView<'a> {
                 4u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.relevant_protocols.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.relevant_protocols
@@ -255,6 +256,7 @@ impl<'a> TestSuiteView<'a> {
                 5u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.relevant_http_versions.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.relevant_http_versions
@@ -282,6 +284,7 @@ impl<'a> TestSuiteView<'a> {
                 6u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.relevant_codecs.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.relevant_codecs
@@ -309,6 +312,7 @@ impl<'a> TestSuiteView<'a> {
                 7u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.relevant_compressions.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.relevant_compressions
@@ -1126,6 +1130,7 @@ impl<'a> TestCaseView<'a> {
                 4u32 => {
                     if tag.wire_type() == ::buffa::encoding::WireType::LengthDelimited {
                         let payload = ::buffa::types::borrow_bytes(&mut cur)?;
+                        view.other_allowed_error_codes.reserve(payload.len());
                         let mut pcur: &[u8] = payload;
                         while !pcur.is_empty() {
                             view.other_allowed_error_codes

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -3214,18 +3214,18 @@ where
 
 /// Scan a collected Connect client-streaming response body.
 ///
-/// The body must contain exactly one data envelope. The END_STREAM envelope,
-/// if present, terminates the scan and supplies the trailers; a body that
-/// ends without one is still accepted (matching the previous behavior).
-/// Returns the (still encoded) message payload and any trailers carried in
-/// the END_STREAM metadata.
+/// The body must contain exactly one data envelope followed by an END_STREAM
+/// envelope, the protocol-level terminus: it supplies the trailers (or a
+/// terminal Connect error) and marks the response complete. A body that
+/// yields the data message and then ends before END_STREAM is truncated, not
+/// successful, and is rejected with `unavailable`, matching the `ServerStream`
+/// Connect EOF behavior. Returns the (still encoded) message payload and any
+/// trailers carried in the END_STREAM metadata.
 ///
-/// Scanning stops at the END_STREAM envelope — it is the protocol-level end
-/// of the response, so anything after it is ignored rather than decoded. A
-/// second data envelope is rejected before its payload is decompressed, so a
-/// response cannot make the client do per-envelope decompression work (or
-/// hold per-envelope decompressed buffers) beyond the single message the RPC
-/// shape allows.
+/// Scanning stops at END_STREAM, so anything after it is ignored rather than
+/// decoded. A second data envelope is rejected before its payload is
+/// decompressed, so the client never spends decompression work or memory on
+/// more than the single message the RPC allows.
 fn parse_connect_client_stream_envelopes(
     body: Bytes,
     compression: &crate::compression::CompressionRegistry,
@@ -3236,6 +3236,7 @@ fn parse_connect_client_stream_envelopes(
     let mut buf = BytesMut::from(body.as_ref());
     let mut message: Option<Bytes> = None;
     let mut trailers = http::HeaderMap::new();
+    let mut saw_end_stream = false;
 
     while !buf.is_empty() {
         let envelope = match Envelope::decode_with_limit(&mut buf, max_msg_size)? {
@@ -3244,6 +3245,7 @@ fn parse_connect_client_stream_envelopes(
         };
 
         if envelope.is_end_stream() {
+            saw_end_stream = true;
             let end_stream_data = if envelope.is_compressed() {
                 let enc = encoding.ok_or_else(|| {
                     ConnectError::internal("received compressed END_STREAM without encoding header")
@@ -3328,6 +3330,15 @@ fn parse_connect_client_stream_envelopes(
     let message = message.ok_or_else(|| {
         ConnectError::unimplemented("client streaming response contains no data messages")
     })?;
+
+    // The data message is present, but the body ended before END_STREAM. That
+    // is a truncated response, not a completed one — match ServerStream's
+    // Connect EOF handling rather than reporting success with no trailers.
+    if !saw_end_stream {
+        return Err(ConnectError::unavailable(
+            "Connect streaming response ended without END_STREAM envelope",
+        ));
+    }
 
     Ok((message, trailers))
 }
@@ -5511,5 +5522,83 @@ mod tests {
             err.to_string().contains("no data messages"),
             "unexpected error: {err}"
         );
+    }
+
+    /// A data envelope followed by EOF, with no END_STREAM envelope, is a
+    /// truncated response rather than a completed one: it is rejected with
+    /// `unavailable` instead of succeeding with empty trailers, matching the
+    /// `ServerStream` Connect EOF behavior.
+    #[test]
+    fn client_stream_response_requires_end_stream_after_message() {
+        let registry = crate::compression::CompressionRegistry::new();
+
+        let body = Envelope::data(Bytes::from_static(b"only")).encode();
+
+        let err = parse_connect_client_stream_envelopes(
+            body,
+            &registry,
+            None,
+            1024,
+            &http::HeaderMap::new(),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("Connect streaming response ended without END_STREAM envelope"),
+        );
+    }
+
+    /// A data envelope followed by a truncated END_STREAM envelope (its
+    /// declared payload never arrives) is also a truncated response: the
+    /// partial envelope decodes to "needs more data", so END_STREAM is never
+    /// observed and the response is rejected with `unavailable`.
+    #[test]
+    fn client_stream_response_requires_complete_end_stream_after_message() {
+        let registry = crate::compression::CompressionRegistry::new();
+
+        let mut body = Envelope::data(Bytes::from_static(b"only"))
+            .encode()
+            .to_vec();
+        let end_stream = Envelope::end_stream(Bytes::from_static(b"{}")).encode();
+        // Append everything but the final byte of the END_STREAM envelope.
+        body.extend_from_slice(&end_stream[..end_stream.len() - 1]);
+
+        let err = parse_connect_client_stream_envelopes(
+            Bytes::from(body),
+            &registry,
+            None,
+            1024,
+            &http::HeaderMap::new(),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("Connect streaming response ended without END_STREAM envelope"),
+        );
+    }
+
+    /// A data envelope followed by an empty END_STREAM envelope (`{}`) is a
+    /// complete response: the message is returned with empty trailers.
+    #[test]
+    fn client_stream_response_end_stream_completes_the_response() {
+        let registry = crate::compression::CompressionRegistry::new();
+
+        let mut body = Envelope::data(Bytes::from_static(b"only"))
+            .encode()
+            .to_vec();
+        body.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"{}")).encode());
+
+        let (message, trailers) = parse_connect_client_stream_envelopes(
+            Bytes::from(body),
+            &registry,
+            None,
+            1024,
+            &http::HeaderMap::new(),
+        )
+        .unwrap();
+        assert_eq!(&message[..], b"only");
+        assert!(trailers.is_empty());
     }
 }

--- a/examples/multiservice/src/generated/buffa/anthropic.connectrpc.greet.v1.greet.rs
+++ b/examples/multiservice/src/generated/buffa/anthropic.connectrpc.greet.v1.greet.rs
@@ -79,6 +79,18 @@ impl ::buffa_descriptor::reflect::Reflectable for GreetRequest {
         )
     }
 }
+impl ::buffa_descriptor::reflect::ReflectElement for GreetRequest {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
+        )
+    }
+}
 impl ::buffa::MessageName for GreetRequest {
     const PACKAGE: &'static str = "anthropic.connectrpc.greet.v1";
     const NAME: &'static str = "GreetRequest";
@@ -256,6 +268,18 @@ impl ::buffa_descriptor::reflect::Reflectable for GreetResponse {
                     idx,
                 ),
             ),
+        )
+    }
+}
+impl ::buffa_descriptor::reflect::ReflectElement for GreetResponse {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
         )
     }
 }

--- a/examples/multiservice/src/generated/buffa/anthropic.connectrpc.math.v1.math.rs
+++ b/examples/multiservice/src/generated/buffa/anthropic.connectrpc.math.v1.math.rs
@@ -88,6 +88,18 @@ impl ::buffa_descriptor::reflect::Reflectable for AddRequest {
         )
     }
 }
+impl ::buffa_descriptor::reflect::ReflectElement for AddRequest {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
+        )
+    }
+}
 impl ::buffa::MessageName for AddRequest {
     const PACKAGE: &'static str = "anthropic.connectrpc.math.v1";
     const NAME: &'static str = "AddRequest";
@@ -281,6 +293,18 @@ impl ::buffa_descriptor::reflect::Reflectable for AddResponse {
                     idx,
                 ),
             ),
+        )
+    }
+}
+impl ::buffa_descriptor::reflect::ReflectElement for AddResponse {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
         )
     }
 }

--- a/examples/multiservice/src/generated/buffa/anthropic.connectrpc.wkt.v1.wkt.rs
+++ b/examples/multiservice/src/generated/buffa/anthropic.connectrpc.wkt.v1.wkt.rs
@@ -100,6 +100,18 @@ impl ::buffa_descriptor::reflect::Reflectable for CreateEventRequest {
         )
     }
 }
+impl ::buffa_descriptor::reflect::ReflectElement for CreateEventRequest {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
+        )
+    }
+}
 impl ::buffa::MessageName for CreateEventRequest {
     const PACKAGE: &'static str = "anthropic.connectrpc.wkt.v1";
     const NAME: &'static str = "CreateEventRequest";
@@ -343,6 +355,18 @@ impl ::buffa_descriptor::reflect::Reflectable for CreateEventResponse {
         )
     }
 }
+impl ::buffa_descriptor::reflect::ReflectElement for CreateEventResponse {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
+        )
+    }
+}
 impl ::buffa::MessageName for CreateEventResponse {
     const PACKAGE: &'static str = "anthropic.connectrpc.wkt.v1";
     const NAME: &'static str = "CreateEventResponse";
@@ -571,6 +595,18 @@ impl ::buffa_descriptor::reflect::Reflectable for Event {
                     idx,
                 ),
             ),
+        )
+    }
+}
+impl ::buffa_descriptor::reflect::ReflectElement for Event {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
         )
     }
 }
@@ -882,6 +918,18 @@ impl ::buffa_descriptor::reflect::Reflectable for CalculateDurationRequest {
         )
     }
 }
+impl ::buffa_descriptor::reflect::ReflectElement for CalculateDurationRequest {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
+        )
+    }
+}
 impl ::buffa::MessageName for CalculateDurationRequest {
     const PACKAGE: &'static str = "anthropic.connectrpc.wkt.v1";
     const NAME: &'static str = "CalculateDurationRequest";
@@ -1105,6 +1153,18 @@ impl ::buffa_descriptor::reflect::Reflectable for CalculateDurationResponse {
         )
     }
 }
+impl ::buffa_descriptor::reflect::ReflectElement for CalculateDurationResponse {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
+        )
+    }
+}
 impl ::buffa::MessageName for CalculateDurationResponse {
     const PACKAGE: &'static str = "anthropic.connectrpc.wkt.v1";
     const NAME: &'static str = "CalculateDurationResponse";
@@ -1293,6 +1353,18 @@ impl ::buffa_descriptor::reflect::Reflectable for ProcessMetadataRequest {
                     idx,
                 ),
             ),
+        )
+    }
+}
+impl ::buffa_descriptor::reflect::ReflectElement for ProcessMetadataRequest {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
         )
     }
 }
@@ -1495,6 +1567,18 @@ impl ::buffa_descriptor::reflect::Reflectable for ProcessMetadataResponse {
                     idx,
                 ),
             ),
+        )
+    }
+}
+impl ::buffa_descriptor::reflect::ReflectElement for ProcessMetadataResponse {
+    /// Bridge-mode element reflection: each call snapshots this
+    /// element through [`Reflectable::reflect`]
+    /// (one encode/decode round-trip plus an allocation).
+    ///
+    /// [`Reflectable::reflect`]: ::buffa_descriptor::reflect::Reflectable::reflect
+    fn as_value_ref(&self) -> ::buffa_descriptor::reflect::ValueRef<'_> {
+        ::buffa_descriptor::reflect::ValueRef::Message(
+            ::buffa_descriptor::reflect::Reflectable::reflect(self),
         )
     }
 }


### PR DESCRIPTION
## What this does

`call_client_stream` accepted a Connect response that held the data message but ended before the END_STREAM envelope, returning it as success with empty trailers. A truncated response was therefore indistinguishable from a complete one. The Connect protocol requires a streaming response to end with an EndStreamResponse envelope.

**Fix:** once the data message is present, `parse_connect_client_stream_envelopes` returns `Err(unavailable)` when END_STREAM was never seen, matching the `ServerStream` Connect EOF path (#146). Complete responses and the no-data and multiple-message rejections are unchanged.

## Verification

Red on `main`, green after: data-then-EOF returns `Ok` unpatched.

| Check | Result |
| --- | --- |
| data + EOF / truncated END_STREAM | `Ok` unpatched, `Err(unavailable)` patched |
| data + END_STREAM `{}` / metadata / error | preserved |
| `fmt`, `clippy`, `cargo test -p connectrpc` | clean, 439 passed |

## Review map

- `connectrpc/src/client/mod.rs`: track whether END_STREAM was seen; a missing terminus after the data message returns `unavailable`. Tests pin missing and truncated END_STREAM, plus the success path.
