### PR TITLE
feat(server): enable HTTP/2 adaptive flow-control window by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ increment the patch version.
   keep-alive disabled instead. A symmetric ±10% jitter is applied per
   connection to avoid reconnect bursts. Disabled by default; whole-server
   graceful shutdown still drains in-flight requests indefinitely.
+- **HTTP/2 adaptive flow-control window, on by default** ([#178]). The built-in
+  server now enables hyper's adaptive (BDP-based) flow-control window sizing by
+  default, so HTTP/2 stream and connection windows grow with the measured
+  bandwidth-delay product instead of staying pinned at hyper's fixed 64 KiB.
+  This is a behaviour change: throughput improves on high-latency,
+  high-bandwidth links (cross-region, high-throughput streaming), at the cost
+  of slightly higher per-connection memory under load. It matches grpc-go and
+  grpc-java, which both autotune by default. New setters on `Server` and
+  `BoundServer` give explicit control: `with_http2_adaptive_window(bool)`
+  toggles autotuning, and `with_http2_initial_stream_window_size` /
+  `with_http2_initial_connection_window_size` set fixed windows (supplying a
+  fixed window turns adaptive sizing off, mirroring grpc-go). The new default
+  is exposed as the `DEFAULT_HTTP2_ADAPTIVE_WINDOW` constant.
 
 ### Fixed
 
@@ -66,6 +79,7 @@ increment the patch version.
 [#163]: https://github.com/anthropics/connect-rust/pull/163
 [#164]: https://github.com/anthropics/connect-rust/pull/164
 [#172]: https://github.com/anthropics/connect-rust/pull/172
+[#178]: https://github.com/anthropics/connect-rust/issues/178
 
 ## [0.7.0] - 2026-06-10
 

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -1765,10 +1765,9 @@ mod tests {
 
     #[test]
     fn http2_config_default_enables_adaptive_window() {
-        assert!(DEFAULT_HTTP2_ADAPTIVE_WINDOW);
-
         let config = Http2Config::default();
         assert!(config.adaptive_window);
+        assert_eq!(config.adaptive_window, DEFAULT_HTTP2_ADAPTIVE_WINDOW);
         assert_eq!(config.initial_stream_window_size, None);
         assert_eq!(config.initial_connection_window_size, None);
     }

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -148,6 +148,67 @@ const MAX_CONNECTION_AGE_JITTER_BASIS_POINTS: u128 = 10_000;
 const MAX_CONNECTION_AGE_JITTER_SPREAD_BASIS_POINTS: u128 = 1_000;
 const NANOS_PER_SEC: u128 = 1_000_000_000;
 
+/// Default for HTTP/2 adaptive (BDP-based) flow-control window sizing.
+///
+/// Enabled by default so connections over high bandwidth-delay-product links
+/// (cross-region, high-throughput streaming) are not throttled by hyper's
+/// fixed 64 KiB stream/connection windows. hyper grows the window based on the
+/// measured bandwidth-delay product, matching grpc-go and grpc-java, which both
+/// autotune by default. The trade-off is slightly higher per-connection memory
+/// under load.
+///
+/// Disable with [`Server::with_http2_adaptive_window`] /
+/// [`BoundServer::with_http2_adaptive_window`], or override the windows
+/// explicitly with the `with_http2_initial_*_window_size` setters (which turn
+/// adaptive sizing off).
+pub const DEFAULT_HTTP2_ADAPTIVE_WINDOW: bool = true;
+
+/// HTTP/2 flow-control window configuration applied to every accepted
+/// connection's hyper builder.
+///
+/// `adaptive_window` and the explicit window sizes are mutually exclusive in
+/// hyper: enabling adaptive sizing overrides any explicit window size. The
+/// public setters keep them consistent by clearing the adaptive flag whenever
+/// an explicit size is supplied.
+#[derive(Clone, Copy, Debug)]
+struct Http2Config {
+    adaptive_window: bool,
+    initial_stream_window_size: Option<u32>,
+    initial_connection_window_size: Option<u32>,
+}
+
+impl Default for Http2Config {
+    fn default() -> Self {
+        Self {
+            adaptive_window: DEFAULT_HTTP2_ADAPTIVE_WINDOW,
+            initial_stream_window_size: None,
+            initial_connection_window_size: None,
+        }
+    }
+}
+
+impl Http2Config {
+    /// The `(stream, connection)` explicit window sizes that should actually be
+    /// applied to hyper's builder.
+    ///
+    /// Adaptive sizing takes precedence: when it is on, no explicit window is
+    /// applied, so the two never reach hyper at once regardless of the order
+    /// the builder methods were called in. The public setters already clear the
+    /// adaptive flag when a size is supplied, but a later
+    /// `with_http2_adaptive_window(true)` can leave both set; this resolves that
+    /// case deterministically in favour of adaptive sizing.
+    fn effective_windows(self) -> (Option<u32>, Option<u32>) {
+        if self.adaptive_window {
+            (None, None)
+        } else {
+            (
+                self.initial_stream_window_size,
+                self.initial_connection_window_size,
+            )
+        }
+    }
+}
+
 /// ConnectRPC server built on hyper.
 pub struct Server {
     service: ConnectRpcService,
@@ -158,6 +219,7 @@ pub struct Server {
     tls_handshake_timeout: std::time::Duration,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
+    http2: Http2Config,
 }
 
 impl Server {
@@ -172,6 +234,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            http2: Http2Config::default(),
         }
     }
 
@@ -186,6 +249,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            http2: Http2Config::default(),
         }
     }
 
@@ -353,6 +417,48 @@ impl Server {
         self
     }
 
+    /// Enable or disable HTTP/2 adaptive flow-control window sizing.
+    ///
+    /// The one-step counterpart of
+    /// [`BoundServer::with_http2_adaptive_window`]; see it for full behaviour.
+    /// Enabled by default ([`DEFAULT_HTTP2_ADAPTIVE_WINDOW`]).
+    #[must_use]
+    pub fn with_http2_adaptive_window(mut self, enabled: bool) -> Self {
+        self.http2.adaptive_window = enabled;
+        self
+    }
+
+    /// Set the HTTP/2 initial stream-level flow-control window size, in bytes.
+    ///
+    /// The one-step counterpart of
+    /// [`BoundServer::with_http2_initial_stream_window_size`]; see it for full
+    /// behaviour. Supplying a size turns adaptive sizing off.
+    #[must_use]
+    pub fn with_http2_initial_stream_window_size(mut self, size: impl Into<Option<u32>>) -> Self {
+        self.http2.initial_stream_window_size = size.into();
+        if self.http2.initial_stream_window_size.is_some() {
+            self.http2.adaptive_window = false;
+        }
+        self
+    }
+
+    /// Set the HTTP/2 initial connection-level flow-control window size, in bytes.
+    ///
+    /// The one-step counterpart of
+    /// [`BoundServer::with_http2_initial_connection_window_size`]; see it for
+    /// full behaviour. Supplying a size turns adaptive sizing off.
+    #[must_use]
+    pub fn with_http2_initial_connection_window_size(
+        mut self,
+        size: impl Into<Option<u32>>,
+    ) -> Self {
+        self.http2.initial_connection_window_size = size.into();
+        if self.http2.initial_connection_window_size.is_some() {
+            self.http2.adaptive_window = false;
+        }
+        self
+    }
+
     fn connection_age_config(&self) -> Option<ConnectionAgeConfig> {
         build_connection_age_config(self.max_connection_age, self.max_connection_age_grace)
     }
@@ -393,6 +499,7 @@ impl Server {
             self.tls_handshake_timeout,
             None,
             connection_age,
+            self.http2,
         )
         .await
     }
@@ -424,6 +531,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            http2: Http2Config::default(),
         }
     }
 
@@ -442,6 +550,7 @@ impl Server {
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
+            http2: Http2Config::default(),
         })
     }
 }
