### PR TITLE
server: add with_max_requests_per_connection (count-based connection retirement)

### DIFF
--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -33,24 +33,37 @@
 //!     .await?;
 //! ```
 //!
-//! # Maximum Connection Age
+//! # Connection Retirement
 //!
-//! Use [`Server::with_max_connection_age`] (or the [`BoundServer`] equivalent)
-//! to retire long-lived connections proactively — recommended behind load
+//! Retire long-lived connections proactively — recommended behind load
 //! balancers so clients reconnect periodically and traffic redistributes
-//! across restarts. Each connection is sent a GOAWAY once it reaches the
-//! configured age (with a ±10% jitter), then force-closed after a grace
-//! period. This is independent of whole-server graceful shutdown, which still
-//! drains in-flight requests indefinitely even while a connection is in its
-//! age-grace window.
+//! across restarts. Two independent triggers are available, and either, both,
+//! or neither may be set:
+//!
+//! - [`Server::with_max_connection_age`] (or the [`BoundServer`] equivalent)
+//!   retires by age: a connection is sent a GOAWAY once it reaches the
+//!   configured age (with a ±10% jitter).
+//! - [`Server::with_max_requests_per_connection`] retires by request count: a
+//!   connection is sent a GOAWAY once it has dispatched the configured number
+//!   of requests.
+//!
+//! When both are set, whichever trigger fires first retires the connection.
+//! After a trigger fires the connection is force-closed once the shared grace
+//! period ([`with_max_connection_age_grace`](BoundServer::with_max_connection_age_grace))
+//! elapses. Retirement is independent of whole-server graceful shutdown, which
+//! still drains in-flight requests indefinitely even while a connection is in
+//! its grace window.
 
 use std::any::Any;
 use std::collections::hash_map::RandomState;
 use std::future::Future;
 use std::hash::BuildHasher;
 use std::net::SocketAddr;
+use std::num::NonZeroU64;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -158,6 +171,7 @@ pub struct Server {
     tls_handshake_timeout: std::time::Duration,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
+    max_requests_per_connection: Option<NonZeroU64>,
 }
 
 impl Server {
@@ -172,6 +186,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_requests_per_connection: None,
         }
     }
 
@@ -186,6 +201,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_requests_per_connection: None,
         }
     }
 
@@ -341,20 +357,45 @@ impl Server {
         self
     }
 
-    /// Set the grace period used after a max-age connection begins shutdown.
+    /// Set the grace period used after a retired connection begins shutdown.
     ///
     /// The one-step counterpart of
     /// [`BoundServer::with_max_connection_age_grace`]. Defaults to five
-    /// seconds; has no effect unless [`with_max_connection_age`](Self::with_max_connection_age)
-    /// is also set.
+    /// seconds. The grace period is shared by both retirement triggers
+    /// ([`with_max_connection_age`](Self::with_max_connection_age) and
+    /// [`with_max_requests_per_connection`](Self::with_max_requests_per_connection));
+    /// it has no effect unless at least one of them is set.
     #[must_use]
     pub fn with_max_connection_age_grace(mut self, grace: Duration) -> Self {
         self.max_connection_age_grace = grace;
         self
     }
 
+    /// Retire each accepted connection after it has dispatched `max` requests.
+    ///
+    /// The one-step counterpart of
+    /// [`BoundServer::with_max_requests_per_connection`]; see it for full
+    /// behaviour (GOAWAY, shared grace period, and why `max` is a
+    /// [`NonZeroU64`]). Disabled by default.
+    #[must_use]
+    pub fn with_max_requests_per_connection(mut self, max: NonZeroU64) -> Self {
+        self.max_requests_per_connection = Some(max);
+        self
+    }
+
     fn connection_age_config(&self) -> Option<ConnectionAgeConfig> {
-        build_connection_age_config(self.max_connection_age, self.max_connection_age_grace)
+        build_connection_age_config(
+            self.max_connection_age,
+            self.max_connection_age_grace,
+            self.max_requests_per_connection.is_some(),
+        )
+    }
+
+    fn request_retirement_config(&self) -> Option<RequestRetirementConfig> {
+        build_request_retirement_config(
+            self.max_requests_per_connection,
+            self.max_connection_age_grace,
+        )
     }
 
     /// Get a reference to the underlying router.
