### PR TITLE
Reject malformed Connect END_STREAM JSON

### DIFF
--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2328,36 +2328,15 @@ where
             Err(e) => return e.into(),
         };
 
-        let end_stream: ClientEndStreamResponse =
-            serde_json::from_slice(&end_stream_data).unwrap_or_default();
+        let end_stream = match parse_connect_end_stream(&end_stream_data) {
+            Ok(end_stream) => end_stream,
+            Err(e) => return e.into(),
+        };
 
-        let trailers = end_stream.metadata.map(|metadata| {
-            let mut trailers = http::HeaderMap::new();
-            for (name, values) in metadata {
-                for value in values {
-                    if let (Ok(name), Ok(value)) = (
-                        http::header::HeaderName::from_bytes(name.as_bytes()),
-                        http::header::HeaderValue::from_str(&value),
-                    ) {
-                        trailers.append(name, value);
-                    }
-                }
-            }
-            trailers
-        });
+        let trailers = end_stream.metadata.map(metadata_to_trailers);
 
         let outcome = match end_stream.error {
-            Some(err) => {
-                let mut connect_error = ConnectError::new(
-                    err.code
-                        .as_deref()
-                        .and_then(|c| c.parse().ok())
-                        .unwrap_or(ErrorCode::Unknown),
-                    err.message.unwrap_or_default(),
-                );
-                connect_error.details = err.details;
-                Err(connect_error)
-            }
+            Some(err) => Err(end_stream_error_to_connect_error(err)),
             None => Ok(()),
         };
 
@@ -3257,31 +3236,17 @@ fn parse_connect_client_stream_envelopes(
                 envelope.data
             };
 
-            let end_stream: ClientEndStreamResponse =
-                serde_json::from_slice(&end_stream_data).unwrap_or_default();
+            let end_stream = parse_connect_end_stream(&end_stream_data).map_err(|mut err| {
+                err.set_response_headers(resp_headers.clone());
+                err
+            })?;
 
             if let Some(metadata) = end_stream.metadata {
-                for (name, values) in metadata {
-                    for value in values {
-                        if let (Ok(name), Ok(value)) = (
-                            http::header::HeaderName::from_bytes(name.as_bytes()),
-                            http::header::HeaderValue::from_str(&value),
-                        ) {
-                            trailers.append(name, value);
-                        }
-                    }
-                }
+                trailers = metadata_to_trailers(metadata);
             }
 
             if let Some(err) = end_stream.error {
-                let mut connect_error = ConnectError::new(
-                    err.code
-                        .as_deref()
-                        .and_then(|c| c.parse().ok())
-                        .unwrap_or(ErrorCode::Unknown),
-                    err.message.unwrap_or_default(),
-                );
-                connect_error.details = err.details;
+                let mut connect_error = end_stream_error_to_connect_error(err);
                 connect_error.set_response_headers(resp_headers.clone());
                 connect_error.set_trailers(trailers);
                 return Err(connect_error);
@@ -3357,6 +3322,41 @@ struct ClientEndStreamError {
     message: Option<String>,
     #[serde(default)]
     details: Vec<ErrorDetail>,
+}
+
+fn parse_connect_end_stream(data: &[u8]) -> Result<ClientEndStreamResponse, ConnectError> {
+    serde_json::from_slice(data).map_err(|e| {
+        ConnectError::internal(format!(
+            "protocol error: malformed Connect END_STREAM JSON: {e}"
+        ))
+    })
+}
+
+fn metadata_to_trailers(metadata: HashMap<String, Vec<String>>) -> http::HeaderMap {
+    let mut trailers = http::HeaderMap::new();
+    for (name, values) in metadata {
+        for value in values {
+            if let (Ok(name), Ok(value)) = (
+                http::header::HeaderName::from_bytes(name.as_bytes()),
+                http::header::HeaderValue::from_str(&value),
+            ) {
+                trailers.append(name, value);
+            }
+        }
+    }
+    trailers
+}
+
+fn end_stream_error_to_connect_error(err: ClientEndStreamError) -> ConnectError {
+    let mut connect_error = ConnectError::new(
+        err.code
+            .as_deref()
+            .and_then(|c| c.parse().ok())
+            .unwrap_or(ErrorCode::Unknown),
+        err.message.unwrap_or_default(),
+    );
+    connect_error.details = err.details;
+    connect_error
 }
 
 /// Error response structure from ConnectRPC.
@@ -4040,6 +4040,60 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("42")
         );
+    }
+
+    /// Malformed Connect END_STREAM JSON is a protocol error. It must not be
+    /// treated as an empty successful end-stream payload.
+    #[tokio::test]
+    async fn connect_malformed_end_stream_json_errors() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut body = BytesMut::new();
+        body.extend_from_slice(
+            &Envelope::data(StringValue::from("hello").encode_to_bytes()).encode(),
+        );
+        body.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"not json")).encode());
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers: http::HeaderMap::new(),
+            body: Full::new(body.freeze()),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Connect,
+            max_message_size: Some(1024),
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let msg = stream
+            .message()
+            .await
+            .expect("data envelope should decode")
+            .expect("stream should yield the data message first");
+        assert_eq!(msg.reborrow().value, "hello");
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("malformed END_STREAM must surface as Err, not Ok(None)");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert!(
+            err.to_string()
+                .contains("malformed Connect END_STREAM JSON"),
+            "unexpected error: {err}"
+        );
+
+        let again = stream
+            .message()
+            .await
+            .expect_err("malformed END_STREAM error must be sticky");
+        assert_eq!(again.code, ErrorCode::Internal);
     }
 
     /// Same contract for gRPC: an error in HTTP/2 trailers is a failed RPC
@@ -5475,6 +5529,38 @@ mod tests {
             "m",
             "END_STREAM metadata must be attached to the error as trailers"
         );
+    }
+
+    /// Malformed Connect END_STREAM JSON is a protocol error. It must not be
+    /// treated as an empty successful end-stream payload.
+    #[test]
+    fn client_stream_response_malformed_end_stream_json_errors() {
+        let registry = crate::compression::CompressionRegistry::new();
+
+        let mut body = Envelope::data(Bytes::from_static(b"only"))
+            .encode()
+            .to_vec();
+        body.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"not json")).encode());
+
+        let mut resp_headers = http::HeaderMap::new();
+        resp_headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
+
+        let err = parse_connect_client_stream_envelopes(
+            Bytes::from(body),
+            &registry,
+            None,
+            1024,
+            &resp_headers,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert!(
+            err.to_string()
+                .contains("malformed Connect END_STREAM JSON"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(err.response_headers().get("x-from-headers").unwrap(), "yes");
+        assert!(err.trailers().is_empty());
     }
 
     /// A body with no data envelope (END_STREAM only) is rejected.


### PR DESCRIPTION
## Summary

- Reject malformed Connect END_STREAM JSON as an internal protocol error instead of treating it as an empty successful terminator.
- Share END_STREAM parsing, trailer conversion, and error conversion between the server-stream and client-stream response paths.
- Add regression coverage for malformed END_STREAM JSON in both paths.

## Why

The client used `serde_json::from_slice(...).unwrap_or_default()` when parsing Connect END_STREAM payloads. Invalid JSON therefore became the default successful end-stream shape, so a malformed protocol terminator could be reported as a clean RPC completion.

## Testing

- `cargo test -p connectrpc malformed_end_stream_json`
- `cargo test -p connectrpc`
- `cargo test --workspace`
- `cargo check -p connectrpc --no-default-features`
- `cargo clippy -p connectrpc --all-targets --all-features -- -D warnings`
- `git diff --check`