@@ -456,6 +565,7 @@ pub struct BoundServer {
     tls_handshake_timeout: std::time::Duration,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
+    http2: Http2Config,
 }
 
 impl BoundServer {
@@ -532,6 +642,74 @@ impl BoundServer {
     #[must_use]
     pub fn with_max_connection_age_grace(mut self, grace: Duration) -> Self {
         self.max_connection_age_grace = grace;
+        self
+    }
+
+    /// Enable or disable HTTP/2 adaptive flow-control window sizing.
+    ///
+    /// Enabled by default ([`DEFAULT_HTTP2_ADAPTIVE_WINDOW`]). When enabled,
+    /// hyper grows the stream and connection flow-control windows based on the
+    /// measured bandwidth-delay product, which improves throughput on
+    /// high-latency, high-bandwidth links at the cost of slightly higher
+    /// per-connection memory under load.
+    ///
+    /// Adaptive sizing and an explicit window size are mutually exclusive:
+    /// enabling adaptive sizing overrides any window set via
+    /// [`with_http2_initial_stream_window_size`](Self::with_http2_initial_stream_window_size)
+    /// or
+    /// [`with_http2_initial_connection_window_size`](Self::with_http2_initial_connection_window_size).
+    /// Whichever is set last wins.
+    #[must_use]
+    pub fn with_http2_adaptive_window(mut self, enabled: bool) -> Self {
+        self.http2.adaptive_window = enabled;
+        self
+    }
+
+    /// Set the HTTP/2 initial stream-level flow-control window size, in bytes.
+    ///
+    /// Controls the per-stream `SETTINGS_INITIAL_WINDOW_SIZE` advertised to
+    /// clients. Supplying a size turns
+    /// [adaptive sizing](Self::with_http2_adaptive_window) off, mirroring
+    /// grpc-go semantics; passing `None` leaves hyper's default in place and
+    /// does not change the adaptive flag. The window can be raised above
+    /// hyper's 64 KiB default to improve throughput when adaptive sizing is
+    /// not wanted.
+    ///
+    /// The adaptive toggle and the explicit window are last-write-wins: a later
+    /// [`with_http2_adaptive_window(true)`](Self::with_http2_adaptive_window)
+    /// re-enables autotuning and the explicit window is ignored. Per HTTP/2,
+    /// the window must not exceed `2^31 - 1`; larger values are a protocol error.
+    #[must_use]
+    pub fn with_http2_initial_stream_window_size(mut self, size: impl Into<Option<u32>>) -> Self {
+        self.http2.initial_stream_window_size = size.into();
+        if self.http2.initial_stream_window_size.is_some() {
+            self.http2.adaptive_window = false;
+        }
+        self
+    }
+
+    /// Set the HTTP/2 initial connection-level flow-control window size, in bytes.
+    ///
+    /// Controls the whole-connection flow-control window, which bounds the
+    /// total unacknowledged data across all streams on the connection.
+    /// Supplying a size turns
+    /// [adaptive sizing](Self::with_http2_adaptive_window) off, mirroring
+    /// grpc-go semantics; passing `None` leaves hyper's default in place and
+    /// does not change the adaptive flag.
+    ///
+    /// The adaptive toggle and the explicit window are last-write-wins: a later
+    /// [`with_http2_adaptive_window(true)`](Self::with_http2_adaptive_window)
+    /// re-enables autotuning and the explicit window is ignored. Per HTTP/2,
+    /// the window must not exceed `2^31 - 1`; larger values are a protocol error.
+    #[must_use]
+    pub fn with_http2_initial_connection_window_size(
+        mut self,
+        size: impl Into<Option<u32>>,
+    ) -> Self {
+        self.http2.initial_connection_window_size = size.into();
+        if self.http2.initial_connection_window_size.is_some() {
+            self.http2.adaptive_window = false;
+        }
         self
     }
 
@@ -617,6 +795,7 @@ impl BoundServer {
             self.tls_handshake_timeout,
             None,
             connection_age,
+            self.http2,
         )
         .await
     }
@@ -650,6 +829,7 @@ impl BoundServer {
             self.tls_handshake_timeout,
             Some(Box::pin(signal)),
             connection_age,
+            self.http2,
         )
         .await
     }