@@ -372,6 +413,7 @@ impl Server {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let listener = TcpListener::bind(addr).await?;
         let connection_age = self.connection_age_config();
+        let request_retirement = self.request_retirement_config();
         #[cfg(feature = "server-tls")]
         let tls_acceptor = self.tls_config.map(tokio_rustls::TlsAcceptor::from);
         #[cfg(not(feature = "server-tls"))]
@@ -393,6 +435,7 @@ impl Server {
             self.tls_handshake_timeout,
             None,
             connection_age,
+            request_retirement,
         )
         .await
     }
@@ -424,6 +467,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_requests_per_connection: None,
         }
     }
 
@@ -442,6 +486,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            max_requests_per_connection: None,
         })
     }
 }
@@ -456,6 +501,7 @@ pub struct BoundServer {
     tls_handshake_timeout: std::time::Duration,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
+    max_requests_per_connection: Option<NonZeroU64>,
 }
 
 impl BoundServer {
@@ -523,15 +569,51 @@ impl BoundServer {
         self
     }
 
-    /// Set the grace period used after a max-age connection begins shutdown.
+    /// Set the grace period used after a retired connection begins shutdown.
     ///
-    /// Defaults to five seconds. This only affects connections retired by
-    /// [`with_max_connection_age`](Self::with_max_connection_age) — setting it
-    /// without also setting a max age has no effect. Whole-server graceful
-    /// shutdown still waits indefinitely for in-flight requests.
+    /// Defaults to five seconds. The grace period is shared by both retirement
+    /// triggers — [`with_max_connection_age`](Self::with_max_connection_age) and
+    /// [`with_max_requests_per_connection`](Self::with_max_requests_per_connection)
+    /// — and applies to whichever one fires. Setting it without enabling either
+    /// trigger has no effect. Whole-server graceful shutdown still waits
+    /// indefinitely for in-flight requests.
     #[must_use]
     pub fn with_max_connection_age_grace(mut self, grace: Duration) -> Self {
         self.max_connection_age_grace = grace;
+        self
+    }
+
+    /// Retire each accepted connection after it has dispatched `max` requests.
+    ///
+    /// Disabled by default. The request count is per-connection: every
+    /// inbound request (each HTTP/2 stream, or each HTTP/1.1 request) is
+    /// counted, and once the `max`th request has been dispatched the server
+    /// begins graceful shutdown for that connection — HTTP/2 connections
+    /// receive a GOAWAY, HTTP/1.1 connections have keep-alive disabled — then
+    /// waits up to
+    /// [`with_max_connection_age_grace`](Self::with_max_connection_age_grace)
+    /// for in-flight requests before force-closing it. The `max`th request
+    /// itself still completes; subsequent requests are turned away.
+    ///
+    /// `max` is a soft floor rather than an exact cap: under HTTP/2 a client
+    /// may open several streams concurrently before the GOAWAY takes effect, so
+    /// the connection is retired at or after the `max`th request, not strictly
+    /// at it.
+    ///
+    /// This is the count-based complement of
+    /// [`with_max_connection_age`](Self::with_max_connection_age); both may be
+    /// set at once, in which case whichever trigger fires first retires the
+    /// connection. Whole-server graceful shutdown still drains in-flight
+    /// requests indefinitely.
+    ///
+    /// `max` is a [`NonZeroU64`] so that "retire after zero requests" — which
+    /// would refuse every connection before it served anything — is
+    /// unrepresentable. (This differs from
+    /// [`with_max_connection_age`](Self::with_max_connection_age), which takes a
+    /// plain [`Duration`] and panics on a zero value.)
+    #[must_use]
+    pub fn with_max_requests_per_connection(mut self, max: NonZeroU64) -> Self {
+        self.max_requests_per_connection = Some(max);
         self
     }
 
@@ -602,6 +684,7 @@ impl BoundServer {
         service: ConnectRpcService<D>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let connection_age = self.connection_age_config();
+        let request_retirement = self.request_retirement_config();
 
         #[cfg(feature = "server-tls")]
         let tls_acceptor = self.tls_config.map(tokio_rustls::TlsAcceptor::from);
@@ -617,6 +700,7 @@ impl BoundServer {
             self.tls_handshake_timeout,
             None,
             connection_age,
+            request_retirement,
         )
         .await
     }
@@ -635,6 +719,7 @@ impl BoundServer {
         F: Future<Output = ()> + Send + 'static,
     {
         let connection_age = self.connection_age_config();
+        let request_retirement = self.request_retirement_config();
 
         #[cfg(feature = "server-tls")]
         let tls_acceptor = self.tls_config.map(tokio_rustls::TlsAcceptor::from);
@@ -650,23 +735,41 @@ impl BoundServer {
             self.tls_handshake_timeout,
             Some(Box::pin(signal)),
             connection_age,
+            request_retirement,
         )
         .await
     }
 
     fn connection_age_config(&self) -> Option<ConnectionAgeConfig> {
-        build_connection_age_config(self.max_connection_age, self.max_connection_age_grace)
+        build_connection_age_config(
+            self.max_connection_age,
+            self.max_connection_age_grace,
+            self.max_requests_per_connection.is_some(),
+        )
+    }
+
+    fn request_retirement_config(&self) -> Option<RequestRetirementConfig> {
+        build_request_retirement_config(
+            self.max_requests_per_connection,
+            self.max_connection_age_grace,
+        )
     }
 }
 
 /// Build the per-connection age config, warning if a grace was configured
 /// without a max age (in which case the grace has no effect).
+///
+/// `request_retirement_active` suppresses the warning when
+/// [`with_max_requests_per_connection`](BoundServer::with_max_requests_per_connection)
+/// is also set, since that knob shares the same grace period and so the grace
+/// does have an effect even without a max age.
 fn build_connection_age_config(
     max_age: Option<Duration>,
     grace: Duration,
+    request_retirement_active: bool,
 ) -> Option<ConnectionAgeConfig> {
     let Some(max_age) = max_age else {
-        if grace != DEFAULT_MAX_CONNECTION_AGE_GRACE {
+        if grace != DEFAULT_MAX_CONNECTION_AGE_GRACE && !request_retirement_active {
             tracing::debug!(
                 "max_connection_age_grace is set but max_connection_age is not; \
                  the grace period has no effect",
@@ -675,6 +778,15 @@ fn build_connection_age_config(
         return None;
     };
     Some(ConnectionAgeConfig { max_age, grace })
+}
+
+/// Build the per-connection request-count retirement config. The grace period
+/// is shared with [`with_max_connection_age_grace`](BoundServer::with_max_connection_age_grace).
+fn build_request_retirement_config(
+    max_requests: Option<NonZeroU64>,
+    grace: Duration,
+) -> Option<RequestRetirementConfig> {
+    max_requests.map(|max| RequestRetirementConfig { max, grace })
 }
 
 /// Type alias for the panic-catching wrapper around ConnectRpcService, used
@@ -699,6 +811,17 @@ impl ConnectionAgeConfig {
     }
 }
 
+/// Per-connection request-count retirement settings.
+///
+/// `max` is the number of requests a connection may serve before it is retired
+/// via graceful shutdown; `grace` is how long in-flight requests are allowed to
+/// finish afterwards (shared with the max-age grace period).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RequestRetirementConfig {
+    max: NonZeroU64,
+    grace: Duration,
+}
+
 /// Serve HTTP requests on an already-accepted stream.
 ///
 /// Generic over the IO type so it works for both plain TCP and TLS streams.
@@ -714,15 +837,38 @@ async fn serve_accepted_stream<D, S>(
     http1_keep_alive: bool,
     global_shutdown: watch::Receiver<bool>,
     connection_age: Option<ConnectionAgeConfig>,
+    request_retirement: Option<RequestRetirementConfig>,
 ) where
     D: Dispatcher,
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     tracing::trace!(remote_addr = %peer.addr, "Accepted new connection");
 
+    // When request-count retirement is enabled, the service counts every
+    // dispatched request and flips this watch channel once the limit is
+    // reached; the connection lifecycle observes it and starts draining. The
+    // counter lives only as long as this connection task.
+    let (request_counter, request_retire) = match request_retirement {
+        Some(config) => {
+            let (tx, rx) = watch::channel(false);
+            (
+                Some(RequestCounter {
+                    served: AtomicU64::new(0),
+                    max: config.max,
+                    retire: tx,
+                }),
+                Some((rx, config.grace)),
+            )
+        }
+        None => (None, None),
+    };
+
     let peer_for_requests = peer.clone();
     let svc = hyper::service::service_fn(move |mut req| {
         peer_for_requests.insert_into(req.extensions_mut());
+        if let Some(counter) = &request_counter {
+            counter.record_request();
+        }
         let mut service = (*service).clone();
         async move { service.call(req).await }
     });
@@ -731,7 +877,42 @@ async fn serve_accepted_stream<D, S>(
     builder.http1().keep_alive(http1_keep_alive);
 
     let conn = builder.serve_connection(TokioIo::new(io), svc).into_owned();
-    serve_connection_with_lifecycle(conn, peer.addr, global_shutdown, connection_age).await;
+    serve_connection_with_lifecycle(
+        conn,
+        peer.addr,
+        global_shutdown,
+        connection_age,
+        request_retire,
+    )
+    .await;
+}
+
+/// Per-connection request counter that triggers retirement once the configured
+/// limit is reached.
+struct RequestCounter {
+    served: AtomicU64,
+    max: NonZeroU64,
+    retire: watch::Sender<bool>,
+}
+
+impl RequestCounter {
+    /// Count one dispatched request. Once the count reaches the limit, flip the
+    /// retirement signal so the connection lifecycle begins graceful shutdown.
+    fn record_request(&self) {
+        // The atomic itself wraps on overflow (atomic ops never panic), but the
+        // limit is reached long before 2^64 requests and the watch value is
+        // sticky-true thereafter. `saturating_add` only clamps the local
+        // comparison value so it can't wrap below the limit in that extreme.
+        let served = self
+            .served
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        if served >= self.max.get() {
+            // `send` only errs if the receiver was dropped (the connection is
+            // already gone), in which case there is nothing left to retire.
+            let _ = self.retire.send(true);
+        }
+    }
 }
 
 fn serve_connection_with_lifecycle<C>(
@@ -739,6 +920,7 @@ fn serve_connection_with_lifecycle<C>(
     remote_addr: SocketAddr,
     global_shutdown: watch::Receiver<bool>,
     connection_age: Option<ConnectionAgeConfig>,
+    request_retire: Option<(watch::Receiver<bool>, Duration)>,
 ) -> ConnectionLifecycle<C>
 where
     C: GracefulConnection,
@@ -749,6 +931,10 @@ where
         remote_addr,
         global_shutdown: global_shutdown_future(global_shutdown),
         age: connection_age.map(|config| (Box::pin(tokio::time::sleep(config.max_age)), config)),
+        // The retirement receiver flips to `true` when the connection's request
+        // count reaches its limit; `global_shutdown_future` resolves on that
+        // same watch-channel edge, so it is reused here as the awaiter.
+        requests: request_retire.map(|(rx, grace)| (global_shutdown_future(rx), grace)),
         state: ConnectionLifecycleState::Serving,
     }
 }
@@ -767,18 +953,28 @@ fn global_shutdown_future(
     })
 }
 
