### PR TITLE
feat(server): add with_max_concurrent_streams to Server and BoundServer

### DIFF
--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -43,6 +43,15 @@
 //! period. This is independent of whole-server graceful shutdown, which still
 //! drains in-flight requests indefinitely even while a connection is in its
 //! age-grace window.
+//!
+//! # Maximum Concurrent Streams
+//!
+//! Use [`Server::with_max_concurrent_streams`] (or the [`BoundServer`]
+//! equivalent) to bound the number of concurrent HTTP/2 streams (in-flight
+//! requests) a single connection may have open. This maps to hyper's
+//! `SETTINGS_MAX_CONCURRENT_STREAMS`; it is left at hyper's default (200)
+//! when unset. Raise it for high-fan-in internal services, or lower it as a
+//! cheap hardening measure against less-trusted clients.
 
 use std::any::Any;
 use std::collections::hash_map::RandomState;
@@ -158,6 +167,7 @@ pub struct Server {
     tls_handshake_timeout: std::time::Duration,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
+    max_concurrent_streams: Option<u32>,
 }
 
 impl Server {
@@ -172,6 +182,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_concurrent_streams: None,
         }
     }
 
@@ -186,6 +197,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_concurrent_streams: None,
         }
     }
 
@@ -353,6 +365,26 @@ impl Server {
         self
     }
 
+    /// Set the maximum number of concurrent HTTP/2 streams per connection.
+    ///
+    /// The one-step counterpart of
+    /// [`BoundServer::with_max_concurrent_streams`]; see it for full
+    /// behaviour. Left at hyper's default (200) when unset.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_streams` is zero; see
+    /// [`BoundServer::with_max_concurrent_streams`].
+    #[must_use]
+    pub fn with_max_concurrent_streams(mut self, max_streams: u32) -> Self {
+        assert!(
+            max_streams != 0,
+            "with_max_concurrent_streams requires a non-zero value",
+        );
+        self.max_concurrent_streams = Some(max_streams);
+        self
+    }
+
     fn connection_age_config(&self) -> Option<ConnectionAgeConfig> {
         build_connection_age_config(self.max_connection_age, self.max_connection_age_grace)
     }
@@ -393,6 +425,7 @@ impl Server {
             self.tls_handshake_timeout,
             None,
             connection_age,
+            self.max_concurrent_streams,
         )
         .await
     }
@@ -424,6 +457,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_concurrent_streams: None,
         }
     }
 
@@ -442,6 +476,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_concurrent_streams: None,
         })
     }
 }
@@ -456,6 +491,7 @@ pub struct BoundServer {
     tls_handshake_timeout: std::time::Duration,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
+    max_concurrent_streams: Option<u32>,
 }
 
 impl BoundServer {
@@ -532,6 +568,36 @@ impl BoundServer {
     #[must_use]
     pub fn with_max_connection_age_grace(mut self, grace: Duration) -> Self {
         self.max_connection_age_grace = grace;
+        self
+    }
+
+    /// Set the maximum number of concurrent HTTP/2 streams per connection.
+    ///
+    /// This maps to hyper's HTTP/2 `SETTINGS_MAX_CONCURRENT_STREAMS`, which
+    /// the server advertises to each peer. A client may have at most this
+    /// many in-flight requests (streams) open at once on a single connection;
+    /// attempts to exceed it are refused with a `REFUSED_STREAM` error and
+    /// can be safely retried. The setting has no effect on HTTP/1.1
+    /// connections, which are not multiplexed.
+    ///
+    /// Left at hyper's default (200) when unset. Raise it for high-fan-in
+    /// internal services that multiplex many concurrent RPCs over one
+    /// connection, or lower it as an additional hardening measure when
+    /// serving less-trusted clients.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_streams` is zero — advertising a limit of zero refuses
+    /// every stream, leaving a server that accepts connections but rejects
+    /// all requests. It is rejected at configuration time rather than
+    /// silently producing a dead server.
+    #[must_use]
+    pub fn with_max_concurrent_streams(mut self, max_streams: u32) -> Self {
+        assert!(
+            max_streams != 0,
+            "with_max_concurrent_streams requires a non-zero value",
+        );
+        self.max_concurrent_streams = Some(max_streams);
         self
     }
 
@@ -617,6 +683,7 @@ impl BoundServer {
             self.tls_handshake_timeout,
             None,
             connection_age,
+            self.max_concurrent_streams,
         )
         .await
     }
@@ -650,6 +717,7 @@ impl BoundServer {
             self.tls_handshake_timeout,
             Some(Box::pin(signal)),
             connection_age,
+            self.max_concurrent_streams,
         )
         .await
     }