@@ -714,6 +894,7 @@ async fn serve_accepted_stream<D, S>(
     http1_keep_alive: bool,
     global_shutdown: watch::Receiver<bool>,
     connection_age: Option<ConnectionAgeConfig>,
+    http2: Http2Config,
 ) where
     D: Dispatcher,
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
@@ -729,9 +910,29 @@ async fn serve_accepted_stream<D, S>(
 
     let mut builder = AutoBuilder::new(TokioExecutor::new());
     builder.http1().keep_alive(http1_keep_alive);
+    configure_http2(&mut builder, http2);
 
     let conn = builder.serve_connection(TokioIo::new(io), svc).into_owned();
     serve_connection_with_lifecycle(conn, peer.addr, global_shutdown, connection_age).await;
+}
+
+/// Apply the HTTP/2 flow-control window configuration to a connection builder.
+///
+/// `adaptive_window` is always set explicitly so the default tracks
+/// [`DEFAULT_HTTP2_ADAPTIVE_WINDOW`] regardless of hyper's own default. Explicit
+/// window sizes are applied only when adaptive sizing is off (see
+/// [`Http2Config::effective_windows`]), so the two never reach hyper at once and
+/// the precedence does not depend on hyper's internal call ordering.
+fn configure_http2(builder: &mut AutoBuilder<TokioExecutor>, config: Http2Config) {
+    let mut http2 = builder.http2();
+    http2.adaptive_window(config.adaptive_window);
+    let (stream_window, connection_window) = config.effective_windows();
+    if let Some(size) = stream_window {
+        http2.initial_stream_window_size(size);
+    }
+    if let Some(size) = connection_window {
+        http2.initial_connection_window_size(size);
+    }
 }
 
 fn serve_connection_with_lifecycle<C>(
@@ -918,6 +1119,11 @@ type MaybeTlsAcceptor = Option<()>;
 /// Optional boxed shutdown-signal future.
 type ShutdownSignal = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
+// This internal accept loop carries one parameter per connection-level config
+// knob (TLS, keep-alive, connection age, HTTP/2 flow control, ...), so it
+// exceeds clippy's default argument count. The parameters are all plumbing for
+// the same call; grouping them into a struct would not improve clarity here.
+#[allow(clippy::too_many_arguments)]
 async fn serve_with_listener<D: Dispatcher>(
     listener: TcpListener,
     service: ConnectRpcService<D>,
@@ -926,6 +1132,7 @@ async fn serve_with_listener<D: Dispatcher>(
     #[cfg(feature = "server-tls")] tls_handshake_timeout: std::time::Duration,
     shutdown: ShutdownSignal,
     connection_age: Option<ConnectionAgeConfig>,
+    http2: Http2Config,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Wrap the service with panic handling to convert panics to 500 responses
     let service: WrappedService<D> = ServiceBuilder::new()
@@ -1020,6 +1227,7 @@ async fn serve_with_listener<D: Dispatcher>(
                             http1_keep_alive,
                             global_shutdown,
                             connection_age,
+                            http2,
                         )
                         .await;
                     }
@@ -1053,6 +1261,7 @@ async fn serve_with_listener<D: Dispatcher>(
                 http1_keep_alive,
                 global_shutdown,
                 connection_age,
+                http2,
             )
             .await;
         });