+/// A boxed future that resolves when a per-connection retirement trigger (such
+/// as the request-count limit) fires.
+type RetirementSignal = Pin<Box<dyn Future<Output = ()> + Send>>;
+
 struct ConnectionLifecycle<C: GracefulConnection> {
     conn: Pin<Box<C>>,
     remote_addr: SocketAddr,
     global_shutdown: Pin<Box<dyn Future<Output = ()> + Send>>,
     age: Option<(Pin<Box<tokio::time::Sleep>>, ConnectionAgeConfig)>,
+    /// Resolves when the per-connection request count reaches its limit; the
+    /// `Duration` is the grace period to drain with once it fires.
+    requests: Option<(RetirementSignal, Duration)>,
     state: ConnectionLifecycleState,
 }
 
 enum ConnectionLifecycleState {
     Serving,
     GlobalDraining,
-    AgeDraining {
+    /// Draining after a per-connection retirement trigger (max age or max
+    /// requests). In-flight requests get `grace` to finish before the
+    /// connection is force-closed.
+    Draining {
         grace: Pin<Box<tokio::time::Sleep>>,
         duration: Duration,
     },
@@ -818,9 +1014,26 @@ where
                             "Connection reached maximum age; starting graceful shutdown",
                         );
                         this.conn.as_mut().graceful_shutdown();
-                        this.state = ConnectionLifecycleState::AgeDraining {
+                        this.state = ConnectionLifecycleState::Draining {
                             grace: Box::pin(tokio::time::sleep(config.grace)),
                             duration: config.grace,
+                        };
+                        continue;
+                    }
+
+                    if let Some((requests, grace)) = &mut this.requests
+                        && requests.as_mut().poll(cx).is_ready()
+                    {
+                        let grace = *grace;
+                        tracing::trace!(
+                            remote_addr = %this.remote_addr,
+                            grace = ?grace,
+                            "Connection reached maximum requests; starting graceful shutdown",
+                        );
+                        this.conn.as_mut().graceful_shutdown();
+                        this.state = ConnectionLifecycleState::Draining {
+                            grace: Box::pin(tokio::time::sleep(grace)),
+                            duration: grace,
                         };
                         continue;
                     }
@@ -834,7 +1047,7 @@ where
                     }
                     return Poll::Pending;
                 }