@@ -714,6 +782,7 @@ async fn serve_accepted_stream<D, S>(
     http1_keep_alive: bool,
     global_shutdown: watch::Receiver<bool>,
     connection_age: Option<ConnectionAgeConfig>,
+    max_concurrent_streams: Option<u32>,
 ) where
     D: Dispatcher,
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
@@ -729,6 +798,9 @@ async fn serve_accepted_stream<D, S>(
 
     let mut builder = AutoBuilder::new(TokioExecutor::new());
     builder.http1().keep_alive(http1_keep_alive);
+    if let Some(max) = max_concurrent_streams {
+        builder.http2().max_concurrent_streams(max);
+    }
 
     let conn = builder.serve_connection(TokioIo::new(io), svc).into_owned();
     serve_connection_with_lifecycle(conn, peer.addr, global_shutdown, connection_age).await;
@@ -918,6 +990,10 @@ type MaybeTlsAcceptor = Option<()>;
 /// Optional boxed shutdown-signal future.
 type ShutdownSignal = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
+// Internal plumbing fn: each accepted-connection knob is forwarded verbatim
+// to the per-connection task, so a parameter list is clearer here than a
+// one-off config struct.
+#[allow(clippy::too_many_arguments)]
 async fn serve_with_listener<D: Dispatcher>(
     listener: TcpListener,
     service: ConnectRpcService<D>,
@@ -926,6 +1002,7 @@ async fn serve_with_listener<D: Dispatcher>(
     #[cfg(feature = "server-tls")] tls_handshake_timeout: std::time::Duration,
     shutdown: ShutdownSignal,
     connection_age: Option<ConnectionAgeConfig>,
+    max_concurrent_streams: Option<u32>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Wrap the service with panic handling to convert panics to 500 responses
     let service: WrappedService<D> = ServiceBuilder::new()
@@ -1020,6 +1097,7 @@ async fn serve_with_listener<D: Dispatcher>(
                             http1_keep_alive,
                             global_shutdown,
                             connection_age,
+                            max_concurrent_streams,
                         )
                         .await;
                     }
@@ -1053,6 +1131,7 @@ async fn serve_with_listener<D: Dispatcher>(
                 http1_keep_alive,
                 global_shutdown,
                 connection_age,
+                max_concurrent_streams,
             )
             .await;
         });