@@ -1552,6 +1761,215 @@ mod tests {
     #[should_panic(expected = "non-zero duration")]
     fn with_max_connection_age_rejects_zero() {
         let _ = Server::new(Router::new()).with_max_connection_age(Duration::ZERO);
+    }
+
+    #[test]
+    fn http2_config_default_enables_adaptive_window() {
+        assert!(DEFAULT_HTTP2_ADAPTIVE_WINDOW);
+
+        let config = Http2Config::default();
+        assert!(config.adaptive_window);
+        assert_eq!(config.initial_stream_window_size, None);
+        assert_eq!(config.initial_connection_window_size, None);
+    }
+
+    #[test]
+    fn server_http2_builder_defaults_match_adaptive_on() {
+        let server = Server::new(Router::new());
+        assert!(server.http2.adaptive_window);
+        assert_eq!(server.http2.initial_stream_window_size, None);
+        assert_eq!(server.http2.initial_connection_window_size, None);
+
+        // `from_service` must seed the same defaults as `new`.
+        let from_service = Server::from_service(ConnectRpcService::new(Router::new()));
+        assert!(from_service.http2.adaptive_window);
+    }
+
+    #[tokio::test]
+    async fn bound_server_http2_builder_defaults_match_adaptive_on() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = Server::from_listener(listener);
+        assert!(bound.http2.adaptive_window);
+        assert_eq!(bound.http2.initial_stream_window_size, None);
+        assert_eq!(bound.http2.initial_connection_window_size, None);
+
+        let bound = Server::bind("127.0.0.1:0").await.unwrap();
+        assert!(bound.http2.adaptive_window);
+    }
+
+    #[test]
+    fn with_http2_adaptive_window_toggles_flag() {
+        let server = Server::new(Router::new()).with_http2_adaptive_window(false);
+        assert!(!server.http2.adaptive_window);
+
+        let server = server.with_http2_adaptive_window(true);
+        assert!(server.http2.adaptive_window);
+    }
+
+    #[test]
+    fn explicit_stream_window_disables_adaptive() {
+        let server = Server::new(Router::new()).with_http2_initial_stream_window_size(1 << 20);
+        assert_eq!(server.http2.initial_stream_window_size, Some(1 << 20));
+        assert!(
+            !server.http2.adaptive_window,
+            "an explicit stream window must turn adaptive sizing off"
+        );
+    }
+
+    #[test]
+    fn explicit_connection_window_disables_adaptive() {
+        let server = Server::new(Router::new()).with_http2_initial_connection_window_size(2 << 20);
+        assert_eq!(server.http2.initial_connection_window_size, Some(2 << 20));
+        assert!(
+            !server.http2.adaptive_window,
+            "an explicit connection window must turn adaptive sizing off"
+        );
+    }
+
+    #[test]
+    fn clearing_window_with_none_keeps_adaptive_flag() {
+        // Passing `None` must not flip the adaptive flag in either direction.
+        let server = Server::new(Router::new())
+            .with_http2_initial_stream_window_size(None)
+            .with_http2_initial_connection_window_size(None);
+        assert!(server.http2.adaptive_window);
+        assert_eq!(server.http2.initial_stream_window_size, None);
+        assert_eq!(server.http2.initial_connection_window_size, None);
+    }
+
+    #[test]
+    fn re_enabling_adaptive_after_explicit_window_wins() {
+        // The setters are last-write-wins: re-enabling adaptive after setting a
+        // window leaves the window stored but turns adaptive back on, matching
+        // the documented precedence (and hyper, where adaptive overrides the
+        // explicit window).
+        let server = Server::new(Router::new())
+            .with_http2_initial_stream_window_size(1 << 20)
+            .with_http2_adaptive_window(true);
+        assert!(server.http2.adaptive_window);
+        assert_eq!(server.http2.initial_stream_window_size, Some(1 << 20));
+        // ...and the stored window must not reach hyper while adaptive is on.
+        assert_eq!(server.http2.effective_windows(), (None, None));
+    }
+
+    #[test]
+    fn effective_windows_resolves_adaptive_precedence() {
+        // Default (adaptive on): no explicit window reaches hyper.
+        assert_eq!(Http2Config::default().effective_windows(), (None, None));
+
+        // Adaptive explicitly off but no sizes set: still nothing to apply.
+        let off = Server::new(Router::new()).with_http2_adaptive_window(false);
+        assert_eq!(off.http2.effective_windows(), (None, None));
+
+        // Adaptive off with explicit sizes: both windows are applied.
+        let fixed = Server::new(Router::new())
+            .with_http2_initial_stream_window_size(1 << 20)
+            .with_http2_initial_connection_window_size(2 << 20);
+        assert!(!fixed.http2.adaptive_window);
+        assert_eq!(
+            fixed.http2.effective_windows(),
+            (Some(1 << 20), Some(2 << 20))
+        );
+    }
+
+    #[tokio::test]
+    async fn bound_server_http2_window_setters_thread_through() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = Server::from_listener(listener)
+            .with_http2_initial_stream_window_size(512 * 1024)
+            .with_http2_initial_connection_window_size(1024 * 1024);
+        assert_eq!(bound.http2.initial_stream_window_size, Some(512 * 1024));
+        assert_eq!(
+            bound.http2.initial_connection_window_size,
+            Some(1024 * 1024)
+        );
+        assert!(!bound.http2.adaptive_window);
+    }
+
+    /// End-to-end check that explicit window knobs reach hyper's builder
+    /// (`configure_http2`) without breaking the connection: a server with
+    /// custom stream/connection windows still completes an HTTP/2 request.
+    #[tokio::test]
+    async fn http2_explicit_windows_serve_request() {
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_http2_initial_stream_window_size(256 * 1024)
+            .with_http2_initial_connection_window_size(512 * 1024);
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut send_request, h2_conn) = h2::client::handshake(tcp).await.unwrap();
+        let h2_task = tokio::spawn(h2_conn);
+
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("http://{addr}/svc/Unknown"))
+            .body(())
+            .unwrap();
+        let (resp, _) = send_request.send_request(req, true).unwrap();
+        // The route is unknown; we only need the response to resolve, which
+        // proves the connection negotiated and served under the configured
+        // flow-control windows.
+        let _resp = resp.await.expect("h2 request failed");
+
+        drop(send_request);
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+        h2_task.await.expect("h2 connection task panicked").ok();
+    }
+
+    /// Same as above but with adaptive window left on (the default), proving the
+    /// default `configure_http2` path also serves requests cleanly.
+    #[tokio::test]
+    async fn http2_adaptive_window_default_serves_request() {
+        let bound = Server::bind("127.0.0.1:0").await.unwrap();
+        assert!(bound.http2.adaptive_window);
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut send_request, h2_conn) = h2::client::handshake(tcp).await.unwrap();
+        let h2_task = tokio::spawn(h2_conn);
+
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("http://{addr}/svc/Unknown"))
+            .body(())
+            .unwrap();
+        let (resp, _) = send_request.send_request(req, true).unwrap();
+        // The route is unknown; we only need the response to resolve, which
+        // proves the connection negotiated and served under the configured
+        // flow-control windows.
+        let _resp = resp.await.expect("h2 request failed");
+
+        drop(send_request);
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+        h2_task.await.expect("h2 connection task panicked").ok();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What this does

