### PR TITLE
Make generated client feature gate configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ increment the patch version.
 
 ### Added
 
+- **Configurable codegen client feature gate name** ([#181]).
+  `gate_client_feature=<name>` lets `protoc-gen-connect-rust` emit generated
+  client items behind `#[cfg(feature = "<name>")]` instead of the default
+  `client`; `connectrpc-build` exposes the same through
+  `Config::client_feature_name`. The existing bare `gate_client_feature`
+  option and `Config::gate_client_feature(true)` behavior continue to use
+  `client`.
 - **Optional `json` cargo feature for proto-only builds** ([#172]). The
   Connect JSON codec requires `serde::Serialize`/`Deserialize` on every
   message type, so the code generator derives them by default — pure cost for

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -203,6 +203,19 @@ impl Config {
         self
     }
 
+    /// Set the Cargo feature name used by [`Config::gate_client_feature`]
+    /// (default: `"client"`).
+    ///
+    /// Use this when the generated crate exposes its client surface under a
+    /// different feature name, such as `grpc-client` or `transport`. This
+    /// method does not enable gating by itself; pair it with
+    /// `gate_client_feature(true)`.
+    #[must_use]
+    pub fn client_feature_name(mut self, feature: impl Into<String>) -> Self {
+        self.options.client_feature_name = feature.into();
+        self
+    }
+
     /// Replace the underlying buffa [`CodeGenConfig`] wholesale.
     ///
     /// Any buffa knob not surfaced as a builder method here can be set this
@@ -707,6 +720,7 @@ mod tests {
             .generate_json(false)
             .emit_register_fn(false)
             .gate_client_feature(true)
+            .client_feature_name("grpc-client")
             .include_file("_inc.rs");
         assert_eq!(cfg.files.len(), 2);
         assert_eq!(cfg.includes.len(), 1);
@@ -714,6 +728,7 @@ mod tests {
         assert!(!cfg.options.buffa.generate_json);
         assert!(!cfg.options.buffa.emit_register_fn);
         assert!(cfg.options.gate_client_feature);
+        assert_eq!(cfg.options.client_feature_name, "grpc-client");
         assert_eq!(cfg.include_file.as_deref(), Some("_inc.rs"));
     }
 
@@ -726,6 +741,7 @@ mod tests {
         // `gate_client_feature` defaults off — build.rs consumers don't
         // have to declare a `client` Cargo feature unless they opt in.
         assert!(!cfg.options.gate_client_feature);
+        assert_eq!(cfg.options.client_feature_name, "client");
         assert!(cfg.emit_rerun_directives);
         assert!(matches!(cfg.descriptor_source, DescriptorSource::Protoc));
     }
@@ -768,6 +784,31 @@ mod tests {
                 "`{marker}` must not be gated:\n{gated}"
             );
         }
+
+        // Custom name: cfg attrs use the configured feature name, not the
+        // default `client`.
+        let out_custom = tempfile::tempdir().unwrap();
+        Config::new()
+            .descriptor_set(&fixture)
+            .files(&["echo.proto"])
+            .out_dir(out_custom.path())
+            .gate_client_feature(true)
+            .client_feature_name("grpc-client")
+            .emit_rerun_directives(false)
+            .compile()
+            .expect("compile with custom client feature name");
+        let custom = std::fs::read_to_string(out_custom.path().join("echo.__connect.rs"))
+            .expect("read custom __connect.rs");
+        let custom_count = custom.matches("#[cfg(feature = \"grpc-client\")]").count();
+        assert_eq!(
+            custom_count, 2,
+            "expected exactly 2 custom cfg attrs (struct + impl); got \
+             {custom_count}:\n{custom}"
+        );
+        assert!(
+            !custom.contains("#[cfg(feature = \"client\")]"),
+            "custom client feature name must replace the default gate:\n{custom}"
+        );
 
         // Opt-out (default): no cfg attrs anywhere in the same file.
         let out_without = tempfile::tempdir().unwrap();

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -187,12 +187,16 @@ impl Config {
     }
 
     /// Prefix every generated `FooClient<T>` struct and its `impl` block
-    /// with `#[cfg(feature = "client")]` (default: `false`).
+    /// with `#[cfg(feature = "client")]` (default: `false`). Use
+    /// [`Config::client_feature_name`] to gate on a feature other than
+    /// `"client"` — note that calling `client_feature_name` re-enables
+    /// gating, so order it before `gate_client_feature(false)` if you
+    /// need to set a name but leave gating off.
     ///
     /// Opt in when you want a server-only build of your crate to drop
     /// the `connectrpc/client` transport stack from its dependency
-    /// graph. The consumer crate then declares a `client` Cargo feature
-    /// that forwards to `connectrpc/client`; see the `# Client-side cfg
+    /// graph. The consumer crate then declares the gate's Cargo feature
+    /// and forwards it to `connectrpc/client`; see the `# Client-side cfg
     /// gate` section in [`connectrpc_codegen::codegen::generate`]'s
     /// docs for the minimal pattern. With the option off (the default),
     /// generated client items are unconditional — external consumers
@@ -203,15 +207,16 @@ impl Config {
         self
     }
 
-    /// Set the Cargo feature name used by [`Config::gate_client_feature`]
-    /// (default: `"client"`).
+    /// Enable [`Config::gate_client_feature`] and set the Cargo feature name
+    /// it gates on (default: `"client"`).
     ///
     /// Use this when the generated crate exposes its client surface under a
-    /// different feature name, such as `grpc-client` or `transport`. This
-    /// method does not enable gating by itself; pair it with
-    /// `gate_client_feature(true)`.
+    /// different feature name, such as `grpc-client` or `transport`. Calling
+    /// this implies `gate_client_feature(true)`, mirroring the plugin's
+    /// `gate_client_feature=<name>` form, so you don't need both calls.
     #[must_use]
     pub fn client_feature_name(mut self, feature: impl Into<String>) -> Self {
+        self.options.gate_client_feature = true;
         self.options.client_feature_name = feature.into();
         self
     }
@@ -730,6 +735,17 @@ mod tests {
         assert!(cfg.options.gate_client_feature);
         assert_eq!(cfg.options.client_feature_name, "grpc-client");
         assert_eq!(cfg.include_file.as_deref(), Some("_inc.rs"));
+    }
+
+    #[test]
+    fn client_feature_name_enables_gating() {
+        let cfg = Config::new().client_feature_name("grpc-client");
+        assert!(
+            cfg.options.gate_client_feature,
+            "client_feature_name alone must enable gating (mirrors plugin \
+             gate_client_feature=<name>)"
+        );
+        assert_eq!(cfg.options.client_feature_name, "grpc-client");
     }
 
     #[test]

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use heck::ToSnakeCase;
 use heck::ToUpperCamelCase;
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::format_ident;
 use quote::quote;
 
@@ -68,10 +68,14 @@ pub struct Options {
     pub buffa: CodeGenConfig,
 
     /// When `true`, prefix every emitted `FooClient<T>` struct and its
-    /// `impl` block with `#[cfg(feature = "client")]`. Opt in when
+    /// `impl` block with `#[cfg(feature = "...")]`. Opt in when
     /// the consuming crate wants to give server-only deployments a way
     /// to drop the client transport stack from their dependency graph.
     pub gate_client_feature: bool,
+
+    /// Cargo feature name used when [`Options::gate_client_feature`] is
+    /// enabled (default: `"client"`).
+    pub client_feature_name: String,
 }
 
 impl Default for Options {
@@ -81,6 +85,7 @@ impl Default for Options {
         Self {
             buffa,
             gate_client_feature: false,
+            client_feature_name: "client".into(),
         }
     }
 }
@@ -93,6 +98,14 @@ impl Options {
         config.generate_views = true;
         config
     }
+
+    fn client_feature_name(&self) -> Result<&str> {
+        let name = self.client_feature_name.trim();
+        if self.gate_client_feature && name.is_empty() {
+            anyhow::bail!("client feature name must not be empty");
+        }
+        Ok(if name.is_empty() { "client" } else { name })
+    }
 }
 
 /// Emit one [`GeneratedFile`] per proto file in `file_to_generate` that
@@ -102,6 +115,7 @@ fn emit_service_files(
     file_to_generate: &[String],
     resolver: &TypeResolver<'_>,
     gate_client_feature: bool,
+    client_feature_name: &str,
 ) -> Result<Vec<GeneratedFile>> {
     let mut out = Vec::new();
     // Dedup state shared across the whole batch, not per file:
@@ -114,6 +128,7 @@ fn emit_service_files(
     let mut batch = BatchState {
         colliding_aliases: collect_alias_collisions(proto_file, file_to_generate),
         gate_client_feature,
+        client_feature_name: client_feature_name.to_string(),
         ..BatchState::default()
     };
     for file_name in file_to_generate {
@@ -183,11 +198,13 @@ pub fn generate_files(
         .map_err(|e| anyhow::anyhow!("buffa-codegen failed: {e}"))?;
 
     let resolver = TypeResolver::new(proto_file, file_to_generate, &config, false);
+    let client_feature_name = options.client_feature_name()?;
     let service_files = emit_service_files(
         proto_file,
         file_to_generate,
         &resolver,
         options.gate_client_feature,
+        client_feature_name,
     )?;
 
     if config.file_per_package {
@@ -316,11 +333,13 @@ pub fn generate_services(
 
     let config = options.to_buffa_config();
     let resolver = TypeResolver::new(proto_file, file_to_generate, &config, true);
+    let client_feature_name = options.client_feature_name()?;
     let mut files = emit_service_files(
         proto_file,
         file_to_generate,
         &resolver,
         options.gate_client_feature,
+        client_feature_name,
     )?;
 
     if config.file_per_package {
@@ -461,11 +480,13 @@ pub fn generate_services(
 ///   types emitted); accepted for compatibility with the unified path.
 /// - `gate_client_feature` — prefix every emitted `FooClient<T>`
 ///   struct and its `impl` block with `#[cfg(feature = "client")]`.
+/// - `gate_client_feature=<name>` — same gate, but use `<name>` as the
+///   Cargo feature instead of `client`.
 ///
 /// # Client-side cfg gate
 ///
 /// When `gate_client_feature` is set, the consumer crate must declare
-/// a Cargo feature literally named `client`. Without it, the generated
+/// the named Cargo feature (`client` by default). Without it, the generated
 /// `FooClient` items will be absent from the crate namespace.
 ///
 /// Two consumer patterns:
@@ -520,6 +541,13 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
                     proto.insert(0, '.');
                 }
                 options.buffa.extern_paths.push((proto, rust.to_string()));
+            } else if let Some(value) = opt.strip_prefix("gate_client_feature=") {
+                let feature = value.trim();
+                if feature.is_empty() {
+                    anyhow::bail!("gate_client_feature requires a non-empty feature name");
+                }
+                options.gate_client_feature = true;
+                options.client_feature_name = feature.to_string();
             } else {
                 match opt {
                     "file_per_package" => options.buffa.file_per_package = true,
@@ -532,7 +560,8 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
                             "unknown plugin option: {opt:?}. Supported: \
                              buffa_module=<rust_path>, extern_path=<proto>=<rust>, \
                              file_per_package, strict_utf8_mapping, no_json, \
-                             no_register_fn, gate_client_feature"
+                             no_register_fn, gate_client_feature, \
+                             gate_client_feature=<name>"
                         ));
                     }
                 }
@@ -761,10 +790,22 @@ struct BatchState {
     colliding_aliases: std::collections::BTreeSet<(String, String)>,
     /// Mirrors [`Options::gate_client_feature`]. When `true`, prefix
     /// each emitted `FooClient<T>` struct + `impl` with
-    /// `#[cfg(feature = "client")]`. Threaded here so it propagates
+    /// `#[cfg(feature = "...")]`. Threaded here so it propagates
     /// through the per-file emission loop without changing every
     /// helper's signature.
     gate_client_feature: bool,
+    /// Mirrors [`Options::client_feature_name`].
+    client_feature_name: String,
+}
+
+impl BatchState {
+    fn client_feature_name(&self) -> &str {
+        if self.client_feature_name.is_empty() {
+            "client"
+        } else {
+            &self.client_feature_name
+        }
+    }
 }
 
 fn generate_connect_services(
@@ -1396,7 +1437,7 @@ received message from `.message().await` — bind `msg.reborrow()` for field
 access, or convert with `.to_owned_message()`."#
     );
     let client_doc_tokens = doc_attrs(&client_doc);
-    // Opt-in `#[cfg(feature = "client")]` on every client-side item.
+    // Opt-in feature cfg on every client-side item.
     //
     // INVARIANT: any future emission referencing
     // `::connectrpc::client::*` (an additional `impl`, a free fn, a
@@ -1404,7 +1445,8 @@ access, or convert with `.to_owned_message()`."#
     // The `no_ungated_client_references` test enforces this by scanning
     // the formatted output under the opt-in path.
     let client_cfg_attr: TokenStream = if batch.gate_client_feature {
-        quote! { #[cfg(feature = "client")] }
+        let feature_name = syn::LitStr::new(batch.client_feature_name(), Span::call_site());
+        quote! { #[cfg(feature = #feature_name)] }
     } else {
         TokenStream::new()
     };
@@ -3458,6 +3500,13 @@ mod tests {
     /// whether the opt-in cfg attr is emitted; shared by the `*_client_*`
     /// tests below.
     fn format_minimal_service(gate_client_feature: bool) -> String {
+        format_minimal_service_with_client_feature_name(gate_client_feature, "client")
+    }
+
+    fn format_minimal_service_with_client_feature_name(
+        gate_client_feature: bool,
+        client_feature_name: &str,
+    ) -> String {
         let file = minimal_file(
             Some("example.v1"),
             ".example.v1.PingReq",
@@ -3471,6 +3520,7 @@ mod tests {
         let batch = BatchState {
             colliding_aliases: collect_alias_collisions(std::slice::from_ref(&file), &target),
             gate_client_feature,
+            client_feature_name: client_feature_name.to_string(),
             ..BatchState::default()
         };
         format_token_stream(&generate_service(&file, service, &resolver, &batch).unwrap()).unwrap()
@@ -3504,6 +3554,22 @@ mod tests {
             "expected exactly two #[cfg(feature = \"client\")] attrs (one on \
              `pub struct PingServiceClient`, one on its `impl<T>` block); got \
              {cfg_count}:\n{out}"
+        );
+    }
+
+    #[test]
+    fn client_items_use_custom_feature_name_when_configured() {
+        let out = format_minimal_service_with_client_feature_name(true, "grpc-client");
+        let cfg_count = out.matches("#[cfg(feature = \"grpc-client\")]").count();
+        assert_eq!(
+            cfg_count, 2,
+            "expected exactly two #[cfg(feature = \"grpc-client\")] attrs \
+             (one on `pub struct PingServiceClient`, one on its `impl<T>` \
+             block); got {cfg_count}:\n{out}"
+        );
+        assert!(
+            !out.contains("#[cfg(feature = \"client\")]"),
+            "custom feature name must replace the default `client` gate:\n{out}"
         );
     }
 
@@ -3895,11 +3961,61 @@ mod tests {
     }
 
     #[test]
+    fn plugin_accepts_gate_client_feature_value_form() {
+        let file = minimal_file(
+            Some("example.v1"),
+            ".example.v1.PingReq",
+            ".example.v1.PingResp",
+            &["PingReq", "PingResp"],
+        );
+        let request = CodeGeneratorRequest {
+            parameter: Some("buffa_module=crate::proto,gate_client_feature=grpc-client".into()),
+            file_to_generate: vec!["ping.proto".into()],
+            proto_file: vec![file],
+            ..Default::default()
+        };
+        let response =
+            generate(&request).expect("custom gate_client_feature value should be recognized");
+        let connect_file = response
+            .file
+            .iter()
+            .find(|f| f.name.as_deref() == Some("ping.__connect.rs"))
+            .expect("plugin should emit a connect service companion");
+        let content = connect_file.content.as_deref().unwrap_or_default();
+        let cfg_count = content.matches("#[cfg(feature = \"grpc-client\")]").count();
+        assert_eq!(
+            cfg_count, 2,
+            "expected custom feature gate on generated client struct and impl; got \
+             {cfg_count}:\n{content}"
+        );
+        assert!(
+            !content.contains("#[cfg(feature = \"client\")]"),
+            "custom plugin feature name must replace the default gate:\n{content}"
+        );
+    }
+
+    #[test]
+    fn plugin_rejects_empty_gate_client_feature_value() {
+        let request = CodeGeneratorRequest {
+            parameter: Some("buffa_module=crate::proto,gate_client_feature=".into()),
+            file_to_generate: vec![],
+            proto_file: vec![],
+            ..Default::default()
+        };
+        let err = generate(&request).expect_err("empty gate_client_feature value must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("gate_client_feature requires a non-empty feature name"),
+            "error should describe the empty feature-name problem: {msg}"
+        );
+    }
+
+    #[test]
     fn plugin_rejects_old_client_feature_value_form() {
         // The previous design used `client_feature=<name>` with an
         // arbitrary feature name. That option was renamed to the bare
-        // flag `gate_client_feature` (the feature name is fixed as
-        // `client`). A stale buf.gen.yaml using the old form must fail
+        // flag `gate_client_feature`, and custom names now use
+        // `gate_client_feature=<name>`. A stale buf.gen.yaml using the old form must fail
         // loudly, not silently no-op.
         let request = CodeGeneratorRequest {
             parameter: Some("buffa_module=crate::proto,client_feature=client".into()),

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -101,11 +101,37 @@ impl Options {
 
     fn client_feature_name(&self) -> Result<&str> {
         let name = self.client_feature_name.trim();
-        if self.gate_client_feature && name.is_empty() {
-            anyhow::bail!("client feature name must not be empty");
+        if name.is_empty() {
+            if self.gate_client_feature {
+                anyhow::bail!("client feature name must not be empty");
+            }
+            return Ok("client");
         }
-        Ok(if name.is_empty() { "client" } else { name })
+        if !is_valid_feature_name(name) {
+            anyhow::bail!(
+                "client feature name {name:?} is not a valid Cargo feature name \
+                 (must start with an alphanumeric or `_` and contain only \
+                 alphanumerics, `_`, `-`, `+`, `.`)"
+            );
+        }
+        Ok(name)
     }
+}
+
+/// Conservative ASCII subset of Cargo's feature-name grammar (matches the
+/// crates.io constraint): starts with an ASCII alphanumeric or `_`; remainder
+/// drawn from alphanumerics, `_`, `-`, `+`, `.`. An invalid name would emit
+/// `#[cfg(feature = "...")]` that Cargo can never enable, silently suppressing
+/// every generated client item.
+//
+// Once the buffa-codegen dependency is bumped to 0.8, replace this with
+// `buffa_codegen::FeatureGateNames::is_valid_name` (same rule, single source).
+fn is_valid_feature_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '+' | '.'))
 }
 
 /// Emit one [`GeneratedFile`] per proto file in `file_to_generate` that
@@ -4007,6 +4033,31 @@ mod tests {
         assert!(
             msg.contains("gate_client_feature requires a non-empty feature name"),
             "error should describe the empty feature-name problem: {msg}"
+        );
+    }
+
+    #[test]
+    fn is_valid_feature_name_matches_cargo_grammar() {
+        for ok in ["client", "grpc-client", "_x", "a.b+c", "0abc"] {
+            assert!(is_valid_feature_name(ok), "{ok:?} should be valid");
+        }
+        for bad in ["", "grpc client", "foo/bar", "-leading", ".leading"] {
+            assert!(!is_valid_feature_name(bad), "{bad:?} should be invalid");
+        }
+    }
+
+    #[test]
+    fn options_reject_invalid_client_feature_name() {
+        let opts = Options {
+            gate_client_feature: true,
+            client_feature_name: "grpc client".into(),
+            ..Options::default()
+        };
+        let err = generate_services(&[], &[], &opts)
+            .expect_err("invalid client feature name must be rejected");
+        assert!(
+            err.to_string().contains("not a valid Cargo feature name"),
+            "error should name the grammar problem: {err}"
         );
     }
 


### PR DESCRIPTION
## Problem

`protoc-gen-connect-rust` can already gate generated client items behind a Cargo feature, but the feature name is fixed to `client`. Crates that expose their generated client surface under a different feature name cannot use the existing gate directly.

## Change

- Add `Options::client_feature_name`, defaulting to `client`, and thread it into generated client cfg attributes.
- Accept `gate_client_feature=<name>` in the protoc plugin while preserving the existing bare `gate_client_feature` behavior.
- Add `connectrpc_build::Config::client_feature_name(...)` as the build wrapper companion API.
- Reject empty custom feature names and keep the generated cfg as a string literal so names like `grpc-client` work.
- Document the additive option in the changelog.

This keeps the existing opt-in shape intact: `gate_client_feature` still enables gating, and the default gate remains `client`.

## Validation

Using `protoc` v33.5:

- `cargo test -p connectrpc-codegen gate_client_feature`
- `cargo test -p connectrpc-build gate_client_feature`
- `cargo check -p connectrpc-codegen`
- `cargo check -p connectrpc-build`
- `cargo check --workspace --all-features --all-targets`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo +nightly-2026-02-27 fmt --all -- --check`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `git diff --check`

## Risk

Low. This is additive, the default remains `client`, and the existing bare plugin flag continues to work. The main compatibility risk is rejecting an empty explicitly configured feature name; that is covered by a focused parser test.

## Out of scope

- JSON or message-type feature gating.
- Regenerating checked-in generated code; default output is unchanged.
- Replacing or changing the existing `gate_client_feature(bool)` API.

## Issue linkage

Closes #181