@@ -1552,6 +1631,140 @@ mod tests {
     #[should_panic(expected = "non-zero duration")]
     fn with_max_connection_age_rejects_zero() {
         let _ = Server::new(Router::new()).with_max_connection_age(Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn max_concurrent_streams_builder_defaults_and_overrides() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = Server::from_listener(listener);
+        assert_eq!(bound.max_concurrent_streams, None);
+        let bound = bound.with_max_concurrent_streams(64);
+        assert_eq!(bound.max_concurrent_streams, Some(64));
+
+        let server = Server::new(Router::new());
+        assert_eq!(server.max_concurrent_streams, None);
+        let server = server.with_max_concurrent_streams(64);
+        assert_eq!(server.max_concurrent_streams, Some(64));
+    }
+
+    #[test]
+    #[should_panic(expected = "non-zero value")]
+    fn with_max_concurrent_streams_rejects_zero() {
+        let _ = Server::new(Router::new()).with_max_concurrent_streams(0);
+    }
+
+    #[tokio::test]
+    async fn max_concurrent_streams_is_advertised_in_settings() {
+        // The server must advertise the configured limit to peers via the
+        // HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS parameter. Read the server's
+        // initial SETTINGS frame off the raw connection and assert its value.
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_max_concurrent_streams(7);
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let advertised = read_advertised_max_concurrent_streams(addr).await;
+        assert_eq!(
+            advertised,
+            Some(7),
+            "server did not advertise the configured max_concurrent_streams",
+        );
+
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn max_concurrent_streams_unset_uses_hyper_default() {
+        // When unset, the value is left to hyper. hyper's HTTP/2 server
+        // default is 200, so the advertised value must remain that default.
+        // This deliberately tracks hyper's internal default: if a hyper bump
+        // changes it (or stops advertising it), this canary fails so the doc
+        // comments that quote "200" can be updated in lockstep.
+        let bound = Server::bind("127.0.0.1:0").await.unwrap();
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let advertised = read_advertised_max_concurrent_streams(addr).await;
+        assert_eq!(
+            advertised,
+            Some(200),
+            "unset max_concurrent_streams should keep hyper's default of 200",
+        );
+
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    /// HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS identifier (RFC 7540 §6.5.2).
+    const SETTINGS_MAX_CONCURRENT_STREAMS_ID: u16 = 0x3;
+
+    /// Open a raw HTTP/2 connection, send the client preface plus an empty
+    /// SETTINGS frame, then read the server's initial SETTINGS frame and
+    /// return the advertised `MAX_CONCURRENT_STREAMS` value, if present.
+    async fn read_advertised_max_concurrent_streams(addr: SocketAddr) -> Option<u32> {
+        let mut tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+
+        // Client connection preface, then an empty SETTINGS frame (length 0,
+        // type 0x4, flags 0, stream 0) so the server proceeds with the
+        // connection.
+        tcp.write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+            .await
+            .unwrap();
+        tcp.write_all(&[0, 0, 0, 0x4, 0, 0, 0, 0, 0]).await.unwrap();
+        tcp.flush().await.unwrap();
+
+        // Scan frames until the first non-ACK SETTINGS frame from the server.
+        loop {
+            let mut header = [0u8; 9];
+            tcp.read_exact(&mut header).await.unwrap();
+            let length = u32::from_be_bytes([0, header[0], header[1], header[2]]) as usize;
+            let frame_type = header[3];
+            let flags = header[4];
+
+            let mut payload = vec![0u8; length];
+            tcp.read_exact(&mut payload).await.unwrap();
+
+            // SETTINGS = 0x4; skip the ACK (flag 0x1) the server sends for our
+            // empty SETTINGS frame.
+            if frame_type == 0x4 && flags & 0x1 == 0 {
+                return parse_max_concurrent_streams(&payload);
+            }
+        }
+    }
+
+    /// Parse a SETTINGS frame payload (6-byte id/value entries) for the
+    /// `MAX_CONCURRENT_STREAMS` value.
+    fn parse_max_concurrent_streams(payload: &[u8]) -> Option<u32> {
+        payload.chunks_exact(6).find_map(|entry| {
+            let id = u16::from_be_bytes([entry[0], entry[1]]);
+            (id == SETTINGS_MAX_CONCURRENT_STREAMS_ID)
+                .then(|| u32::from_be_bytes([entry[2], entry[3], entry[4], entry[5]]))
+        })
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `with_max_concurrent_streams(u32)` to both `Server` and `BoundServer`. It bounds the number of concurrent HTTP/2 streams (in-flight requests) a single connection may have open, mapping to hyper's HTTP/2 `SETTINGS_MAX_CONCURRENT_STREAMS`, which the server advertises to each peer.

## Why

We currently inherit hyper's default of 200 concurrent streams per connection with no way to change it. Operators legitimately need to tune it in both directions:

- Raise it for high-fan-in internal services that multiplex many concurrent RPCs over one connection, where 200 becomes a throughput ceiling.
- Lower it as a cheap hardening and fairness measure when serving less-trusted clients.

Every peer stack exposes this knob (tonic `max_concurrent_streams`, grpc-go `MaxConcurrentStreams`, grpc-java `maxConcurrentCallsPerConnection`, x/net/http2 `MaxConcurrentStreams`), and there is no escape hatch via `axum::serve`, so it belongs on our server.

## Changes

- New `max_concurrent_streams: Option<u32>` field on `Server` and `BoundServer`, defaulting to `None` in all constructors.
- New `with_max_concurrent_streams` builder on both types. It is threaded through `serve_with_listener` to the per-connection serve path and applied to the auto HTTP/1/2 builder via `builder.http2().max_concurrent_streams(...)`, but only when set. HTTP/1.1 connections are unaffected.
- A zero value is rejected at configuration time (it would advertise a limit of zero and refuse every request), matching the existing `with_max_connection_age` guard, with a `# Panics` doc.

## Default behaviour

Unchanged when unset: the value is left to hyper, whose HTTP/2 server default is 200. A test asserts the advertised value stays 200 when the knob is not used.

## How we know it works

- `task lint` (clippy `-D warnings` plus the pinned-nightly fmt check), full `task test`, and `cargo doc` with broken-link/warning denial all pass.
- New tests: builder default/override round-trip, a zero-value panic guard, advertised `SETTINGS_MAX_CONCURRENT_STREAMS` verified over raw HTTP/2 framing (=7), and the unset case verified to keep hyper's default (=200).

Closes #176
