### PR TITLE
client: return unknown for Connect EOF without END_STREAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,23 +12,24 @@ increment the patch version.
 
 ### Changed
 
-- **Connect streaming EOF without END_STREAM now returns `unknown`**
+- **Connect streaming EOF without END_STREAM now returns `internal`**
   ([#168]). The `ServerStream` Connect EOF path that 0.7.0's [#140]
-  introduced as `unavailable` now returns `unknown` — the code gRPC's
-  status guidance assigns to "error parsing returned status", and the
-  primary expected code in the upstream conformance suite addition
-  ([connectrpc/conformance#1104]). The HTTP body completes cleanly in
-  this case; it is the Connect envelope sequence that is missing its
-  terminus, so the upstream classification treats it as a
-  protocol-framing error rather than the transport flakiness [#140]'s
-  entry described. **Clients on 0.7.0 that match `Unavailable` for a
-  truncated Connect stream must match `Unknown` after this release**, and
-  generic retry middleware that retries on `unavailable` will now treat
-  this case as terminal — a server that omits END_STREAM is not expected
-  to start sending it on retry. The client-streaming check from [#163]
-  ships with the same `unknown` code. (The 0.7.0 [#140] entry's
-  "matching connect-go" parenthetical was also inaccurate: connect-go
-  returns `internal` for this path.)
+  introduced as `unavailable` now returns `internal` — the code
+  connect-go reports for this path, and the primary expected code in the
+  upstream conformance suite addition ([connectrpc/conformance#1104]).
+  The HTTP body completes cleanly in this case; it is the Connect
+  envelope sequence that is missing its terminus, so connect-go and other
+  gRPC stacks classify it as a wire-level error in the same family as a
+  failed decompression or an unparseable response, rather than the
+  transport flakiness [#140]'s entry described. **Clients on 0.7.0 that
+  match `Unavailable` for a truncated Connect stream must match `Internal`
+  after this release**, and generic retry middleware that retries on
+  `unavailable` will now treat this case as terminal — a server that omits
+  END_STREAM is not expected to start sending it on retry. The
+  client-streaming check from [#163] ships with the same `internal` code.
+  (The 0.7.0 [#140] entry's "matching connect-go" parenthetical was also
+  inaccurate as to the code, but correct that connect-go is the reference:
+  it returns `internal` for this path.)
 
 ### Fixed
 
@@ -36,7 +37,7 @@ increment the patch version.
   ([#163]). A response that ended after its single data message but before
   the END_STREAM envelope was accepted as a success with empty trailers, so
   a truncated response was indistinguishable from a complete one. It now
-  returns `Err(unknown)` (see [#168]); complete responses are unchanged.
+  returns `Err(internal)` (see [#168]); complete responses are unchanged.
 
 [#163]: https://github.com/anthropics/connect-rust/pull/163
 [#168]: https://github.com/anthropics/connect-rust/pull/168

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,37 @@ increment the patch version.
 
 ## [Unreleased]
 
+### Changed
+
+- **Connect streaming EOF without END_STREAM now returns `unknown`**
+  ([#168]). The `ServerStream` Connect EOF path that 0.7.0's [#140]
+  introduced as `unavailable` now returns `unknown` — the code gRPC's
+  status guidance assigns to "error parsing returned status", and the
+  primary expected code in the upstream conformance suite addition
+  ([connectrpc/conformance#1104]). The HTTP body completes cleanly in
+  this case; it is the Connect envelope sequence that is missing its
+  terminus, so the upstream classification treats it as a
+  protocol-framing error rather than the transport flakiness [#140]'s
+  entry described. **Clients on 0.7.0 that match `Unavailable` for a
+  truncated Connect stream must match `Unknown` after this release**, and
+  generic retry middleware that retries on `unavailable` will now treat
+  this case as terminal — a server that omits END_STREAM is not expected
+  to start sending it on retry. The client-streaming check from [#163]
+  ships with the same `unknown` code. (The 0.7.0 [#140] entry's
+  "matching connect-go" parenthetical was also inaccurate: connect-go
+  returns `internal` for this path.)
+
 ### Fixed
 
 - **Connect client-streaming responses require the END_STREAM envelope**
   ([#163]). A response that ended after its single data message but before
   the END_STREAM envelope was accepted as a success with empty trailers, so
   a truncated response was indistinguishable from a complete one. It now
-  returns `Err(unavailable)`, matching the `ServerStream` Connect EOF path
-  ([#140]); complete responses are unchanged.
+  returns `Err(unknown)` (see [#168]); complete responses are unchanged.
 
 [#163]: https://github.com/anthropics/connect-rust/pull/163
+[#168]: https://github.com/anthropics/connect-rust/pull/168
+[connectrpc/conformance#1104]: https://github.com/connectrpc/conformance/pull/1104
 
 ## [0.7.0] - 2026-06-10
 

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2011,7 +2011,7 @@ where
     ///
     /// A response body that ends without its protocol's termination
     /// metadata is not a clean end and returns `Err` rather than
-    /// `Ok(None)`: `unknown` for a Connect stream missing its
+    /// `Ok(None)`: `internal` for a Connect stream missing its
     /// END_STREAM envelope; for gRPC/gRPC-Web, `internal` when no
     /// trailers arrived at all, `unknown` when trailers arrived without a
     /// `grpc-status`, and `unknown` for a malformed `grpc-status` value —
@@ -2119,10 +2119,10 @@ where
                         if matches!(self.protocol, Protocol::Connect) {
                             // The HTTP body completed cleanly but the Connect
                             // envelope sequence is missing its terminus: a
-                            // protocol-framing error, not a transport one.
-                            // gRPC's status-code guidance maps "error parsing
-                            // returned status" to `unknown`.
-                            return Err(ConnectError::unknown(
+                            // wire-level error, classified as `internal` the
+                            // same way connect-go and other gRPC stacks treat a
+                            // failed decompression or an unparseable response.
+                            return Err(ConnectError::internal(
                                 "Connect streaming response ended without END_STREAM envelope",
                             )
                             .into());
@@ -3223,9 +3223,10 @@ where
 /// envelope, the protocol-level terminus: it supplies the trailers (or a
 /// terminal Connect error) and marks the response complete. A body that
 /// yields the data message and then ends before END_STREAM is truncated, not
-/// successful, and is rejected with `unknown` (matching the `ServerStream`
-/// Connect EOF behavior and gRPC's status-code guidance for "error parsing
-/// returned status"). Returns the (still encoded) message payload and any
+/// successful, and is rejected with `internal` (matching the `ServerStream`
+/// Connect EOF behavior and connect-go's classification of a missing
+/// terminus as a wire-level error). Returns the (still encoded) message
+/// payload and any
 /// trailers carried in the END_STREAM metadata.
 ///
 /// Scanning stops at END_STREAM, so anything after it is ignored rather than
@@ -3341,7 +3342,7 @@ fn parse_connect_client_stream_envelopes(
     // is a truncated response, not a completed one — match ServerStream's
     // Connect EOF handling rather than reporting success with no trailers.
     if !saw_end_stream {
-        return Err(ConnectError::unknown(
+        return Err(ConnectError::internal(
             "Connect streaming response ended without END_STREAM envelope",
         ));
     }
@@ -3909,7 +3910,7 @@ mod tests {
             Ok(Some(_)) => panic!("truncated stream unexpectedly yielded another message"),
             Ok(None) => panic!("truncated stream ended cleanly without END_STREAM"),
         };
-        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(err.code, ErrorCode::Internal);
         assert!(
             err.to_string().contains("END_STREAM"),
             "unexpected error: {err}"
@@ -3921,7 +3922,7 @@ mod tests {
             .message()
             .await
             .expect_err("truncation error must be sticky");
-        assert_eq!(again.code, ErrorCode::Unknown);
+        assert_eq!(again.code, ErrorCode::Internal);
     }
 
     /// A Connect streaming response whose body is empty (zero envelopes,
@@ -3952,7 +3953,7 @@ mod tests {
             Ok(Some(_)) => panic!("empty body unexpectedly yielded a message"),
             Ok(None) => panic!("empty body without END_STREAM ended cleanly"),
         };
-        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(err.code, ErrorCode::Internal);
         assert!(
             err.to_string().contains("END_STREAM"),
             "unexpected error: {err}"
@@ -3962,7 +3963,7 @@ mod tests {
             .message()
             .await
             .expect_err("truncation error must be sticky");
-        assert_eq!(again.code, ErrorCode::Unknown);
+        assert_eq!(again.code, ErrorCode::Internal);
     }
 
     /// `Ok(None)` means the RPC succeeded — a Connect END_STREAM envelope
@@ -5532,7 +5533,7 @@ mod tests {
 
     /// A data envelope followed by EOF, with no END_STREAM envelope, is a
     /// truncated response rather than a completed one: it is rejected with
-    /// `unknown` instead of succeeding with empty trailers, matching the
+    /// `internal` instead of succeeding with empty trailers, matching the
     /// `ServerStream` Connect EOF behavior.
     #[test]
     fn client_stream_response_requires_end_stream_after_message() {
@@ -5548,7 +5549,7 @@ mod tests {
             &http::HeaderMap::new(),
         )
         .unwrap_err();
-        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(err.code, ErrorCode::Internal);
         assert_eq!(
             err.message.as_deref(),
             Some("Connect streaming response ended without END_STREAM envelope"),
@@ -5558,7 +5559,7 @@ mod tests {
     /// A data envelope followed by a truncated END_STREAM envelope (its
     /// declared payload never arrives) is also a truncated response: the
     /// partial envelope decodes to "needs more data", so END_STREAM is never
-    /// observed and the response is rejected with `unknown`.
+    /// observed and the response is rejected with `internal`.
     #[test]
     fn client_stream_response_requires_complete_end_stream_after_message() {
         let registry = crate::compression::CompressionRegistry::new();
@@ -5578,7 +5579,7 @@ mod tests {
             &http::HeaderMap::new(),
         )
         .unwrap_err();
-        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(err.code, ErrorCode::Internal);
         assert_eq!(
             err.message.as_deref(),
             Some("Connect streaming response ended without END_STREAM envelope"),

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2011,7 +2011,7 @@ where
     ///
     /// A response body that ends without its protocol's termination
     /// metadata is not a clean end and returns `Err` rather than
-    /// `Ok(None)`: `unavailable` for a Connect stream missing its
+    /// `Ok(None)`: `unknown` for a Connect stream missing its
     /// END_STREAM envelope; for gRPC/gRPC-Web, `internal` when no
     /// trailers arrived at all, `unknown` when trailers arrived without a
     /// `grpc-status`, and `unknown` for a malformed `grpc-status` value —
@@ -2117,7 +2117,12 @@ where
                     }
                     BodyPoll::Eof => {
                         if matches!(self.protocol, Protocol::Connect) {
-                            return Err(ConnectError::unavailable(
+                            // The HTTP body completed cleanly but the Connect
+                            // envelope sequence is missing its terminus: a
+                            // protocol-framing error, not a transport one.
+                            // gRPC's status-code guidance maps "error parsing
+                            // returned status" to `unknown`.
+                            return Err(ConnectError::unknown(
                                 "Connect streaming response ended without END_STREAM envelope",
                             )
                             .into());
@@ -3218,8 +3223,9 @@ where
 /// envelope, the protocol-level terminus: it supplies the trailers (or a
 /// terminal Connect error) and marks the response complete. A body that
 /// yields the data message and then ends before END_STREAM is truncated, not
-/// successful, and is rejected with `unavailable`, matching the `ServerStream`
-/// Connect EOF behavior. Returns the (still encoded) message payload and any
+/// successful, and is rejected with `unknown` (matching the `ServerStream`
+/// Connect EOF behavior and gRPC's status-code guidance for "error parsing
+/// returned status"). Returns the (still encoded) message payload and any
 /// trailers carried in the END_STREAM metadata.
 ///
 /// Scanning stops at END_STREAM, so anything after it is ignored rather than
@@ -3335,7 +3341,7 @@ fn parse_connect_client_stream_envelopes(
     // is a truncated response, not a completed one — match ServerStream's
     // Connect EOF handling rather than reporting success with no trailers.
     if !saw_end_stream {
-        return Err(ConnectError::unavailable(
+        return Err(ConnectError::unknown(
             "Connect streaming response ended without END_STREAM envelope",
         ));
     }
@@ -3903,7 +3909,7 @@ mod tests {
             Ok(Some(_)) => panic!("truncated stream unexpectedly yielded another message"),
             Ok(None) => panic!("truncated stream ended cleanly without END_STREAM"),
         };
-        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.code, ErrorCode::Unknown);
         assert!(
             err.to_string().contains("END_STREAM"),
             "unexpected error: {err}"
@@ -3915,7 +3921,7 @@ mod tests {
             .message()
             .await
             .expect_err("truncation error must be sticky");
-        assert_eq!(again.code, ErrorCode::Unavailable);
+        assert_eq!(again.code, ErrorCode::Unknown);
     }
 
     /// A Connect streaming response whose body is empty (zero envelopes,
@@ -3946,7 +3952,7 @@ mod tests {
             Ok(Some(_)) => panic!("empty body unexpectedly yielded a message"),
             Ok(None) => panic!("empty body without END_STREAM ended cleanly"),
         };
-        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.code, ErrorCode::Unknown);
         assert!(
             err.to_string().contains("END_STREAM"),
             "unexpected error: {err}"
@@ -3956,7 +3962,7 @@ mod tests {
             .message()
             .await
             .expect_err("truncation error must be sticky");
-        assert_eq!(again.code, ErrorCode::Unavailable);
+        assert_eq!(again.code, ErrorCode::Unknown);
     }
 
     /// `Ok(None)` means the RPC succeeded — a Connect END_STREAM envelope
@@ -5526,7 +5532,7 @@ mod tests {
 
     /// A data envelope followed by EOF, with no END_STREAM envelope, is a
     /// truncated response rather than a completed one: it is rejected with
-    /// `unavailable` instead of succeeding with empty trailers, matching the
+    /// `unknown` instead of succeeding with empty trailers, matching the
     /// `ServerStream` Connect EOF behavior.
     #[test]
     fn client_stream_response_requires_end_stream_after_message() {
@@ -5542,7 +5548,7 @@ mod tests {
             &http::HeaderMap::new(),
         )
         .unwrap_err();
-        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.code, ErrorCode::Unknown);
         assert_eq!(
             err.message.as_deref(),
             Some("Connect streaming response ended without END_STREAM envelope"),
@@ -5552,7 +5558,7 @@ mod tests {
     /// A data envelope followed by a truncated END_STREAM envelope (its
     /// declared payload never arrives) is also a truncated response: the
     /// partial envelope decodes to "needs more data", so END_STREAM is never
-    /// observed and the response is rejected with `unavailable`.
+    /// observed and the response is rejected with `unknown`.
     #[test]
     fn client_stream_response_requires_complete_end_stream_after_message() {
         let registry = crate::compression::CompressionRegistry::new();
@@ -5572,7 +5578,7 @@ mod tests {
             &http::HeaderMap::new(),
         )
         .unwrap_err();
-        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.code, ErrorCode::Unknown);
         assert_eq!(
             err.message.as_deref(),
             Some("Connect streaming response ended without END_STREAM envelope"),


### PR DESCRIPTION
## What this does

Both Connect-protocol "streaming response ended without END_STREAM envelope" paths — `ServerStream::message()` (from #140) and `parse_connect_client_stream_envelopes` (from #163) — previously returned `unavailable`. They now return `unknown`.

The HTTP body completes cleanly in this case; it is the Connect envelope sequence that is missing its terminus, so this is a protocol-framing error rather than a transport-level one. gRPC's [status-code guidance](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) maps "error parsing returned status" to `UNKNOWN`, and the upstream conformance addition (connectrpc/conformance#1104) expects `UNKNOWN` as the primary code following [maintainer review](https://github.com/connectrpc/conformance/pull/1104#discussion).

The error message string is unchanged.

## Verification

- Unit: 6 assertions across the two ServerStream EOF tests (data-then-EOF, empty body) and the two #163 client-stream tests now pin `ErrorCode::Unknown`; `cargo test -p connectrpc` 408 passed.
- Conformance HEAD with the connectrpc/conformance#1104 update applied (UNKNOWN primary, INTERNAL allowed, server-stream and bidi cases added), client-connect-only config: `**/no-end-stream` 12/12; full suite 2588/2592 — the 4 remaining failures are the GET param-order tests that #167 fixes.
- Doc comments at `ServerStream::message()` `# Errors`, `parse_connect_client_stream_envelopes`, and the two #163 test docs updated.

## Review map

- `connectrpc/src/client/mod.rs`: two `ConnectError::unavailable` → `unknown` at the EOF paths; in-code rationale comment at the ServerStream site; doc comments and 6 test assertions.
- `CHANGELOG.md`: amends the still-Unreleased #163 entry to say `Err(unknown)` and adds this entry covering the #140 ServerStream path.
