### PR TITLE
router: add top-down multi-service registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ increment the patch version.
 
 ## [Unreleased]
 
+### Added
+
+- **Top-down service registration on `Router`** ([#164]). `Router::add_service`
+  registers a generated service from the router outward
+  (`Router::new().add_service(Arc::new(svc))`), the discoverable counterpart to
+  the existing `FooServiceExt::register` extension method, which remains
+  available. New `Router::merge` / `Router::merge_in_place` combine routers, and
+  a new public `ServiceRegister` trait (implemented by codegen) backs
+  `add_service`. Registering or merging a method path that already exists now
+  fails by default so an accidental collision — such as adding the same service
+  twice — surfaces loudly instead of silently shadowing a route: `add_service`,
+  `register`, `merge`, `merge_in_place`, and `merge_routers` panic. Call
+  `Router::allow_overrides` to opt into last-wins replacement across all of
+  them. For assembling routers from dynamic input, `Router::try_merge` /
+  `Router::try_merge_in_place` return a `RouterMergeError` listing the
+  conflicting paths instead of panicking.
+
 ### Fixed
 
 - **Connect client-streaming responses require the END_STREAM envelope**
@@ -20,6 +37,7 @@ increment the patch version.
   ([#140]); complete responses are unchanged.
 
 [#163]: https://github.com/anthropics/connect-rust/pull/163
+[#164]: https://github.com/anthropics/connect-rust/pull/164
 
 ## [0.7.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -224,8 +224,7 @@ use axum::{Router, routing::get};
 use connectrpc::Router as ConnectRouter;
 use std::sync::Arc;
 
-let service = Arc::new(MyGreetService);
-let connect = service.register(ConnectRouter::new());
+let connect = ConnectRouter::new().add_service(Arc::new(MyGreetService));
 
 // Plain HTTP liveness probe for `kubectl`'s httpGet style. For the
 // standard gRPC Health protocol (grpc_health_probe, kubelet `grpc:`
@@ -247,8 +246,7 @@ For simple cases, enable the `server` feature for a built-in hyper server:
 use connectrpc::{Router, Server};
 use std::sync::Arc;
 
-let service = Arc::new(MyGreetService);
-let router = service.register(Router::new());
+let router = Router::new().add_service(Arc::new(MyGreetService));
 
 Server::new(router).serve("127.0.0.1:8080".parse()?).await?;
 ```

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -338,6 +338,9 @@ pub trait BenchService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -512,6 +515,15 @@ impl<S: BenchService> BenchServiceExt for S {
                 },
             )
             .with_spec(BENCH_SERVICE_LOG_UNARY_OWNED_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct BenchServiceRegisterMarker;
+impl<S: BenchService> ::connectrpc::ServiceRegister<BenchServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as BenchServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `BenchService`.
@@ -1167,6 +1179,9 @@ pub trait EchoService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -1219,6 +1234,15 @@ impl<S: EchoService> EchoServiceExt for S {
                 },
             )
             .with_spec(ECHO_SERVICE_ECHO_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct EchoServiceRegisterMarker;
+impl<S: EchoService> ::connectrpc::ServiceRegister<EchoServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as EchoServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `EchoService`.
@@ -1555,6 +1579,9 @@ pub trait LogIngestService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -1609,6 +1636,15 @@ impl<S: LogIngestService> LogIngestServiceExt for S {
                 },
             )
             .with_spec(LOG_INGEST_SERVICE_INGEST_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct LogIngestServiceRegisterMarker;
+impl<S: LogIngestService> ::connectrpc::ServiceRegister<LogIngestServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as LogIngestServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `LogIngestService`.

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -114,6 +114,9 @@ pub trait LogIngestService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -168,6 +171,15 @@ impl<S: LogIngestService> LogIngestServiceExt for S {
                 },
             )
             .with_spec(LOG_INGEST_SERVICE_INGEST_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct LogIngestServiceRegisterMarker;
+impl<S: LogIngestService> ::connectrpc::ServiceRegister<LogIngestServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as LogIngestServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `LogIngestService`.

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -112,6 +112,9 @@ pub trait BloatEchoService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -164,6 +167,15 @@ impl<S: BloatEchoService> BloatEchoServiceExt for S {
                 },
             )
             .with_spec(BLOAT_ECHO_SERVICE_ECHO_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct BloatEchoServiceRegisterMarker;
+impl<S: BloatEchoService> ::connectrpc::ServiceRegister<BloatEchoServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as BloatEchoServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `BloatEchoService`.

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -112,6 +112,9 @@ pub trait FilterService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -166,6 +169,15 @@ impl<S: FilterService> FilterServiceExt for S {
                 },
             )
             .with_spec(FILTER_SERVICE_REDACT_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct FilterServiceRegisterMarker;
+impl<S: FilterService> ::connectrpc::ServiceRegister<FilterServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as FilterServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `FilterService`.

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -114,6 +114,9 @@ pub trait FortuneService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -168,6 +171,15 @@ impl<S: FortuneService> FortuneServiceExt for S {
                 },
             )
             .with_spec(FORTUNE_SERVICE_GET_FORTUNES_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct FortuneServiceRegisterMarker;
+impl<S: FortuneService> ::connectrpc::ServiceRegister<FortuneServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as FortuneServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `FortuneService`.

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -554,6 +554,9 @@ pub trait ConformanceService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -736,6 +739,17 @@ impl<S: ConformanceService> ConformanceServiceExt for S {
                 },
             )
             .with_spec(CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct ConformanceServiceRegisterMarker;
+impl<
+    S: ConformanceService,
+> ::connectrpc::ServiceRegister<ConformanceServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as ConformanceServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `ConformanceService`.

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1088,6 +1088,7 @@ fn generate_service(
         format_ident!("{}", service_upper)
     };
     let ext_trait_name = format_ident!("{}Ext", service_upper);
+    let register_marker_name = format_ident!("{}RegisterMarker", service_upper);
     let client_name = format_ident!("{}Client", service_upper);
     let server_name = format_ident!("{}Server", service_upper);
     let service_name_const = format_ident!(
@@ -1430,6 +1431,9 @@ access, or convert with `.to_owned_message()`."#
         /// Extension trait for registering a service implementation with a Router.
         ///
         /// This trait is automatically implemented for all types that implement the service trait.
+        /// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+        /// top-down registration; `register` remains available for compatibility
+        /// and cases where the service-first call shape is more convenient.
         ///
         /// # Example
         ///
@@ -1451,6 +1455,18 @@ access, or convert with `.to_owned_message()`."#
             fn register(self: ::std::sync::Arc<Self>, router: ::connectrpc::Router) -> ::connectrpc::Router {
                 router
                     #(#route_registrations)*
+            }
+        }
+
+        /// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+        #[doc(hidden)]
+        pub struct #register_marker_name;
+
+        impl<S: #trait_name> ::connectrpc::ServiceRegister<#register_marker_name>
+            for ::std::sync::Arc<S>
+        {
+            fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+                <S as #ext_trait_name>::register(self, router)
             }
         }
 
@@ -3498,6 +3514,7 @@ mod tests {
         for marker in [
             "pub trait PingService",
             "pub trait PingServiceExt",
+            "pub struct PingServiceRegisterMarker",
             "pub struct PingServiceServer",
             "pub const PING_SERVICE_SERVICE_NAME",
         ] {
@@ -3511,6 +3528,33 @@ mod tests {
                  server-side items are always compiled in:\n{out}"
             );
         }
+    }
+
+    #[test]
+    fn service_register_impl_and_marker_are_generated() {
+        let out = format_minimal_service(false);
+        assert!(
+            out.contains("pub struct PingServiceRegisterMarker;"),
+            "generated service must expose an inference marker:\n{out}"
+        );
+        assert!(
+            out.contains(
+                "impl<S: PingService> ::connectrpc::ServiceRegister<PingServiceRegisterMarker>"
+            ),
+            "generated service must implement ServiceRegister for Arc<S>:\n{out}"
+        );
+        assert!(
+            out.contains("for ::std::sync::Arc<S>"),
+            "ServiceRegister implementation must accept Arc<S>:\n{out}"
+        );
+        assert!(
+            out.contains("fn register_service(self, router: ::connectrpc::Router)"),
+            "ServiceRegister implementation must expose the bridge method:\n{out}"
+        );
+        assert!(
+            out.contains("<S as PingServiceExt>::register(self, router)"),
+            "ServiceRegister must forward to the existing extension trait:\n{out}"
+        );
     }
 
     /// The strongest invariant: every reference to

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -159,6 +159,9 @@ pub trait Health: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -241,6 +244,15 @@ impl<S: Health> HealthExt for S {
                 }),
             )
             .with_spec(HEALTH_WATCH_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct HealthRegisterMarker;
+impl<S: Health> ::connectrpc::ServiceRegister<HealthRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as HealthExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `Health`.

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -125,6 +125,9 @@ pub trait ServerReflection: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -171,6 +174,15 @@ impl<S: ServerReflection> ServerReflectionExt for S {
                 }),
             )
             .with_spec(SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct ServerReflectionRegisterMarker;
+impl<S: ServerReflection> ::connectrpc::ServiceRegister<ServerReflectionRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as ServerReflectionExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `ServerReflection`.

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -127,6 +127,9 @@ pub trait ServerReflection: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -173,6 +176,15 @@ impl<S: ServerReflection> ServerReflectionExt for S {
                 }),
             )
             .with_spec(SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct ServerReflectionRegisterMarker;
+impl<S: ServerReflection> ::connectrpc::ServiceRegister<ServerReflectionRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as ServerReflectionExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `ServerReflection`.

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! // Build your router with RPC handlers
 //! let greet_impl = Arc::new(MyGreetService);
-//! let router = greet_impl.register(Router::new());
+//! let router = Router::new().add_service(greet_impl);
 //!
 //! // Get a tower::Service - use with ANY compatible framework
 //! let service = ConnectRpcService::new(router);
@@ -32,7 +32,7 @@
 //! use std::sync::Arc;
 //!
 //! let greet_impl = Arc::new(MyGreetService);
-//! let connect = greet_impl.register(ConnectRouter::new());
+//! let connect = ConnectRouter::new().add_service(greet_impl);
 //!
 //! let app = Router::new()
 //!     .route("/health", get(health))
@@ -241,6 +241,7 @@ pub use service::StreamingResponseBody;
 // Router for registering RPC handlers
 pub use router::MethodKind;
 pub use router::Router;
+pub use router::ServiceRegister;
 
 // Dispatcher trait for monomorphic dispatch (codegen-backed alternative to Router)
 pub use dispatcher::Chain;

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -241,7 +241,9 @@ pub use service::StreamingResponseBody;
 // Router for registering RPC handlers
 pub use router::MethodKind;
 pub use router::Router;
+pub use router::RouterMergeError;
 pub use router::ServiceRegister;
+pub use router::merge_routers;
 
 // Dispatcher trait for monomorphic dispatch (codegen-backed alternative to Router)
 pub use dispatcher::Chain;

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -112,6 +112,28 @@ pub trait ServiceRegister<Marker> {
     fn register_service(self, router: Router) -> Router;
 }
 
+/// Error returned by [`Router::try_merge`] and
+/// [`Router::try_merge_in_place`] when both routers register one or more of
+/// the same method paths.
+///
+/// Only produced when [`Router::allow_overrides`] was not set; with overrides
+/// enabled, colliding routes are replaced and no error is returned. Read the
+/// conflicting paths with [`conflicting_paths`](Self::conflicting_paths).
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("router merge conflict on path(s): {conflicts:?}")]
+#[non_exhaustive]
+pub struct RouterMergeError {
+    conflicts: Vec<String>,
+}
+
+impl RouterMergeError {
+    /// The procedure paths registered by both routers, sorted.
+    #[must_use]
+    pub fn conflicting_paths(&self) -> &[String] {
+        &self.conflicts
+    }
+}
+
 /// Router for ConnectRPC services.
 ///
 /// The router maps service/method paths to their handlers and manages
@@ -137,6 +159,10 @@ pub trait ServiceRegister<Marker> {
 pub struct Router {
     /// Map from "service_name/method_name" to handler.
     methods: HashMap<String, RegisteredMethod>,
+    /// When `true`, [`merge`](Self::merge) replaces colliding routes instead
+    /// of panicking. Off by default so an accidental path collision fails
+    /// loudly. Set via [`allow_overrides`](Self::allow_overrides).
+    allow_overrides: bool,
 }
 
 impl Router {
@@ -157,10 +183,29 @@ impl Router {
     /// ```
     ///
     /// The generated marker type is normally inferred. If one concrete type
-    /// implements multiple generated service traits, specify the desired
-    /// marker with a turbofish, for example
-    /// `router.add_service::<_, FooServiceRegisterMarker>(service)`.
+    /// implements multiple generated service traits, `add_service` cannot
+    /// infer which one; register through the generated extension trait
+    /// directly instead — it is public and takes no marker:
+    ///
+    /// ```rust,ignore
+    /// let router = FooServiceExt::register(Arc::new(service), router);
+    /// ```
+    ///
+    /// If the compiler reports that `ServiceRegister` is not satisfied, the
+    /// service type does not implement the generated service trait — check
+    /// that the value is `Arc`-wrapped and that the trait `impl` is in scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a registered method path already exists on this router — for
+    /// example registering the same service twice — unless
+    /// [`allow_overrides`](Self::allow_overrides) was called first. Distinct
+    /// services never collide, since each path is prefixed with the
+    /// fully-qualified service name.
     #[must_use]
+    // `?Sized` keeps the door open for a hand-written
+    // `impl ServiceRegister<M> for Arc<dyn Trait>`; codegen only ever emits
+    // impls for `Arc<S>` with a concrete, sized `S`.
     pub fn add_service<S: ?Sized, Marker>(self, service: Arc<S>) -> Self
     where
         Arc<S>: ServiceRegister<Marker>,
@@ -168,22 +213,121 @@ impl Router {
         <Arc<S> as ServiceRegister<Marker>>::register_service(service, self)
     }
 
-    /// Merge another router into this router.
+    /// Allow registrations and merges into this router to replace routes whose
+    /// paths already exist, instead of failing on the collision.
     ///
-    /// If both routers contain the same method path, the route from `other`
-    /// replaces the existing route.
+    /// By default any operation that would overwrite an existing path fails, so
+    /// a duplicate surfaces instead of silently shadowing a route. This governs
+    /// the whole router: [`add_service`](Self::add_service) and the generated
+    /// `register` panic on a duplicate path; [`merge`](Self::merge) /
+    /// [`merge_in_place`](Self::merge_in_place) panic; and
+    /// [`try_merge`](Self::try_merge) / [`try_merge_in_place`](Self::try_merge_in_place)
+    /// return a [`RouterMergeError`]. Opt into last-wins replacement when that
+    /// is what you intend — for example layering an override router over
+    /// defaults:
+    ///
+    /// ```rust,ignore
+    /// let router = defaults.allow_overrides().merge(overrides);
+    /// ```
+    ///
+    /// The mode is read from the router being merged *into*, so call it on that
+    /// router (`defaults.allow_overrides().merge(overrides)`, not
+    /// `defaults.merge(overrides.allow_overrides())` — the latter drops the
+    /// flag and still fails). It is also sticky: once set it stays on for every
+    /// later merge into this router.
     #[must_use]
-    pub fn merge(mut self, other: Self) -> Self {
-        self.extend(other);
+    pub fn allow_overrides(mut self) -> Self {
+        self.allow_overrides = true;
         self
     }
 
-    /// Move all routes from another router into this router.
+    /// Merge another router into this router, returning the combined router.
     ///
-    /// If both routers contain the same method path, the route from `other`
-    /// replaces the existing route.
-    pub fn extend(&mut self, other: Self) {
+    /// The owned, chainable counterpart of
+    /// [`merge_in_place`](Self::merge_in_place); see
+    /// [`merge_routers`] to combine many routers at once, and
+    /// [`try_merge`](Self::try_merge) for the non-panicking variant.
+    ///
+    /// # Panics
+    ///
+    /// Panics if both routers register the same method path, unless
+    /// [`allow_overrides`](Self::allow_overrides) was called on `self` first —
+    /// in which case the route from `other` replaces the existing one.
+    #[must_use]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.merge_in_place(other);
+        self
+    }
+
+    /// Move all routes from another router into this router in place.
+    ///
+    /// The `&mut` counterpart of [`merge`](Self::merge), for accumulating into
+    /// an existing `Router` binding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if both routers register the same method path, unless
+    /// [`allow_overrides`](Self::allow_overrides) was called on `self` first —
+    /// in which case the route from `other` replaces the existing one. Use
+    /// [`try_merge_in_place`](Self::try_merge_in_place) to handle collisions
+    /// without panicking.
+    pub fn merge_in_place(&mut self, other: Self) {
+        if let Err(err) = self.try_merge_in_place(other) {
+            panic!(
+                "router merge conflict on path(s) {:?} — both routers register \
+                 these paths. Call `allow_overrides()` if replacing the existing \
+                 routes is intended.",
+                err.conflicting_paths()
+            );
+        }
+    }
+
+    /// Merge another router into this router, returning an error instead of
+    /// panicking on a path collision.
+    ///
+    /// The fallible counterpart of [`merge`](Self::merge), for assembling a
+    /// router from dynamic or untrusted input where a collision is a condition
+    /// to handle rather than a programming error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RouterMergeError`] listing every path registered by both
+    /// routers, unless [`allow_overrides`](Self::allow_overrides) was called on
+    /// `self` first. On error `self` is dropped; to keep the original router so
+    /// you can retry (for example with overrides enabled), use
+    /// [`try_merge_in_place`](Self::try_merge_in_place), which leaves `self`
+    /// untouched on error.
+    pub fn try_merge(mut self, other: Self) -> Result<Self, RouterMergeError> {
+        self.try_merge_in_place(other)?;
+        Ok(self)
+    }
+
+    /// Move all routes from another router into this router in place, returning
+    /// an error instead of panicking on a path collision.
+    ///
+    /// The `&mut` counterpart of [`try_merge`](Self::try_merge).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RouterMergeError`] listing every path registered by both
+    /// routers, unless [`allow_overrides`](Self::allow_overrides) was called on
+    /// `self` first. The operation is transactional: on error `self` is left
+    /// unchanged and no routes from `other` are added.
+    pub fn try_merge_in_place(&mut self, other: Self) -> Result<(), RouterMergeError> {
+        if !self.allow_overrides {
+            let mut conflicts: Vec<String> = other
+                .methods
+                .keys()
+                .filter(|path| self.methods.contains_key(*path))
+                .cloned()
+                .collect();
+            if !conflicts.is_empty() {
+                conflicts.sort();
+                return Err(RouterMergeError { conflicts });
+            }
+        }
         self.methods.extend(other.methods);
+        Ok(())
     }
 
     /// Register a unary RPC handler.
@@ -220,6 +364,27 @@ impl Router {
     }
 
     /// Internal helper for registering unary handlers with configurable idempotency.
+    /// Insert a registered method, enforcing the same path-collision rule as
+    /// [`merge`](Self::merge): registering a path that already exists panics
+    /// unless [`allow_overrides`](Self::allow_overrides) was set, in which case
+    /// the new route replaces the old one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a route is already registered at `path` and overrides are not
+    /// enabled. This catches double-registering a service (e.g. calling
+    /// [`add_service`](Self::add_service) twice with the same service).
+    fn insert_method(&mut self, path: String, method: RegisteredMethod) {
+        if !self.allow_overrides && self.methods.contains_key(&path) {
+            panic!(
+                "router registration conflict on path {path:?} — a route is \
+                 already registered here (registering the same service twice?). \
+                 Call `allow_overrides()` if replacing it is intended."
+            );
+        }
+        self.methods.insert(path, method);
+    }
+
     fn route_unary_internal<H, Req, Res>(
         mut self,
         service_name: &str,
@@ -234,7 +399,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = UnaryHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::Unary(UnaryMethod {
                 handler: Arc::new(wrapper),
@@ -263,7 +428,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ServerStreamingHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::Streaming(StreamingMethod {
                 handler: Arc::new(wrapper),
@@ -291,7 +456,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ClientStreamingHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::ClientStreaming(ClientStreamingMethod {
                 handler: Arc::new(wrapper),
@@ -318,7 +483,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = BidiStreamingHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::BidiStreaming(BidiStreamingMethod {
                 handler: Arc::new(wrapper),
@@ -374,7 +539,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = UnaryViewHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::Unary(UnaryMethod {
                 handler: Arc::new(wrapper),
@@ -401,7 +566,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ServerStreamingViewHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::Streaming(StreamingMethod {
                 handler: Arc::new(wrapper),
@@ -427,7 +592,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ClientStreamingViewHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::ClientStreaming(ClientStreamingMethod {
                 handler: Arc::new(wrapper),
@@ -453,7 +618,7 @@ impl Router {
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = BidiStreamingViewHandlerWrapper::new(handler);
-        self.methods.insert(
+        self.insert_method(
             path,
             Method::BidiStreaming(BidiStreamingMethod {
                 handler: Arc::new(wrapper),
@@ -593,10 +758,19 @@ impl crate::dispatcher::Dispatcher for Router {
 }
 
 /// Merge multiple routers into one.
+///
+/// Equivalent to folding [`Router::merge_in_place`] over `routers`.
+///
+/// # Panics
+///
+/// Panics if two of the routers register the same method path. To combine
+/// routers with intentionally overlapping paths (last wins), fold them onto a
+/// router built with [`Router::allow_overrides`] instead, e.g.
+/// `routers.into_iter().fold(Router::new().allow_overrides(), Router::merge)`.
 pub fn merge_routers(routers: impl IntoIterator<Item = Router>) -> Router {
     let mut merged = Router::new();
     for router in routers {
-        merged.extend(router);
+        merged.merge_in_place(router);
     }
     merged
 }
@@ -636,13 +810,67 @@ mod tests {
         assert!(router.has_method("test.Service/Method"));
     }
 
+    struct DualService;
+    struct DualServiceAMarker;
+    struct DualServiceBMarker;
+
+    impl ServiceRegister<DualServiceAMarker> for Arc<DualService> {
+        fn register_service(self, router: Router) -> Router {
+            router.route("test.DualA", "Call", unary_handler())
+        }
+    }
+
+    impl ServiceRegister<DualServiceBMarker> for Arc<DualService> {
+        fn register_service(self, router: Router) -> Router {
+            router.route("test.DualB", "Call", unary_handler())
+        }
+    }
+
     #[test]
-    fn merge_and_extend_combine_routes() {
+    fn add_service_disambiguates_multi_impl_with_turbofish() {
+        // One concrete type implementing two service traits needs the marker
+        // turbofish; this locks in that the documented disambiguation compiles.
+        let router = Router::new()
+            .add_service::<_, DualServiceAMarker>(Arc::new(DualService))
+            .add_service::<_, DualServiceBMarker>(Arc::new(DualService));
+        assert!(router.has_method("test.DualA/Call"));
+        assert!(router.has_method("test.DualB/Call"));
+    }
+
+    #[test]
+    #[should_panic(expected = "router registration conflict")]
+    fn add_service_panics_on_double_registration() {
+        // Registering the same service twice collides on its method path and
+        // fails loudly, like a conflicting merge.
+        let _ = Router::new()
+            .add_service(Arc::new(TestService))
+            .add_service(Arc::new(TestService));
+    }
+
+    #[test]
+    fn add_service_with_allow_overrides_permits_re_registration() {
+        let router = Router::new()
+            .allow_overrides()
+            .add_service(Arc::new(TestService))
+            .add_service(Arc::new(TestService));
+        assert!(router.has_method("test.Service/Method"));
+    }
+
+    #[test]
+    #[should_panic(expected = "router registration conflict")]
+    fn route_panics_on_duplicate_path() {
+        let _ = Router::new()
+            .route("test.Service", "Method", unary_handler())
+            .route("test.Service", "Method", unary_handler());
+    }
+
+    #[test]
+    fn merge_and_merge_in_place_combine_routes() {
         let first = Router::new().route("test.First", "Call", unary_handler());
         let second = Router::new().route("test.Second", "Call", unary_handler());
         let mut router = first.merge(second);
 
-        router.extend(Router::new().route("test.Third", "Call", unary_handler()));
+        router.merge_in_place(Router::new().route("test.Third", "Call", unary_handler()));
 
         assert!(router.has_method("test.First/Call"));
         assert!(router.has_method("test.Second/Call"));
@@ -650,13 +878,73 @@ mod tests {
     }
 
     #[test]
-    fn merge_replaces_duplicate_routes_with_other() {
+    #[should_panic(expected = "router merge conflict")]
+    fn merge_panics_on_duplicate_path_by_default() {
+        let original = Router::new().route("test.Service", "Method", unary_handler());
+        let replacement = Router::new().route("test.Service", "Method", unary_handler());
+        let _ = original.merge(replacement);
+    }
+
+    #[test]
+    fn merge_with_allow_overrides_replaces_duplicate_routes() {
         let original = Router::new().route("test.Service", "Method", unary_handler());
         let replacement = Router::new().route_idempotent("test.Service", "Method", unary_handler());
 
-        let router = original.merge(replacement);
+        let router = original.allow_overrides().merge(replacement);
         let descriptor = router.lookup("test.Service/Method").expect("route exists");
         assert!(descriptor.idempotent);
+    }
+
+    #[test]
+    fn try_merge_ok_when_paths_are_disjoint() {
+        let first = Router::new().route("test.First", "Call", unary_handler());
+        let second = Router::new().route("test.Second", "Call", unary_handler());
+
+        let router = first.try_merge(second).expect("disjoint merge succeeds");
+        assert!(router.has_method("test.First/Call"));
+        assert!(router.has_method("test.Second/Call"));
+    }
+
+    #[test]
+    fn try_merge_reports_conflicting_paths_without_panicking() {
+        let original = Router::new().route("test.Service", "Method", unary_handler());
+        let other = Router::new().route("test.Service", "Method", unary_handler());
+
+        // `Router` is not `Debug`, so match rather than `expect_err`.
+        let Err(err) = original.try_merge(other) else {
+            panic!("conflict must error");
+        };
+        assert_eq!(err.conflicting_paths(), ["test.Service/Method".to_string()]);
+    }
+
+    #[test]
+    fn try_merge_in_place_is_transactional_on_conflict() {
+        let mut router = Router::new()
+            .route("test.Keep", "Call", unary_handler())
+            .route("test.Service", "Method", unary_handler());
+        let other = Router::new()
+            .route("test.Service", "Method", unary_handler())
+            .route("test.New", "Call", unary_handler());
+
+        let err = router
+            .try_merge_in_place(other)
+            .expect_err("conflict must error");
+        assert_eq!(err.conflicting_paths(), ["test.Service/Method".to_string()]);
+        // On error nothing from `other` is added; existing routes are untouched.
+        assert!(router.has_method("test.Keep/Call"));
+        assert!(!router.has_method("test.New/Call"));
+    }
+
+    #[test]
+    fn try_merge_with_allow_overrides_replaces_and_returns_ok() {
+        let original = Router::new().route("test.Service", "Method", unary_handler());
+        let replacement = Router::new().route_idempotent("test.Service", "Method", unary_handler());
+
+        let router = original
+            .allow_overrides()
+            .try_merge(replacement)
+            .expect("overrides suppress the conflict error");
+        assert!(router.lookup("test.Service/Method").unwrap().idempotent);
     }
 
     /// `with_spec` attaches the `Spec` and `lookup` returns it. This is

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -97,6 +97,21 @@ impl From<Method> for RegisteredMethod {
     }
 }
 
+/// Registers a generated service implementation with a [`Router`].
+///
+/// Implementations are emitted by `connectrpc-codegen`. The `Marker` type
+/// distinguishes implementations for different generated service traits,
+/// allowing a concrete Rust type to implement more than one service without
+/// conflicting blanket implementations.
+///
+/// Most callers do not name this trait or its marker type directly. Pass an
+/// `Arc`-wrapped service to [`Router::add_service`] and type inference selects
+/// the generated implementation.
+pub trait ServiceRegister<Marker> {
+    /// Register this service's RPC methods with `router`.
+    fn register_service(self, router: Router) -> Router;
+}
+
 /// Router for ConnectRPC services.
 ///
 /// The router maps service/method paths to their handlers and manages
@@ -128,6 +143,47 @@ impl Router {
     /// Create a new empty router.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Register a generated service implementation.
+    ///
+    /// This is the top-down equivalent of calling the generated
+    /// `FooServiceExt::register` extension method:
+    ///
+    /// ```rust,ignore
+    /// let router = Router::new()
+    ///     .add_service(Arc::new(greeter))
+    ///     .add_service(Arc::new(echo));
+    /// ```
+    ///
+    /// The generated marker type is normally inferred. If one concrete type
+    /// implements multiple generated service traits, specify the desired
+    /// marker with a turbofish, for example
+    /// `router.add_service::<_, FooServiceRegisterMarker>(service)`.
+    #[must_use]
+    pub fn add_service<S: ?Sized, Marker>(self, service: Arc<S>) -> Self
+    where
+        Arc<S>: ServiceRegister<Marker>,
+    {
+        <Arc<S> as ServiceRegister<Marker>>::register_service(service, self)
+    }
+
+    /// Merge another router into this router.
+    ///
+    /// If both routers contain the same method path, the route from `other`
+    /// replaces the existing route.
+    #[must_use]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.extend(other);
+        self
+    }
+
+    /// Move all routes from another router into this router.
+    ///
+    /// If both routers contain the same method path, the route from `other`
+    /// replaces the existing route.
+    pub fn extend(&mut self, other: Self) {
+        self.methods.extend(other.methods);
     }
 
     /// Register a unary RPC handler.
@@ -540,7 +596,7 @@ impl crate::dispatcher::Dispatcher for Router {
 pub fn merge_routers(routers: impl IntoIterator<Item = Router>) -> Router {
     let mut merged = Router::new();
     for router in routers {
-        merged.methods.extend(router.methods);
+        merged.extend(router);
     }
     merged
 }
@@ -563,6 +619,44 @@ mod tests {
 
     fn unary_handler() -> impl Handler<Empty, Empty> {
         handler_fn(|_ctx, _req: Empty| async { crate::Response::ok(Empty::default()) })
+    }
+
+    struct TestService;
+    struct TestServiceRegisterMarker;
+
+    impl ServiceRegister<TestServiceRegisterMarker> for Arc<TestService> {
+        fn register_service(self, router: Router) -> Router {
+            router.route("test.Service", "Method", unary_handler())
+        }
+    }
+
+    #[test]
+    fn add_service_forwards_to_generated_registration() {
+        let router = Router::new().add_service(Arc::new(TestService));
+        assert!(router.has_method("test.Service/Method"));
+    }
+
+    #[test]
+    fn merge_and_extend_combine_routes() {
+        let first = Router::new().route("test.First", "Call", unary_handler());
+        let second = Router::new().route("test.Second", "Call", unary_handler());
+        let mut router = first.merge(second);
+
+        router.extend(Router::new().route("test.Third", "Call", unary_handler()));
+
+        assert!(router.has_method("test.First/Call"));
+        assert!(router.has_method("test.Second/Call"));
+        assert!(router.has_method("test.Third/Call"));
+    }
+
+    #[test]
+    fn merge_replaces_duplicate_routes_with_other() {
+        let original = Router::new().route("test.Service", "Method", unary_handler());
+        let replacement = Router::new().route_idempotent("test.Service", "Method", unary_handler());
+
+        let router = original.merge(replacement);
+        let descriptor = router.lookup("test.Service/Method").expect("route exists");
+        assert!(descriptor.idempotent);
     }
 
     /// `with_spec` attaches the `Spec` and `lookup` returns it. This is

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -152,8 +152,7 @@ impl GreetService for MyGreet {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let service = Arc::new(MyGreet);
-    let router = service.register(Router::new());
+    let router = Router::new().add_service(Arc::new(MyGreet));
     let app = router.into_axum_router();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:8080").await?;
@@ -464,20 +463,20 @@ need to know which protocol the caller chose.
 
 ### Registering services on a Router
 
-Generated services have a `register` method (via the `register`
-extension trait) that wires every RPC into a `connectrpc::Router`:
+Register generated services from the router so multiple services read
+top-to-bottom:
 
 ```rust
-let service = Arc::new(MyGreet);
-let router = service.register(Router::new());
+let router = Router::new()
+    .add_service(Arc::new(MyGreet))
+    .add_service(Arc::new(MyBilling));
 ```
 
-To compose multiple services on one server, chain `register` calls:
+The generated `register` extension method remains available when the
+inside-out form is useful:
 
 ```rust
-let router = Router::new();
-let router = Arc::new(MyGreet).register(router);
-let router = Arc::new(MyBilling).register(router);
+let router = Arc::new(MyGreet).register(Router::new());
 ```
 
 The router is what you mount on axum (`router.into_axum_router()`)
@@ -634,7 +633,7 @@ use std::time::Duration;
 use tower::ServiceBuilder;
 use tower_http::{trace::TraceLayer, timeout::TimeoutLayer};
 
-let connect_router = service.register(Router::new());
+let connect_router = Router::new().add_service(service);
 let tokens = Arc::new(token_table());
 let app = axum::Router::new()
     .fallback_service(connect_router.into_axum_service())
@@ -960,7 +959,7 @@ configuration:
 ```rust
 use connectrpc::Server;
 
-let connect_router = service.register(Router::new());
+let connect_router = Router::new().add_service(service);
 Server::new(connect_router)
     .serve("127.0.0.1:8080".parse()?)
     .await?;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -479,6 +479,21 @@ inside-out form is useful:
 let router = Arc::new(MyGreet).register(Router::new());
 ```
 
+To combine routers that were built separately, use `Router::merge` (owned,
+chainable), `Router::merge_in_place` (in place), or the `merge_routers` free
+function for many at once. Merging two routers that register the same method
+path panics by default, so an accidental collision fails loudly at startup;
+call `Router::allow_overrides()` first when last-wins replacement is intended:
+
+```rust
+let router = defaults.allow_overrides().merge(overrides);
+```
+
+When the routers come from dynamic input (a plugin list, config-driven
+service set) and a collision should be handled rather than crash the process,
+use `Router::try_merge` / `Router::try_merge_in_place`, which return a
+`RouterMergeError` listing the conflicting paths instead of panicking.
+
 The router is what you mount on axum (`router.into_axum_router()`)
 or pass to the built-in `Server`.
 

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -242,6 +242,9 @@ pub trait ElizaService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -345,6 +348,15 @@ impl<S: ElizaService> ElizaServiceExt for S {
                 }),
             )
             .with_spec(ELIZA_SERVICE_INTRODUCE_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct ElizaServiceRegisterMarker;
+impl<S: ElizaService> ::connectrpc::ServiceRegister<ElizaServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as ElizaServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `ElizaService`.

--- a/examples/multiservice/src/bin/server.rs
+++ b/examples/multiservice/src/bin/server.rs
@@ -279,9 +279,10 @@ async fn main() {
     let math_service = Arc::new(MyMathService);
     let well_known_types_service = Arc::new(MyWellKnownTypesService);
 
-    let connect_router = greet_service.register(ConnectRouter::new());
-    let connect_router = math_service.register(connect_router);
-    let connect_router = well_known_types_service.register(connect_router);
+    let connect_router = ConnectRouter::new()
+        .add_service(greet_service)
+        .add_service(math_service)
+        .add_service(well_known_types_service);
 
     // Mount gRPC server reflection (v1 + v1alpha) so `grpcurl`, `buf curl`,
     // Postman, and `grpcui` can discover and call the services above with

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -127,6 +127,9 @@ pub trait GreetService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -181,6 +184,15 @@ impl<S: GreetService> GreetServiceExt for S {
                 },
             )
             .with_spec(GREET_SERVICE_GREET_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct GreetServiceRegisterMarker;
+impl<S: GreetService> ::connectrpc::ServiceRegister<GreetServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as GreetServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `GreetService`.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -118,6 +118,9 @@ pub trait MathService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -172,6 +175,15 @@ impl<S: MathService> MathServiceExt for S {
                 },
             )
             .with_spec(MATH_SERVICE_ADD_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct MathServiceRegisterMarker;
+impl<S: MathService> ::connectrpc::ServiceRegister<MathServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as MathServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `MathService`.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -308,6 +308,9 @@ pub trait WellKnownTypesService: Send + Sync + 'static {
 /// Extension trait for registering a service implementation with a Router.
 ///
 /// This trait is automatically implemented for all types that implement the service trait.
+/// Prefer [`Router::add_service`](::connectrpc::Router::add_service) for
+/// top-down registration; `register` remains available for compatibility
+/// and cases where the service-first call shape is more convenient.
 ///
 /// # Example
 ///
@@ -449,6 +452,17 @@ impl<S: WellKnownTypesService> WellKnownTypesServiceExt for S {
                 },
             )
             .with_spec(WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC)
+    }
+}
+/// Type-inference marker used by [`Router::add_service`](::connectrpc::Router::add_service).
+#[doc(hidden)]
+pub struct WellKnownTypesServiceRegisterMarker;
+impl<
+    S: WellKnownTypesService,
+> ::connectrpc::ServiceRegister<WellKnownTypesServiceRegisterMarker>
+for ::std::sync::Arc<S> {
+    fn register_service(self, router: ::connectrpc::Router) -> ::connectrpc::Router {
+        <S as WellKnownTypesServiceExt>::register(self, router)
     }
 }
 /// Monomorphic dispatcher for `WellKnownTypesService`.


### PR DESCRIPTION
## Summary

- add `Router::add_service` for discoverable, top-down service registration
- generate `ServiceRegister` implementations that forward to the existing service extension traits
- add `Router::merge` and `Router::extend`, with later routes replacing duplicate paths
- update the README, guide, crate documentation, and multi-service example
- regenerate checked-in Connect service code

The existing `FooServiceExt::register` API remains available and continues
to provide the underlying registration behavior, so this change is additive
and backward compatible.

```rust
let router = Router::new()
    .add_service(Arc::new(greeter))
    .add_service(Arc::new(eliza));
```

## Testing

- `cargo +nightly-2026-02-27 fmt --all -- --check`
- `cargo +1.88 check -p connectrpc -p connectrpc-codegen -p multiservice-example --all-features`
- `cargo test -p connectrpc --lib`
- `cargo test -p connectrpc-codegen --lib`
- `cargo test -p connectrpc --no-default-features`
- `cargo check -p multiservice-example --all-features`
- `cargo clippy -p connectrpc -p connectrpc-codegen -p multiservice-example -p connectrpc-health -p connectrpc-reflection -p eliza-example --all-features -- -D warnings`

Closes #88