### PR TITLE
docs: document raw hyper transport config

### DIFF
--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -43,6 +43,10 @@
 //! period. This is independent of whole-server graceful shutdown, which still
 //! drains in-flight requests indefinitely even while a connection is in its
 //! age-grace window.
+//!
+//! For transport and HTTP/2 knobs that [`Server`] does not expose, drive
+//! [`ConnectRpcService`] directly from a hyper accept loop. The crate guide's
+//! "Advanced transport configuration" section shows the `hyper_util` pattern.
 
 use std::any::Any;
 use std::collections::hash_map::RandomState;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1045,7 +1045,69 @@ Server::new(connect_router)
 The standalone `Server` handles HTTP/1.1, HTTP/2 with prior knowledge,
 and graceful shutdown. It's a single dispatcher with no per-route
 configuration, so add things like health endpoints either as RPC
-methods or by switching to the axum path.
+methods or by mounting the Connect service in axum.
+
+For connection and HTTP/2 settings that `Server` does not expose, drop
+down to raw hyper instead.
+
+### Advanced transport configuration
+
+The built-in `Server` exposes the common connection knobs, but it does
+not try to mirror every hyper option. For long-tail transport tuning —
+flow-control windows, HPACK table size, frame size, or exact keepalive
+behavior — drive the Connect service from your own hyper accept loop.
+
+Add `hyper-util` as a direct dependency with the `server-auto`,
+`service`, and `tokio` features enabled. Then wrap `ConnectRpcService`
+with `TowerToHyperService` before handing each connection to hyper's
+auto builder:
+
+```rust,ignore
+use connectrpc::{ConnectRpcService, Router};
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server::conn::auto::Builder as AutoBuilder,
+    service::TowerToHyperService,
+};
+
+let connect_router = Router::new().add_service(greeter_service);
+let connect_service = ConnectRpcService::new(connect_router);
+
+let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+let mut builder = AutoBuilder::new(TokioExecutor::new());
+builder
+    .http2()
+    .max_concurrent_streams(1_000)
+    .max_frame_size(1 << 20)
+    .adaptive_window(true);
+
+loop {
+    let (stream, _peer_addr) = listener.accept().await?;
+    let conn = builder
+        .serve_connection(
+            TokioIo::new(stream),
+            TowerToHyperService::new(connect_service.clone()),
+        )
+        .into_owned();
+
+    tokio::spawn(async move {
+        if let Err(err) = conn.await {
+            eprintln!("connection ended with error: {err}");
+        }
+    });
+}
+```
+
+This is the escape hatch for connection- and protocol-level settings.
+Axum remains the better fit for routing, health checks, ordinary HTTP
+endpoints, and request-level Tower middleware such as auth, timeouts,
+or rate limiting.
+
+Unlike the built-in `Server` and `connectrpc::axum::serve_tls`, a raw
+hyper loop does not automatically insert `PeerAddr` or `PeerCerts` into
+request extensions. If handlers call `ctx.peer_addr()` or
+`ctx.peer_certs()`, insert those extensions in your own Tower layer or
+service wrapper before the request reaches `ConnectRpcService`.
 
 ### TLS
 


### PR DESCRIPTION
## Problem

The hosting guide tells users to switch to axum when the built-in `Server`
does not fit, but `axum::serve` is not the escape hatch for transport-level
HTTP/2 settings. Users who need knobs such as flow-control windows, frame
size, HPACK table size, or exact keepalive behavior need to drive
`ConnectRpcService` with hyper directly.

## Change

- Narrow the standalone-server guidance so axum is recommended for routing,
  health checks, ordinary HTTP endpoints, and request-level Tower middleware.
- Add an "Advanced transport configuration" section showing the
  `ConnectRpcService` + `TowerToHyperService` + `hyper_util` auto-builder
  pattern.
- Cross-link from the `server` module docs so readers of `Server` can discover
  the raw-hyper path for unexposed transport/HTTP/2 knobs.

This keeps `Server`'s API focused while documenting the lower-level hosting
path that already exists through the Tower service implementation.

## Validation

- `rg -n 'Advanced transport configuration|TowerToHyperService|serve_connection|adaptive_window|max_concurrent_streams' docs/guide.md connectrpc/src/server.rs`
- `rg -n 'switching to the axum path|axum.*transport|axum::serve.*HTTP/2|axum::serve.*transport' docs/guide.md README.md connectrpc/src`
- `git diff --check`
- `cargo +nightly-2026-02-27 fmt --all -- --check`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc -p connectrpc --all-features --no-deps`
- `cargo check -p connectrpc --all-features --offline`
- `cargo check -p connectrpc --no-default-features --features server --offline`

## Risk

The new example is intentionally a small hosting pattern, not a full production
accept loop. It calls out that raw hyper users must insert `PeerAddr` /
`PeerCerts` themselves if handlers rely on `ctx.peer_addr()` or
`ctx.peer_certs()`.

## Out of scope

- No new `Server` builder APIs.
- No axum behavior changes.
- No generated code, dependency, or lockfile changes.

## Issue linkage

Closes #179