-                ConnectionLifecycleState::AgeDraining { grace, duration } => {
+                ConnectionLifecycleState::Draining { grace, duration } => {
                     if let Poll::Ready(result) = this.conn.as_mut().poll(cx) {
                         log_connection_result(this.remote_addr, result);
                         return Poll::Ready(());
@@ -849,7 +1062,7 @@ where
                         tracing::trace!(
                             remote_addr = %this.remote_addr,
                             grace = ?duration,
-                            "Connection maximum-age grace expired; closing connection",
+                            "Connection retirement grace expired; closing connection",
                         );
                         return Poll::Ready(());
                     }
@@ -918,6 +1131,11 @@ type MaybeTlsAcceptor = Option<()>;
 /// Optional boxed shutdown-signal future.
 type ShutdownSignal = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
+// This internal plumbing function fans every per-listener and per-connection
+// setting out to the accept loop; grouping them into a config struct would add
+// indirection without improving the call sites, which are the three `serve*`
+// methods.
+#[allow(clippy::too_many_arguments)]
 async fn serve_with_listener<D: Dispatcher>(
     listener: TcpListener,
     service: ConnectRpcService<D>,
@@ -926,6 +1144,7 @@ async fn serve_with_listener<D: Dispatcher>(
     #[cfg(feature = "server-tls")] tls_handshake_timeout: std::time::Duration,
     shutdown: ShutdownSignal,
     connection_age: Option<ConnectionAgeConfig>,
+    request_retirement: Option<RequestRetirementConfig>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Wrap the service with panic handling to convert panics to 500 responses
     let service: WrappedService<D> = ServiceBuilder::new()
@@ -1020,6 +1239,7 @@ async fn serve_with_listener<D: Dispatcher>(
                             http1_keep_alive,
                             global_shutdown,
                             connection_age,
+                            request_retirement,
                         )
                         .await;
                     }
@@ -1053,6 +1273,7 @@ async fn serve_with_listener<D: Dispatcher>(
                 http1_keep_alive,
                 global_shutdown,
                 connection_age,
+                request_retirement,
             )
             .await;
         });
@@ -2009,6 +2230,233 @@ mod tests {
             .expect("server did not shut down")
             .expect("join error");
         assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn max_requests_per_connection_builder_defaults_and_threads_through() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = Server::from_listener(listener);
+        assert_eq!(bound.max_requests_per_connection, None);
+        assert_eq!(bound.request_retirement_config(), None);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = Server::from_listener(listener)
+            .with_max_requests_per_connection(NonZeroU64::new(100).unwrap())
+            .with_max_connection_age_grace(Duration::from_secs(3));
+        assert_eq!(bound.max_requests_per_connection, NonZeroU64::new(100));
+        assert_eq!(
+            bound.request_retirement_config(),
+            Some(RequestRetirementConfig {
+                max: NonZeroU64::new(100).unwrap(),
+                grace: Duration::from_secs(3),
+            })
+        );
+
+        // `Server` mirrors the `BoundServer` knob and uses the default grace.
+        let server = Server::new(Router::new());
+        assert_eq!(server.max_requests_per_connection, None);
+        assert_eq!(server.request_retirement_config(), None);
+        let server = Server::new(Router::new())
+            .with_max_requests_per_connection(NonZeroU64::new(5).unwrap());
+        assert_eq!(
+            server.request_retirement_config(),
+            Some(RequestRetirementConfig {
+                max: NonZeroU64::new(5).unwrap(),
+                grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            })
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn max_requests_per_connection_retires_h2_after_limit() {
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_max_requests_per_connection(NonZeroU64::new(2).unwrap());
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut send_request, h2_conn) = h2::client::handshake(tcp).await.unwrap();
+        let h2_task = tokio::spawn(h2_conn);
+
+        // First request stays under the limit: the connection must remain open.
+        send_unary(&mut send_request, addr).await;
+        yield_to_tasks().await;
+        assert!(
+            !h2_task.is_finished(),
+            "connection retired before reaching the request limit"
+        );
+
+        // Second request reaches the limit and triggers a GOAWAY.
+        send_unary(&mut send_request, addr).await;
+        yield_to_tasks().await;
+        assert!(
+            h2_task.is_finished(),
+            "connection did not retire after reaching the request limit"
+        );
+        let conn_result = h2_task.await.expect("h2 connection task panicked");
+        if let Err(err) = conn_result {
+            assert!(
+                err.is_go_away(),
+                "h2 connection ended with non-GOAWAY error: {err:?}"
+            );
+        }
+
+        drop(send_request);
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn max_requests_per_connection_unlimited_when_unset() {
+        // No request limit configured: the connection serves many requests
+        // without being retired.
+        let bound = Server::bind("127.0.0.1:0").await.unwrap();
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut send_request, h2_conn) = h2::client::handshake(tcp).await.unwrap();
+        let h2_task = tokio::spawn(h2_conn);
+
+        for _ in 0..5 {
+            send_unary(&mut send_request, addr).await;
+        }
+        yield_to_tasks().await;
+        assert!(
+            !h2_task.is_finished(),
+            "connection retired despite no request limit being configured"
+        );
+
+        drop(send_request);
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn max_requests_per_connection_first_trigger_wins_over_age() {
+        // A far-off max age combined with a request limit of one: the request
+        // count must retire the connection first.
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_max_connection_age(Duration::from_secs(3600))
+            .with_max_requests_per_connection(NonZeroU64::new(1).unwrap());
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut send_request, h2_conn) = h2::client::handshake(tcp).await.unwrap();
+        let h2_task = tokio::spawn(h2_conn);
+
+        send_unary(&mut send_request, addr).await;
+        yield_to_tasks().await;
+        assert!(
+            h2_task.is_finished(),
+            "request limit should retire the connection before the max age"
+        );
+        h2_task.await.expect("h2 connection task panicked").ok();
+
+        drop(send_request);
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn max_requests_per_connection_retires_http1_after_limit() {
+        let router = Router::new().route(
+            "svc",
+            "Echo",
+            crate::handler_fn(
+                |_ctx: crate::RequestContext, _req: buffa_types::Empty| async move {
+                    crate::Response::ok(buffa_types::Empty::default())
+                },
+            ),
+        );
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_max_requests_per_connection(NonZeroU64::new(1).unwrap());
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(router, async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        stream.write_all(KEEPALIVE_ECHO_REQ).await.unwrap();
+        let resp = read_http1_response(&mut stream).await;
+        assert!(
+            resp.starts_with(b"HTTP/1.1 2"),
+            "expected 2xx, got: {}",
+            String::from_utf8_lossy(&resp[..resp.len().min(80)])
+        );
+
+        yield_to_tasks().await;
+        // The single request hit the limit, so the keep-alive connection must
+        // close even though the client requested keep-alive.
+        let mut buf = [0; 1];
+        let read = stream.read(&mut buf).await.unwrap();
+        assert_eq!(
+            read, 0,
+            "HTTP/1.1 keep-alive connection stayed open past the request limit"
+        );
+
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    /// Send one unary request over an h2 connection and await its response.
+    async fn send_unary(send_request: &mut h2::client::SendRequest<Bytes>, addr: SocketAddr) {
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("http://{addr}/svc/Unknown"))
+            .body(())
+            .unwrap();
+        let (resp, _) = send_request.send_request(req, true).unwrap();
+        resp.await.unwrap();
     }
 
     fn slow_router() -> (


### PR DESCRIPTION
## What

Add `Server::with_max_requests_per_connection` and
`BoundServer::with_max_requests_per_connection`. After a connection has served
a configured number of requests, it is retired via graceful shutdown — HTTP/2
connections receive a GOAWAY, HTTP/1.1 connections have keep-alive disabled —
then in-flight requests are given the grace period before the connection is
force-closed.

This is the count-based complement of the time-based
`with_max_connection_age` added in #165.

## Why

Retiring long-lived connections is recommended behind load balancers: it
prevents connection pinning and lets load redistribute across pod restarts.
Age is a poor proxy when traffic is bursty, so the mainstream proxies offer a
request-count trigger too (Envoy's `max_requests_per_connection`, Traefik's
`keepAliveMaxRequests`). This adds that knob.

## Changes

- New builder `with_max_requests_per_connection(NonZeroU64)` on both `Server`
  and `BoundServer`. Disabled by default. `NonZeroU64` makes "retire after
  zero requests" unrepresentable.
- The grace period is shared with `with_max_connection_age_grace`.
- A per-connection request counter (`AtomicU64`) in the hyper service counts
  each dispatched request and, on reaching the limit, signals the existing
  per-connection `ConnectionLifecycle` to begin graceful shutdown. The `max`th
  request still completes; only later requests are turned away.
- Age and request-count retirement share one drain state; whichever trigger
  fires first retires the connection. Whole-server graceful shutdown still
  drains in-flight requests indefinitely.

## Validation

- `cargo test --workspace` passes (connectrpc: 472 unit tests, +5 new).
- `task lint` (clippy `-D warnings` + fmt check) passes.
- `cargo +nightly-2026-02-27 fmt --all -- --check` passes.
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p connectrpc --all-features --no-deps`
  passes.
- `cargo check -p connectrpc --no-default-features --features server` passes.

New tests cover: retirement after N requests (HTTP/2 GOAWAY and HTTP/1.1
keep-alive close), unlimited behaviour when unset, first-trigger-wins when both
age and request-count are configured, and builder defaults/threading.

Closes #174
