### PR TITLE
server: apply an HTTP/1.1 header read timeout to accepted connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,35 @@ increment the patch version.
   connection to avoid reconnect bursts. Disabled by default; whole-server
   graceful shutdown still drains in-flight requests indefinitely.
 
+- **Connection-level HTTP/1.1 header read timeout** ([#135]). The built-in
+  `Server`/`BoundServer` and the axum `serve_tls` path now install a
+  `TokioTimer` on every accepted connection and apply a header read timeout,
+  configurable via `with_header_read_timeout(Option<Duration>)` (default
+  `DEFAULT_HEADER_READ_TIMEOUT`, 30 seconds; pass `None` to disable). The
+  timeout bounds how long the server waits to read a complete request header
+  block, measured from when hyper begins reading a new request; on a keep-alive
+  connection it also bounds the idle wait between requests. A peer that opens a
+  connection — or finishes one request — and then stalls without sending the
+  next request's headers is now disconnected instead of holding a task and file
+  descriptor open indefinitely, which mitigates slowloris-style
+  connection-exhaustion attacks. Previously no timer was installed, so hyper's
+  built-in header read timeout never took effect; the default is now active.
+  Applies to HTTP/1.1 only — HTTP/2 connection liveness (keep-alive pings) and
+  idle-connection reaping are tracked separately.
+
+### Changed
+
+- **The built-in server now closes idle/stalled HTTP/1.1 connections by
+  default** ([#135]). Because a connection timer is now installed (see the
+  Added entry above), the 30-second header read timeout is active by default
+  where previously no timer was installed and it never fired. An HTTP/1.1
+  keep-alive connection that sits idle for more than 30 seconds between
+  requests — or that opens and never finishes sending request headers — is now
+  closed. Connect/gRPC traffic is predominantly HTTP/2 and is unaffected, but
+  an HTTP/1.1 client that pools a connection across long idle gaps must
+  reconnect. Raise the duration with `with_header_read_timeout(Some(d))` or
+  disable it with `with_header_read_timeout(None)`.
+
 ### Fixed
 
 - **Connect client-streaming responses require the END_STREAM envelope**
@@ -62,6 +91,7 @@ increment the patch version.
   returns `Err(unavailable)`, matching the `ServerStream` Connect EOF path
   ([#140]); complete responses are unchanged.
 
+[#135]: https://github.com/anthropics/connect-rust/issues/135
 [#151]: https://github.com/anthropics/connect-rust/issues/151
 [#163]: https://github.com/anthropics/connect-rust/pull/163
 [#164]: https://github.com/anthropics/connect-rust/pull/164

--- a/connectrpc/src/axum.rs
+++ b/connectrpc/src/axum.rs
@@ -60,14 +60,15 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use hyper_util::server::conn::auto::Builder as AutoBuilder;
 use hyper_util::server::graceful::GracefulShutdown;
 use tokio::net::TcpListener;
 use tower::ServiceExt;
 
 use crate::server::{
-    DEFAULT_TLS_HANDSHAKE_TIMEOUT, PeerAddr, PeerCerts, is_transient_accept_error,
+    DEFAULT_HEADER_READ_TIMEOUT, DEFAULT_TLS_HANDSHAKE_TIMEOUT, PeerAddr, PeerCerts,
+    is_transient_accept_error,
 };
 
 /// Serve an `axum::Router` over TLS, exposing peer identity to handlers.
@@ -127,6 +128,7 @@ pub fn serve_tls(
         router,
         acceptor: tokio_rustls::TlsAcceptor::from(tls_config),
         tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+        header_read_timeout: Some(DEFAULT_HEADER_READ_TIMEOUT),
         shutdown: None,
     }
 }
@@ -142,6 +144,7 @@ pub struct ServeTls {
     router: axum::Router,
     acceptor: tokio_rustls::TlsAcceptor,
     tls_handshake_timeout: Duration,
+    header_read_timeout: Option<Duration>,
     shutdown: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
 }
 
@@ -152,6 +155,25 @@ impl ServeTls {
     #[must_use = "ServeTls does nothing unless `.await`ed"]
     pub fn with_tls_handshake_timeout(mut self, timeout: Duration) -> Self {
         self.tls_handshake_timeout = timeout;
+        self
+    }
+
+    /// Override the HTTP/1.1 header read timeout (default
+    /// [`DEFAULT_HEADER_READ_TIMEOUT`], 30 seconds).
+    ///
+    /// Bounds how long the server waits to read a complete set of request
+    /// headers, measured from when hyper begins reading a new request; on a
+    /// keep-alive connection this also bounds the idle wait between requests.
+    /// A peer that connects (or finishes a request) and then stalls without
+    /// sending the next request's headers is disconnected, which mitigates
+    /// slowloris-style connection-exhaustion attacks. Pass `None` to disable.
+    ///
+    /// Applies to HTTP/1.1 only; it does not bound idle or stalled HTTP/2
+    /// connections — use `Server::with_max_connection_age` to retire those by
+    /// age.
+    #[must_use = "ServeTls does nothing unless `.await`ed"]
+    pub fn with_header_read_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.header_read_timeout = timeout.into();
         self
     }
 
@@ -173,6 +195,7 @@ impl std::fmt::Debug for ServeTls {
         f.debug_struct("ServeTls")
             .field("listener", &self.listener)
             .field("tls_handshake_timeout", &self.tls_handshake_timeout)
+            .field("header_read_timeout", &self.header_read_timeout)
             .field("shutdown", &self.shutdown.is_some())
             .finish_non_exhaustive()
     }
@@ -194,6 +217,7 @@ impl ServeTls {
             router,
             acceptor,
             tls_handshake_timeout,
+            header_read_timeout,
             shutdown,
         } = self;
 
@@ -277,7 +301,17 @@ impl ServeTls {
                 // (WebSockets) work out of the box. ConnectRPC routes don't
                 // upgrade, so this is a no-op for them. Keep this divergence —
                 // it matches what `axum::serve` does internally.
-                let conn = AutoBuilder::new(TokioExecutor::new())
+                let mut builder = AutoBuilder::new(TokioExecutor::new());
+                // A timer is required for hyper's header read timeout (and any
+                // other time-based connection behaviour) to take effect;
+                // without it the configured `header_read_timeout` is silently
+                // ignored.
+                builder
+                    .http1()
+                    .timer(TokioTimer::new())
+                    .header_read_timeout(header_read_timeout);
+                builder.http2().timer(TokioTimer::new());
+                let conn = builder
                     .serve_connection_with_upgrades(TokioIo::new(tls_stream), svc)
                     .into_owned();
                 if let Err(err) = watcher.watch(conn).await {
@@ -467,6 +501,55 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), serve)
             .await
             .expect("handshake timeout must release the watcher so drain completes")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn header_read_timeout_closes_stalled_connection() {
+        let (server_cfg, client_cfg, _) = pki();
+        let app = axum::Router::new();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(
+            serve_tls(listener, app, server_cfg)
+                .with_header_read_timeout(Some(Duration::from_millis(150)))
+                .with_graceful_shutdown(async {
+                    rx.await.ok();
+                })
+                .into_future(),
+        );
+
+        // Complete the TLS handshake, then send a partial HTTP/1.1 request whose
+        // header block never terminates, so hyper stays in "reading headers".
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let connector = tokio_rustls::TlsConnector::from(client_cfg);
+        let sni = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        let mut tls = connector.connect(sni, tcp).await.unwrap();
+        tls.write_all(b"POST /svc/Echo HTTP/1.1\r\nHost: localhost\r\n")
+            .await
+            .unwrap();
+
+        // The header read timeout must close the connection. `read_to_end`
+        // resolves on close; if the timeout were not wired, it would hang until
+        // the outer guard fails the test. The server tears the connection down
+        // abruptly when the timeout fires, so rustls reports an `UnexpectedEof`
+        // rather than a clean close — either outcome confirms closure.
+        let mut buf = Vec::new();
+        let _ = tokio::time::timeout(Duration::from_secs(5), tls.read_to_end(&mut buf))
+            .await
+            .expect("server did not close the stalled connection");
+        assert!(
+            !buf.starts_with(b"HTTP/1.1 2"),
+            "stalled request should not have been served: {}",
+            String::from_utf8_lossy(&buf[..buf.len().min(80)])
+        );
+
+        tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .expect("serve should shut down")
             .unwrap()
             .unwrap();
     }

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -62,6 +62,7 @@ use http::header;
 use http_body_util::Full;
 use hyper_util::rt::TokioExecutor;
 use hyper_util::rt::TokioIo;
+use hyper_util::rt::TokioTimer;
 use hyper_util::server::conn::auto::Builder as AutoBuilder;
 use hyper_util::server::graceful::GracefulConnection;
 use tokio::net::TcpListener;
@@ -143,6 +144,28 @@ impl PeerInfo {
 #[cfg_attr(docsrs, doc(cfg(feature = "server-tls")))]
 pub const DEFAULT_TLS_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Default HTTP/1.1 header read timeout.
+///
+/// Bounds how long the server waits to receive a complete set of request
+/// headers, measured from the point hyper begins reading a new request on the
+/// connection. On a keep-alive connection this also bounds the idle wait
+/// between requests, so a peer that opens a connection (or finishes one
+/// request) and then stalls without sending the next request's headers is
+/// disconnected rather than holding a task and file descriptor open
+/// indefinitely. This mitigates slowloris-style connection-exhaustion attacks.
+///
+/// Applies to HTTP/1.1 only; it does not bound idle or stalled HTTP/2
+/// connections — use `with_max_connection_age` to retire those by age.
+///
+/// This default is applied to every accepted connection. Earlier releases
+/// installed no connection timer, so the header read timeout never took
+/// effect; it is active by default as of the release that introduced
+/// [`Server::with_header_read_timeout`].
+///
+/// Override via [`Server::with_header_read_timeout`] or
+/// [`BoundServer::with_header_read_timeout`]; pass `None` to disable.
+pub const DEFAULT_HEADER_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
 const DEFAULT_MAX_CONNECTION_AGE_GRACE: Duration = Duration::from_secs(5);
 const MAX_CONNECTION_AGE_JITTER_BASIS_POINTS: u128 = 10_000;
 const MAX_CONNECTION_AGE_JITTER_SPREAD_BASIS_POINTS: u128 = 1_000;
@@ -156,6 +179,7 @@ pub struct Server {
     tls_config: Option<Arc<rustls::ServerConfig>>,
     #[cfg(feature = "server-tls")]
     tls_handshake_timeout: std::time::Duration,
+    header_read_timeout: Option<Duration>,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
 }
@@ -170,6 +194,7 @@ impl Server {
             tls_config: None,
             #[cfg(feature = "server-tls")]
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+            header_read_timeout: Some(DEFAULT_HEADER_READ_TIMEOUT),
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
         }
@@ -184,6 +209,7 @@ impl Server {
             tls_config: None,
             #[cfg(feature = "server-tls")]
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+            header_read_timeout: Some(DEFAULT_HEADER_READ_TIMEOUT),
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
         }
@@ -227,6 +253,24 @@ impl Server {
     #[must_use]
     pub fn with_tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.tls_handshake_timeout = timeout;
+        self
+    }
+
+    /// Set the HTTP/1.1 header read timeout.
+    ///
+    /// Defaults to [`DEFAULT_HEADER_READ_TIMEOUT`] (30 seconds). Bounds how
+    /// long the server waits to read a complete set of request headers,
+    /// measured from when hyper begins reading a new request; on a keep-alive
+    /// connection this also bounds the idle wait between requests. A peer that
+    /// connects (or finishes a request) and then stalls without sending the
+    /// next request's headers is disconnected, which mitigates slowloris-style
+    /// connection-exhaustion attacks. Pass `None` to disable.
+    ///
+    /// Applies to HTTP/1.1 only; it does not bound idle or stalled HTTP/2
+    /// connections — use `with_max_connection_age` to retire those by age.
+    #[must_use]
+    pub fn with_header_read_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.header_read_timeout = timeout.into();
         self
     }
 
@@ -389,6 +433,7 @@ impl Server {
             self.service,
             tls_acceptor,
             self.http1_keep_alive,
+            self.header_read_timeout,
             #[cfg(feature = "server-tls")]
             self.tls_handshake_timeout,
             None,
@@ -422,6 +467,7 @@ impl Server {
             tls_config: None,
             #[cfg(feature = "server-tls")]
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+            header_read_timeout: Some(DEFAULT_HEADER_READ_TIMEOUT),
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
         }
@@ -440,6 +486,7 @@ impl Server {
             tls_config: None,
             #[cfg(feature = "server-tls")]
             tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+            header_read_timeout: Some(DEFAULT_HEADER_READ_TIMEOUT),
             max_connection_age: None,
             max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
         })
@@ -454,6 +501,7 @@ pub struct BoundServer {
     tls_config: Option<Arc<rustls::ServerConfig>>,
     #[cfg(feature = "server-tls")]
     tls_handshake_timeout: std::time::Duration,
+    header_read_timeout: Option<Duration>,
     max_connection_age: Option<Duration>,
     max_connection_age_grace: Duration,
 }
@@ -481,6 +529,24 @@ impl BoundServer {
     #[must_use]
     pub fn with_tls_handshake_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.tls_handshake_timeout = timeout;
+        self
+    }
+
+    /// Set the HTTP/1.1 header read timeout.
+    ///
+    /// Defaults to [`DEFAULT_HEADER_READ_TIMEOUT`] (30 seconds). Bounds how
+    /// long the server waits to read a complete set of request headers,
+    /// measured from when hyper begins reading a new request; on a keep-alive
+    /// connection this also bounds the idle wait between requests. A peer that
+    /// connects (or finishes a request) and then stalls without sending the
+    /// next request's headers is disconnected, which mitigates slowloris-style
+    /// connection-exhaustion attacks. Pass `None` to disable.
+    ///
+    /// Applies to HTTP/1.1 only; it does not bound idle or stalled HTTP/2
+    /// connections — use `with_max_connection_age` to retire those by age.
+    #[must_use]
+    pub fn with_header_read_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.header_read_timeout = timeout.into();
         self
     }
 
@@ -613,6 +679,7 @@ impl BoundServer {
             service,
             tls_acceptor,
             self.http1_keep_alive,
+            self.header_read_timeout,
             #[cfg(feature = "server-tls")]
             self.tls_handshake_timeout,
             None,
@@ -646,6 +713,7 @@ impl BoundServer {
             service,
             tls_acceptor,
             self.http1_keep_alive,
+            self.header_read_timeout,
             #[cfg(feature = "server-tls")]
             self.tls_handshake_timeout,
             Some(Box::pin(signal)),
@@ -712,6 +780,7 @@ async fn serve_accepted_stream<D, S>(
     peer: PeerInfo,
     service: Arc<WrappedService<D>>,
     http1_keep_alive: bool,
+    header_read_timeout: Option<Duration>,
     global_shutdown: watch::Receiver<bool>,
     connection_age: Option<ConnectionAgeConfig>,
 ) where
@@ -728,7 +797,15 @@ async fn serve_accepted_stream<D, S>(
     });
 
     let mut builder = AutoBuilder::new(TokioExecutor::new());
-    builder.http1().keep_alive(http1_keep_alive);
+    // A timer is required for hyper's header read timeout (and any other
+    // time-based connection behaviour) to take effect; without it the
+    // configured `header_read_timeout` is silently ignored.
+    builder
+        .http1()
+        .timer(TokioTimer::new())
+        .keep_alive(http1_keep_alive)
+        .header_read_timeout(header_read_timeout);
+    builder.http2().timer(TokioTimer::new());
 
     let conn = builder.serve_connection(TokioIo::new(io), svc).into_owned();
     serve_connection_with_lifecycle(conn, peer.addr, global_shutdown, connection_age).await;
@@ -918,11 +995,16 @@ type MaybeTlsAcceptor = Option<()>;
 /// Optional boxed shutdown-signal future.
 type ShutdownSignal = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
+// This internal helper threads each per-connection tuning knob through as its
+// own parameter, matching the surrounding style; grouping them into a struct
+// would be a larger churn than the values warrant.
+#[allow(clippy::too_many_arguments)]
 async fn serve_with_listener<D: Dispatcher>(
     listener: TcpListener,
     service: ConnectRpcService<D>,
     tls_acceptor: MaybeTlsAcceptor,
     http1_keep_alive: bool,
+    header_read_timeout: Option<Duration>,
     #[cfg(feature = "server-tls")] tls_handshake_timeout: std::time::Duration,
     shutdown: ShutdownSignal,
     connection_age: Option<ConnectionAgeConfig>,
@@ -1018,6 +1100,7 @@ async fn serve_with_listener<D: Dispatcher>(
                             peer,
                             service,
                             http1_keep_alive,
+                            header_read_timeout,
                             global_shutdown,
                             connection_age,
                         )
@@ -1051,6 +1134,7 @@ async fn serve_with_listener<D: Dispatcher>(
                 peer,
                 service,
                 http1_keep_alive,
+                header_read_timeout,
                 global_shutdown,
                 connection_age,
             )
@@ -1552,6 +1636,131 @@ mod tests {
     #[should_panic(expected = "non-zero duration")]
     fn with_max_connection_age_rejects_zero() {
         let _ = Server::new(Router::new()).with_max_connection_age(Duration::ZERO);
+    }
+
+    #[test]
+    fn header_read_timeout_builder_defaults_and_overrides() {
+        // Default is on at DEFAULT_HEADER_READ_TIMEOUT.
+        let server = Server::new(Router::new());
+        assert_eq!(
+            server.header_read_timeout,
+            Some(DEFAULT_HEADER_READ_TIMEOUT)
+        );
+
+        // An explicit value overrides the default.
+        let server =
+            Server::new(Router::new()).with_header_read_timeout(Some(Duration::from_secs(5)));
+        assert_eq!(server.header_read_timeout, Some(Duration::from_secs(5)));
+
+        // `None` disables it.
+        let server = Server::new(Router::new()).with_header_read_timeout(None::<Duration>);
+        assert_eq!(server.header_read_timeout, None);
+    }
+
+    #[tokio::test]
+    async fn bound_server_header_read_timeout_builder_defaults_and_overrides() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = Server::from_listener(listener);
+        assert_eq!(bound.header_read_timeout, Some(DEFAULT_HEADER_READ_TIMEOUT));
+
+        let bound = bound.with_header_read_timeout(Some(Duration::from_secs(2)));
+        assert_eq!(bound.header_read_timeout, Some(Duration::from_secs(2)));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = Server::from_listener(listener).with_header_read_timeout(None::<Duration>);
+        assert_eq!(bound.header_read_timeout, None);
+    }
+
+    /// A peer that opens a connection and sends an incomplete header block must
+    /// be disconnected once the header read timeout elapses, rather than
+    /// holding the connection (and its task and file descriptor) open forever.
+    #[tokio::test(start_paused = true)]
+    async fn header_read_timeout_closes_stalled_connection() {
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_header_read_timeout(Some(Duration::from_secs(10)));
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(Router::new(), async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        // Send a partial request that never terminates the header block, so
+        // hyper stays in "reading request headers" and arms the timeout.
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"POST /svc/Echo HTTP/1.1\r\nHost: localhost\r\n")
+            .await
+            .unwrap();
+
+        // Relies on tokio's paused-clock auto-advance: once the connection
+        // task has armed the header-read timer and parked, the runtime
+        // advances to fire it. The explicit advance keeps the intent obvious.
+        tokio::time::advance(Duration::from_secs(11)).await;
+        yield_to_tasks().await;
+
+        let mut buf = [0; 1];
+        let read = stream.read(&mut buf).await.unwrap();
+        assert_eq!(
+            read, 0,
+            "stalled connection stayed open past the header read timeout"
+        );
+
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(1), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
+    }
+
+    /// A complete request well within the header read timeout is served
+    /// normally — the timer must not interfere with healthy traffic.
+    #[tokio::test]
+    async fn header_read_timeout_allows_prompt_requests() {
+        let router = Router::new().route(
+            "svc",
+            "Echo",
+            crate::handler_fn(
+                |_ctx: crate::RequestContext, _req: buffa_types::Empty| async move {
+                    crate::Response::ok(buffa_types::Empty::default())
+                },
+            ),
+        );
+        let bound = Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_header_read_timeout(Some(Duration::from_secs(30)));
+        let addr = bound.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let serve = tokio::spawn(async move {
+            bound
+                .serve_with_graceful_shutdown(router, async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+        });
+
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        stream.write_all(ECHO_REQ).await.unwrap();
+        let resp = read_http1_response(&mut stream).await;
+        assert!(
+            resp.starts_with(b"HTTP/1.1 2"),
+            "expected 2xx, got: {}",
+            String::from_utf8_lossy(&resp[..resp.len().min(80)])
+        );
+
+        shutdown_tx.send(()).unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(5), serve)
+            .await
+            .expect("server did not shut down")
+            .expect("join error");
+        assert!(result.is_ok(), "serve returned error: {result:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The built-in server builds hyper connections without installing a timer, so
hyper's header read timeout never takes effect. A peer that opens a connection
and then stalls before sending a complete request — or that finishes a request
and then sits idle on a keep-alive connection — is held open indefinitely along
with its task and file descriptor. Today this can only be bounded by an external
load balancer or reverse proxy, leaving the server exposed to slowloris-style
connection-exhaustion.

## Change

This installs a `TokioTimer` on every accepted connection (both HTTP/1 and
HTTP/2 builders) in the standalone `Server`/`BoundServer` and in the axum
`serve_tls` path, and applies an HTTP/1.1 header read timeout.

New configuration, mirroring the existing `with_tls_handshake_timeout` and
`with_max_connection_age` knobs:

- `Server::with_header_read_timeout(impl Into<Option<Duration>>)`
- `BoundServer::with_header_read_timeout(impl Into<Option<Duration>>)`
- `ServeTls::with_header_read_timeout(impl Into<Option<Duration>>)`
- `pub const DEFAULT_HEADER_READ_TIMEOUT: Duration` (30 seconds)

The timeout bounds how long the server waits to read a complete request header
block, measured from when hyper begins reading a new request. On a keep-alive
connection it also bounds the idle wait between requests, so a stalled or idle
peer is disconnected rather than pinning resources. It defaults to 30 seconds
(hyper's own default, now made explicit and actually active because the timer is
installed); pass `None` to disable.

This is a behavior change: previously no timer was installed, so the default
header read timeout never fired. An HTTP/1.1 keep-alive connection that sits
idle for 30 seconds without a new request is now closed. Raise the duration or
pass `None` to opt out.

Applies to HTTP/1.1 only. HTTP/2 connection liveness (keep-alive pings) and
dedicated idle-connection reaping are tracked separately (#175, #177); this PR
deliberately does not add those knobs to avoid overlapping that work.

## Validation

- `cargo test --workspace --all-features` — 652 passed.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean.
- `cargo +nightly-2026-02-27 fmt --all -- --check` — clean.
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p connectrpc --all-features --no-deps` — clean.
- `cargo check -p connectrpc --no-default-features [--features server]` — clean.

New tests: builder default/override/disable round-trip on `Server` and
`BoundServer`; a `start_paused` test proving a connection sending an incomplete
header block is closed once the timeout elapses; a positive control that prompt
requests are served normally; and a TLS-path test in `serve_tls`.

Closes #135
