### PR TITLE
client: saturate gRPC-Web trailer-length add to avoid overflow panic

### DIFF
--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2054,7 +2054,13 @@ where
                 let trailer_len =
                     u32::from_be_bytes([self.buf[1], self.buf[2], self.buf[3], self.buf[4]])
                         as usize;
-                if self.buf.len() >= 5 + trailer_len {
+                // `saturating_add`: `trailer_len` is a server-controlled u32, so
+                // on a 32-bit target (e.g. the supported `wasm32` gRPC-Web
+                // client) `5 + trailer_len` can overflow `usize` and panic in a
+                // debug build. Matches the sibling framing sites, which already
+                // saturate. A saturated sum is never `<= buf.len()`, so an
+                // over-large prefix simply waits for bytes that never arrive.
+                if self.buf.len() >= trailer_len.saturating_add(5) {
                     // Complete trailer frame — parse and classify. An
                     // unparseable frame classifies as `None` (no usable
                     // termination metadata).


### PR DESCRIPTION
## What

The streaming gRPC-Web path tests whether a complete trailer frame has
arrived with:

```rust
if self.buf.len() >= 5 + trailer_len {
```

`trailer_len` is a server-supplied `u32` read from the frame's length
prefix. The `5 + trailer_len` add is unchecked.

## Why it matters

On a 32-bit target — including the supported `wasm32` gRPC-Web client —
`usize` is 32-bit, so a length prefix near `u32::MAX` overflows the add
and panics in a debug build. The sibling framing sites
(`client/mod.rs:1701`, `:2238`, `:3186`) already use `saturating_add`;
this one was the outlier.

## Fix

Use `saturating_add`. A saturated sum is never `<= buf.len()`, so an
over-large prefix simply waits for bytes that never arrive instead of
panicking, and the downstream parser re-validates against its own size
cap regardless.

## Testing

No new test: the overflow only manifests on a 32-bit debug build, and on
the 64-bit CI host the arithmetic never overflows, so a test cannot
distinguish the before/after behaviour. The change mirrors the three
already-tested sibling sites. Existing tests pass.