Enables hyper's HTTP/2 adaptive (BDP-based) flow-control window sizing on the built-in server **by default**, and adds explicit window-size setters for manual control. Closes #178.

## Why now

The server inherited hyper's fixed 64 KiB stream/connection flow-control windows with adaptive sizing off. On high bandwidth-delay-product links (cross-region, high-throughput streaming) a fixed 64 KiB window caps throughput well below the link capacity. Both reference gRPC implementations autotune by default (grpc-go and grpc-java); we were the outlier.

## Behaviour change (please note)

The default flips from fixed 64 KiB windows to **adaptive sizing on**. The trade-off is higher throughput on high-latency, high-bandwidth links in exchange for slightly higher per-connection memory under load. This matches grpc-go / grpc-java. The change is flagged in the CHANGELOG with the trade-off spelled out. It is additive at the API level (no breaking signatures) but a runtime behaviour change.

## What changed

New setters on both `Server` and `BoundServer`:

- `with_http2_adaptive_window(bool)` — toggle autotuning (default on).
- `with_http2_initial_stream_window_size(impl Into<Option<u32>>)` — pin a fixed per-stream window.
- `with_http2_initial_connection_window_size(impl Into<Option<u32>>)` — pin a fixed whole-connection window.

Plus a `DEFAULT_HTTP2_ADAPTIVE_WINDOW: bool` constant documenting the new default.

Adaptive sizing and an explicit window are mutually exclusive: supplying a fixed window turns adaptive off (mirroring grpc-go); a later `with_http2_adaptive_window(true)` wins. The values flow through a small `Copy` `Http2Config` to the per-connection hyper builder, where an `effective_windows` helper resolves precedence deterministically (adaptive always wins when on) so the outcome does not depend on hyper's internal call ordering.

The change is scoped to `connectrpc/src/server.rs` (plus CHANGELOG). No new dependencies, no generated-code changes.

## How we know it works

- Unit tests cover defaults, each setter, the adaptive/explicit-window interaction (including the re-enable precedence), and `None` handling.
- Two end-to-end tests serve an HTTP/2 request with explicit windows and with the adaptive default, confirming the apply path negotiates and serves cleanly.
- `task test` (485 pass), `task lint` (clippy `-D warnings`), `cargo +nightly fmt --check`, `cargo doc` (broken-links denied), and the no-TLS server-only build all pass.

## After merge

Operators upgrading get the throughput improvement automatically; anyone who needs the old behaviour can call `with_http2_adaptive_window(false)` or pin explicit windows.

Closes #178
