### PR TITLE
connectrpc: add optional `json` feature for proto-only builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,15 @@ increment the patch version.
   message-type bounds to just `buffa::Message` via the new
   `JsonSerialize`/`JsonDeserialize` marker traits, so message types
   generated with the codegen `no_json` option (no serde derives) compile
-  against the runtime. A JSON request to a proto-only server returns
-  `Unimplemented`. The Connect error/end-stream wire format is always JSON per
-  spec, so `serde`/`serde_json` remain required dependencies. See the
+  against the runtime. A proto-only server declines JSON at content
+  negotiation — `application/json` / `application/connect+json` (and the
+  Connect GET `encoding=json` parameter) return HTTP 415, and
+  `application/grpc+json` / `application/grpc-web+json` return a gRPC error
+  status — with message-level encode/decode returning `Unimplemented` as a
+  backstop; the client's `ClientConfig::json` selector is removed from the API
+  in that build. The Connect error/end-stream wire format
+  is always JSON per spec, so `serde`/`serde_json` remain required
+  dependencies. See the
   [proto-only build guide](docs/guide.md#proto-only-no-json-builds).
 
 [#172]: https://github.com/anthropics/connect-rust/pull/172

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ increment the patch version.
 
 ## [Unreleased]
 
+### Added
+
+- **Optional `json` cargo feature for proto-only builds** ([#172]). The
+  Connect JSON codec requires `serde::Serialize`/`Deserialize` on every
+  message type, so the code generator derives them by default — pure cost for
+  crates that only speak binary proto. The new default-on `json` feature, when
+  disabled (`connectrpc = { default-features = false }`), relaxes the runtime's
+  message-type bounds to just `buffa::Message` via the new
+  `JsonSerialize`/`JsonDeserialize` marker traits, so message types
+  generated with the codegen `no_json` option (no serde derives) compile
+  against the runtime. A JSON request to a proto-only server returns
+  `Unimplemented`. The Connect error/end-stream wire format is always JSON per
+  spec, so `serde`/`serde_json` remain required dependencies. See the
+  [proto-only build guide](docs/guide.md#proto-only-no-json-builds).
+
+[#172]: https://github.com/anthropics/connect-rust/pull/172
+
 ### Fixed
 
 - **Connect client-streaming responses require the END_STREAM envelope**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ async-trait = "0.1"
 # `OwnedView` `Deref` impl that earlier handler signatures relied on.
 # (connectrpc-build also sources the generated `mod.rs` `#[allow(...)]` list
 # from `buffa_codegen::ALLOW_LINTS`, present since 0.5.1.)
+# NOTE: the `connectrpc` crate pins `buffa` directly (not `workspace = true`)
+# so its `json` cargo feature can gate `buffa/json` for proto-only builds —
+# keep that floor aligned with this one when bumping.
 buffa = { version = "0.7", features = ["json"] }
 buffa-types = { version = "0.7", features = ["json"] }
 buffa-codegen = { version = "0.7" }

--- a/README.md
+++ b/README.md
@@ -355,14 +355,25 @@ feature:
 
 ```toml
 [dependencies]
-connectrpc = { version = "0.7", default-features = false, features = ["server"] }
+# Note: `default-features = false` is the only way to drop `json`, so it also
+# drops the default compression features — re-list any you still want.
+connectrpc = { version = "0.7", default-features = false, features = ["server", "gzip", "zstd", "streaming"] }
 ```
 
 With `json` off, message-type bounds relax from `Message + Serialize` to just
 `Message`, so serde-free generated code compiles. A JSON request to such a
-server gets a Connect `Unimplemented` error (the error body stays JSON, as the
-protocol requires). See the [user guide](docs/guide.md#proto-only-no-json-builds)
-for details.
+server is declined at content negotiation with HTTP 415 Unsupported Media Type
+(for gRPC / gRPC-Web, a gRPC error status); the JSON codec selectors on the
+client (`ClientConfig::json`) are removed from the API too. See the [user guide](docs/guide.md#proto-only-no-json-builds) for
+details.
+
+> **Cargo feature unification:** `json` is an additive, default-on feature, so
+> it is only truly off when *every* crate in your dependency graph that pulls in
+> `connectrpc` disables it. If any other crate depends on `connectrpc` with
+> `json` on, unification turns it back on for the whole build and your
+> serde-free generated types will fail to compile (`Serialize is not
+> satisfied`). Proto-only mode therefore fits leaf binaries and fully
+> proto-only graphs, not a single library in a mixed workspace.
 
 ### With Axum integration
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The Quick Start above shows the unary path. For everything else, see the user gu
 
 | Feature      | Default | Description                                      |
 | ------------ | ------- | ------------------------------------------------ |
+| `json`       | Yes     | JSON codec for protobuf messages. Disable (with codegen `no_json`) for proto-only builds — see [Proto-only builds](#proto-only-no-json-builds) |
 | `gzip`       | Yes     | Gzip compression via flate2                      |
 | `zstd`       | Yes     | Zstandard compression via zstd                   |
 | `streaming`  | Yes     | Streaming compression via async-compression      |
@@ -344,6 +345,25 @@ connectrpc = { version = "0.7", default-features = false, features = ["gzip"] }
 connectrpc = { version = "0.7", default-features = false }
 ```
 
+### Proto-only (no-JSON) builds
+
+A deployment that only speaks binary proto can drop the JSON codec and the
+`serde` derives it requires on message types. Generate code with the `no_json`
+plugin option (or `connectrpc-build`'s `.generate_json(false)`) so message
+structs are emitted without serde derives, and disable the runtime `json`
+feature:
+
+```toml
+[dependencies]
+connectrpc = { version = "0.7", default-features = false, features = ["server"] }
+```
+
+With `json` off, message-type bounds relax from `Message + Serialize` to just
+`Message`, so serde-free generated code compiles. A JSON request to such a
+server gets a Connect `Unimplemented` error (the error body stays JSON, as the
+protocol requires). See the [user guide](docs/guide.md#proto-only-no-json-builds)
+for details.
+
 ### With Axum integration
 
 ```toml
@@ -364,6 +384,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 http-body = "1"
 ```
+
+For **proto-only** code (generated with `no_json`, and `connectrpc` built with
+`default-features = false`), drop the `json` feature on `buffa`/`buffa-types`
+and omit `serde`/`serde_json` — the generated message types no longer derive
+them. See [Proto-only builds](#proto-only-no-json-builds).
 
 ### Optional: gate the client behind a Cargo feature
 

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -130,10 +130,18 @@ impl Config {
         self
     }
 
-    /// Emit `serde` derives and proto3 JSON helpers (default: true).
+    /// Emit `serde` derives and proto3 JSON helpers on generated message
+    /// types (default: true).
     ///
-    /// Disable only for binary-only clients; the Connect protocol's JSON
-    /// codec requires this. See [`CodeGenConfig::generate_json`].
+    /// Disable for **proto-only** builds that never speak the Connect JSON
+    /// codec: message types are emitted without
+    /// `#[derive(serde::Serialize, serde::Deserialize)]`, cutting code size
+    /// and serde compile time. Pair it with `connectrpc`'s
+    /// `default-features = false` (the `json` cargo feature off) so the
+    /// runtime drops its matching serde bounds — proto-only generated code
+    /// only compiles against a proto-only runtime, and a JSON request to such
+    /// a server returns `Unimplemented`. With `json` left on, the runtime
+    /// still requires these derives. See [`CodeGenConfig::generate_json`].
     #[must_use]
     pub fn generate_json(mut self, enabled: bool) -> Self {
         self.options.buffa.generate_json = enabled;

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -450,8 +450,10 @@ pub fn generate_services(
 ///   [`CodeGenConfig::file_per_package`] for the `strategy: directory`
 ///   constraint.
 /// - `strict_utf8_mapping` — see [`CodeGenConfig::strict_utf8_mapping`].
-/// - `no_json` — disable `serde` derives on generated message types.
-///   Ignored in this plugin (no message types emitted); accepted for
+/// - `no_json` — disable `serde` derives on generated message types, for
+///   proto-only builds. Pair it with `connectrpc`'s `default-features = false`
+///   (the `json` cargo feature off) so the runtime drops its matching serde
+///   bounds. Ignored in this plugin (no message types emitted); accepted for
 ///   compatibility with the unified path.
 /// - `no_register_fn` — suppress the per-file
 ///   `register_types(&mut TypeRegistry)` aggregator. See

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -30,10 +30,19 @@ futures = { workspace = true }
 pin-project = { workspace = true }
 async-trait = { workspace = true }
 
-# Protobuf
-buffa = { workspace = true }
+# Protobuf.
+# Declared directly (not `workspace = true`) so the `json` feature can gate
+# `buffa/json`: the workspace `buffa` entry forces `features = ["json"]`, which
+# a member inheriting it cannot drop. The runtime only ever uses buffa's core
+# `Message`/view traits (never its JSON helpers), so a proto-only build needs
+# no buffa JSON. Keep the version in sync with the `[workspace.dependencies]`
+# `buffa` entry (which documents the 0.7 floor).
+buffa = { version = "0.7", default-features = false }
 
-# Serialization
+# Serialization. Non-optional even in proto-only builds: the Connect error and
+# streaming end-of-stream wire frames are always JSON regardless of the message
+# codec, so `serde`/`serde_json` are always required. The `json` feature gates
+# only *message-type* JSON (see `JsonSerialize`/`JsonDeserialize`).
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
@@ -80,7 +89,15 @@ buffa-types = { workspace = true }
 h2 = { workspace = true }
 
 [features]
-default = ["gzip", "zstd", "streaming"]
+default = ["gzip", "zstd", "streaming", "json"]
+
+# JSON codec for protobuf message types. On by default. Disabling it drops the
+# `serde::Serialize`/`DeserializeOwned` requirement on message types (see
+# `JsonSerialize`/`JsonDeserialize`), so proto-only code generated with the
+# codegen `no_json` option compiles against this crate. The Connect *error*
+# wire format is always JSON, so `serde`/`serde_json` remain unconditional
+# dependencies; only message-level JSON support is gated.
+json = ["buffa/json"]
 
 # Compression algorithms
 gzip = ["dep:flate2", "async-compression?/gzip"]

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -35,9 +35,12 @@ async-trait = { workspace = true }
 # `buffa/json`: the workspace `buffa` entry forces `features = ["json"]`, which
 # a member inheriting it cannot drop. The runtime only ever uses buffa's core
 # `Message`/view traits (never its JSON helpers), so a proto-only build needs
-# no buffa JSON. Keep the version in sync with the `[workspace.dependencies]`
-# `buffa` entry (which documents the 0.7 floor).
-buffa = { version = "0.7", default-features = false }
+# no buffa JSON. `std` is kept explicitly — `default-features = false` drops it
+# along with `json`, but `connectrpc` is unconditionally a std crate (tokio,
+# hyper), so building buffa as no_std would buy nothing and only risk a future
+# buffa change std-gating a core path we rely on. Keep the version in sync with
+# the `[workspace.dependencies]` `buffa` entry (which documents the 0.7 floor).
+buffa = { version = "0.7", default-features = false, features = ["std"] }
 
 # Serialization. Non-optional even in proto-only builds: the Connect error and
 # streaming end-of-stream wire frames are always JSON regardless of the message

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -120,6 +120,7 @@ use buffa::view::ViewReborrow;
 
 use crate::codec::CodecFormat;
 use crate::codec::content_type;
+use crate::codec::encode_json;
 use crate::codec::header as connect_header;
 use crate::compression::CompressionPolicy;
 use crate::compression::CompressionRegistry;
@@ -1150,11 +1151,12 @@ fn decode_response_view<RespView>(
 ) -> Result<OwnedView<RespView>, ConnectError>
 where
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     match format {
         CodecFormat::Proto => OwnedView::<RespView>::decode(data)
             .map_err(|e| ConnectError::internal(format!("failed to decode response: {e}"))),
+        #[cfg(feature = "json")]
         CodecFormat::Json => {
             let owned: RespView::Owned = serde_json::from_slice(&data).map_err(|e| {
                 ConnectError::internal(format!("failed to decode JSON response: {e}"))
@@ -1162,6 +1164,10 @@ where
             OwnedView::<RespView>::from_owned(&owned)
                 .map_err(|e| ConnectError::internal(format!("failed to re-encode for view: {e}")))
         }
+        #[cfg(not(feature = "json"))]
+        CodecFormat::Json => Err(ConnectError::unimplemented(
+            crate::codec::JSON_FEATURE_DISABLED,
+        )),
     }
 }
 
@@ -1180,9 +1186,9 @@ pub async fn call_unary<T, Req, RespView>(
 where
     T: ClientTransport,
     <T::ResponseBody as Body>::Error: std::fmt::Display,
-    Req: buffa::Message + serde::Serialize,
+    Req: buffa::Message + crate::codec::JsonSerialize,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let options = effective_options(config, options);
 
@@ -1197,12 +1203,7 @@ where
     // Encode the request body
     let body = match config.codec_format {
         CodecFormat::Proto => request.encode_to_bytes(),
-        CodecFormat::Json => {
-            let buf = serde_json::to_vec(&request).map_err(|e| {
-                ConnectError::internal(format!("failed to encode JSON request: {e}"))
-            })?;
-            Bytes::from(buf)
-        }
+        CodecFormat::Json => encode_json(&request)?,
     };
 
     // Apply compression and framing based on protocol.
@@ -1320,9 +1321,9 @@ pub async fn call_unary_get<T, Req, RespView>(
 where
     T: ClientTransport,
     <T::ResponseBody as Body>::Error: std::fmt::Display,
-    Req: buffa::Message + serde::Serialize,
+    Req: buffa::Message + crate::codec::JsonSerialize,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     // Connect GET is a Connect-protocol-only feature.
     if !matches!(config.protocol, Protocol::Connect) {
@@ -1340,12 +1341,7 @@ where
     // Encode the request body
     let body = match config.codec_format {
         CodecFormat::Proto => request.encode_to_bytes(),
-        CodecFormat::Json => {
-            let buf = serde_json::to_vec(&request).map_err(|e| {
-                ConnectError::internal(format!("failed to encode JSON request: {e}"))
-            })?;
-            Bytes::from(buf)
-        }
+        CodecFormat::Json => encode_json(&request)?,
     };
 
     // Apply compression if configured (compression makes base64 mandatory).
@@ -1474,7 +1470,7 @@ where
     B: Body<Data = Bytes> + Send,
     B::Error: std::fmt::Display,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let status = response.status();
     if !status.is_success() {
@@ -1646,7 +1642,7 @@ where
     B: Body<Data = Bytes> + Send,
     B::Error: std::fmt::Display,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let status = response.status();
     let resp_headers = response.headers().clone();
@@ -1975,7 +1971,7 @@ where
     B: Body<Data = Bytes> + Unpin,
     B::Error: std::fmt::Display,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     /// Returns the response headers.
     #[must_use]
@@ -2377,9 +2373,9 @@ pub async fn call_server_stream<T, Req, RespView>(
 where
     T: ClientTransport,
     <T::ResponseBody as Body>::Error: std::fmt::Display,
-    Req: buffa::Message + serde::Serialize,
+    Req: buffa::Message + crate::codec::JsonSerialize,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let options = effective_options(config, options);
 
@@ -2394,12 +2390,7 @@ where
     // Encode the request body
     let body = match config.codec_format {
         CodecFormat::Proto => request.encode_to_bytes(),
-        CodecFormat::Json => {
-            let buf = serde_json::to_vec(&request).map_err(|e| {
-                ConnectError::internal(format!("failed to encode JSON request: {e}"))
-            })?;
-            Bytes::from(buf)
-        }
+        CodecFormat::Json => encode_json(&request)?,
     };
 
     // Compress and envelope-frame the request body (streaming protocol
@@ -2479,7 +2470,7 @@ where
     B: Body<Data = Bytes> + Send,
     B::Error: std::fmt::Display,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let response_headers = response.headers().clone();
     let status = response.status();
@@ -2698,9 +2689,9 @@ impl<B, Req, RespView> BidiStream<B, Req, RespView>
 where
     B: Body<Data = Bytes> + Send + Unpin,
     B::Error: std::fmt::Display,
-    Req: buffa::Message + serde::Serialize,
+    Req: buffa::Message + crate::codec::JsonSerialize,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     /// Send a request message.
     ///
@@ -2727,12 +2718,7 @@ where
         // compression). Same logic as call_server_stream's request encoding.
         let msg_bytes = match self.codec_format {
             CodecFormat::Proto => msg.encode_to_bytes(),
-            CodecFormat::Json => {
-                let buf = serde_json::to_vec(&msg).map_err(|e| {
-                    ConnectError::internal(format!("failed to encode JSON request: {e}"))
-                })?;
-                Bytes::from(buf)
-            }
+            CodecFormat::Json => encode_json(&msg)?,
         };
 
         let mut envelope_buf = BytesMut::new();
@@ -2893,9 +2879,9 @@ pub async fn call_bidi_stream<T, Req, RespView>(
 where
     T: ClientTransport,
     <T::ResponseBody as Body>::Error: std::fmt::Display,
-    Req: buffa::Message + serde::Serialize,
+    Req: buffa::Message + crate::codec::JsonSerialize,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let options = effective_options(config, options);
 
@@ -2995,9 +2981,9 @@ pub async fn call_client_stream<T, Req, RespView>(
 where
     T: ClientTransport,
     <T::ResponseBody as Body>::Error: std::fmt::Display,
-    Req: buffa::Message + serde::Serialize,
+    Req: buffa::Message + crate::codec::JsonSerialize,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let options = effective_options(config, options);
 
@@ -3066,12 +3052,7 @@ where
         for request in requests {
             let msg_bytes = match config.codec_format {
                 CodecFormat::Proto => request.encode_to_bytes(),
-                CodecFormat::Json => {
-                    let buf = serde_json::to_vec(&request).map_err(|e| {
-                        ConnectError::internal(format!("failed to encode JSON request: {e}"))
-                    })?;
-                    Bytes::from(buf)
-                }
+                CodecFormat::Json => encode_json(&request)?,
             };
 
             let mut envelope_buf = BytesMut::new();
@@ -3117,7 +3098,7 @@ where
     B: Body<Data = Bytes> + Send,
     B::Error: std::fmt::Display,
     RespView: MessageView<'static> + Send,
-    RespView::Owned: buffa::Message + serde::de::DeserializeOwned,
+    RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     let status = response.status();
 
@@ -4816,6 +4797,28 @@ mod tests {
 
         let config = config.with_codec_format(CodecFormat::Json);
         assert_eq!(unary_request_content_type(&config), "application/json");
+    }
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn decode_response_view_json_is_unimplemented_without_feature() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+        // Proto-only client: the response-decode JSON arm is compiled out and
+        // surfaces `Unimplemented` instead of attempting serde. The
+        // request-encode paths are the symmetric `return Err(Unimplemented)`
+        // guards that fire before any transport I/O.
+        let err = decode_response_view::<StringValueView>(
+            Bytes::from_static(b"\"x\""),
+            CodecFormat::Json,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::Unimplemented);
+
+        // Proto decoding still works.
+        let bytes = StringValue::from("ok").encode_to_bytes();
+        assert!(decode_response_view::<StringValueView>(bytes, CodecFormat::Proto).is_ok());
     }
 
     #[test]

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -647,6 +647,13 @@ impl ClientConfig {
     /// Set the codec format (proto or json).
     ///
     /// Read via [`Self::codec_format`].
+    ///
+    /// In a proto-only build (the `json` feature disabled) selecting
+    /// [`CodecFormat::Json`] produces a client whose every RPC returns
+    /// [`Unimplemented`](crate::ErrorCode::Unimplemented) before any
+    /// network I/O — the JSON codec is not compiled in. Prefer the default
+    /// [`CodecFormat::Proto`]; the [`json`](Self::json) shorthand is removed
+    /// from the API entirely in that build.
     #[must_use]
     pub fn with_codec_format(mut self, format: CodecFormat) -> Self {
         self.codec_format = format;
@@ -654,6 +661,11 @@ impl ClientConfig {
     }
 
     /// Use JSON encoding. Shorthand for `with_codec_format(CodecFormat::Json)`.
+    ///
+    /// Only available when the `json` feature is enabled; a proto-only build
+    /// omits it so JSON cannot be selected through this shorthand.
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     #[must_use]
     pub fn json(mut self) -> Self {
         self.codec_format = CodecFormat::Json;
@@ -3710,6 +3722,7 @@ fn parse_grpc_web_trailer_frame_with_compression(
 mod tests {
     use super::*;
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_client_config() {
         let config = ClientConfig::new("http://localhost:8080".parse().unwrap())
@@ -3717,6 +3730,18 @@ mod tests {
             .compress_requests("gzip");
 
         assert_eq!(config.codec_format, CodecFormat::Json);
+        assert_eq!(config.request_compression, Some("gzip".to_string()));
+    }
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn test_client_config_proto_only() {
+        // The `.json()` shorthand is removed in a proto-only build; the default
+        // codec is proto and the rest of the builder is unaffected.
+        let config =
+            ClientConfig::new("http://localhost:8080".parse().unwrap()).compress_requests("gzip");
+
+        assert_eq!(config.codec_format, CodecFormat::Proto);
         assert_eq!(config.request_compression, Some("gzip".to_string()));
     }
 

--- a/connectrpc/src/codec.rs
+++ b/connectrpc/src/codec.rs
@@ -5,7 +5,9 @@
 
 use buffa::Message;
 use bytes::Bytes;
+#[cfg(feature = "json")]
 use serde::Serialize;
+#[cfg(feature = "json")]
 use serde::de::DeserializeOwned;
 
 use crate::error::ConnectError;
@@ -34,6 +36,61 @@ pub mod header {
     pub const ACCEPT_ENCODING: &str = "connect-accept-encoding";
 }
 
+/// Marker bound for message types the JSON codec can **serialize**.
+///
+/// When the `json` feature is enabled this is exactly [`serde::Serialize`]:
+/// if a bound such as `T: Message + JsonSerialize` fails to hold, derive
+/// `serde::Serialize` on `T` (generated code does this unless you pass the
+/// codegen `no_json` option). When the feature is disabled it is an empty
+/// bound satisfied by every type, so proto-only message types generated
+/// without serde derives still qualify and the JSON codec is simply
+/// unavailable at runtime.
+///
+/// Auto-implemented for every qualifying type — do not implement it manually.
+#[cfg(feature = "json")]
+pub trait JsonSerialize: Serialize {}
+#[cfg(feature = "json")]
+impl<T: Serialize> JsonSerialize for T {}
+
+/// Marker bound for message types the JSON codec can **serialize**.
+///
+/// With the `json` feature disabled this is an empty bound, so message types
+/// without serde derives satisfy it. See the `json`-enabled definition for
+/// the full contract.
+///
+/// Auto-implemented for every type — do not implement it manually.
+#[cfg(not(feature = "json"))]
+pub trait JsonSerialize {}
+#[cfg(not(feature = "json"))]
+impl<T> JsonSerialize for T {}
+
+/// Marker bound for message types the JSON codec can **deserialize**.
+///
+/// When the `json` feature is enabled this is exactly
+/// [`serde::de::DeserializeOwned`]: if a bound such as
+/// `T: Message + JsonDeserialize` fails to hold, derive `serde::Deserialize`
+/// on `T` (generated code does this unless you pass the codegen `no_json`
+/// option). When the feature is disabled it is an empty bound satisfied by
+/// every type, so proto-only message types generated without serde derives
+/// still qualify.
+///
+/// Auto-implemented for every qualifying type — do not implement it manually.
+#[cfg(feature = "json")]
+pub trait JsonDeserialize: DeserializeOwned {}
+#[cfg(feature = "json")]
+impl<T: DeserializeOwned> JsonDeserialize for T {}
+
+/// Marker bound for message types the JSON codec can **deserialize**.
+///
+/// With the `json` feature disabled this is an empty bound. See the
+/// `json`-enabled definition for the full contract.
+///
+/// Auto-implemented for every type — do not implement it manually.
+#[cfg(not(feature = "json"))]
+pub trait JsonDeserialize {}
+#[cfg(not(feature = "json"))]
+impl<T> JsonDeserialize for T {}
+
 /// Encode a protobuf message to binary format.
 pub fn encode_proto<M: Message>(message: &M) -> Result<Bytes, ConnectError> {
     Ok(message.encode_to_bytes())
@@ -45,17 +102,47 @@ pub fn decode_proto<M: Message>(data: &[u8]) -> Result<M, ConnectError> {
         .map_err(|e| ConnectError::invalid_argument(format!("failed to decode proto: {e}")))
 }
 
+/// Message shared by the JSON codec entry points when the `json` feature is
+/// disabled.
+#[cfg(not(feature = "json"))]
+pub(crate) const JSON_FEATURE_DISABLED: &str =
+    "JSON codec not compiled in (connectrpc built without the `json` feature)";
+
 /// Encode a message to JSON format.
+///
+/// This (with [`decode_json`]) is the single place the `json` feature is gated:
+/// with it disabled, the JSON codec is unavailable and this returns
+/// [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented) without
+/// requiring `M: serde::Serialize`, so proto-only callers compile. Callers can
+/// therefore invoke it unconditionally on their `CodecFormat::Json` arm.
+#[cfg(feature = "json")]
 pub fn encode_json<M: Serialize>(message: &M) -> Result<Bytes, ConnectError> {
     serde_json::to_vec(message)
         .map(Bytes::from)
         .map_err(|e| ConnectError::internal(format!("failed to encode JSON: {e}")))
 }
 
+/// Encode a message to JSON format — proto-only build: always `Unimplemented`.
+#[cfg(not(feature = "json"))]
+pub fn encode_json<M>(_message: &M) -> Result<Bytes, ConnectError> {
+    Err(ConnectError::unimplemented(JSON_FEATURE_DISABLED))
+}
+
 /// Decode JSON bytes into a message.
+///
+/// See [`encode_json`]: with the `json` feature disabled this returns
+/// [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented) without
+/// requiring `M: serde::de::DeserializeOwned`.
+#[cfg(feature = "json")]
 pub fn decode_json<M: DeserializeOwned>(data: &[u8]) -> Result<M, ConnectError> {
     serde_json::from_slice(data)
         .map_err(|e| ConnectError::invalid_argument(format!("failed to decode JSON: {e}")))
+}
+
+/// Decode JSON bytes into a message — proto-only build: always `Unimplemented`.
+#[cfg(not(feature = "json"))]
+pub fn decode_json<M>(_data: &[u8]) -> Result<M, ConnectError> {
+    Err(ConnectError::unimplemented(JSON_FEATURE_DISABLED))
 }
 
 /// Codec for binary protobuf encoding.
@@ -80,9 +167,12 @@ impl ProtoCodec {
 }
 
 /// Codec for JSON encoding of protobuf messages.
+#[cfg(feature = "json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct JsonCodec;
 
+#[cfg(feature = "json")]
 impl JsonCodec {
     /// Get the content type for this codec.
     pub fn content_type() -> &'static str {
@@ -107,6 +197,12 @@ pub enum CodecFormat {
     /// Binary protobuf format.
     Proto,
     /// JSON format.
+    ///
+    /// Fully supported only when the `json` feature is enabled. With it
+    /// disabled the variant still exists (so content-type negotiation can
+    /// recognize JSON requests), but encoding or decoding a *message* in this
+    /// format returns [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented)
+    /// at runtime. Connect *error* bodies are always JSON regardless.
     Json,
 }
 
@@ -121,6 +217,12 @@ impl std::fmt::Display for CodecFormat {
 
 impl CodecFormat {
     /// Parse codec format from content type string.
+    ///
+    /// These parsers stay codec-agnostic regardless of the `json` feature:
+    /// a JSON content type still parses to [`CodecFormat::Json`] in a
+    /// proto-only build so negotiation can recognize the request and the
+    /// codec layer can surface a precise `Unimplemented` error. The feature
+    /// gating lives at encode/decode, not here.
     pub fn from_content_type(content_type: &str) -> Option<Self> {
         if content_type.starts_with(content_type::PROTO)
             || content_type.starts_with(content_type::CONNECT_PROTO)
@@ -169,5 +271,29 @@ impl CodecFormat {
     pub fn is_streaming_content_type(content_type: &str) -> bool {
         content_type.starts_with(content_type::CONNECT_PROTO)
             || content_type.starts_with(content_type::CONNECT_JSON)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// With the `json` feature disabled, the message-type markers must be
+    /// empty bounds: a type with no serde derives — as emitted by the codegen
+    /// `no_json` option — still satisfies them. This is exactly what lets
+    /// proto-only generated code compile against this crate. (When `json` is
+    /// enabled the markers are `serde::Serialize` / `DeserializeOwned`, so the
+    /// assertion below would not even build — hence the `cfg`.)
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn markers_are_empty_bounds_without_json() {
+        use super::{JsonDeserialize, JsonSerialize};
+
+        // Derives neither `Serialize` nor `Deserialize`.
+        struct NoSerde;
+
+        fn assert_serialize<T: JsonSerialize>() {}
+        fn assert_deserialize<T: JsonDeserialize>() {}
+
+        assert_serialize::<NoSerde>();
+        assert_deserialize::<NoSerde>();
     }
 }

--- a/connectrpc/src/codec.rs
+++ b/connectrpc/src/codec.rs
@@ -110,11 +110,14 @@ pub(crate) const JSON_FEATURE_DISABLED: &str =
 
 /// Encode a message to JSON format.
 ///
-/// This (with [`decode_json`]) is the single place the `json` feature is gated:
-/// with it disabled, the JSON codec is unavailable and this returns
+/// This (with [`decode_json`]) is the primary place the `json` feature is
+/// gated: with it disabled, the JSON codec is unavailable and this returns
 /// [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented) without
 /// requiring `M: serde::Serialize`, so proto-only callers compile. Callers can
-/// therefore invoke it unconditionally on their `CodecFormat::Json` arm.
+/// therefore invoke it unconditionally on their `CodecFormat::Json` arm. The
+/// one deliberate exception is the client's `decode_response_view`, which keeps
+/// its own `#[cfg]` gate so a failed response decode stays an `internal` error
+/// rather than `decode_json`'s `invalid_argument`.
 #[cfg(feature = "json")]
 pub fn encode_json<M: Serialize>(message: &M) -> Result<Bytes, ConnectError> {
     serde_json::to_vec(message)
@@ -198,11 +201,16 @@ pub enum CodecFormat {
     Proto,
     /// JSON format.
     ///
-    /// Fully supported only when the `json` feature is enabled. With it
-    /// disabled the variant still exists (so content-type negotiation can
-    /// recognize JSON requests), but encoding or decoding a *message* in this
-    /// format returns [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented)
-    /// at runtime. Connect *error* bodies are always JSON regardless.
+    /// Fully supported only when the `json` feature is enabled. The variant
+    /// always exists (the wire-protocol enums are codec-total), but with the
+    /// feature disabled a proto-only build rejects JSON at the edges: the
+    /// server declines JSON content types at negotiation
+    /// ([`from_content_type`](Self::from_content_type) /
+    /// [`from_codec`](Self::from_codec) return `None`), which yields HTTP 415
+    /// for Connect or a gRPC error status for gRPC/gRPC-Web; and message
+    /// encode/decode returns
+    /// [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented) as a
+    /// backstop. Connect *error* bodies are always JSON regardless.
     Json,
 }
 
@@ -218,31 +226,36 @@ impl std::fmt::Display for CodecFormat {
 impl CodecFormat {
     /// Parse codec format from content type string.
     ///
-    /// These parsers stay codec-agnostic regardless of the `json` feature:
-    /// a JSON content type still parses to [`CodecFormat::Json`] in a
-    /// proto-only build so negotiation can recognize the request and the
-    /// codec layer can surface a precise `Unimplemented` error. The feature
-    /// gating lives at encode/decode, not here.
+    /// With the `json` feature disabled (a proto-only build) a JSON content
+    /// type returns `None` instead of [`CodecFormat::Json`], so the server
+    /// rejects it as an unsupported media type at content negotiation rather
+    /// than accepting it and failing later at decode. The message-level
+    /// encode/decode gating remains as a backstop.
     pub fn from_content_type(content_type: &str) -> Option<Self> {
         if content_type.starts_with(content_type::PROTO)
             || content_type.starts_with(content_type::CONNECT_PROTO)
         {
-            Some(Self::Proto)
-        } else if content_type.starts_with(content_type::JSON)
+            return Some(Self::Proto);
+        }
+        #[cfg(feature = "json")]
+        if content_type.starts_with(content_type::JSON)
             || content_type.starts_with(content_type::CONNECT_JSON)
         {
-            Some(Self::Json)
-        } else {
-            None
+            return Some(Self::Json);
         }
+        None
     }
 
     /// Parse codec format from encoding name (used in GET request query params).
     ///
-    /// Accepts "proto" or "json" (the values used in the `encoding` query parameter).
+    /// Accepts `"proto"`, and `"json"` only when the `json` feature is enabled
+    /// (the values used in the `encoding` query parameter). In a proto-only
+    /// build `"json"` returns `None`, so a Connect GET requesting the JSON
+    /// codec is rejected as an unsupported media type.
     pub fn from_codec(codec: &str) -> Option<Self> {
         match codec {
             "proto" => Some(Self::Proto),
+            #[cfg(feature = "json")]
             "json" => Some(Self::Json),
             _ => None,
         }
@@ -267,10 +280,20 @@ impl CodecFormat {
     }
 
     /// Check if the given content type indicates a streaming request.
+    ///
+    /// With the `json` feature disabled, the `application/connect+json`
+    /// streaming content type is not recognized (a proto-only build treats it
+    /// as an unsupported media type), matching [`Self::from_content_type`].
     #[inline]
     pub fn is_streaming_content_type(content_type: &str) -> bool {
-        content_type.starts_with(content_type::CONNECT_PROTO)
-            || content_type.starts_with(content_type::CONNECT_JSON)
+        if content_type.starts_with(content_type::CONNECT_PROTO) {
+            return true;
+        }
+        #[cfg(feature = "json")]
+        if content_type.starts_with(content_type::CONNECT_JSON) {
+            return true;
+        }
+        false
     }
 }
 
@@ -295,5 +318,46 @@ mod tests {
 
         assert_serialize::<NoSerde>();
         assert_deserialize::<NoSerde>();
+    }
+
+    /// Proto-only build: the codec parsers decline every JSON content type and
+    /// the `json` GET encoding, so the server rejects them at negotiation.
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn parsers_reject_json_without_feature() {
+        use super::CodecFormat;
+
+        assert_eq!(CodecFormat::from_codec("json"), None);
+        assert_eq!(CodecFormat::from_codec("proto"), Some(CodecFormat::Proto));
+
+        for ct in ["application/json", "application/connect+json"] {
+            assert_eq!(CodecFormat::from_content_type(ct), None, "{ct}");
+        }
+        assert_eq!(
+            CodecFormat::from_content_type("application/proto"),
+            Some(CodecFormat::Proto)
+        );
+
+        assert!(!CodecFormat::is_streaming_content_type(
+            "application/connect+json"
+        ));
+        assert!(CodecFormat::is_streaming_content_type(
+            "application/connect+proto"
+        ));
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn parsers_accept_json_with_feature() {
+        use super::CodecFormat;
+
+        assert_eq!(CodecFormat::from_codec("json"), Some(CodecFormat::Json));
+        assert_eq!(
+            CodecFormat::from_content_type("application/json"),
+            Some(CodecFormat::Json)
+        );
+        assert!(CodecFormat::is_streaming_content_type(
+            "application/connect+json"
+        ));
     }
 }

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -338,9 +338,9 @@ pub mod codegen {
     use bytes::Bytes;
     use futures::Stream;
     use futures::StreamExt;
-    use serde::de::DeserializeOwned;
 
     use crate::codec::CodecFormat;
+    use crate::codec::JsonDeserialize;
     use crate::error::ConnectError;
     use crate::handler::BoxStream;
 
@@ -421,7 +421,7 @@ pub mod codegen {
         format: CodecFormat,
     ) -> crate::ServiceStream<crate::StreamMessage<M>>
     where
-        M: crate::HasMessageView + DeserializeOwned + 'static,
+        M: crate::HasMessageView + JsonDeserialize + 'static,
         M::View<'static>: 'static,
     {
         Box::pin(requests.map(move |r| {

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -30,10 +30,10 @@ use buffa::view::MessageView;
 use buffa::view::OwnedView;
 use bytes::Bytes;
 use futures::Stream;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 
 use crate::codec::CodecFormat;
+use crate::codec::decode_json;
+use crate::codec::{JsonDeserialize, JsonSerialize};
 use crate::error::ConnectError;
 use crate::response::{
     Encodable, EncodedResponse, RequestContext, Response, ServiceResult, ServiceStream,
@@ -42,15 +42,13 @@ use crate::response::{
 /// Decode a request message from bytes using the specified codec format.
 pub(crate) fn decode_request<Req>(request: &Bytes, format: CodecFormat) -> Result<Req, ConnectError>
 where
-    Req: Message + DeserializeOwned,
+    Req: Message + JsonDeserialize,
 {
     match format {
         CodecFormat::Proto => Req::decode_from_slice(&request[..]).map_err(|e| {
             ConnectError::invalid_argument(format!("failed to decode proto request: {e}"))
         }),
-        CodecFormat::Json => serde_json::from_slice(request).map_err(|e| {
-            ConnectError::invalid_argument(format!("failed to decode JSON request: {e}"))
-        }),
+        CodecFormat::Json => decode_json(&request[..]),
     }
 }
 
@@ -213,8 +211,8 @@ where
 pub(crate) struct UnaryHandlerWrapper<H, Req, Res>
 where
     H: Handler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
+    Res: Message + JsonSerialize + Send + 'static,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(Req) -> Res>,
@@ -223,8 +221,8 @@ where
 impl<H, Req, Res> UnaryHandlerWrapper<H, Req, Res>
 where
     H: Handler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
+    Res: Message + JsonSerialize + Send + 'static,
 {
     /// Create a new wrapper around the given handler.
     pub fn new(handler: H) -> Self {
@@ -238,8 +236,8 @@ where
 impl<H, Req, Res> ErasedHandler for UnaryHandlerWrapper<H, Req, Res>
 where
     H: Handler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
+    Res: Message + JsonSerialize + Send + 'static,
 {
     fn call_erased(
         &self,
@@ -364,7 +362,7 @@ where
 pub(crate) struct ServerStreamingHandlerWrapper<H, Req, Res>
 where
     H: StreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
     Res: Message + Send + 'static,
 {
     handler: Arc<H>,
@@ -374,7 +372,7 @@ where
 impl<H, Req, Res> ServerStreamingHandlerWrapper<H, Req, Res>
 where
     H: StreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
     Res: Message + Send + 'static,
 {
     /// Create a new wrapper around the given streaming handler.
@@ -389,7 +387,7 @@ where
 impl<H, Req, Res> ErasedStreamingHandler for ServerStreamingHandlerWrapper<H, Req, Res>
 where
     H: StreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
     Res: Message + Send + 'static,
 {
     fn call_erased(
@@ -476,8 +474,8 @@ where
 pub(crate) struct ClientStreamingHandlerWrapper<H, Req, Res>
 where
     H: ClientStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
+    Res: Message + JsonSerialize + Send + 'static,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(Req) -> Res>,
@@ -486,8 +484,8 @@ where
 impl<H, Req, Res> ClientStreamingHandlerWrapper<H, Req, Res>
 where
     H: ClientStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
+    Res: Message + JsonSerialize + Send + 'static,
 {
     /// Create a new wrapper around the given client streaming handler.
     pub fn new(handler: H) -> Self {
@@ -501,8 +499,8 @@ where
 impl<H, Req, Res> ErasedClientStreamingHandler for ClientStreamingHandlerWrapper<H, Req, Res>
 where
     H: ClientStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
-    Res: Message + Serialize + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
+    Res: Message + JsonSerialize + Send + 'static,
 {
     fn call_erased(
         &self,
@@ -601,7 +599,7 @@ where
 pub(crate) struct BidiStreamingHandlerWrapper<H, Req, Res>
 where
     H: BidiStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
     Res: Message + Send + 'static,
 {
     handler: Arc<H>,
@@ -611,7 +609,7 @@ where
 impl<H, Req, Res> BidiStreamingHandlerWrapper<H, Req, Res>
 where
     H: BidiStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
     Res: Message + Send + 'static,
 {
     /// Create a new wrapper around the given bidi streaming handler.
@@ -626,7 +624,7 @@ where
 impl<H, Req, Res> ErasedBidiStreamingHandler for BidiStreamingHandlerWrapper<H, Req, Res>
 where
     H: BidiStreamingHandler<Req, Res>,
-    Req: Message + DeserializeOwned + Send + 'static,
+    Req: Message + JsonDeserialize + Send + 'static,
     Res: Message + Send + 'static,
 {
     fn call_erased(
@@ -663,7 +661,7 @@ pub(crate) fn decode_request_view<ReqView>(
 ) -> Result<OwnedView<ReqView>, ConnectError>
 where
     ReqView: MessageView<'static> + Send,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
 {
     let body = request_proto_bytes::<ReqView::Owned>(request, format)?;
     OwnedView::<ReqView>::decode(body)
@@ -687,14 +685,12 @@ where
 #[doc(hidden)] // exposed only for dispatcher::codegen (generated code)
 pub fn request_proto_bytes<Req>(request: Bytes, format: CodecFormat) -> Result<Bytes, ConnectError>
 where
-    Req: Message + DeserializeOwned,
+    Req: Message + JsonDeserialize,
 {
     match format {
         CodecFormat::Proto => Ok(request),
         CodecFormat::Json => {
-            let owned: Req = serde_json::from_slice(&request).map_err(|e| {
-                ConnectError::invalid_argument(format!("failed to decode JSON request: {e}"))
-            })?;
+            let owned: Req = decode_json(&request[..])?;
             Ok(Bytes::from(owned.encode_to_vec()))
         }
     }
@@ -798,7 +794,7 @@ pub(crate) struct UnaryViewHandlerWrapper<H, ReqView>
 where
     H: ViewHandler<ReqView>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(ReqView)>,
@@ -808,7 +804,7 @@ impl<H, ReqView> UnaryViewHandlerWrapper<H, ReqView>
 where
     H: ViewHandler<ReqView>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
 {
     pub fn new(handler: H) -> Self {
         Self {
@@ -822,7 +818,7 @@ impl<H, ReqView> ErasedHandler for UnaryViewHandlerWrapper<H, ReqView>
 where
     H: ViewHandler<ReqView>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
 {
     fn call_erased(
         &self,
@@ -915,7 +911,7 @@ pub(crate) struct ServerStreamingViewHandlerWrapper<H, ReqView, Res>
 where
     H: ViewStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
     Res: Message + Send + 'static,
 {
     handler: Arc<H>,
@@ -926,7 +922,7 @@ impl<H, ReqView, Res> ServerStreamingViewHandlerWrapper<H, ReqView, Res>
 where
     H: ViewStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
     Res: Message + Send + 'static,
 {
     pub fn new(handler: H) -> Self {
@@ -941,7 +937,7 @@ impl<H, ReqView, Res> ErasedStreamingHandler for ServerStreamingViewHandlerWrapp
 where
     H: ViewStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
     Res: Message + Send + 'static,
 {
     fn call_erased(
@@ -1026,7 +1022,7 @@ pub(crate) struct ClientStreamingViewHandlerWrapper<H, ReqView>
 where
     H: ViewClientStreamingHandler<ReqView>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
 {
     handler: Arc<H>,
     _phantom: std::marker::PhantomData<fn(ReqView)>,
@@ -1036,7 +1032,7 @@ impl<H, ReqView> ClientStreamingViewHandlerWrapper<H, ReqView>
 where
     H: ViewClientStreamingHandler<ReqView>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
 {
     pub fn new(handler: H) -> Self {
         Self {
@@ -1050,7 +1046,7 @@ impl<H, ReqView> ErasedClientStreamingHandler for ClientStreamingViewHandlerWrap
 where
     H: ViewClientStreamingHandler<ReqView>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
 {
     fn call_erased(
         &self,
@@ -1142,7 +1138,7 @@ pub(crate) struct BidiStreamingViewHandlerWrapper<H, ReqView, Res>
 where
     H: ViewBidiStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
     Res: Message + Send + 'static,
 {
     handler: Arc<H>,
@@ -1153,7 +1149,7 @@ impl<H, ReqView, Res> BidiStreamingViewHandlerWrapper<H, ReqView, Res>
 where
     H: ViewBidiStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
     Res: Message + Send + 'static,
 {
     pub fn new(handler: H) -> Self {
@@ -1169,7 +1165,7 @@ impl<H, ReqView, Res> ErasedBidiStreamingHandler
 where
     H: ViewBidiStreamingHandler<ReqView, Res>,
     ReqView: MessageView<'static> + Send + Sync + 'static,
-    ReqView::Owned: Message + DeserializeOwned,
+    ReqView::Owned: Message + JsonDeserialize,
     Res: Message + Send + 'static,
 {
     fn call_erased(
@@ -1205,6 +1201,7 @@ mod tests {
         assert_eq!(decoded.value, "hello");
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_decode_request_json() {
         let encoded = Bytes::from_static(b"\"world\"");
@@ -1219,6 +1216,7 @@ mod tests {
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_decode_request_json_invalid() {
         let garbage = Bytes::from_static(b"not json");
@@ -1234,11 +1232,33 @@ mod tests {
         assert_eq!(view.reborrow().value, "view-test");
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_decode_request_view_json() {
         let encoded = Bytes::from_static(b"\"json-view\"");
         let view = decode_request_view::<StringValueView>(encoded, CodecFormat::Json).unwrap();
         assert_eq!(view.reborrow().value, "json-view");
+    }
+
+    // Proto-only build: the JSON request-decode arms (`decode_request` and
+    // `request_proto_bytes`, the latter reached via `decode_request_view`)
+    // are compiled out and report `Unimplemented`; proto decoding is
+    // unaffected (covered by the `*_proto` tests above).
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn decode_request_json_is_unimplemented_without_feature() {
+        let body = Bytes::from_static(b"\"world\"");
+        let err = decode_request::<StringValue>(&body, CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::Unimplemented);
+    }
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn decode_request_view_json_is_unimplemented_without_feature() {
+        let body = Bytes::from_static(b"\"world\"");
+        let err = decode_request_view::<StringValueView>(body, CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::Unimplemented);
     }
 
     #[test]
@@ -1289,6 +1309,7 @@ mod tests {
         assert!(out.next().await.is_none());
     }
 
+    #[cfg(feature = "json")]
     #[tokio::test]
     async fn encode_body_stream_pre_encoded_json_decodes_per_item() {
         use crate::PreEncoded;

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -319,7 +319,11 @@ pub use interceptor::unary_interceptor;
 // ============================================================================
 
 pub use codec::CodecFormat;
+#[cfg(feature = "json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub use codec::JsonCodec;
+pub use codec::JsonDeserialize;
+pub use codec::JsonSerialize;
 pub use codec::ProtoCodec;
 
 // ============================================================================

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -151,6 +151,7 @@
 //!
 //! | Feature | Default | Description |
 //! |---------|---------|-------------|
+//! | `json` | ✓ | JSON codec for protobuf messages; disable for proto-only builds |
 //! | `gzip` | ✓ | Gzip compression |
 //! | `zstd` | ✓ | Zstandard compression |
 //! | `streaming` | ✓ | Streaming compression support |

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -26,10 +26,11 @@ use std::sync::OnceLock;
 use buffa::Message;
 use buffa::view::{MessageView, OwnedView};
 use bytes::Bytes;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 
-use crate::codec::{CodecFormat, decode_json, decode_proto, encode_json, encode_proto};
+use crate::codec::{
+    CodecFormat, JsonDeserialize, JsonSerialize, decode_json, decode_proto, encode_json,
+    encode_proto,
+};
 use crate::error::ConnectError;
 
 /// Object-safe, type-erased RPC message.
@@ -40,7 +41,7 @@ use crate::error::ConnectError;
 /// interceptor swaps it.
 ///
 /// You will almost never implement this trait directly. A blanket
-/// implementation covers every type that is `Message + Serialize`, which
+/// implementation covers every type that is `Message + JsonSerialize`, which
 /// includes every owned message the code generator emits. A manual impl
 /// must uphold a round-trip invariant: bytes returned by
 /// [`encode`](AnyMessage::encode)`(format)` must decode back to an
@@ -77,7 +78,7 @@ pub trait AnyMessage: Send + Sync + 'static {
 impl<T> AnyMessage for T
 where
     // Message already requires Send + Sync as supertraits.
-    T: Message + Serialize + 'static,
+    T: Message + JsonSerialize + 'static,
 {
     fn as_any(&self) -> &dyn Any {
         self
@@ -175,7 +176,7 @@ impl Payload {
     ///   holds whichever type decoded first.
     pub fn message<M>(&self) -> Result<&M, ConnectError>
     where
-        M: Message + Serialize + DeserializeOwned + 'static,
+        M: Message + JsonSerialize + JsonDeserialize + 'static,
     {
         if let Some(replaced) = &self.replaced {
             return replaced.as_any().downcast_ref::<M>().ok_or_else(|| {
@@ -246,10 +247,10 @@ impl Payload {
     pub fn take_message<M>(self) -> Result<M, ConnectError>
     where
         // Unlike `message()`, this never *populates* the cache, so it
-        // does not need `M: Serialize` (the bound `message()` carries to
+        // does not need `M: JsonSerialize` (the bound `message()` carries to
         // box `M` as `dyn AnyMessage`). It only reads the cache or
         // decodes fresh.
-        M: Message + DeserializeOwned + 'static,
+        M: Message + JsonDeserialize + 'static,
     {
         if let Some(replaced) = self.replaced {
             let type_name = replaced.type_name();
@@ -397,6 +398,7 @@ mod tests {
         assert!(std::ptr::eq(m1, m2), "second call should hit the cache");
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn message_decodes_json() {
         let bytes = encode_json(&StringValue {
@@ -424,6 +426,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn view_errors_on_json() {
         let bytes = encode_json(&StringValue {
@@ -464,6 +467,7 @@ mod tests {
         assert_eq!(orig.value, "before");
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn set_message_round_trips_json_format() {
         let bytes = encode_json(&StringValue {
@@ -517,6 +521,31 @@ mod tests {
         assert_eq!(err.code, ErrorCode::InvalidArgument, "{err:?}");
     }
 
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn message_json_format_is_unimplemented_without_feature() {
+        // A JSON-format payload can't be decoded in a proto-only build; the
+        // codec reports `Unimplemented` rather than attempting serde.
+        let p = Payload::new(Bytes::from_static(b"{}"), CodecFormat::Json);
+        assert_eq!(
+            p.message::<StringValue>().unwrap_err().code,
+            crate::ErrorCode::Unimplemented
+        );
+        // Proto-format payloads still decode normally.
+        assert!(proto_payload("ok").message::<StringValue>().is_ok());
+    }
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn take_message_json_format_is_unimplemented_without_feature() {
+        let p = Payload::new(Bytes::from_static(b"{}"), CodecFormat::Json);
+        assert_eq!(
+            p.take_message::<StringValue>().unwrap_err().code,
+            crate::ErrorCode::Unimplemented
+        );
+        assert!(proto_payload("ok").take_message::<StringValue>().is_ok());
+    }
+
     #[test]
     fn message_replacement_wrong_type_errors() {
         use buffa_types::google::protobuf::Int32Value;
@@ -534,6 +563,7 @@ mod tests {
         assert!(msg.contains("StringValue"), "{err:?}");
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn view_replaced_json_format_payload() {
         // A replacement is always re-encoded to proto for view(), so a

--- a/connectrpc/src/protocol.rs
+++ b/connectrpc/src/protocol.rs
@@ -136,8 +136,14 @@ impl Protocol {
 
         // Check Connect streaming
         if let Some(rest) = content_type.strip_prefix("application/connect+") {
+            // The `json` arm is gated: with the `json` feature off this is a
+            // proto-only build, so a JSON content type is an unsupported media
+            // type and must be rejected here at negotiation (the caller maps a
+            // `None` to HTTP 415 / a gRPC "unsupported content type" error)
+            // rather than accepted and failed late at decode.
             let codec_format = match rest {
                 "proto" => CodecFormat::Proto,
+                #[cfg(feature = "json")]
                 "json" => CodecFormat::Json,
                 _ => return None,
             };
@@ -149,7 +155,9 @@ impl Protocol {
             });
         }
 
-        // Check Connect unary
+        // Check Connect unary. `application/json` is gated for the same reason
+        // as the streaming `+json` arm above: a proto-only build rejects it as
+        // an unsupported media type.
         match content_type {
             "application/proto" => Some(RequestProtocol {
                 protocol: Protocol::Connect,
@@ -157,6 +165,7 @@ impl Protocol {
                 is_streaming: false,
                 is_text_mode: false,
             }),
+            #[cfg(feature = "json")]
             "application/json" => Some(RequestProtocol {
                 protocol: Protocol::Connect,
                 codec_format: CodecFormat::Json,
@@ -176,6 +185,10 @@ impl Protocol {
         match suffix {
             "" => Some(CodecFormat::Proto),
             "+proto" => Some(CodecFormat::Proto),
+            // Gated: a proto-only build (no `json` feature) rejects
+            // `application/grpc+json` / `application/grpc-web+json` as an
+            // unsupported codec at negotiation.
+            #[cfg(feature = "json")]
             "+json" => Some(CodecFormat::Json),
             _ => None,
         }
@@ -277,6 +290,7 @@ mod tests {
         assert!(!result.is_streaming);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_detect_connect_unary_json() {
         let result = Protocol::detect_from_content_type("application/json").unwrap();
@@ -293,6 +307,7 @@ mod tests {
         assert!(result.is_streaming);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_detect_connect_streaming_json() {
         let result = Protocol::detect_from_content_type("application/connect+json").unwrap();
@@ -316,6 +331,7 @@ mod tests {
         assert_eq!(result.codec_format, CodecFormat::Proto);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_detect_grpc_json() {
         let result = Protocol::detect_from_content_type("application/grpc+json").unwrap();
@@ -338,6 +354,7 @@ mod tests {
         assert_eq!(result.codec_format, CodecFormat::Proto);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_detect_grpc_web_json() {
         let result = Protocol::detect_from_content_type("application/grpc-web+json").unwrap();
@@ -373,11 +390,47 @@ mod tests {
         assert!(Protocol::detect_from_content_type("application/grpc-web-text+json").is_none());
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn test_detect_with_charset_parameter() {
         let result = Protocol::detect_from_content_type("application/json; charset=utf-8").unwrap();
         assert_eq!(result.protocol, Protocol::Connect);
         assert_eq!(result.codec_format, CodecFormat::Json);
+    }
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn test_detect_with_charset_parameter_proto_only() {
+        // Charset stripping still applies in a proto-only build.
+        let result =
+            Protocol::detect_from_content_type("application/proto; charset=utf-8").unwrap();
+        assert_eq!(result.protocol, Protocol::Connect);
+        assert_eq!(result.codec_format, CodecFormat::Proto);
+    }
+
+    // Proto-only build (no `json` feature): every JSON content type is an
+    // unsupported media type and must be declined at negotiation, so the
+    // dispatch layer maps it to HTTP 415 / a gRPC "unsupported content type"
+    // error rather than accepting it and failing late at decode.
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn test_detect_json_content_types_rejected_without_feature() {
+        for ct in [
+            "application/json",
+            "application/json; charset=utf-8",
+            "application/connect+json",
+            "application/grpc+json",
+            "application/grpc-web+json",
+        ] {
+            assert!(
+                Protocol::detect_from_content_type(ct).is_none(),
+                "{ct} must not be detected in a proto-only build"
+            );
+        }
+        // Proto content types are still detected.
+        assert!(Protocol::detect_from_content_type("application/proto").is_some());
+        assert!(Protocol::detect_from_content_type("application/connect+proto").is_some());
+        assert!(Protocol::detect_from_content_type("application/grpc+proto").is_some());
     }
 
     #[test]

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -18,9 +18,10 @@ use bytes::Bytes;
 use futures::Stream;
 use http::HeaderMap;
 use http::header::{HeaderName, HeaderValue};
-use serde::Serialize;
 
 use crate::codec::CodecFormat;
+use crate::codec::JsonSerialize;
+use crate::codec::encode_json;
 use crate::error::ConnectError;
 
 // ---------------------------------------------------------------------------
@@ -503,7 +504,7 @@ pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> +
 ///
 /// This is the bound on the response body in generated trait methods.
 /// Provided implementations:
-/// - the owned `M` itself (blanket `M: Message + Serialize` below);
+/// - the owned `M` itself (blanket `M: Message + JsonSerialize` below);
 /// - `MView<'_>` and [`OwnedView<MView<'static>>`](buffa::view::OwnedView),
 ///   emitted by codegen per RPC output type;
 /// - [`MaybeBorrowed<M, V>`] for handlers that conditionally return
@@ -529,13 +530,11 @@ pub trait Encodable<M> {
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError>;
 }
 
-impl<M: Message + Serialize> Encodable<M> for M {
+impl<M: Message + JsonSerialize> Encodable<M> for M {
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError> {
         match codec {
             CodecFormat::Proto => Ok(self.encode_to_bytes()),
-            CodecFormat::Json => serde_json::to_vec(self).map(Bytes::from).map_err(|e| {
-                ConnectError::internal(format!("failed to encode JSON response: {e}"))
-            }),
+            CodecFormat::Json => encode_json(self),
         }
     }
 }
@@ -547,7 +546,7 @@ impl<M: Message + Serialize> Encodable<M> for M {
 /// Used by codegen-emitted `impl Encodable<Foo> for FooView<'_>` /
 /// `impl Encodable<Foo> for OwnedView<FooView<'static>>` blocks. A
 /// runtime blanket on [`OwnedView`](buffa::view::OwnedView) would
-/// conflict with the `M: Message + Serialize` blanket above (coherence
+/// conflict with the `M: Message + JsonSerialize` blanket above (coherence
 /// can't rule out upstream adding `Message`/`Serialize` for
 /// `OwnedView`), so the impls are emitted per output type instead.
 #[doc(hidden)]
@@ -611,7 +610,7 @@ pub enum MaybeBorrowed<M, V> {
 
 impl<M, V> Encodable<M> for MaybeBorrowed<M, V>
 where
-    // satisfied via the blanket impl for M: Message + Serialize
+    // satisfied via the blanket impl for M: Message + JsonSerialize
     M: Encodable<M>,
     V: Encodable<M>,
 {
@@ -854,19 +853,19 @@ impl<M: Message> From<&M> for PreEncoded<M> {
 }
 
 // Coherence: this impl is non-overlapping with the
-// `impl<M: Message + Serialize> Encodable<M> for M` blanket above for
+// `impl<M: Message + JsonSerialize> Encodable<M> for M` blanket above for
 // structural reasons. For the two to overlap, some `T` would have to satisfy
-// both `T: Encodable<T>` (blanket, with `T: Message + Serialize`) and
+// both `T: Encodable<T>` (blanket, with `T: Message + JsonSerialize`) and
 // `T = PreEncoded<U>` with `T: Encodable<U>` (this impl) for the *same* trait
 // parameter — i.e. `T = U`, i.e. `PreEncoded<U> = U`, which is infinite. So
 // the impls cannot overlap even if a future change made `PreEncoded` a
 // `Message` (which would only add `PreEncoded<M>: Encodable<PreEncoded<M>>` —
 // a different trait instantiation). No invariant to maintain here.
 //
-// The `M: Message + Serialize` bound matches the blanket so a `PreEncoded<M>`
+// The `M: Message + JsonSerialize` bound matches the blanket so a `PreEncoded<M>`
 // is `Encodable<M>` exactly when an owned `M` would be — and is what makes the
 // JSON fallback path possible (decode as `M`, re-serialize).
-impl<M: Message + Serialize> Encodable<M> for PreEncoded<M> {
+impl<M: Message + JsonSerialize> Encodable<M> for PreEncoded<M> {
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError> {
         match codec {
             CodecFormat::Proto => Ok(self.bytes.clone()),
@@ -882,9 +881,7 @@ impl<M: Message + Serialize> Encodable<M> for PreEncoded<M> {
                         std::any::type_name::<M>(),
                     ))
                 })?;
-                serde_json::to_vec(&msg).map(Bytes::from).map_err(|e| {
-                    ConnectError::internal(format!("failed to encode JSON response: {e}"))
-                })
+                encode_json(&msg)
             }
         }
     }
@@ -986,6 +983,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn encodable_owned_json() {
         let m = StringValue::from("hello");
@@ -1212,6 +1210,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn pre_encoded_json_decodes_then_serializes() {
         // The JSON path round-trips: proto bytes → owned `M` → JSON. Slow,
@@ -1224,6 +1223,7 @@ mod tests {
         assert_eq!(out, Bytes::from(serde_json::to_vec(&m).unwrap()));
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn pre_encoded_json_decode_failure_is_internal_error() {
         // `from_bytes_unchecked` is unvalidated on the proto path. The JSON
@@ -1274,6 +1274,7 @@ mod tests {
         assert_eq!(out2, out);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn pre_encoded_codec_fidelity_diverges_on_unknown_fields() {
         // Documents the codec-dependent fidelity caveat: the proto path
@@ -1302,6 +1303,29 @@ mod tests {
             json,
             Bytes::from(serde_json::to_vec(&StringValue::from("hi")).unwrap())
         );
+    }
+
+    // --- proto-only (json feature disabled) fallback behaviour ---
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn encodable_owned_json_is_unimplemented_without_feature() {
+        let m = StringValue::from("hello");
+        // Proto still encodes normally...
+        assert!(Encodable::<StringValue>::encode(&m, CodecFormat::Proto).is_ok());
+        // ...but the JSON codec is compiled out and reports it cleanly.
+        let err = Encodable::<StringValue>::encode(&m, CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Unimplemented);
+    }
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn pre_encoded_json_is_unimplemented_without_feature() {
+        let m = StringValue::from("hi");
+        let body = PreEncoded::<StringValue>::from_bytes_unchecked(m.encode_to_bytes());
+        assert!(Encodable::<StringValue>::encode(&body, CodecFormat::Proto).is_ok());
+        let err = Encodable::<StringValue>::encode(&body, CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Unimplemented);
     }
 
     #[test]

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -6,11 +6,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use buffa::Message;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 
 use buffa::view::MessageView;
 
+use crate::codec::{JsonDeserialize, JsonSerialize};
 use crate::handler::BidiStreamingHandler;
 use crate::handler::BidiStreamingHandlerWrapper;
 use crate::handler::BidiStreamingViewHandlerWrapper;
@@ -142,8 +141,8 @@ impl Router {
     pub fn route<H, Req, Res>(self, service_name: &str, method_name: &str, handler: H) -> Self
     where
         H: Handler<Req, Res>,
-        Req: Message + DeserializeOwned + Send + 'static,
-        Res: Message + Serialize + Send + 'static,
+        Req: Message + JsonDeserialize + Send + 'static,
+        Res: Message + JsonSerialize + Send + 'static,
     {
         self.route_unary_internal(service_name, method_name, handler, false)
     }
@@ -176,8 +175,8 @@ impl Router {
     ) -> Self
     where
         H: Handler<Req, Res>,
-        Req: Message + DeserializeOwned + Send + 'static,
-        Res: Message + Serialize + Send + 'static,
+        Req: Message + JsonDeserialize + Send + 'static,
+        Res: Message + JsonSerialize + Send + 'static,
     {
         self.route_unary_internal(service_name, method_name, handler, true)
     }
@@ -192,8 +191,8 @@ impl Router {
     ) -> Self
     where
         H: Handler<Req, Res>,
-        Req: Message + DeserializeOwned + Send + 'static,
-        Res: Message + Serialize + Send + 'static,
+        Req: Message + JsonDeserialize + Send + 'static,
+        Res: Message + JsonSerialize + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = UnaryHandlerWrapper::new(handler);
@@ -232,7 +231,7 @@ impl Router {
     ) -> Self
     where
         H: StreamingHandler<Req, Res>,
-        Req: Message + DeserializeOwned + Send + 'static,
+        Req: Message + JsonDeserialize + Send + 'static,
         Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
@@ -259,8 +258,8 @@ impl Router {
     ) -> Self
     where
         H: ClientStreamingHandler<Req, Res>,
-        Req: Message + DeserializeOwned + Send + 'static,
-        Res: Message + Serialize + Send + 'static,
+        Req: Message + JsonDeserialize + Send + 'static,
+        Res: Message + JsonSerialize + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ClientStreamingHandlerWrapper::new(handler);
@@ -285,7 +284,7 @@ impl Router {
     ) -> Self
     where
         H: BidiStreamingHandler<Req, Res>,
-        Req: Message + DeserializeOwned + Send + 'static,
+        Req: Message + JsonDeserialize + Send + 'static,
         Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
@@ -309,7 +308,7 @@ impl Router {
     where
         H: ViewHandler<ReqView>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
-        ReqView::Owned: Message + DeserializeOwned,
+        ReqView::Owned: Message + JsonDeserialize,
     {
         self.route_view_internal(service_name, method_name, handler, false)
     }
@@ -324,7 +323,7 @@ impl Router {
     where
         H: ViewHandler<ReqView>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
-        ReqView::Owned: Message + DeserializeOwned,
+        ReqView::Owned: Message + JsonDeserialize,
     {
         self.route_view_internal(service_name, method_name, handler, true)
     }
@@ -340,7 +339,7 @@ impl Router {
     where
         H: ViewHandler<ReqView>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
-        ReqView::Owned: Message + DeserializeOwned,
+        ReqView::Owned: Message + JsonDeserialize,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = UnaryViewHandlerWrapper::new(handler);
@@ -365,7 +364,7 @@ impl Router {
     where
         H: ViewStreamingHandler<ReqView, Res>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
-        ReqView::Owned: Message + DeserializeOwned,
+        ReqView::Owned: Message + JsonDeserialize,
         Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");
@@ -391,7 +390,7 @@ impl Router {
     where
         H: ViewClientStreamingHandler<ReqView>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
-        ReqView::Owned: Message + DeserializeOwned,
+        ReqView::Owned: Message + JsonDeserialize,
     {
         let path = format!("{service_name}/{method_name}");
         let wrapper = ClientStreamingViewHandlerWrapper::new(handler);
@@ -415,7 +414,7 @@ impl Router {
     where
         H: ViewBidiStreamingHandler<ReqView, Res>,
         ReqView: MessageView<'static> + Send + Sync + 'static,
-        ReqView::Owned: Message + DeserializeOwned,
+        ReqView::Owned: Message + JsonDeserialize,
         Res: Message + Send + 'static,
     {
         let path = format!("{service_name}/{method_name}");

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -1447,6 +1447,16 @@ where
         span.record("codec", tracing::field::display(rp.codec_format));
     }
 
+    // Only GET and POST carry RPCs. Reject every other verb uniformly with
+    // 405 Method Not Allowed plus an `Allow` header (connect-go parity),
+    // regardless of whether a Content-Type is present. Without this, a bodyless
+    // OPTIONS/HEAD request (no Content-Type, so protocol detection returns
+    // None) would fall through to the unsupported-media-type path and be
+    // misreported as 415. An unknown path still maps to 404.
+    if req.method() != Method::GET && req.method() != Method::POST {
+        return reject_unsupported_method(&*dispatcher, req, limits, deadline_policy).await;
+    }
+
     // Connect GET requests don't have a Content-Type header, so protocol
     // detection returns None. Route GET requests directly to the unary handler
     // which handles Connect GET query parameter parsing.
@@ -1464,13 +1474,12 @@ where
         .map(|r| r.map(ConnectRpcBody::Full));
     }
 
-    // Check for gRPC/gRPC-Web content type prefix with unsupported codec
-    // (e.g., application/grpc+thrift). We need to return a gRPC-style error
-    // rather than falling through to the Connect unary handler.
-    //
-    // For HTTP/2 requests with completely unknown content types, also return
-    // a gRPC error since gRPC requires HTTP/2 and the client likely expects
-    // gRPC framing. For HTTP/1.1, fall through to the Connect handler.
+    // Content type didn't resolve to a known protocol+codec. A gRPC/gRPC-Web
+    // prefix with an unsupported codec (e.g. application/grpc+thrift, or
+    // application/grpc+json in a proto-only build) returns a gRPC-style error so
+    // the client gets gRPC framing it can parse. Any other unrecognized content
+    // type returns HTTP 415 Unsupported Media Type with an `Accept-Post` header
+    // advertising the content types this server does accept.
     if request_protocol.is_none() {
         let ct = req
             .headers()
@@ -1510,11 +1519,14 @@ where
             return Ok(response.map(ConnectRpcBody::Streaming));
         } else {
             // Unknown content type that doesn't match any protocol.
-            // Return HTTP 415 Unsupported Media Type with no body.
-            // All protocol clients (Connect, gRPC, gRPC-Web) can handle
-            // non-200 HTTP status codes by mapping to an appropriate error.
+            // Return HTTP 415 Unsupported Media Type with no body, advertising
+            // the content types we do accept via `Accept-Post` (connect-go
+            // parity). The empty body means clients map the 415 status to an
+            // error code (Connect: unknown) per the protocol's HTTP-status
+            // mapping.
             let response = Response::builder()
                 .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
+                .header("accept-post", ACCEPT_POST)
                 .body(Full::new(Bytes::new()))
                 .unwrap();
             return Ok(response.map(ConnectRpcBody::Full));
@@ -1604,6 +1616,85 @@ where
             .await
             .map(|r| r.map(ConnectRpcBody::Full))
         }
+    }
+}
+
+/// `Accept-Post` advertised on a 415 response: the content types this server
+/// accepts. JSON media types appear only when the `json` feature is enabled — a
+/// proto-only build advertises proto-only. gRPC-Web text mode is intentionally
+/// omitted: the server detects but rejects it (`Unimplemented`), so it must not
+/// be advertised as accepted.
+#[cfg(feature = "json")]
+const ACCEPT_POST: &str = "application/connect+json, application/connect+proto, \
+application/grpc, application/grpc+json, application/grpc+proto, \
+application/grpc-web, application/grpc-web+json, application/grpc-web+proto, \
+application/json, application/proto";
+
+/// See the `json`-enabled variant; a proto-only build drops every JSON media
+/// type so it never advertises a codec it cannot serve.
+#[cfg(not(feature = "json"))]
+const ACCEPT_POST: &str = "application/connect+proto, application/grpc, \
+application/grpc+proto, application/grpc-web, application/grpc-web+proto, \
+application/proto";
+
+/// Reject an HTTP method other than GET or POST.
+///
+/// Mirrors connect-go: a known procedure path returns 405 Method Not Allowed
+/// with an `Allow` header listing the methods it accepts (always `POST`; plus
+/// `GET` for idempotent unary methods). An unknown path returns the same
+/// `unimplemented` (HTTP 404) as any other route miss. The request body is
+/// drained first so HTTP/1.1 connections stay reusable.
+async fn reject_unsupported_method<D, B>(
+    dispatcher: &D,
+    req: Request<B>,
+    limits: Limits,
+    deadline_policy: &DeadlinePolicy,
+) -> Result<Response<ConnectRpcBody>, ConnectError>
+where
+    D: Dispatcher,
+    B: Body<Data = Bytes> + Send + 'static,
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let raw_path = req.uri().path();
+    let path = raw_path.strip_prefix('/').unwrap_or(raw_path).to_owned();
+    let allow = dispatcher.lookup(&path).map(|desc| {
+        if desc.kind == MethodKind::Unary && desc.idempotent {
+            "GET, POST"
+        } else {
+            "POST"
+        }
+    });
+
+    // Drain the request body so an early response doesn't break HTTP/1.1
+    // keep-alive (see the streaming body-drop race notes).
+    let deadline = deadline_from_headers(
+        req.headers(),
+        Protocol::Connect,
+        req.uri().path(),
+        deadline_policy,
+    );
+    let (_parts, body) = req.into_parts();
+    let _ = with_request_deadline(
+        deadline,
+        collect_body_limited(body, limits.max_request_body_size),
+    )
+    .await;
+
+    match allow {
+        // Bare 405 with `Allow`: the empty body makes the client map the 405
+        // status to an error code (Connect: unknown) per the HTTP-status table.
+        Some(allow) => {
+            let response = Response::builder()
+                .status(StatusCode::METHOD_NOT_ALLOWED)
+                .header(header::ALLOW, allow)
+                .body(Full::new(Bytes::new()))
+                .unwrap();
+            Ok(response.map(ConnectRpcBody::Full))
+        }
+        None => Err(
+            ConnectError::unimplemented(format!("method not found: {path}"))
+                .with_http_status(StatusCode::NOT_FOUND),
+        ),
     }
 }
 
@@ -1731,6 +1822,8 @@ where
 
         (body, codec_format)
     } else {
+        // Backstop: `handle_request` rejects every non-GET/POST verb upstream
+        // (with 405 + `Allow`), so this arm is unreachable in normal dispatch.
         return Err(ConnectError::method_not_allowed(
             "only GET and POST methods are supported",
         ));
@@ -1872,7 +1965,8 @@ where
         })
     };
 
-    // gRPC requires POST
+    // gRPC requires POST. Backstop: `handle_request` already rejects non-GET/
+    // POST verbs upstream, and GET never routes here, so this is defensive.
     if req.method() != Method::POST {
         let err = ConnectError::internal(format!("invalid method for gRPC: {}", req.method()));
         // Drain the request body to avoid broken pipe on HTTP/1.1.
@@ -2091,7 +2185,8 @@ where
     let mut metadata = RequestMetadata::from_headers(req.headers(), protocol);
     metadata.timeout = deadline_policy.moderate(metadata.timeout, &path);
 
-    // gRPC and gRPC-Web require POST method
+    // gRPC and gRPC-Web require POST method. Backstop: non-GET/POST verbs are
+    // already rejected upstream in `handle_request`, and GET never routes here.
     if matches!(protocol, Protocol::Grpc | Protocol::GrpcWeb) && req.method() != Method::POST {
         let err = ConnectError::internal(format!("invalid method for gRPC: {}", req.method()));
         // Drain the request body to avoid broken pipe on HTTP/1.1.
@@ -4225,6 +4320,10 @@ mod tests {
         assert!(trailer_text.contains("grpc-status: 7"), "{trailer_text:?}");
     }
 
+    // Echoing a JSON request codec into the error response only applies when
+    // the `json` feature is on; a proto-only build declines JSON content types
+    // at negotiation, so these scenarios are unreachable there.
+    #[cfg(feature = "json")]
     #[tokio::test]
     async fn into_http_response_connect_streaming_json_codec() {
         // The codec format from the request Content-Type must round-trip into
@@ -4240,6 +4339,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "json")]
     #[tokio::test]
     async fn into_http_response_grpc_json_codec() {
         let err = ConnectError::permission_denied("nope");
@@ -4253,6 +4353,188 @@ mod tests {
         assert_eq!(
             resp.headers().get(&GRPC_STATUS).unwrap(),
             &crate::ErrorCode::PermissionDenied.grpc_code().to_string()
+        );
+    }
+
+    // The Connect protocol requires HTTP 415 Unsupported Media Type when the
+    // server does not support the requested message codec. A proto-only build
+    // (no `json` feature) declines every JSON content type at content
+    // negotiation, before the request body is touched.
+    #[cfg(not(feature = "json"))]
+    #[tokio::test]
+    async fn proto_only_server_rejects_json_content_types_with_415() {
+        let dispatcher = Arc::new(Router::new());
+
+        for ct in ["application/json", "application/connect+json"] {
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("/svc/Method")
+                .header(header::CONTENT_TYPE, ct)
+                .body(Full::new(Bytes::new()))
+                .unwrap();
+            let resp = handle_request(
+                Arc::clone(&dispatcher),
+                req,
+                Limits::default(),
+                Arc::new(CompressionRegistry::new()),
+                &CompressionPolicy::default(),
+                &DeadlinePolicy::new(),
+                &[],
+            )
+            .await
+            .expect("415 is returned as an Ok response, not an Err");
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "{ct} must be rejected with HTTP 415 in a proto-only build"
+            );
+        }
+
+        // A proto request passes content negotiation (it fails later as
+        // route-not-found, not as a 415) — proving only JSON is declined.
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/svc/Method")
+            .header(header::CONTENT_TYPE, "application/proto")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let status = match handle_request(
+            Arc::clone(&dispatcher),
+            req,
+            Limits::default(),
+            Arc::new(CompressionRegistry::new()),
+            &CompressionPolicy::default(),
+            &DeadlinePolicy::new(),
+            &[],
+        )
+        .await
+        {
+            Ok(resp) => resp.status(),
+            Err(err) => err.http_status(),
+        };
+        assert_ne!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    // Mirrors connect-go: an unsupported HTTP verb on a known procedure returns
+    // 405 with an `Allow` header (POST, plus GET for idempotent unary methods);
+    // an unknown path returns 404. Also covers the bug where a bodyless
+    // OPTIONS/HEAD (no Content-Type) was previously misreported as 415.
+    #[tokio::test]
+    async fn unsupported_http_verb_returns_405_with_allow() {
+        let dispatcher = Arc::new(
+            Router::new()
+                .route(
+                    "svc",
+                    "Unary",
+                    crate::handler_fn(|_ctx: RequestContext, _req: buffa_types::Empty| async {
+                        crate::Response::ok(buffa_types::Empty::default())
+                    }),
+                )
+                .route_idempotent(
+                    "svc",
+                    "Get",
+                    crate::handler_fn(|_ctx: RequestContext, _req: buffa_types::Empty| async {
+                        crate::Response::ok(buffa_types::Empty::default())
+                    }),
+                ),
+        );
+
+        async fn call(
+            dispatcher: &Arc<Router>,
+            req: Request<Full<Bytes>>,
+        ) -> Result<Response<ConnectRpcBody>, ConnectError> {
+            handle_request(
+                Arc::clone(dispatcher),
+                req,
+                Limits::default(),
+                Arc::new(CompressionRegistry::new()),
+                &CompressionPolicy::default(),
+                &DeadlinePolicy::new(),
+                &[],
+            )
+            .await
+        }
+
+        // Non-idempotent unary procedure: Allow lists POST only. Includes a
+        // bodyless OPTIONS/HEAD with no Content-Type (the original 415 bug).
+        for (verb, with_ct) in [
+            (Method::DELETE, true),
+            (Method::PUT, true),
+            (Method::OPTIONS, false),
+            (Method::HEAD, false),
+        ] {
+            let mut builder = Request::builder().method(verb.clone()).uri("/svc/Unary");
+            if with_ct {
+                builder = builder.header(header::CONTENT_TYPE, "application/proto");
+            }
+            let req = builder.body(Full::new(Bytes::new())).unwrap();
+            let resp = call(&dispatcher, req)
+                .await
+                .expect("405 is returned as an Ok response");
+            assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED, "{verb}");
+            assert_eq!(resp.headers().get(header::ALLOW).unwrap(), "POST", "{verb}");
+        }
+
+        // Idempotent unary procedure: Allow also lists GET.
+        let req = Request::builder()
+            .method(Method::DELETE)
+            .uri("/svc/Get")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let resp = call(&dispatcher, req).await.expect("405");
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(resp.headers().get(header::ALLOW).unwrap(), "GET, POST");
+
+        // Unknown path with a bad verb maps to 404 route-not-found.
+        let req = Request::builder()
+            .method(Method::DELETE)
+            .uri("/svc/Missing")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let status = match call(&dispatcher, req).await {
+            Ok(resp) => resp.status(),
+            Err(err) => err.http_status(),
+        };
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    // A 415 advertises the content types the server accepts via `Accept-Post`
+    // (connect-go parity); a proto-only build never lists a JSON media type.
+    #[tokio::test]
+    async fn unknown_content_type_returns_415_with_accept_post() {
+        let dispatcher = Arc::new(Router::new());
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/svc/Method")
+            .header(header::CONTENT_TYPE, "application/foo")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let resp = handle_request(
+            Arc::clone(&dispatcher),
+            req,
+            Limits::default(),
+            Arc::new(CompressionRegistry::new()),
+            &CompressionPolicy::default(),
+            &DeadlinePolicy::new(),
+            &[],
+        )
+        .await
+        .expect("415 is returned as an Ok response");
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+        let accept_post = resp
+            .headers()
+            .get("accept-post")
+            .expect("415 advertises Accept-Post")
+            .to_str()
+            .unwrap();
+        assert!(accept_post.contains("application/proto"), "{accept_post}");
+        #[cfg(feature = "json")]
+        assert!(accept_post.contains("application/json"), "{accept_post}");
+        #[cfg(not(feature = "json"))]
+        assert!(
+            !accept_post.contains("json"),
+            "proto-only must not advertise json: {accept_post}"
         );
     }
 

--- a/connectrpc/src/stream_message.rs
+++ b/connectrpc/src/stream_message.rs
@@ -8,9 +8,10 @@
 
 use buffa::view::{OwnedView, ViewReborrow};
 use bytes::Bytes;
-use serde::Serialize;
 
 use crate::codec::CodecFormat;
+use crate::codec::JsonSerialize;
+use crate::codec::encode_json;
 use crate::error::ConnectError;
 use crate::request::HasMessageView;
 use crate::response::Encodable;
@@ -129,16 +130,12 @@ where
 /// the byte/HTTP layer instead.
 impl<M> Encodable<M> for StreamMessage<M>
 where
-    M: HasMessageView + Serialize,
+    M: HasMessageView + JsonSerialize,
 {
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError> {
         match codec {
             CodecFormat::Proto => Ok(self.inner.as_ref().bytes().clone()),
-            CodecFormat::Json => serde_json::to_vec(&self.to_owned_message())
-                .map(Bytes::from)
-                .map_err(|e| {
-                    ConnectError::internal(format!("failed to encode JSON response: {e}"))
-                }),
+            CodecFormat::Json => encode_json(&self.to_owned_message()),
         }
     }
 }
@@ -175,6 +172,7 @@ mod tests {
         assert_eq!(format!("{msg:?}"), format!("{cloned:?}"));
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn encodable_forwards_proto_bytes_without_reencoding() {
         let msg = message("forward me");
@@ -189,5 +187,16 @@ mod tests {
         let json = msg.encode(CodecFormat::Json).expect("json encode");
         let owned_json = serde_json::to_vec(&msg.to_owned_message()).unwrap();
         assert_eq!(json.as_ref(), owned_json.as_slice());
+    }
+
+    #[cfg(not(feature = "json"))]
+    #[test]
+    fn encode_json_is_unimplemented_without_feature() {
+        let msg = message("forward me");
+        // Proto forwarding still works in a proto-only build...
+        assert!(msg.encode(CodecFormat::Proto).is_ok());
+        // ...the JSON arm is compiled out and reports `Unimplemented`.
+        let err = msg.encode(CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Unimplemented);
     }
 }

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,6 +61,7 @@ The runtime is feature-gated so you only pay for what you use:
 
 | Feature | Default | What it adds |
 |---|---|---|
+| `json` | yes | JSON codec for protobuf messages (the proto3-JSON wire format). Disabling it drops the `serde` requirement on message types — see [Proto-only builds](#proto-only-no-json-builds) |
 | `gzip` | yes | Gzip compression via `flate2` |
 | `zstd` | yes | Zstandard compression via `zstd` |
 | `streaming` | yes | Streaming compression via `async-compression` |
@@ -86,6 +87,46 @@ connectrpc = { version = "0.7", features = ["server"] }
 # Minimal (wasm-friendly: no networking, no native compression)
 connectrpc = { version = "0.7", default-features = false }
 ```
+
+### Proto-only (no-JSON) builds
+
+The Connect protocol supports two message codecs: binary proto and proto3
+JSON. The JSON codec needs every message type to be `serde::Serialize` /
+`Deserialize`, which is why the code generator derives those impls by default.
+A deployment that only ever speaks binary proto can turn JSON off and shed
+those derives — smaller generated code, no `serde_derive` in the message-type
+build.
+
+It takes two coordinated settings:
+
+1. **Generate without serde derives.** Pass the `no_json` plugin option (or
+   `connectrpc-build`'s [`.generate_json(false)`](#connectrpc-build-build-time-simplest)),
+   so message structs are emitted without `#[derive(serde::Serialize,
+   serde::Deserialize)]`.
+2. **Disable the runtime `json` feature**, which relaxes the message-type
+   bounds from `Message + Serialize`/`DeserializeOwned` to just `Message`:
+
+   ```toml
+   # Proto-only server: no JSON codec, no serde on message types
+   connectrpc = { version = "0.7", default-features = false, features = ["server"] }
+   ```
+
+With `json` off, the `Message + serde` requirement is replaced by the
+`JsonSerialize` / `JsonDeserialize` marker traits, which become empty bounds —
+so a serde-free generated type still satisfies every handler, router, and
+client signature. If a JSON request
+nonetheless reaches a proto-only server, the codec returns a Connect
+`Unimplemented` error (the error body itself is still JSON, as the Connect spec
+requires regardless of the request codec).
+
+`connectrpc` itself still depends on `serde` and `serde_json` even in a
+proto-only build — the always-JSON error wire format needs them — so they stay
+in `cargo tree`. What proto-only mode removes is the serde *derive* on your
+generated message types and the per-message JSON (de)serialization paths.
+
+> View-body responses are already proto-only and return `Unimplemented` for the
+> JSON codec — see [Returning a view body](#returning-a-view-body) — so a
+> proto-only build changes nothing for them.
 
 ## Quick start
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -107,22 +107,43 @@ It takes two coordinated settings:
    bounds from `Message + Serialize`/`DeserializeOwned` to just `Message`:
 
    ```toml
-   # Proto-only server: no JSON codec, no serde on message types
-   connectrpc = { version = "0.7", default-features = false, features = ["server"] }
+   # Proto-only server: no JSON codec, no serde on message types.
+   # `default-features = false` is the only way to drop `json`, so it also drops
+   # the default compression features (`gzip`/`zstd`/`streaming`) — re-list the
+   # ones you still want.
+   connectrpc = { version = "0.7", default-features = false, features = ["server", "gzip", "zstd", "streaming"] }
    ```
 
 With `json` off, the `Message + serde` requirement is replaced by the
 `JsonSerialize` / `JsonDeserialize` marker traits, which become empty bounds —
 so a serde-free generated type still satisfies every handler, router, and
-client signature. If a JSON request
-nonetheless reaches a proto-only server, the codec returns a Connect
-`Unimplemented` error (the error body itself is still JSON, as the Connect spec
-requires regardless of the request codec).
+client signature.
+
+A proto-only server **rejects JSON at content negotiation**, before it touches
+the request body: `application/json` and `application/connect+json` (and the
+Connect GET `encoding=json` parameter) are unsupported media types, so the
+server responds with a bodyless **HTTP 415 Unsupported Media Type** (the client
+maps the status to an error code); `application/grpc+json` and
+`application/grpc-web+json` get a gRPC error status. Message-level encode/decode
+also returns `Unimplemented` as a defense-in-depth backstop. Handler-level
+errors (and the streaming end-of-stream frame) remain JSON, as the Connect spec
+requires regardless of the request codec. On the client side, the
+`ClientConfig::json` shorthand is removed from the API in a proto-only build, so
+JSON cannot be selected by mistake.
 
 `connectrpc` itself still depends on `serde` and `serde_json` even in a
 proto-only build — the always-JSON error wire format needs them — so they stay
 in `cargo tree`. What proto-only mode removes is the serde *derive* on your
 generated message types and the per-message JSON (de)serialization paths.
+
+Because `json` is an additive, default-on Cargo feature, it is only truly off
+when *every* crate in your dependency graph that depends on `connectrpc`
+disables it. If any other crate pulls in `connectrpc` with `json` enabled,
+feature unification turns it back on for the whole build, the markers revert to
+`Serialize`/`DeserializeOwned`, and your serde-free generated types stop
+compiling (`Serialize is not satisfied` — note the error names the trait, not
+the feature). Proto-only mode therefore fits a leaf binary or a fully
+proto-only graph, not one library inside a mixed workspace.
 
 > View-body responses are already proto-only and return `Unimplemented` for the
 > JSON codec — see [Returning a view body](#returning-a-view-body) — so a


### PR DESCRIPTION
## Motivation

Adding `serde` to **every** protobuf-generated type is a real compile-time tax. The Connect JSON codec requires `serde::Serialize`/`Deserialize` on every message type, so the code generator derives them by default — and for a workspace with many `.proto` files, those derives (and the `serde_derive` proc-macro expansion + monomorphized `serde_json` paths) add up across hundreds of generated structs. Crates that only ever speak **binary proto** pay that cost for nothing.

This adds a way to opt out: generate without serde derives, and compile against a `connectrpc` that doesn't demand them.

## What this does

A default-on **`json` cargo feature** on `connectrpc`. With it disabled (`default-features = false`):

- Message-type bounds relax from `Message + Serialize`/`DeserializeOwned` to just `Message`, via two new public marker traits **`JsonSerialize`/`JsonDeserialize`** (serde supertraits when `json` is on, empty blanket bounds when off). So types generated with the existing codegen **`no_json`** option (which drops the serde derives) compile against the runtime.
- JSON message encode/decode is gated at a **single point** — `codec::encode_json`/`decode_json` — which returns `Unimplemented` when the feature is off. A JSON request to a proto-only server gets a clean Connect error; content-type negotiation stays codec-agnostic.
- `connectrpc`'s `buffa` dependency is pinned directly (not `workspace = true`) so the feature truly gates `buffa/json` — a proto-only build resolves `buffa` with **no features**, shedding its JSON runtime too.

The Connect **error** and **end-of-stream** wire frames are always JSON per the protocol spec (they use connectrpc's own structs), so `serde`/`serde_json` stay required dependencies — only *message-type* JSON is gated.

## Proto-only recipe

```toml
# generate without serde derives: codegen `no_json`, or connectrpc-build's
# .generate_json(false)
connectrpc = { version = "0.7", default-features = false, features = ["server"] }
```

Verified `cargo tree -p connectrpc --no-default-features` resolves `buffa` with no features; with `json` on it shows `buffa json`.

## Implementation notes

- ~50 trait-bound sites swapped to the marker traits; all `CodecFormat::Json` message arms route through `encode_json`/`decode_json` (no per-site `#[cfg]`). One deliberate exception: the client's `decode_response_view` keeps an explicit gate to preserve its `internal` error code (response-decode semantics ≠ `decode_json`'s `invalid_argument`).
- Docs: proto-only section in the guide + README; `connectrpc-build::generate_json` and the codegen `no_json` option docs updated.

## Testing

- `cargo test -p connectrpc` (json on): **403 passed**.
- `cargo test -p connectrpc --no-default-features` (proto-only): **349 passed**, including new `#[cfg(not(feature = "json"))]` assertions that every fallback (response / payload / handler / stream_message / client) returns `Unimplemented`, plus a marker-empty-bound compile assertion.
- Clippy, nightly `fmt`, and `cargo doc --all-features` clean in both configs.

> Reviewed by the repo's `rust-code-reviewer` and `rust-api-ergonomics-reviewer` (no Critical/High/Medium outstanding).

## Follow-ups (out of scope)

- Workspace-wide `buffa`/`buffa-types` de-unification so `connectrpc-health` / `connectrpc-reflection` and other members can also shed `buffa/json` when proto-only.
- Matching `json` features on `connectrpc-health` / `connectrpc-reflection`.