### PR TITLE
client: bound h2 connection establishment by default; proxy keep-alive knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ increment the patch version.
 
 ### Added
 
+- **`Http2ConnectionBuilder` with establishment-timeout and HTTP/2 keep-alive
+  knobs** ([#137], [#197]). `Http2Connection::builder()` is now the single
+  configuration surface for every transport flavour (plaintext, TLS,
+  caller-supplied connector, Unix socket); the existing `Http2Connection`
+  constructors are shortcuts for it with default settings. The builder adds
+  `establishment_timeout` (a wall-clock bound on DNS + TCP + TLS + HTTP/2
+  preface as one budget) and `tcp_connect_timeout` (a per-address TCP bound on
+  the built-in connector), and proxies hyper's `keep_alive_interval`,
+  `keep_alive_timeout`, `keep_alive_while_idle`, `initial_stream_window_size`,
+  `initial_connection_window_size`, and `adaptive_window` setters directly,
+  with a `TokioTimer` pre-wired so the keep-alive setters work without hyper's
+  "supply a timer" panic. `h2_settings(|b| ...)` is the escape hatch for hyper
+  knobs not proxied. `HttpClientBuilder` gains the matching
+  `establishment_timeout` (covering DNS + TCP + TLS) and `tcp_connect_timeout`
+  (the canonical name for [#117]'s `connect_timeout`, which remains as an
+  alias). Both builders also expose `no_establishment_timeout` /
+  `no_tcp_connect_timeout` to opt out of the new defaults below.
 - **Optional `json` cargo feature for proto-only builds** ([#172]). The
   Connect JSON codec requires `serde::Serialize`/`Deserialize` on every
   message type, so the code generator derives them by default — pure cost for
@@ -55,6 +72,22 @@ increment the patch version.
 
 ### Changed
 
+- **Client connection establishment is bounded by default** ([#137], [#197]).
+  `Http2Connection` and `HttpClient` now bound connection establishment to
+  `DEFAULT_ESTABLISHMENT_TIMEOUT` (20s, matching grpc-go's `MinConnectTimeout`)
+  with an additional `DEFAULT_TCP_CONNECT_TIMEOUT` (5s) per-address TCP bound
+  on the built-in connector. Previously, a server that accepted the TCP
+  connection but stalled the TLS handshake — for example a draining pod whose
+  kernel backlog still accepts — would stall `poll_ready` indefinitely for
+  every caller sharing the connection. Exceeding either bound surfaces as
+  `ErrorCode::Unavailable`. **This applies to every existing constructor**
+  (they now delegate through the new builders), so this supersedes the [#117]
+  changelog entry's "behaviour is unchanged for callers who don't opt in"
+  statement under 0.7.0. To restore the unbounded pre-0.8.0 behaviour, call
+  `.no_establishment_timeout().no_tcp_connect_timeout()` on the builder. Note
+  that hyper divides the per-address TCP budget across the resolved address
+  set, so a hostname resolving to many addresses on a high-latency link may
+  need a larger `tcp_connect_timeout` than the 5s default.
 - **Connect streaming EOF without END_STREAM now returns `internal`**
   ([#168]). The `ServerStream` Connect EOF path that 0.7.0's [#140]
   introduced as `unavailable` now returns `internal` — the code
@@ -88,6 +121,14 @@ increment the patch version.
   an unsupported `grpc-encoding`. Clients that branch on grpc-status will
   observe 13 → 12 for this case on upgrade.
 
+### Deprecated
+
+- `Http2Connection::with_builder_plaintext` / `with_builder_tls` ([#197]). Use
+  `Http2Connection::builder()` and configure via the proxied keep-alive /
+  window-size setters or `h2_settings(|b| ...)`. The old names collide with the
+  new `builder()` entry point, where "builder" now means
+  `Http2ConnectionBuilder` rather than hyper's HTTP/2 builder.
+
 ### Fixed
 
 - **Connect client-streaming responses require the END_STREAM envelope**
@@ -96,6 +137,7 @@ increment the patch version.
   a truncated response was indistinguishable from a complete one. It now
   returns `Err(internal)` (see [#168]); complete responses are unchanged.
 
+[#137]: https://github.com/anthropics/connect-rust/issues/137
 [#151]: https://github.com/anthropics/connect-rust/issues/151
 [#163]: https://github.com/anthropics/connect-rust/pull/163
 [#164]: https://github.com/anthropics/connect-rust/pull/164
@@ -103,6 +145,7 @@ increment the patch version.
 [#168]: https://github.com/anthropics/connect-rust/pull/168
 [#172]: https://github.com/anthropics/connect-rust/pull/172
 [#180]: https://github.com/anthropics/connect-rust/issues/180
+[#197]: https://github.com/anthropics/connect-rust/pull/197
 [connectrpc/conformance#1104]: https://github.com/connectrpc/conformance/pull/1104
 
 ## [0.7.0] - 2026-06-10
@@ -494,7 +537,8 @@ rebuilds `OUT_DIR` automatically.
   call so a silently dropped SYN fails in milliseconds instead of the
   kernel's `tcp_syn_retries` default (~130s). The existing constructors
   delegate to the builder with no timeout, so behaviour is unchanged for
-  current callers. `connect_timeout` covers TCP connect only, not DNS
+  current callers. (**Note:** [#197] in 0.8.0 changes this — the constructors
+  are now bounded by default.) `connect_timeout` covers TCP connect only, not DNS
   resolution or the TLS handshake — use `CallOptions::with_timeout` for
   an end-to-end bound.
 

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -291,15 +291,16 @@ impl Http2Connection {
 
     /// Customize the HTTP/2 settings (window sizes, keep-alive, etc).
     ///
-    /// Plaintext only; use with [`lazy_plaintext`](Self::lazy_plaintext)
-    /// semantics — the connection establishes on first `poll_ready`.
+    /// Plaintext only; uses [`lazy_plaintext`](Self::lazy_plaintext) semantics
+    /// — the connection establishes on first `poll_ready`. To also bound
+    /// connection establishment, use
+    /// [`builder()`](Self::builder)`.h2_settings(h2).lazy_plaintext(uri)`.
+    #[must_use]
     pub fn with_builder_plaintext(
         uri: Uri,
         builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
     ) -> Self {
-        Self {
-            inner: Reconnect::new(MakeSendRequest::with_builder(builder), uri, true),
-        }
+        Self::builder().h2_settings(builder).lazy_plaintext(uri)
     }
 
     /// Create an h2c connection using a **caller-supplied connector** that
@@ -451,21 +452,19 @@ impl Http2Connection {
     ///
     /// TLS-only; uses lazy semantics — the connection establishes on
     /// first `poll_ready`. See [`lazy_tls`](Self::lazy_tls) for ALPN and
-    /// cert rotation details.
+    /// cert rotation details. To also bound connection establishment, use
+    /// [`builder()`](Self::builder)`.h2_settings(h2).lazy_tls(uri, tls)`.
     #[cfg(feature = "client-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
+    #[must_use]
     pub fn with_builder_tls(
         uri: Uri,
         builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
         tls_config: Arc<rustls::ClientConfig>,
     ) -> Self {
-        Self {
-            inner: Reconnect::new(
-                MakeSendRequest::with_builder_tls(builder, tls_config),
-                uri,
-                true,
-            ),
-        }
+        Self::builder()
+            .h2_settings(builder)
+            .lazy_tls(uri, tls_config)
     }
 }
 
@@ -484,17 +483,37 @@ impl Http2Connection {
 ///
 /// # Scope
 ///
-/// The builder offers bounds only for the **plaintext** and **TLS** transports
-/// (the ones that dial through the built-in connector). The custom-connector,
-/// Unix-socket, and `with_builder_*` constructors on [`Http2Connection`] own
-/// their own dialing and are not reachable through this builder, so they
-/// establish without these bounds.
+/// The builder covers the **plaintext** and **TLS** transports (the ones that
+/// dial through the built-in connector). HTTP/2 keep-alive and flow-control
+/// knobs are proxied directly; for hyper settings not surfaced here use
+/// [`h2_settings`](Self::h2_settings). The custom-connector and Unix-socket
+/// constructors on [`Http2Connection`] own their own dialing and are not
+/// reachable through this builder, so they establish without these bounds.
 ///
 /// [`CallOptions::with_timeout`]: super::CallOptions::with_timeout
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Http2ConnectionBuilder {
     connect_timeout: Option<Duration>,
     handshake_timeout: Option<Duration>,
+    h2_builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
+}
+
+impl Default for Http2ConnectionBuilder {
+    /// A fresh builder with no establishment bounds and default HTTP/2
+    /// settings. A [`TokioTimer`](hyper_util::rt::TokioTimer) is pre-wired so
+    /// the keep-alive setters work without the caller having to install one
+    /// (hyper otherwise panics at handshake time if a keep-alive interval is
+    /// set without a timer).
+    fn default() -> Self {
+        let mut h2_builder =
+            hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
+        h2_builder.timer(hyper_util::rt::TokioTimer::new());
+        Self {
+            connect_timeout: None,
+            handshake_timeout: None,
+            h2_builder,
+        }
+    }
 }
 
 impl Http2ConnectionBuilder {
@@ -503,8 +522,9 @@ impl Http2ConnectionBuilder {
     /// Applied to the built-in connector via hyper's
     /// [`HttpConnector::set_connect_timeout`][hyper-ct]; it covers only the TCP
     /// `connect(2)` call (per resolved address — the budget is divided across
-    /// the address set). It does **not** cover the TLS handshake or HTTP/2
-    /// preface — use [`handshake_timeout`](Self::handshake_timeout) for those.
+    /// the address set). It does **not** cover DNS resolution, the TLS
+    /// handshake, or the HTTP/2 preface — set
+    /// [`handshake_timeout`](Self::handshake_timeout) too to bound those.
     ///
     /// Unset (the default) means TCP connect is governed by the kernel's
     /// `tcp_syn_retries` (typically ~130s on Linux).
@@ -516,12 +536,11 @@ impl Http2ConnectionBuilder {
         self
     }
 
-    /// Bound the post-connect handshake: the TLS handshake (for `tls`
-    /// connections) plus the HTTP/2 preface. Runs from the moment the TCP
-    /// connect resolves until the h2 preface completes; it does **not** cover the
-    /// TCP connect itself (use [`connect_timeout`](Self::connect_timeout) for
-    /// that). It mirrors the server-side TLS handshake timeout
-    /// (`Server::with_tls_handshake_timeout`).
+    /// Bound the connection handshake: DNS resolution, TCP connect, the TLS
+    /// handshake (for `tls` connections), and the HTTP/2 preface, as one
+    /// wall-clock budget. [`connect_timeout`](Self::connect_timeout) is an
+    /// additional per-address TCP bound *inside* this budget. It mirrors the
+    /// server-side TLS handshake timeout (`Server::with_tls_handshake_timeout`).
     ///
     /// # Where this bites
     ///
@@ -545,6 +564,88 @@ impl Http2ConnectionBuilder {
     #[must_use]
     pub fn handshake_timeout(mut self, dur: Duration) -> Self {
         self.handshake_timeout = Some(dur);
+        self
+    }
+
+    /// Set the HTTP/2 keep-alive PING interval. Disabled by default.
+    ///
+    /// While the connection has at least one open stream (or always, if
+    /// [`keep_alive_while_idle`](Self::keep_alive_while_idle) is set), a PING
+    /// is sent every `interval`; if no acknowledgement arrives within
+    /// [`keep_alive_timeout`](Self::keep_alive_timeout) the connection is
+    /// closed and the next `poll_ready` reconnects. This is the post-handshake
+    /// liveness bound — together with
+    /// [`handshake_timeout`](Self::handshake_timeout) it bounds the transport
+    /// against a peer that goes silent at any point.
+    #[must_use]
+    pub fn keep_alive_interval(mut self, interval: Duration) -> Self {
+        self.h2_builder.keep_alive_interval(interval);
+        self
+    }
+
+    /// Set how long to wait for a keep-alive PING acknowledgement before
+    /// closing the connection. Only applies when
+    /// [`keep_alive_interval`](Self::keep_alive_interval) is set. hyper
+    /// defaults to 20 seconds.
+    #[must_use]
+    pub fn keep_alive_timeout(mut self, timeout: Duration) -> Self {
+        self.h2_builder.keep_alive_timeout(timeout);
+        self
+    }
+
+    /// Send keep-alive PINGs even when the connection has no open streams.
+    /// hyper defaults to `false`.
+    ///
+    /// Set this to `true` for a fully bounded transport: with it `false`, the
+    /// window between handshake completion and the first request (where no
+    /// stream is open yet) is not covered by keep-alive, so a peer that goes
+    /// half-open exactly there is unbounded by both
+    /// [`handshake_timeout`](Self::handshake_timeout) (already ended) and
+    /// keep-alive (not armed).
+    #[must_use]
+    pub fn keep_alive_while_idle(mut self, enabled: bool) -> Self {
+        self.h2_builder.keep_alive_while_idle(enabled);
+        self
+    }
+
+    /// Set the initial HTTP/2 stream-level flow-control window size.
+    /// hyper defaults to 65,535 bytes.
+    #[must_use]
+    pub fn initial_stream_window_size(mut self, size: u32) -> Self {
+        self.h2_builder.initial_stream_window_size(size);
+        self
+    }
+
+    /// Set the initial HTTP/2 connection-level flow-control window size.
+    /// hyper defaults to 65,535 bytes.
+    #[must_use]
+    pub fn initial_connection_window_size(mut self, size: u32) -> Self {
+        self.h2_builder.initial_connection_window_size(size);
+        self
+    }
+
+    /// Enable hyper's adaptive flow-control window (BDP-based auto-tuning).
+    /// When enabled, the explicit window-size setters are ignored.
+    #[must_use]
+    pub fn adaptive_window(mut self, enabled: bool) -> Self {
+        self.h2_builder.adaptive_window(enabled);
+        self
+    }
+
+    /// Replace the underlying hyper HTTP/2 builder wholesale.
+    ///
+    /// This is the escape hatch for hyper knobs not proxied above. It
+    /// **replaces** any prior keep-alive / window-size settings on this
+    /// builder, and the caller takes ownership of timer setup — set
+    /// `.timer(hyper_util::rt::TokioTimer::new())` on the passed builder if
+    /// enabling keep-alive (hyper panics at handshake time otherwise). Prefer
+    /// the individual setters above for the common cases.
+    #[must_use]
+    pub fn h2_settings(
+        mut self,
+        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
+    ) -> Self {
+        self.h2_builder = builder;
         self
     }
 
@@ -607,13 +708,14 @@ impl Http2ConnectionBuilder {
         Ok(conn)
     }
 
-    fn make_plaintext(&self) -> MakeSendRequest {
-        MakeSendRequest::new().with_timeouts(self.connect_timeout, self.handshake_timeout)
+    fn make_plaintext(self) -> MakeSendRequest {
+        MakeSendRequest::with_builder(self.h2_builder)
+            .with_timeouts(self.connect_timeout, self.handshake_timeout)
     }
 
     #[cfg(feature = "client-tls")]
-    fn make_tls(&self, tls_config: Arc<rustls::ClientConfig>) -> MakeSendRequest {
-        MakeSendRequest::new_tls(tls_config)
+    fn make_tls(self, tls_config: Arc<rustls::ClientConfig>) -> MakeSendRequest {
+        MakeSendRequest::with_builder_tls(self.h2_builder, tls_config)
             .with_timeouts(self.connect_timeout, self.handshake_timeout)
     }
 }
@@ -768,28 +870,14 @@ struct MakeSendRequest {
     /// instead of the built-in `HttpConnector`; the URI is used only for the
     /// h2 `:authority` pseudo-header. See [`Http2Connection::lazy_with_connector`].
     custom: Option<BoxedConnector>,
-    /// Bound on the post-connect handshake (TLS handshake, if any, plus the
-    /// HTTP/2 preface). `None` means unbounded. The TCP connect is bounded
-    /// separately via `connector`'s `set_connect_timeout`.
+    /// Wall-clock bound on connection establishment in `call()`: DNS, TCP
+    /// connect, TLS handshake (if any), and the HTTP/2 preface. `None` means
+    /// unbounded. `connector`'s `set_connect_timeout` is an additional
+    /// per-address TCP bound inside this budget.
     handshake_timeout: Option<Duration>,
 }
 
 impl MakeSendRequest {
-    fn new() -> Self {
-        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
-        connector.set_nodelay(true);
-        let builder =
-            hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
-        Self {
-            connector,
-            builder,
-            #[cfg(feature = "client-tls")]
-            tls: None,
-            custom: None,
-            handshake_timeout: None,
-        }
-    }
-
     fn with_builder(
         builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
     ) -> Self {
@@ -818,23 +906,6 @@ impl MakeSendRequest {
             #[cfg(feature = "client-tls")]
             tls: None,
             custom: Some(conn),
-            handshake_timeout: None,
-        }
-    }
-
-    #[cfg(feature = "client-tls")]
-    fn new_tls(tls: Arc<rustls::ClientConfig>) -> Self {
-        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
-        connector.set_nodelay(true);
-        // Allow https:// scheme to pass through (default enforces http).
-        connector.enforce_http(false);
-        let builder =
-            hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
-        Self {
-            connector,
-            builder,
-            tls: Some(prepare_tls_for_h2(&tls)),
-            custom: None,
             handshake_timeout: None,
         }
     }
@@ -938,14 +1009,15 @@ impl tower::Service<Uri> for MakeSendRequest {
         let handshake_timeout = self.handshake_timeout;
 
         Box::pin(async move {
-            // TCP connect — bounded by `connect_timeout` on the connector.
-            let io = connect_fut.await.map_err(Into::<BoxError>::into)?;
-
-            // TLS handshake (if configured) + HTTP/2 preface — bounded together
-            // by `handshake_timeout` so a server that accepts the TCP
-            // connection but stalls the handshake can't hang `poll_ready` for
-            // every caller sharing this connection.
+            // DNS + TCP connect + TLS handshake (if configured) + HTTP/2
+            // preface — bounded together by `handshake_timeout` so a server
+            // that accepts the TCP connection but stalls the handshake (or a
+            // hung resolver) can't hang `poll_ready` for every caller sharing
+            // this connection. The per-address TCP connect is additionally
+            // bounded by `connect_timeout` on the connector.
             let establish = async move {
+                let io = connect_fut.await.map_err(Into::<BoxError>::into)?;
+
                 // TLS handshake if configured. This is the same pattern tonic
                 // uses for its Channel (transport/channel/service/connector.rs).
                 // The two concrete IO types are unified via BoxedIo for handshake().
@@ -1000,8 +1072,8 @@ impl tower::Service<Uri> for MakeSendRequest {
 /// Run a connection-establishment future under an optional time bound.
 ///
 /// `None` runs it unbounded; `Some(dur)` cancels it (dropping the in-flight
-/// handshake) and returns a `deadline_exceeded` error if it doesn't finish
-/// within `dur`. The future's own error type is coerced to [`BoxError`].
+/// handshake) and returns an `unavailable` error if it doesn't finish within
+/// `dur`. The future's own error type is coerced to [`BoxError`].
 async fn run_handshake<F, T, E>(fut: F, timeout: Option<Duration>) -> Result<T, BoxError>
 where
     F: Future<Output = Result<T, E>>,
@@ -1010,7 +1082,7 @@ where
     match timeout {
         Some(dur) => match tokio::time::timeout(dur, fut).await {
             Ok(res) => res.map_err(Into::into),
-            Err(_) => Err(ConnectError::deadline_exceeded(format!(
+            Err(_) => Err(ConnectError::unavailable(format!(
                 "connection handshake did not complete within {dur:?}"
             ))
             .into()),
@@ -1358,6 +1430,20 @@ mod tests {
         let elapsed = start.elapsed();
 
         assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
+        // Some CI hosts actively reject TEST-NET-1 (ENETUNREACH / ICMP) instead
+        // of dropping SYNs; that fails in <1ms without exercising the timeout.
+        // Skip the lower-bound check there rather than hard-fail.
+        if elapsed < Duration::from_millis(50) {
+            eprintln!(
+                "skipping lower-bound check: host rejected TEST-NET-1 \
+                 in {elapsed:?} ({err:?})"
+            );
+            return;
+        }
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "expected to wait out the 100ms budget, took {elapsed:?}: {err:?}"
+        );
         assert!(
             elapsed < Duration::from_secs(2),
             "connect_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err:?}"
@@ -1394,6 +1480,55 @@ mod tests {
         let uri: Uri = format!("https://{addr}").parse().unwrap();
         let start = Instant::now();
         let err = Http2Connection::builder()
+            .handshake_timeout(Duration::from_millis(150))
+            .connect_tls(uri, tls_config)
+            .await
+            .unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
+        assert!(
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("handshake did not complete"),
+            "expected a handshake-timeout message, got: {err:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}"
+        );
+
+        server.abort();
+    }
+
+    #[cfg(feature = "client-tls")]
+    #[tokio::test]
+    async fn handshake_timeout_applies_with_custom_h2_settings() {
+        use std::time::Instant;
+
+        // Same stalled-TLS scenario, but constructed via the proxied keep-alive
+        // setters — the path callers use to set h2 keep-alive. Regression-guards
+        // the setter-exposure gap that left `with_builder_tls` unbounded.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let tls_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let uri: Uri = format!("https://{addr}").parse().unwrap();
+        let start = Instant::now();
+        let err = Http2Connection::builder()
+            .keep_alive_interval(Duration::from_secs(30))
+            .keep_alive_while_idle(true)
             .handshake_timeout(Duration::from_millis(150))
             .connect_tls(uri, tls_config)
             .await

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -88,56 +88,6 @@ where
     )
 }
 
-/// DNS resolver that rotates the address list across successive resolutions.
-///
-/// `HttpConnector` tries same-family addresses serially and stops at the first
-/// TCP success — so if address A accepts TCP but stalls TLS, B and C are never
-/// tried within that attempt and the establishment timeout fires. Rotating the
-/// list per attempt means the next reconnect starts with B, bounding the
-/// worst-case time to reach a healthy address at `establishment_timeout × N`
-/// rather than relying on DNS-result reordering.
-#[derive(Clone, Debug)]
-struct RotatingGaiResolver {
-    inner: hyper_util::client::legacy::connect::dns::GaiResolver,
-    attempt: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-}
-
-impl RotatingGaiResolver {
-    fn new() -> Self {
-        Self {
-            inner: hyper_util::client::legacy::connect::dns::GaiResolver::new(),
-            attempt: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-        }
-    }
-}
-
-impl tower::Service<hyper_util::client::legacy::connect::dns::Name> for RotatingGaiResolver {
-    type Response = std::vec::IntoIter<std::net::SocketAddr>;
-    type Error = std::io::Error;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, name: hyper_util::client::legacy::connect::dns::Name) -> Self::Future {
-        let n = self
-            .attempt
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let fut = self.inner.call(name);
-        Box::pin(async move {
-            let mut addrs: Vec<std::net::SocketAddr> = fut.await?.collect();
-            if addrs.len() > 1 {
-                let len = addrs.len();
-                addrs.rotate_left(n % len);
-            }
-            Ok(addrs.into_iter())
-        })
-    }
-}
-
-type Http2HttpConnector = hyper_util::client::legacy::connect::HttpConnector<RotatingGaiResolver>;
-
 /// Build a connector that dials a Unix domain socket. The URI argument
 /// is ignored — `:authority` is supplied separately to
 /// [`Http2Connection::lazy_unix`].
@@ -543,12 +493,21 @@ pub struct Http2ConnectionBuilder {
 
 /// Default wall-clock bound on connection establishment (DNS, TCP, TLS, h2
 /// preface). Override via [`Http2ConnectionBuilder::establishment_timeout`].
-/// Matches grpc-go's default `MinConnectTimeout`.
+/// Same default value as grpc-go's `MinConnectTimeout` (note: grpc-go's is a
+/// floor that grows with exponential backoff; this is a fixed ceiling).
 pub const DEFAULT_ESTABLISHMENT_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Default per-address TCP `connect(2)` budget on the built-in connector.
+/// Default TCP `connect(2)` budget on the built-in connector. hyper divides
+/// this evenly across the resolved address set (e.g. 8 addresses → 625ms each).
 /// Override via [`Http2ConnectionBuilder::tcp_connect_timeout`].
 pub const DEFAULT_TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Normalize a setter argument: `Duration::MAX` is the documented opt-out, so
+/// store it as `None` (no timer at all) rather than arming a saturated tokio
+/// timer.
+pub(super) fn finite(dur: Duration) -> Option<Duration> {
+    (dur != Duration::MAX).then_some(dur)
+}
 
 impl Default for Http2ConnectionBuilder {
     /// A fresh builder with [`DEFAULT_ESTABLISHMENT_TIMEOUT`] /
@@ -581,13 +540,13 @@ impl Http2ConnectionBuilder {
     /// have no built-in `HttpConnector` to apply it to).
     ///
     /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// effectively disable.
+    /// disable.
     ///
     /// [`establishment_timeout`]: Self::establishment_timeout
     /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
     #[must_use]
     pub fn tcp_connect_timeout(mut self, dur: Duration) -> Self {
-        self.tcp_connect_timeout = Some(dur);
+        self.tcp_connect_timeout = finite(dur);
         self
     }
 
@@ -597,7 +556,7 @@ impl Http2ConnectionBuilder {
     /// is an additional per-address TCP bound *inside* this budget.
     ///
     /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// effectively disable.
+    /// disable.
     ///
     /// # Where this bites
     ///
@@ -618,7 +577,7 @@ impl Http2ConnectionBuilder {
     /// connect is retryable); the message names the phase.
     #[must_use]
     pub fn establishment_timeout(mut self, dur: Duration) -> Self {
-        self.establishment_timeout = Some(dur);
+        self.establishment_timeout = finite(dur);
         self
     }
 
@@ -841,12 +800,10 @@ impl Http2ConnectionBuilder {
             .await
     }
 
-    /// Built-in TCP connector with `nodelay`, the configured
-    /// `tcp_connect_timeout`, and a [`RotatingGaiResolver`] applied.
-    fn http_connector(&self) -> Http2HttpConnector {
-        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new_with_resolver(
-            RotatingGaiResolver::new(),
-        );
+    /// Built-in TCP connector with `nodelay` and the configured
+    /// `tcp_connect_timeout` applied. Mirrors `HttpClientBuilder::http_connector`.
+    fn http_connector(&self) -> hyper_util::client::legacy::connect::HttpConnector {
+        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
         connector.set_nodelay(true);
         connector.set_connect_timeout(self.tcp_connect_timeout);
         connector
@@ -1030,7 +987,7 @@ impl tower::Service<Request<ClientBody>> for SendRequest {
 /// HTTP/2 handshake, returning a ready `SendRequest`. Used by [`Reconnect`]
 /// to (re)establish connections.
 struct MakeSendRequest {
-    connector: Http2HttpConnector,
+    connector: hyper_util::client::legacy::connect::HttpConnector,
     builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
     /// TLS config for https:// connections. When `Some`, the URI scheme
     /// must be https:// and a TLS handshake happens after TCP connect.
@@ -1532,6 +1489,14 @@ mod tests {
             builder.establishment_timeout,
             Some(Duration::from_millis(20))
         );
+
+        // Duration::MAX is the documented opt-out — normalized to None so no
+        // timer is armed.
+        let unbounded = Http2Connection::builder()
+            .tcp_connect_timeout(Duration::MAX)
+            .establishment_timeout(Duration::MAX);
+        assert_eq!(unbounded.tcp_connect_timeout, None);
+        assert_eq!(unbounded.establishment_timeout, None);
     }
 
     #[tokio::test]

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -253,7 +253,6 @@ impl Http2Connection {
     /// establishment bounds are finite — see
     /// [`Http2ConnectionBuilder::establishment_timeout`] and
     /// [`Http2ConnectionBuilder::tcp_connect_timeout`].
-    #[must_use]
     pub fn builder() -> Http2ConnectionBuilder {
         Http2ConnectionBuilder::default()
     }
@@ -264,6 +263,10 @@ impl Http2Connection {
     /// The TCP+h2 handshake happens inside `poll_ready`, so the first request
     /// sees connect latency. Use this when building a balance pool — services
     /// that aren't selected won't eagerly connect.
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`]
+    /// (and [`DEFAULT_TCP_CONNECT_TIMEOUT`] per address); use
+    /// [`builder()`](Self::builder) to adjust or opt out.
     ///
     /// # Errors
     ///
@@ -280,6 +283,10 @@ impl Http2Connection {
     /// After the initial connect succeeds, reconnect-on-failure is handled
     /// automatically by the next `poll_ready`.
     ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`]
+    /// (and [`DEFAULT_TCP_CONNECT_TIMEOUT`] per address); use
+    /// [`builder()`](Self::builder) to adjust or opt out.
+    ///
     /// # Errors
     ///
     /// Returns an error if the URI scheme is `https://` (use
@@ -292,15 +299,21 @@ impl Http2Connection {
     /// Customize the HTTP/2 settings (window sizes, keep-alive, etc).
     ///
     /// Plaintext only; uses [`lazy_plaintext`](Self::lazy_plaintext) semantics
-    /// — the connection establishes on first `poll_ready`. To also bound
-    /// connection establishment, use
-    /// [`builder()`](Self::builder)`.h2_settings(h2).lazy_plaintext(uri)`.
+    /// — the connection establishes on first `poll_ready`.
+    #[deprecated(
+        since = "0.8.0",
+        note = "use `Http2Connection::builder()` and configure via the proxied \
+                keep-alive/window setters or `h2_settings(|b| ...)`"
+    )]
     #[must_use]
     pub fn with_builder_plaintext(
         uri: Uri,
-        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
+        mut builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
     ) -> Self {
-        Self::builder().h2_settings(builder).lazy_plaintext(uri)
+        builder.timer(hyper_util::rt::TokioTimer::new());
+        let mut b = Self::builder();
+        b.h2_builder = builder;
+        b.lazy_plaintext(uri)
     }
 
     /// Create an h2c connection using a **caller-supplied connector** that
@@ -330,6 +343,9 @@ impl Http2Connection {
     ///     "http://localhost".parse().unwrap(),
     /// );
     /// ```
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`];
+    /// use [`builder()`](Self::builder) to adjust or opt out.
     #[must_use]
     pub fn lazy_with_connector<C>(connector: C, authority: Uri) -> Self
     where
@@ -342,6 +358,9 @@ impl Http2Connection {
     }
 
     /// Eagerly establish an h2c connection using a **caller-supplied connector**.
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`];
+    /// use [`builder()`](Self::builder) to adjust or opt out.
     ///
     /// # Errors
     ///
@@ -372,6 +391,9 @@ impl Http2Connection {
     /// `authority` sets the HTTP/2 `:authority` pseudo-header. For
     /// local IPC sockets, `http://localhost` is typical; the server
     /// generally doesn't validate it.
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`];
+    /// use [`builder()`](Self::builder) to adjust or opt out.
     #[cfg(unix)]
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     #[must_use]
@@ -380,6 +402,9 @@ impl Http2Connection {
     }
 
     /// Eagerly establish an h2c connection over a **Unix domain socket**.
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`];
+    /// use [`builder()`](Self::builder) to adjust or opt out.
     ///
     /// # Errors
     ///
@@ -409,6 +434,10 @@ impl Http2Connection {
     /// `Arc<dyn ResolvesClientCert>`, so the clone done here to set ALPN
     /// shares the same resolver instance — rotation keeps working.
     ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`]
+    /// (and [`DEFAULT_TCP_CONNECT_TIMEOUT`] per address); use
+    /// [`builder()`](Self::builder) to adjust or opt out.
+    ///
     /// # Errors
     ///
     /// Returns an error (surfaced from the first `poll_ready`) if the URI
@@ -423,6 +452,10 @@ impl Http2Connection {
     /// Eagerly establish a **TLS** h2 connection now. Only for `https://` URIs.
     ///
     /// See [`lazy_tls`](Self::lazy_tls) for ALPN and cert rotation details.
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`]
+    /// (and [`DEFAULT_TCP_CONNECT_TIMEOUT`] per address); use
+    /// [`builder()`](Self::builder) to adjust or opt out.
     ///
     /// # Errors
     ///
@@ -441,19 +474,24 @@ impl Http2Connection {
     ///
     /// TLS-only; uses lazy semantics — the connection establishes on
     /// first `poll_ready`. See [`lazy_tls`](Self::lazy_tls) for ALPN and
-    /// cert rotation details. To also bound connection establishment, use
-    /// [`builder()`](Self::builder)`.h2_settings(h2).lazy_tls(uri, tls)`.
+    /// cert rotation details.
+    #[deprecated(
+        since = "0.8.0",
+        note = "use `Http2Connection::builder()` and configure via the proxied \
+                keep-alive/window setters or `h2_settings(|b| ...)`"
+    )]
     #[cfg(feature = "client-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
     #[must_use]
     pub fn with_builder_tls(
         uri: Uri,
-        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
+        mut builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
         tls_config: Arc<rustls::ClientConfig>,
     ) -> Self {
-        Self::builder()
-            .h2_settings(builder)
-            .lazy_tls(uri, tls_config)
+        builder.timer(hyper_util::rt::TokioTimer::new());
+        let mut b = Self::builder();
+        b.h2_builder = builder;
+        b.lazy_tls(uri, tls_config)
     }
 }
 
@@ -485,6 +523,7 @@ impl Http2Connection {
 ///
 /// [`CallOptions::with_timeout`]: super::CallOptions::with_timeout
 #[derive(Debug, Clone)]
+#[must_use = "call a lazy_*/connect_* terminal to build the connection"]
 pub struct Http2ConnectionBuilder {
     tcp_connect_timeout: Option<Duration>,
     establishment_timeout: Option<Duration>,
@@ -502,9 +541,10 @@ pub const DEFAULT_ESTABLISHMENT_TIMEOUT: Duration = Duration::from_secs(20);
 /// Override via [`Http2ConnectionBuilder::tcp_connect_timeout`].
 pub const DEFAULT_TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Normalize a setter argument: `Duration::MAX` is the documented opt-out, so
-/// store it as `None` (no timer at all) rather than arming a saturated tokio
-/// timer.
+/// Normalize a setter argument: `Duration::MAX` is treated as `None` (no timer
+/// at all) rather than arming a saturated tokio timer. The explicit
+/// `no_*_timeout()` builder methods are the documented opt-out; this keeps the
+/// `MAX` spelling working for callers who reach for it.
 pub(super) fn finite(dur: Duration) -> Option<Duration> {
     (dur != Duration::MAX).then_some(dur)
 }
@@ -539,14 +579,22 @@ impl Http2ConnectionBuilder {
     /// It is **ignored** by the custom-connector / Unix-socket terminals (which
     /// have no built-in `HttpConnector` to apply it to).
     ///
-    /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// disable.
+    /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. To disable, use
+    /// [`no_tcp_connect_timeout`](Self::no_tcp_connect_timeout). Passing
+    /// `Duration::ZERO` causes every per-address connect to fail immediately.
     ///
     /// [`establishment_timeout`]: Self::establishment_timeout
     /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
-    #[must_use]
     pub fn tcp_connect_timeout(mut self, dur: Duration) -> Self {
         self.tcp_connect_timeout = finite(dur);
+        self
+    }
+
+    /// Disable the per-address TCP connect bound (the
+    /// [`DEFAULT_TCP_CONNECT_TIMEOUT`] default). The whole-establishment
+    /// [`establishment_timeout`](Self::establishment_timeout) still applies.
+    pub fn no_tcp_connect_timeout(mut self) -> Self {
+        self.tcp_connect_timeout = None;
         self
     }
 
@@ -555,8 +603,9 @@ impl Http2ConnectionBuilder {
     /// preface, as one budget. [`tcp_connect_timeout`](Self::tcp_connect_timeout)
     /// is an additional per-address TCP bound *inside* this budget.
     ///
-    /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// disable.
+    /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. To disable, use
+    /// [`no_establishment_timeout`](Self::no_establishment_timeout). Passing
+    /// `Duration::ZERO` causes every establishment to fail immediately.
     ///
     /// # Where this bites
     ///
@@ -575,9 +624,17 @@ impl Http2ConnectionBuilder {
     /// Exceeding this bound surfaces as a [`ConnectError`] with
     /// [`ErrorCode::Unavailable`](crate::error::ErrorCode::Unavailable) (the
     /// connect is retryable); the message names the phase.
-    #[must_use]
     pub fn establishment_timeout(mut self, dur: Duration) -> Self {
         self.establishment_timeout = finite(dur);
+        self
+    }
+
+    /// Disable the wall-clock establishment bound (the
+    /// [`DEFAULT_ESTABLISHMENT_TIMEOUT`] default). With both this and
+    /// [`no_tcp_connect_timeout`](Self::no_tcp_connect_timeout), a hung server
+    /// can stall `poll_ready` indefinitely — the pre-0.8.0 behaviour.
+    pub fn no_establishment_timeout(mut self) -> Self {
+        self.establishment_timeout = None;
         self
     }
 
@@ -591,7 +648,6 @@ impl Http2ConnectionBuilder {
     /// liveness bound — together with
     /// [`establishment_timeout`](Self::establishment_timeout) it bounds the transport
     /// against a peer that goes silent at any point.
-    #[must_use]
     pub fn keep_alive_interval(mut self, interval: Duration) -> Self {
         self.h2_builder.keep_alive_interval(interval);
         self
@@ -601,7 +657,6 @@ impl Http2ConnectionBuilder {
     /// closing the connection. Only applies when
     /// [`keep_alive_interval`](Self::keep_alive_interval) is set. hyper
     /// defaults to 20 seconds.
-    #[must_use]
     pub fn keep_alive_timeout(mut self, timeout: Duration) -> Self {
         self.h2_builder.keep_alive_timeout(timeout);
         self
@@ -616,7 +671,6 @@ impl Http2ConnectionBuilder {
     /// half-open exactly there is unbounded by both
     /// [`establishment_timeout`](Self::establishment_timeout) (already ended) and
     /// keep-alive (not armed).
-    #[must_use]
     pub fn keep_alive_while_idle(mut self, enabled: bool) -> Self {
         self.h2_builder.keep_alive_while_idle(enabled);
         self
@@ -624,7 +678,6 @@ impl Http2ConnectionBuilder {
 
     /// Set the initial HTTP/2 stream-level flow-control window size.
     /// hyper defaults to 65,535 bytes.
-    #[must_use]
     pub fn initial_stream_window_size(mut self, size: u32) -> Self {
         self.h2_builder.initial_stream_window_size(size);
         self
@@ -632,7 +685,6 @@ impl Http2ConnectionBuilder {
 
     /// Set the initial HTTP/2 connection-level flow-control window size.
     /// hyper defaults to 65,535 bytes.
-    #[must_use]
     pub fn initial_connection_window_size(mut self, size: u32) -> Self {
         self.h2_builder.initial_connection_window_size(size);
         self
@@ -640,27 +692,33 @@ impl Http2ConnectionBuilder {
 
     /// Enable hyper's adaptive flow-control window (BDP-based auto-tuning).
     /// When enabled, the explicit window-size setters are ignored.
-    #[must_use]
     pub fn adaptive_window(mut self, enabled: bool) -> Self {
         self.h2_builder.adaptive_window(enabled);
         self
     }
 
-    /// Replace the underlying hyper HTTP/2 builder wholesale.
+    /// Configure the underlying hyper HTTP/2 builder directly.
     ///
-    /// This is the escape hatch for hyper knobs not proxied above. It
-    /// **replaces** any prior keep-alive / window-size settings on this
-    /// builder, so call it before the individual setters if you use both. A
-    /// [`TokioTimer`](hyper_util::rt::TokioTimer) is re-applied to the passed
-    /// builder so keep-alive works without the caller wiring one. Prefer the
-    /// individual setters above for the common cases.
-    #[must_use]
+    /// This is the escape hatch for hyper knobs not proxied above. The closure
+    /// receives a mutable reference to the same builder the proxied setters
+    /// write to, so it composes with them in either order:
+    ///
+    /// ```rust,ignore
+    /// Http2Connection::builder()
+    ///     .keep_alive_interval(Duration::from_secs(30))
+    ///     .h2_settings(|b| { b.max_concurrent_reset_streams(32); })
+    ///     .lazy_plaintext(uri)
+    /// ```
+    ///
+    /// A [`TokioTimer`](hyper_util::rt::TokioTimer) is already wired on the
+    /// builder, so keep-alive works without the caller installing one. Hyper's
+    /// setters return `&mut Self`, so end the closure body with `;` (as above)
+    /// when calling exactly one.
     pub fn h2_settings(
         mut self,
-        mut builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
+        f: impl FnOnce(&mut hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>),
     ) -> Self {
-        builder.timer(hyper_util::rt::TokioTimer::new());
-        self.h2_builder = builder;
+        f(&mut self.h2_builder);
         self
     }
 
@@ -1145,7 +1203,7 @@ pub(super) async fn run_establishment<F, T, E>(
 ) -> Result<T, BoxError>
 where
     F: Future<Output = Result<T, E>>,
-    E: Into<BoxError> + 'static,
+    E: Into<BoxError>,
 {
     match timeout {
         Some(dur) => match tokio::time::timeout(dur, fut).await {
@@ -1490,45 +1548,59 @@ mod tests {
             Some(Duration::from_millis(20))
         );
 
-        // Duration::MAX is the documented opt-out — normalized to None so no
-        // timer is armed.
+        // Explicit no_* methods are the documented opt-out.
         let unbounded = Http2Connection::builder()
-            .tcp_connect_timeout(Duration::MAX)
-            .establishment_timeout(Duration::MAX);
+            .no_tcp_connect_timeout()
+            .no_establishment_timeout();
         assert_eq!(unbounded.tcp_connect_timeout, None);
         assert_eq!(unbounded.establishment_timeout, None);
+
+        // Duration::MAX is also normalized to None so no saturated timer is
+        // armed (back-compat with the original opt-out spelling).
+        let max = Http2Connection::builder()
+            .tcp_connect_timeout(Duration::MAX)
+            .establishment_timeout(Duration::MAX);
+        assert_eq!(max.tcp_connect_timeout, None);
+        assert_eq!(max.establishment_timeout, None);
     }
 
     #[tokio::test]
     async fn builder_tcp_connect_timeout_bounds_tcp_connect() {
         use std::time::Instant;
 
-        // RFC 5737 TEST-NET-1: guaranteed unroutable, so SYNs are dropped and an
-        // unbounded connect would stall on kernel retransmits (~130s). A 100ms
-        // tcp_connect_timeout must abort well before that.
+        // RFC 5737 TEST-NET-1: reserved for documentation. Most hosts drop SYNs
+        // to it (so an unbounded connect stalls on kernel retransmits, ~130s),
+        // but RFC 5737 doesn't mandate that — some CI hosts actively reject
+        // (ENETUNREACH / ICMP) and a transparent proxy may even accept. The
+        // assertion that matters is the upper bound: a 100ms tcp_connect_timeout
+        // must abort well before the kernel retry floor.
         let start = Instant::now();
-        let err = Http2Connection::builder()
+        let result = Http2Connection::builder()
             .tcp_connect_timeout(Duration::from_millis(100))
             .connect_plaintext("http://192.0.2.1:9".parse().unwrap())
-            .await
-            .unwrap_err();
+            .await;
         let elapsed = start.elapsed();
 
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => {
+                // Transparent proxy accepted the connect; the h2c preface
+                // resolves locally so this succeeds. Nothing to assert.
+                eprintln!("skipping: TEST-NET-1 connect succeeded (proxy?) in {elapsed:?}");
+                return;
+            }
+        };
         assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
-        // Some CI hosts actively reject TEST-NET-1 (ENETUNREACH / ICMP) instead
-        // of dropping SYNs; that fails in <1ms without exercising the timeout.
-        // Skip the lower-bound check there rather than hard-fail.
-        if elapsed < Duration::from_millis(50) {
+        // Widened skip window: an ICMP reject on a slow path can land anywhere
+        // under the budget without exercising the timeout. Only assert the
+        // lower bound when we clearly waited it out.
+        if elapsed < Duration::from_millis(90) {
             eprintln!(
                 "skipping lower-bound check: host rejected TEST-NET-1 \
                  in {elapsed:?} ({err:?})"
             );
             return;
         }
-        assert!(
-            elapsed >= Duration::from_millis(100),
-            "expected to wait out the 100ms budget, took {elapsed:?}: {err:?}"
-        );
         assert!(
             elapsed < Duration::from_secs(2),
             "tcp_connect_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err:?}"
@@ -1614,6 +1686,9 @@ mod tests {
         let err = Http2Connection::builder()
             .keep_alive_interval(Duration::from_secs(30))
             .keep_alive_while_idle(true)
+            .h2_settings(|b| {
+                b.max_frame_size(1 << 14);
+            })
             .establishment_timeout(Duration::from_millis(150))
             .connect_tls(uri, tls_config)
             .await

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -276,15 +276,14 @@ impl Http2Connection {
     /// Eagerly establish a **plaintext** h2c connection now.
     /// Only for `http://` URIs.
     ///
-    /// Returns an error if the URI scheme is `https://` (use
-    /// [`connect_tls`](Self::connect_tls) instead), or if the initial TCP
-    /// connect or h2 handshake fails. After the initial connect succeeds,
-    /// reconnect-on-failure is handled automatically by the next `poll_ready`.
+    /// After the initial connect succeeds, reconnect-on-failure is handled
+    /// automatically by the next `poll_ready`.
     ///
     /// # Errors
     ///
-    /// Returns an error if the URI scheme is `https://` or the initial TCP
-    /// connect or h2 handshake fails.
+    /// Returns an error if the URI scheme is `https://` (use
+    /// [`connect_tls`](Self::connect_tls) instead) or the initial TCP connect
+    /// or h2 handshake fails.
     pub async fn connect_plaintext(uri: Uri) -> Result<Self, ConnectError> {
         Self::builder().connect_plaintext(uri).await
     }
@@ -423,9 +422,6 @@ impl Http2Connection {
     /// Eagerly establish a **TLS** h2 connection now. Only for `https://` URIs.
     ///
     /// See [`lazy_tls`](Self::lazy_tls) for ALPN and cert rotation details.
-    ///
-    /// Returns an error if the URI scheme is `http://`, if the TCP/TLS
-    /// handshake fails, or if the server doesn't negotiate h2 via ALPN.
     ///
     /// # Errors
     ///
@@ -784,21 +780,51 @@ impl Http2ConnectionBuilder {
             .await
     }
 
+    /// Built-in TCP connector with `nodelay` and the configured
+    /// `connect_timeout` applied. Mirrors `HttpClientBuilder::http_connector`.
+    fn http_connector(&self) -> hyper_util::client::legacy::connect::HttpConnector {
+        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
+        connector.set_nodelay(true);
+        connector.set_connect_timeout(self.connect_timeout);
+        connector
+    }
+
     fn make_plaintext(self) -> MakeSendRequest {
-        MakeSendRequest::with_builder(self.h2_builder)
-            .with_timeouts(self.connect_timeout, self.handshake_timeout)
+        MakeSendRequest {
+            connector: self.http_connector(),
+            builder: self.h2_builder,
+            #[cfg(feature = "client-tls")]
+            tls: None,
+            custom: None,
+            handshake_timeout: self.handshake_timeout,
+        }
     }
 
     #[cfg(feature = "client-tls")]
     fn make_tls(self, tls_config: Arc<rustls::ClientConfig>) -> MakeSendRequest {
-        MakeSendRequest::with_builder_tls(self.h2_builder, tls_config)
-            .with_timeouts(self.connect_timeout, self.handshake_timeout)
+        let mut connector = self.http_connector();
+        connector.enforce_http(false);
+        MakeSendRequest {
+            connector,
+            builder: self.h2_builder,
+            tls: Some(prepare_tls_for_h2(&tls_config)),
+            custom: None,
+            handshake_timeout: self.handshake_timeout,
+        }
     }
 
     fn make_custom(self, conn: BoxedConnector) -> MakeSendRequest {
-        // `connect_timeout` is intentionally dropped: it's the per-address TCP
-        // bound on the built-in `HttpConnector`, which is not in play here.
-        MakeSendRequest::new_custom(self.h2_builder, conn, self.handshake_timeout)
+        MakeSendRequest {
+            // Unused when `custom` is Some — `call()` branches to the custom
+            // connector before touching it. `connect_timeout` is therefore
+            // dropped here (it's the per-address TCP bound on this connector).
+            connector: hyper_util::client::legacy::connect::HttpConnector::new(),
+            builder: self.h2_builder,
+            #[cfg(feature = "client-tls")]
+            tls: None,
+            custom: Some(conn),
+            handshake_timeout: self.handshake_timeout,
+        }
     }
 }
 
@@ -959,74 +985,6 @@ struct MakeSendRequest {
     handshake_timeout: Option<Duration>,
 }
 
-impl MakeSendRequest {
-    fn with_builder(
-        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
-    ) -> Self {
-        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
-        connector.set_nodelay(true);
-        Self {
-            connector,
-            builder,
-            #[cfg(feature = "client-tls")]
-            tls: None,
-            custom: None,
-            handshake_timeout: None,
-        }
-    }
-
-    fn new_custom(
-        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
-        conn: BoxedConnector,
-        handshake_timeout: Option<Duration>,
-    ) -> Self {
-        Self {
-            // Unused when `custom` is Some — `call()` branches to the custom
-            // connector before touching it. `HttpConnector::new()` is cheap.
-            connector: hyper_util::client::legacy::connect::HttpConnector::new(),
-            builder,
-            #[cfg(feature = "client-tls")]
-            tls: None,
-            custom: Some(conn),
-            handshake_timeout,
-        }
-    }
-
-    #[cfg(feature = "client-tls")]
-    fn with_builder_tls(
-        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
-        tls: Arc<rustls::ClientConfig>,
-    ) -> Self {
-        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
-        connector.set_nodelay(true);
-        connector.enforce_http(false);
-        Self {
-            connector,
-            builder,
-            tls: Some(prepare_tls_for_h2(&tls)),
-            custom: None,
-            handshake_timeout: None,
-        }
-    }
-
-    /// Apply connection-establishment bounds. `connect_timeout` is pushed into
-    /// the built-in `HttpConnector` (per-address TCP connect);
-    /// `handshake_timeout` is stored and applied around the whole
-    /// establishment future (DNS, TCP, TLS handshake, HTTP/2 preface) in
-    /// `call()`.
-    fn with_timeouts(
-        mut self,
-        connect_timeout: Option<Duration>,
-        handshake_timeout: Option<Duration>,
-    ) -> Self {
-        if let Some(dur) = connect_timeout {
-            self.connector.set_connect_timeout(Some(dur));
-        }
-        self.handshake_timeout = handshake_timeout;
-        self
-    }
-}
-
 impl tower::Service<Uri> for MakeSendRequest {
     type Response = SendRequest;
     type Error = BoxError;
@@ -1160,10 +1118,10 @@ impl tower::Service<Uri> for MakeSendRequest {
 /// `None` runs it unbounded; `Some(dur)` cancels it (dropping the in-flight
 /// handshake) and returns an `unavailable` error if it doesn't finish within
 /// `dur`. The future's own error type is coerced to [`BoxError`].
-async fn run_handshake<F, T, E>(fut: F, timeout: Option<Duration>) -> Result<T, BoxError>
+pub(super) async fn run_handshake<F, T, E>(fut: F, timeout: Option<Duration>) -> Result<T, BoxError>
 where
     F: Future<Output = Result<T, E>>,
-    E: Into<BoxError>,
+    E: Into<BoxError> + 'static,
 {
     match timeout {
         Some(dur) => match tokio::time::timeout(dur, fut).await {

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -34,6 +34,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
+use std::time::Duration;
 
 use http::Request;
 use http::Response;
@@ -242,6 +243,20 @@ fn require_http_scheme(uri: &Uri) -> Result<(), ConnectError> {
 }
 
 impl Http2Connection {
+    /// Returns a builder for bounding connection establishment (TCP connect,
+    /// TLS handshake, HTTP/2 preface) before choosing a transport flavour.
+    ///
+    /// The constructors on `Http2Connection` are shortcuts for the builder
+    /// with no bounds set, so `Http2Connection::lazy_plaintext(uri)` is exactly
+    /// `Http2Connection::builder().lazy_plaintext(uri)`. Reach for the builder
+    /// when you want to bound a stalled connect or handshake — see
+    /// [`Http2ConnectionBuilder::connect_timeout`] and
+    /// [`Http2ConnectionBuilder::handshake_timeout`].
+    #[must_use]
+    pub fn builder() -> Http2ConnectionBuilder {
+        Http2ConnectionBuilder::default()
+    }
+
     /// Create a **plaintext** h2c connection that establishes lazily on
     /// first `poll_ready`. Only for `http://` URIs.
     ///
@@ -253,14 +268,9 @@ impl Http2Connection {
     ///
     /// Returns an error (surfaced from the first `poll_ready`) if the URI
     /// scheme is `https://` — use [`lazy_tls`](Self::lazy_tls) instead.
+    #[must_use]
     pub fn lazy_plaintext(uri: Uri) -> Self {
-        // Scheme check is deferred to the first poll_ready via the
-        // Reconnect state machine's deferred_error mechanism, so this
-        // constructor is infallible and balance pools can be built uniformly.
-        // The actual check is in MakeSendRequest::call.
-        Self {
-            inner: Reconnect::new(MakeSendRequest::new(), uri, true),
-        }
+        Self::builder().lazy_plaintext(uri)
     }
 
     /// Eagerly establish a **plaintext** h2c connection now.
@@ -270,16 +280,13 @@ impl Http2Connection {
     /// [`connect_tls`](Self::connect_tls) instead), or if the initial TCP
     /// connect or h2 handshake fails. After the initial connect succeeds,
     /// reconnect-on-failure is handled automatically by the next `poll_ready`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URI scheme is `https://` or the initial TCP
+    /// connect or h2 handshake fails.
     pub async fn connect_plaintext(uri: Uri) -> Result<Self, ConnectError> {
-        require_http_scheme(&uri)?;
-        let mut conn = Self {
-            inner: Reconnect::new(MakeSendRequest::new(), uri, false),
-        };
-        // Drive poll_ready to completion to force the connect now.
-        std::future::poll_fn(|cx| conn.inner.poll_ready(cx))
-            .await
-            .map_err(|e| ConnectError::unavailable(format!("connect failed: {e}")))?;
-        Ok(conn)
+        Self::builder().connect_plaintext(uri).await
     }
 
     /// Customize the HTTP/2 settings (window sizes, keep-alive, etc).
@@ -415,10 +422,9 @@ impl Http2Connection {
     /// scheme is `http://` — use [`lazy_plaintext`](Self::lazy_plaintext).
     #[cfg(feature = "client-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
+    #[must_use]
     pub fn lazy_tls(uri: Uri, tls_config: Arc<rustls::ClientConfig>) -> Self {
-        Self {
-            inner: Reconnect::new(MakeSendRequest::new_tls(tls_config), uri, true),
-        }
+        Self::builder().lazy_tls(uri, tls_config)
     }
 
     /// Eagerly establish a **TLS** h2 connection now. Only for `https://` URIs.
@@ -427,20 +433,18 @@ impl Http2Connection {
     ///
     /// Returns an error if the URI scheme is `http://`, if the TCP/TLS
     /// handshake fails, or if the server doesn't negotiate h2 via ALPN.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URI scheme is `http://`, the TCP/TLS handshake
+    /// fails, or the server doesn't negotiate h2 via ALPN.
     #[cfg(feature = "client-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
     pub async fn connect_tls(
         uri: Uri,
         tls_config: Arc<rustls::ClientConfig>,
     ) -> Result<Self, ConnectError> {
-        require_https_scheme(&uri)?;
-        let mut conn = Self {
-            inner: Reconnect::new(MakeSendRequest::new_tls(tls_config), uri, false),
-        };
-        std::future::poll_fn(|cx| conn.inner.poll_ready(cx))
-            .await
-            .map_err(|e| ConnectError::unavailable(format!("TLS connect failed: {e}")))?;
-        Ok(conn)
+        Self::builder().connect_tls(uri, tls_config).await
     }
 
     /// Customize the HTTP/2 settings (window sizes, keep-alive, etc) with TLS.
@@ -463,6 +467,162 @@ impl Http2Connection {
             ),
         }
     }
+}
+
+/// Builder for [`Http2Connection`] connection-establishment bounds.
+///
+/// Obtain one via [`Http2Connection::builder`]. The terminal methods mirror the
+/// `Http2Connection` constructors; the bare constructors delegate here with no
+/// bounds set, so behaviour is unchanged unless you call a setter.
+///
+/// Both bounds default to unset (no time limit). Establishment then runs until
+/// it succeeds, errors, or the kernel gives up — a server that accepts the TCP
+/// connection but stalls during the TLS handshake would otherwise stall
+/// `poll_ready` for every caller sharing the connection. The bounds here are the
+/// *establishment* budget; [`CallOptions::with_timeout`] remains the end-to-end
+/// per-request bound.
+///
+/// # Scope
+///
+/// The builder offers bounds only for the **plaintext** and **TLS** transports
+/// (the ones that dial through the built-in connector). The custom-connector,
+/// Unix-socket, and `with_builder_*` constructors on [`Http2Connection`] own
+/// their own dialing and are not reachable through this builder, so they
+/// establish without these bounds.
+///
+/// [`CallOptions::with_timeout`]: super::CallOptions::with_timeout
+#[derive(Debug, Default, Clone)]
+pub struct Http2ConnectionBuilder {
+    connect_timeout: Option<Duration>,
+    handshake_timeout: Option<Duration>,
+}
+
+impl Http2ConnectionBuilder {
+    /// Bound the TCP connect phase.
+    ///
+    /// Applied to the built-in connector via hyper's
+    /// [`HttpConnector::set_connect_timeout`][hyper-ct]; it covers only the TCP
+    /// `connect(2)` call (per resolved address — the budget is divided across
+    /// the address set). It does **not** cover the TLS handshake or HTTP/2
+    /// preface — use [`handshake_timeout`](Self::handshake_timeout) for those.
+    ///
+    /// Unset (the default) means TCP connect is governed by the kernel's
+    /// `tcp_syn_retries` (typically ~130s on Linux).
+    ///
+    /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
+    #[must_use]
+    pub fn connect_timeout(mut self, dur: Duration) -> Self {
+        self.connect_timeout = Some(dur);
+        self
+    }
+
+    /// Bound the post-connect handshake: the TLS handshake (for `tls`
+    /// connections) plus the HTTP/2 preface. Runs from the moment the TCP
+    /// connect resolves until the h2 preface completes; it does **not** cover the
+    /// TCP connect itself (use [`connect_timeout`](Self::connect_timeout) for
+    /// that). It mirrors the server-side TLS handshake timeout
+    /// (`Server::with_tls_handshake_timeout`).
+    ///
+    /// # Where this bites
+    ///
+    /// For **TLS** connections this is the bound that protects shared callers
+    /// from a server that accepts the TCP connection but stalls the TLS
+    /// handshake — the handshake genuinely blocks on the server, so the bound
+    /// fires.
+    ///
+    /// For **plaintext** h2c, hyper's HTTP/2 handshake resolves locally (it
+    /// sends the client preface without waiting for the server's `SETTINGS`), so
+    /// a stalled cleartext server stalls the first *request*, not the handshake.
+    /// On plaintext this bound therefore only catches a slow local h2 setup;
+    /// bound a stalled cleartext server with a per-request
+    /// [`CallOptions::with_timeout`](super::CallOptions::with_timeout) instead.
+    ///
+    /// Exceeding this bound surfaces as a [`ConnectError`] with
+    /// [`ErrorCode::Unavailable`](crate::error::ErrorCode::Unavailable) (the
+    /// connect is retryable); the message names the phase.
+    ///
+    /// Unset (the default) means the handshake is unbounded.
+    #[must_use]
+    pub fn handshake_timeout(mut self, dur: Duration) -> Self {
+        self.handshake_timeout = Some(dur);
+        self
+    }
+
+    /// Finish as a lazily-established **plaintext** connection.
+    /// See [`Http2Connection::lazy_plaintext`].
+    #[must_use]
+    pub fn lazy_plaintext(self, uri: Uri) -> Http2Connection {
+        Http2Connection {
+            inner: Reconnect::new(self.make_plaintext(), uri, true),
+        }
+    }
+
+    /// Finish by eagerly establishing a **plaintext** connection now.
+    /// See [`Http2Connection::connect_plaintext`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URI scheme is `https://` or the initial TCP
+    /// connect or h2 handshake fails (including exceeding a configured bound).
+    pub async fn connect_plaintext(self, uri: Uri) -> Result<Http2Connection, ConnectError> {
+        require_http_scheme(&uri)?;
+        let mut conn = Http2Connection {
+            inner: Reconnect::new(self.make_plaintext(), uri, false),
+        };
+        drive_connect(&mut conn, "connect failed").await?;
+        Ok(conn)
+    }
+
+    /// Finish as a lazily-established **TLS** connection.
+    /// See [`Http2Connection::lazy_tls`].
+    #[cfg(feature = "client-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
+    #[must_use]
+    pub fn lazy_tls(self, uri: Uri, tls_config: Arc<rustls::ClientConfig>) -> Http2Connection {
+        Http2Connection {
+            inner: Reconnect::new(self.make_tls(tls_config), uri, true),
+        }
+    }
+
+    /// Finish by eagerly establishing a **TLS** connection now.
+    /// See [`Http2Connection::connect_tls`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URI scheme is `http://`, the TCP/TLS handshake
+    /// fails (including exceeding a configured bound), or the server doesn't
+    /// negotiate h2 via ALPN.
+    #[cfg(feature = "client-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
+    pub async fn connect_tls(
+        self,
+        uri: Uri,
+        tls_config: Arc<rustls::ClientConfig>,
+    ) -> Result<Http2Connection, ConnectError> {
+        require_https_scheme(&uri)?;
+        let mut conn = Http2Connection {
+            inner: Reconnect::new(self.make_tls(tls_config), uri, false),
+        };
+        drive_connect(&mut conn, "TLS connect failed").await?;
+        Ok(conn)
+    }
+
+    fn make_plaintext(&self) -> MakeSendRequest {
+        MakeSendRequest::new().with_timeouts(self.connect_timeout, self.handshake_timeout)
+    }
+
+    #[cfg(feature = "client-tls")]
+    fn make_tls(&self, tls_config: Arc<rustls::ClientConfig>) -> MakeSendRequest {
+        MakeSendRequest::new_tls(tls_config)
+            .with_timeouts(self.connect_timeout, self.handshake_timeout)
+    }
+}
+
+/// Drive a connection's `poll_ready` to completion, forcing the eager connect.
+async fn drive_connect(conn: &mut Http2Connection, ctx: &str) -> Result<(), ConnectError> {
+    std::future::poll_fn(|cx| conn.inner.poll_ready(cx))
+        .await
+        .map_err(|e| ConnectError::unavailable(format!("{ctx}: {e}")))
 }
 
 impl tower::Service<Request<ClientBody>> for Http2Connection {
@@ -608,6 +768,10 @@ struct MakeSendRequest {
     /// instead of the built-in `HttpConnector`; the URI is used only for the
     /// h2 `:authority` pseudo-header. See [`Http2Connection::lazy_with_connector`].
     custom: Option<BoxedConnector>,
+    /// Bound on the post-connect handshake (TLS handshake, if any, plus the
+    /// HTTP/2 preface). `None` means unbounded. The TCP connect is bounded
+    /// separately via `connector`'s `set_connect_timeout`.
+    handshake_timeout: Option<Duration>,
 }
 
 impl MakeSendRequest {
@@ -622,6 +786,7 @@ impl MakeSendRequest {
             #[cfg(feature = "client-tls")]
             tls: None,
             custom: None,
+            handshake_timeout: None,
         }
     }
 
@@ -636,6 +801,7 @@ impl MakeSendRequest {
             #[cfg(feature = "client-tls")]
             tls: None,
             custom: None,
+            handshake_timeout: None,
         }
     }
 
@@ -652,6 +818,7 @@ impl MakeSendRequest {
             #[cfg(feature = "client-tls")]
             tls: None,
             custom: Some(conn),
+            handshake_timeout: None,
         }
     }
 
@@ -668,6 +835,7 @@ impl MakeSendRequest {
             builder,
             tls: Some(prepare_tls_for_h2(&tls)),
             custom: None,
+            handshake_timeout: None,
         }
     }
 
@@ -684,7 +852,23 @@ impl MakeSendRequest {
             builder,
             tls: Some(prepare_tls_for_h2(&tls)),
             custom: None,
+            handshake_timeout: None,
         }
+    }
+
+    /// Apply connection-establishment bounds. `connect_timeout` is pushed into
+    /// the built-in `HttpConnector` (TCP connect); `handshake_timeout` is stored
+    /// and applied around the TLS handshake and HTTP/2 preface in `call()`.
+    fn with_timeouts(
+        mut self,
+        connect_timeout: Option<Duration>,
+        handshake_timeout: Option<Duration>,
+    ) -> Self {
+        if let Some(dur) = connect_timeout {
+            self.connector.set_connect_timeout(Some(dur));
+        }
+        self.handshake_timeout = handshake_timeout;
+        self
     }
 }
 
@@ -704,9 +888,13 @@ impl tower::Service<Uri> for MakeSendRequest {
         if let Some(c) = &mut self.custom {
             let io_fut = c.call(uri);
             let builder = self.builder.clone();
+            let handshake_timeout = self.handshake_timeout;
             return Box::pin(async move {
                 let io = io_fut.await?;
-                let (send_request, conn) = builder.handshake(io).await?;
+                // The caller owns the dial, so only the HTTP/2 preface is
+                // bounded here (there is no TLS handshake we control).
+                let handshake = builder.handshake(io);
+                let (send_request, conn) = run_handshake(handshake, handshake_timeout).await?;
                 tokio::spawn(async move {
                     if let Err(e) = conn.await {
                         tracing::debug!("h2 connection task exited with error: {e}");
@@ -747,41 +935,53 @@ impl tower::Service<Uri> for MakeSendRequest {
 
         let connect_fut = <_ as tower::Service<Uri>>::call(&mut self.connector, uri);
         let builder = self.builder.clone();
+        let handshake_timeout = self.handshake_timeout;
 
         Box::pin(async move {
+            // TCP connect — bounded by `connect_timeout` on the connector.
             let io = connect_fut.await.map_err(Into::<BoxError>::into)?;
 
-            // TLS handshake if configured. This is the same pattern tonic
-            // uses for its Channel (transport/channel/service/connector.rs).
-            // The two concrete IO types are unified via BoxedIo for handshake().
-            #[cfg(feature = "client-tls")]
-            let io: BoxedIo = if let (Some(tls), Some(server_name)) = (tls, server_name) {
-                // Unwrap the TokioIo to get the raw TcpStream for TLS.
-                let tcp = io.into_inner();
-                let connector = tokio_rustls::TlsConnector::from(tls);
-                let tls_stream = connector
-                    .connect(server_name, tcp)
-                    .await
-                    .map_err(|e| ConnectError::unavailable(format!("TLS handshake failed: {e}")))?;
+            // TLS handshake (if configured) + HTTP/2 preface — bounded together
+            // by `handshake_timeout` so a server that accepts the TCP
+            // connection but stalls the handshake can't hang `poll_ready` for
+            // every caller sharing this connection.
+            let establish = async move {
+                // TLS handshake if configured. This is the same pattern tonic
+                // uses for its Channel (transport/channel/service/connector.rs).
+                // The two concrete IO types are unified via BoxedIo for handshake().
+                #[cfg(feature = "client-tls")]
+                let io: BoxedIo = if let (Some(tls), Some(server_name)) = (tls, server_name) {
+                    // Unwrap the TokioIo to get the raw TcpStream for TLS.
+                    let tcp = io.into_inner();
+                    let connector = tokio_rustls::TlsConnector::from(tls);
+                    let tls_stream = connector.connect(server_name, tcp).await.map_err(|e| {
+                        BoxError::from(ConnectError::unavailable(format!(
+                            "TLS handshake failed: {e}"
+                        )))
+                    })?;
 
-                // Verify ALPN negotiated h2. A server that doesn't speak h2
-                // would otherwise fail cryptically in the h2 handshake.
-                // Same check tonic does (transport/channel/service/tls.rs:125).
-                let (_, session) = tls_stream.get_ref();
-                if session.alpn_protocol() != Some(b"h2") {
-                    return Err(ConnectError::unavailable(
-                        "TLS handshake succeeded but server did not negotiate \
-                         HTTP/2 via ALPN (is the server h2-capable?)",
-                    )
-                    .into());
-                }
+                    // Verify ALPN negotiated h2. A server that doesn't speak h2
+                    // would otherwise fail cryptically in the h2 handshake.
+                    // Same check tonic does (transport/channel/service/tls.rs:125).
+                    let (_, session) = tls_stream.get_ref();
+                    if session.alpn_protocol() != Some(b"h2") {
+                        return Err(BoxError::from(ConnectError::unavailable(
+                            "TLS handshake succeeded but server did not negotiate \
+                             HTTP/2 via ALPN (is the server h2-capable?)",
+                        )));
+                    }
 
-                Box::pin(hyper_util::rt::TokioIo::new(tls_stream))
-            } else {
-                Box::pin(io)
+                    Box::pin(hyper_util::rt::TokioIo::new(tls_stream))
+                } else {
+                    Box::pin(io)
+                };
+                #[cfg(not(feature = "client-tls"))]
+                let io: BoxedIo = Box::pin(io);
+
+                builder.handshake(io).await.map_err(BoxError::from)
             };
 
-            let (send_request, conn) = builder.handshake(io).await?;
+            let (send_request, conn) = run_handshake(establish, handshake_timeout).await?;
             // The connection task drives the h2 state machine (reads frames,
             // processes flow control, etc). Detach it — it exits when the
             // connection closes or errors.
@@ -794,6 +994,28 @@ impl tower::Service<Uri> for MakeSendRequest {
                 inner: send_request,
             })
         })
+    }
+}
+
+/// Run a connection-establishment future under an optional time bound.
+///
+/// `None` runs it unbounded; `Some(dur)` cancels it (dropping the in-flight
+/// handshake) and returns a `deadline_exceeded` error if it doesn't finish
+/// within `dur`. The future's own error type is coerced to [`BoxError`].
+async fn run_handshake<F, T, E>(fut: F, timeout: Option<Duration>) -> Result<T, BoxError>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<BoxError>,
+{
+    match timeout {
+        Some(dur) => match tokio::time::timeout(dur, fut).await {
+            Ok(res) => res.map_err(Into::into),
+            Err(_) => Err(ConnectError::deadline_exceeded(format!(
+                "connection handshake did not complete within {dur:?}"
+            ))
+            .into()),
+        },
+        None => fut.await.map_err(Into::into),
     }
 }
 
@@ -1102,5 +1324,133 @@ mod tests {
             err.message.as_deref().unwrap().contains(path),
             "error should include socket path, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn builder_defaults_are_unset() {
+        let builder = Http2Connection::builder();
+        assert!(builder.connect_timeout.is_none());
+        assert!(builder.handshake_timeout.is_none());
+    }
+
+    #[test]
+    fn builder_setters_record_durations() {
+        let builder = Http2Connection::builder()
+            .connect_timeout(Duration::from_millis(10))
+            .handshake_timeout(Duration::from_millis(20));
+        assert_eq!(builder.connect_timeout, Some(Duration::from_millis(10)));
+        assert_eq!(builder.handshake_timeout, Some(Duration::from_millis(20)));
+    }
+
+    #[tokio::test]
+    async fn builder_connect_timeout_bounds_tcp_connect() {
+        use std::time::Instant;
+
+        // RFC 5737 TEST-NET-1: guaranteed unroutable, so SYNs are dropped and an
+        // unbounded connect would stall on kernel retransmits (~130s). A 100ms
+        // connect_timeout must abort well before that.
+        let start = Instant::now();
+        let err = Http2Connection::builder()
+            .connect_timeout(Duration::from_millis(100))
+            .connect_plaintext("http://192.0.2.1:9".parse().unwrap())
+            .await
+            .unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "connect_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err:?}"
+        );
+    }
+
+    // hyper's plaintext h2c handshake resolves locally (it sends the client
+    // preface without waiting for the server's SETTINGS), so a stalled cleartext
+    // server stalls the first *request*, not the handshake. The TLS handshake,
+    // by contrast, genuinely blocks on the server, so that is where
+    // handshake_timeout has observable effect — exercised here.
+    #[cfg(feature = "client-tls")]
+    #[tokio::test]
+    async fn handshake_timeout_fires_when_tls_server_stalls_after_accept() {
+        use std::time::Instant;
+
+        // A listener that accepts the TCP connection but never performs the TLS
+        // handshake. The TCP connect succeeds, so only handshake_timeout can
+        // release the stalled connect.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let tls_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let uri: Uri = format!("https://{addr}").parse().unwrap();
+        let start = Instant::now();
+        let err = Http2Connection::builder()
+            .handshake_timeout(Duration::from_millis(150))
+            .connect_tls(uri, tls_config)
+            .await
+            .unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
+        assert!(
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("handshake did not complete"),
+            "expected a handshake-timeout message, got: {err:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}"
+        );
+
+        server.abort();
+    }
+
+    #[cfg(feature = "server")]
+    #[tokio::test]
+    async fn handshake_succeeds_within_generous_bound() {
+        // A real h2c server completes the preface promptly, so a generous
+        // handshake_timeout must not interfere with normal establishment.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let io = hyper_util::rt::TokioIo::new(stream);
+                    let service =
+                        hyper::service::service_fn(|_req: Request<hyper::body::Incoming>| async {
+                            Ok::<_, std::convert::Infallible>(Response::new(
+                                http_body_util::Full::new(bytes::Bytes::from_static(b"ok")),
+                            ))
+                        });
+                    let _ = hyper::server::conn::http2::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection(io, service)
+                    .await;
+                });
+            }
+        });
+
+        let uri: Uri = format!("http://{addr}").parse().unwrap();
+        let conn = Http2Connection::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .handshake_timeout(Duration::from_secs(5))
+            .connect_plaintext(uri)
+            .await
+            .expect("establishment should succeed within a generous bound");
+        let _ = conn;
+
+        server.abort();
     }
 }

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -88,6 +88,56 @@ where
     )
 }
 
+/// DNS resolver that rotates the address list across successive resolutions.
+///
+/// `HttpConnector` tries same-family addresses serially and stops at the first
+/// TCP success — so if address A accepts TCP but stalls TLS, B and C are never
+/// tried within that attempt and the establishment timeout fires. Rotating the
+/// list per attempt means the next reconnect starts with B, bounding the
+/// worst-case time to reach a healthy address at `establishment_timeout × N`
+/// rather than relying on DNS-result reordering.
+#[derive(Clone, Debug)]
+struct RotatingGaiResolver {
+    inner: hyper_util::client::legacy::connect::dns::GaiResolver,
+    attempt: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl RotatingGaiResolver {
+    fn new() -> Self {
+        Self {
+            inner: hyper_util::client::legacy::connect::dns::GaiResolver::new(),
+            attempt: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl tower::Service<hyper_util::client::legacy::connect::dns::Name> for RotatingGaiResolver {
+    type Response = std::vec::IntoIter<std::net::SocketAddr>;
+    type Error = std::io::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, name: hyper_util::client::legacy::connect::dns::Name) -> Self::Future {
+        let n = self
+            .attempt
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let fut = self.inner.call(name);
+        Box::pin(async move {
+            let mut addrs: Vec<std::net::SocketAddr> = fut.await?.collect();
+            if addrs.len() > 1 {
+                let len = addrs.len();
+                addrs.rotate_left(n % len);
+            }
+            Ok(addrs.into_iter())
+        })
+    }
+}
+
+type Http2HttpConnector = hyper_util::client::legacy::connect::HttpConnector<RotatingGaiResolver>;
+
 /// Build a connector that dials a Unix domain socket. The URI argument
 /// is ignored — `:authority` is supplied separately to
 /// [`Http2Connection::lazy_unix`].
@@ -243,15 +293,16 @@ fn require_http_scheme(uri: &Uri) -> Result<(), ConnectError> {
 }
 
 impl Http2Connection {
-    /// Returns a builder for bounding connection establishment (TCP connect,
-    /// TLS handshake, HTTP/2 preface) before choosing a transport flavour.
+    /// Returns a builder for configuring connection establishment (timeout
+    /// bounds, HTTP/2 keep-alive, flow-control windows) before choosing a
+    /// transport flavour.
     ///
     /// The constructors on `Http2Connection` are shortcuts for the builder
-    /// with no bounds set, so `Http2Connection::lazy_plaintext(uri)` is exactly
-    /// `Http2Connection::builder().lazy_plaintext(uri)`. Reach for the builder
-    /// when you want to bound a stalled connect or handshake — see
-    /// [`Http2ConnectionBuilder::connect_timeout`] and
-    /// [`Http2ConnectionBuilder::handshake_timeout`].
+    /// with default settings, so `Http2Connection::lazy_plaintext(uri)` is
+    /// exactly `Http2Connection::builder().lazy_plaintext(uri)`. The default
+    /// establishment bounds are finite — see
+    /// [`Http2ConnectionBuilder::establishment_timeout`] and
+    /// [`Http2ConnectionBuilder::tcp_connect_timeout`].
     #[must_use]
     pub fn builder() -> Http2ConnectionBuilder {
         Http2ConnectionBuilder::default()
@@ -459,82 +510,94 @@ impl Http2Connection {
 /// Builder for [`Http2Connection`] connection-establishment bounds.
 ///
 /// Obtain one via [`Http2Connection::builder`]. The terminal methods mirror the
-/// `Http2Connection` constructors; the bare constructors delegate here with no
-/// bounds set, so behaviour is unchanged unless you call a setter.
+/// `Http2Connection` constructors; the bare constructors delegate here with
+/// default settings.
 ///
-/// Both bounds default to unset (no time limit). Establishment then runs until
-/// it succeeds, errors, or the kernel gives up — a server that accepts the TCP
-/// connection but stalls during the TLS handshake would otherwise stall
-/// `poll_ready` for every caller sharing the connection. The bounds here are the
-/// *establishment* budget; [`CallOptions::with_timeout`] remains the end-to-end
-/// per-request bound.
+/// Establishment is bounded by default ([`DEFAULT_ESTABLISHMENT_TIMEOUT`] /
+/// [`DEFAULT_TCP_CONNECT_TIMEOUT`]), so a server that accepts the TCP
+/// connection but stalls during the TLS handshake cannot stall `poll_ready` for
+/// every caller sharing the connection. The bounds here are the *establishment*
+/// budget; [`CallOptions::with_timeout`] remains the end-to-end per-request
+/// bound.
 ///
 /// # Scope
 ///
 /// The builder covers every [`Http2Connection`] transport: plaintext, TLS,
 /// caller-supplied connectors, and Unix sockets. HTTP/2 keep-alive and
 /// flow-control knobs are proxied directly; for hyper settings not surfaced
-/// here use [`h2_settings`](Self::h2_settings). [`connect_timeout`] is the
+/// here use [`h2_settings`](Self::h2_settings). [`tcp_connect_timeout`] is the
 /// per-address TCP bound on the built-in connector and is ignored by the
-/// custom-connector / Unix-socket terminals — use [`handshake_timeout`] there
+/// custom-connector / Unix-socket terminals — use [`establishment_timeout`] there
 /// as the establishment bound.
 ///
-/// [`connect_timeout`]: Self::connect_timeout
-/// [`handshake_timeout`]: Self::handshake_timeout
+/// [`tcp_connect_timeout`]: Self::tcp_connect_timeout
+/// [`establishment_timeout`]: Self::establishment_timeout
 ///
 /// [`CallOptions::with_timeout`]: super::CallOptions::with_timeout
 #[derive(Debug, Clone)]
 pub struct Http2ConnectionBuilder {
-    connect_timeout: Option<Duration>,
-    handshake_timeout: Option<Duration>,
+    tcp_connect_timeout: Option<Duration>,
+    establishment_timeout: Option<Duration>,
     h2_builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
 }
 
+/// Default wall-clock bound on connection establishment (DNS, TCP, TLS, h2
+/// preface). Override via [`Http2ConnectionBuilder::establishment_timeout`].
+/// Matches grpc-go's default `MinConnectTimeout`.
+pub const DEFAULT_ESTABLISHMENT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Default per-address TCP `connect(2)` budget on the built-in connector.
+/// Override via [`Http2ConnectionBuilder::tcp_connect_timeout`].
+pub const DEFAULT_TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl Default for Http2ConnectionBuilder {
-    /// A fresh builder with no establishment bounds and default HTTP/2
-    /// settings. A [`TokioTimer`](hyper_util::rt::TokioTimer) is pre-wired so
-    /// the keep-alive setters work without the caller having to install one
-    /// (hyper otherwise panics at handshake time if a keep-alive interval is
-    /// set without a timer).
+    /// A fresh builder with [`DEFAULT_ESTABLISHMENT_TIMEOUT`] /
+    /// [`DEFAULT_TCP_CONNECT_TIMEOUT`] and default HTTP/2 settings. A
+    /// [`TokioTimer`](hyper_util::rt::TokioTimer) is pre-wired so the
+    /// keep-alive setters work without the caller having to install one (hyper
+    /// otherwise panics at handshake time if a keep-alive interval is set
+    /// without a timer).
     fn default() -> Self {
         let mut h2_builder =
             hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
         h2_builder.timer(hyper_util::rt::TokioTimer::new());
         Self {
-            connect_timeout: None,
-            handshake_timeout: None,
+            tcp_connect_timeout: Some(DEFAULT_TCP_CONNECT_TIMEOUT),
+            establishment_timeout: Some(DEFAULT_ESTABLISHMENT_TIMEOUT),
             h2_builder,
         }
     }
 }
 
 impl Http2ConnectionBuilder {
-    /// Bound the TCP connect phase.
+    /// Set the per-address TCP connect budget.
     ///
     /// Applied to the built-in connector via hyper's
     /// [`HttpConnector::set_connect_timeout`][hyper-ct]; it covers only the TCP
     /// `connect(2)` call (per resolved address — the budget is divided across
-    /// the address set). It does **not** cover DNS resolution, the TLS
-    /// handshake, or the HTTP/2 preface — set
-    /// [`handshake_timeout`](Self::handshake_timeout) too to bound those — and
-    /// is **ignored** by the custom-connector / Unix-socket terminals (which
+    /// the address set), so the connector moves on to the next address rather
+    /// than burning the whole [`establishment_timeout`] on one blackholed peer.
+    /// It is **ignored** by the custom-connector / Unix-socket terminals (which
     /// have no built-in `HttpConnector` to apply it to).
     ///
-    /// Unset (the default) means TCP connect is governed by the kernel's
-    /// `tcp_syn_retries` (typically ~130s on Linux).
+    /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. Pass `Duration::MAX` to
+    /// effectively disable.
     ///
+    /// [`establishment_timeout`]: Self::establishment_timeout
     /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
     #[must_use]
-    pub fn connect_timeout(mut self, dur: Duration) -> Self {
-        self.connect_timeout = Some(dur);
+    pub fn tcp_connect_timeout(mut self, dur: Duration) -> Self {
+        self.tcp_connect_timeout = Some(dur);
         self
     }
 
-    /// Bound the connection handshake: DNS resolution, TCP connect, the TLS
-    /// handshake (for `tls` connections), and the HTTP/2 preface, as one
-    /// wall-clock budget. [`connect_timeout`](Self::connect_timeout) is an
-    /// additional per-address TCP bound *inside* this budget. It mirrors the
-    /// server-side TLS handshake timeout (`Server::with_tls_handshake_timeout`).
+    /// Set the wall-clock bound on connection establishment: DNS resolution,
+    /// TCP connect, the TLS handshake (for `tls` connections), and the HTTP/2
+    /// preface, as one budget. [`tcp_connect_timeout`](Self::tcp_connect_timeout)
+    /// is an additional per-address TCP bound *inside* this budget.
+    ///
+    /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. Pass `Duration::MAX` to
+    /// effectively disable.
     ///
     /// # Where this bites
     ///
@@ -553,11 +616,9 @@ impl Http2ConnectionBuilder {
     /// Exceeding this bound surfaces as a [`ConnectError`] with
     /// [`ErrorCode::Unavailable`](crate::error::ErrorCode::Unavailable) (the
     /// connect is retryable); the message names the phase.
-    ///
-    /// Unset (the default) means the handshake is unbounded.
     #[must_use]
-    pub fn handshake_timeout(mut self, dur: Duration) -> Self {
-        self.handshake_timeout = Some(dur);
+    pub fn establishment_timeout(mut self, dur: Duration) -> Self {
+        self.establishment_timeout = Some(dur);
         self
     }
 
@@ -569,7 +630,7 @@ impl Http2ConnectionBuilder {
     /// [`keep_alive_timeout`](Self::keep_alive_timeout) the connection is
     /// closed and the next `poll_ready` reconnects. This is the post-handshake
     /// liveness bound — together with
-    /// [`handshake_timeout`](Self::handshake_timeout) it bounds the transport
+    /// [`establishment_timeout`](Self::establishment_timeout) it bounds the transport
     /// against a peer that goes silent at any point.
     #[must_use]
     pub fn keep_alive_interval(mut self, interval: Duration) -> Self {
@@ -594,7 +655,7 @@ impl Http2ConnectionBuilder {
     /// window between handshake completion and the first request (where no
     /// stream is open yet) is not covered by keep-alive, so a peer that goes
     /// half-open exactly there is unbounded by both
-    /// [`handshake_timeout`](Self::handshake_timeout) (already ended) and
+    /// [`establishment_timeout`](Self::establishment_timeout) (already ended) and
     /// keep-alive (not armed).
     #[must_use]
     pub fn keep_alive_while_idle(mut self, enabled: bool) -> Self {
@@ -706,9 +767,9 @@ impl Http2ConnectionBuilder {
     /// Finish as a lazily-established connection over a **caller-supplied
     /// connector**. See [`Http2Connection::lazy_with_connector`].
     ///
-    /// `handshake_timeout` bounds the connector's dial *and* the HTTP/2 preface
+    /// `establishment_timeout` bounds the connector's dial *and* the HTTP/2 preface
     /// as one wall-clock budget — the same semantics as the built-in
-    /// transports. `connect_timeout` is the per-address TCP bound on the
+    /// transports. `tcp_connect_timeout` is the per-address TCP bound on the
     /// built-in connector and is **ignored** here; to bound the dial separately
     /// from the preface, wrap the connector in `tower::timeout::Timeout`.
     #[must_use]
@@ -732,7 +793,7 @@ impl Http2ConnectionBuilder {
     /// # Errors
     ///
     /// Returns an error if the connector or h2 handshake fails (including
-    /// exceeding a configured `handshake_timeout`).
+    /// exceeding a configured `establishment_timeout`).
     pub async fn connect_with_connector<C>(
         self,
         connector: C,
@@ -768,7 +829,7 @@ impl Http2ConnectionBuilder {
     /// # Errors
     ///
     /// Returns an error if the socket path doesn't exist or the h2 handshake
-    /// fails (including exceeding a configured `handshake_timeout`).
+    /// fails (including exceeding a configured `establishment_timeout`).
     #[cfg(unix)]
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub async fn connect_unix(
@@ -780,12 +841,14 @@ impl Http2ConnectionBuilder {
             .await
     }
 
-    /// Built-in TCP connector with `nodelay` and the configured
-    /// `connect_timeout` applied. Mirrors `HttpClientBuilder::http_connector`.
-    fn http_connector(&self) -> hyper_util::client::legacy::connect::HttpConnector {
-        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
+    /// Built-in TCP connector with `nodelay`, the configured
+    /// `tcp_connect_timeout`, and a [`RotatingGaiResolver`] applied.
+    fn http_connector(&self) -> Http2HttpConnector {
+        let mut connector = hyper_util::client::legacy::connect::HttpConnector::new_with_resolver(
+            RotatingGaiResolver::new(),
+        );
         connector.set_nodelay(true);
-        connector.set_connect_timeout(self.connect_timeout);
+        connector.set_connect_timeout(self.tcp_connect_timeout);
         connector
     }
 
@@ -796,7 +859,7 @@ impl Http2ConnectionBuilder {
             #[cfg(feature = "client-tls")]
             tls: None,
             custom: None,
-            handshake_timeout: self.handshake_timeout,
+            establishment_timeout: self.establishment_timeout,
         }
     }
 
@@ -809,21 +872,21 @@ impl Http2ConnectionBuilder {
             builder: self.h2_builder,
             tls: Some(prepare_tls_for_h2(&tls_config)),
             custom: None,
-            handshake_timeout: self.handshake_timeout,
+            establishment_timeout: self.establishment_timeout,
         }
     }
 
     fn make_custom(self, conn: BoxedConnector) -> MakeSendRequest {
         MakeSendRequest {
             // Unused when `custom` is Some — `call()` branches to the custom
-            // connector before touching it. `connect_timeout` is therefore
+            // connector before touching it. `tcp_connect_timeout` is therefore
             // dropped here (it's the per-address TCP bound on this connector).
-            connector: hyper_util::client::legacy::connect::HttpConnector::new(),
+            connector: self.http_connector(),
             builder: self.h2_builder,
             #[cfg(feature = "client-tls")]
             tls: None,
             custom: Some(conn),
-            handshake_timeout: self.handshake_timeout,
+            establishment_timeout: self.establishment_timeout,
         }
     }
 }
@@ -967,7 +1030,7 @@ impl tower::Service<Request<ClientBody>> for SendRequest {
 /// HTTP/2 handshake, returning a ready `SendRequest`. Used by [`Reconnect`]
 /// to (re)establish connections.
 struct MakeSendRequest {
-    connector: hyper_util::client::legacy::connect::HttpConnector,
+    connector: Http2HttpConnector,
     builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
     /// TLS config for https:// connections. When `Some`, the URI scheme
     /// must be https:// and a TLS handshake happens after TCP connect.
@@ -982,7 +1045,7 @@ struct MakeSendRequest {
     /// connect, TLS handshake (if any), and the HTTP/2 preface. `None` means
     /// unbounded. `connector`'s `set_connect_timeout` is an additional
     /// per-address TCP bound inside this budget.
-    handshake_timeout: Option<Duration>,
+    establishment_timeout: Option<Duration>,
 }
 
 impl tower::Service<Uri> for MakeSendRequest {
@@ -1001,7 +1064,7 @@ impl tower::Service<Uri> for MakeSendRequest {
         if let Some(c) = &mut self.custom {
             let io_fut = c.call(uri);
             let builder = self.builder.clone();
-            let handshake_timeout = self.handshake_timeout;
+            let establishment_timeout = self.establishment_timeout;
             return Box::pin(async move {
                 // Dial + HTTP/2 preface as one wall-clock budget — same
                 // semantics as the built-in branch's `establish` block below.
@@ -1009,7 +1072,8 @@ impl tower::Service<Uri> for MakeSendRequest {
                     let io = io_fut.await?;
                     builder.handshake(io).await.map_err(BoxError::from)
                 };
-                let (send_request, conn) = run_handshake(establish, handshake_timeout).await?;
+                let (send_request, conn) =
+                    run_establishment(establish, establishment_timeout).await?;
                 tokio::spawn(async move {
                     if let Err(e) = conn.await {
                         tracing::debug!("h2 connection task exited with error: {e}");
@@ -1050,15 +1114,15 @@ impl tower::Service<Uri> for MakeSendRequest {
 
         let connect_fut = <_ as tower::Service<Uri>>::call(&mut self.connector, uri);
         let builder = self.builder.clone();
-        let handshake_timeout = self.handshake_timeout;
+        let establishment_timeout = self.establishment_timeout;
 
         Box::pin(async move {
             // DNS + TCP connect + TLS handshake (if configured) + HTTP/2
-            // preface — bounded together by `handshake_timeout` so a server
+            // preface — bounded together by `establishment_timeout` so a server
             // that accepts the TCP connection but stalls the handshake (or a
             // hung resolver) can't hang `poll_ready` for every caller sharing
             // this connection. The per-address TCP connect is additionally
-            // bounded by `connect_timeout` on the connector.
+            // bounded by `tcp_connect_timeout` on the connector.
             let establish = async move {
                 let io = connect_fut.await.map_err(Into::<BoxError>::into)?;
 
@@ -1097,7 +1161,7 @@ impl tower::Service<Uri> for MakeSendRequest {
                 builder.handshake(io).await.map_err(BoxError::from)
             };
 
-            let (send_request, conn) = run_handshake(establish, handshake_timeout).await?;
+            let (send_request, conn) = run_establishment(establish, establishment_timeout).await?;
             // The connection task drives the h2 state machine (reads frames,
             // processes flow control, etc). Detach it — it exits when the
             // connection closes or errors.
@@ -1118,7 +1182,10 @@ impl tower::Service<Uri> for MakeSendRequest {
 /// `None` runs it unbounded; `Some(dur)` cancels it (dropping the in-flight
 /// handshake) and returns an `unavailable` error if it doesn't finish within
 /// `dur`. The future's own error type is coerced to [`BoxError`].
-pub(super) async fn run_handshake<F, T, E>(fut: F, timeout: Option<Duration>) -> Result<T, BoxError>
+pub(super) async fn run_establishment<F, T, E>(
+    fut: F,
+    timeout: Option<Duration>,
+) -> Result<T, BoxError>
 where
     F: Future<Output = Result<T, E>>,
     E: Into<BoxError> + 'static,
@@ -1127,7 +1194,7 @@ where
         Some(dur) => match tokio::time::timeout(dur, fut).await {
             Ok(res) => res.map_err(Into::into),
             Err(_) => Err(ConnectError::unavailable(format!(
-                "connection handshake did not complete within {dur:?}"
+                "connection establishment did not complete within {dur:?}"
             ))
             .into()),
         },
@@ -1443,31 +1510,40 @@ mod tests {
     }
 
     #[test]
-    fn builder_defaults_are_unset() {
+    fn builder_defaults_are_finite() {
         let builder = Http2Connection::builder();
-        assert!(builder.connect_timeout.is_none());
-        assert!(builder.handshake_timeout.is_none());
+        assert_eq!(
+            builder.tcp_connect_timeout,
+            Some(DEFAULT_TCP_CONNECT_TIMEOUT)
+        );
+        assert_eq!(
+            builder.establishment_timeout,
+            Some(DEFAULT_ESTABLISHMENT_TIMEOUT)
+        );
     }
 
     #[test]
     fn builder_setters_record_durations() {
         let builder = Http2Connection::builder()
-            .connect_timeout(Duration::from_millis(10))
-            .handshake_timeout(Duration::from_millis(20));
-        assert_eq!(builder.connect_timeout, Some(Duration::from_millis(10)));
-        assert_eq!(builder.handshake_timeout, Some(Duration::from_millis(20)));
+            .tcp_connect_timeout(Duration::from_millis(10))
+            .establishment_timeout(Duration::from_millis(20));
+        assert_eq!(builder.tcp_connect_timeout, Some(Duration::from_millis(10)));
+        assert_eq!(
+            builder.establishment_timeout,
+            Some(Duration::from_millis(20))
+        );
     }
 
     #[tokio::test]
-    async fn builder_connect_timeout_bounds_tcp_connect() {
+    async fn builder_tcp_connect_timeout_bounds_tcp_connect() {
         use std::time::Instant;
 
         // RFC 5737 TEST-NET-1: guaranteed unroutable, so SYNs are dropped and an
         // unbounded connect would stall on kernel retransmits (~130s). A 100ms
-        // connect_timeout must abort well before that.
+        // tcp_connect_timeout must abort well before that.
         let start = Instant::now();
         let err = Http2Connection::builder()
-            .connect_timeout(Duration::from_millis(100))
+            .tcp_connect_timeout(Duration::from_millis(100))
             .connect_plaintext("http://192.0.2.1:9".parse().unwrap())
             .await
             .unwrap_err();
@@ -1490,7 +1566,7 @@ mod tests {
         );
         assert!(
             elapsed < Duration::from_secs(2),
-            "connect_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err:?}"
+            "tcp_connect_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err:?}"
         );
     }
 
@@ -1498,14 +1574,14 @@ mod tests {
     // preface without waiting for the server's SETTINGS), so a stalled cleartext
     // server stalls the first *request*, not the handshake. The TLS handshake,
     // by contrast, genuinely blocks on the server, so that is where
-    // handshake_timeout has observable effect — exercised here.
+    // establishment_timeout has observable effect — exercised here.
     #[cfg(feature = "client-tls")]
     #[tokio::test]
-    async fn handshake_timeout_fires_when_tls_server_stalls_after_accept() {
+    async fn establishment_timeout_fires_when_tls_server_stalls_after_accept() {
         use std::time::Instant;
 
         // A listener that accepts the TCP connection but never performs the TLS
-        // handshake. The TCP connect succeeds, so only handshake_timeout can
+        // handshake. The TCP connect succeeds, so only establishment_timeout can
         // release the stalled connect.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1524,7 +1600,7 @@ mod tests {
         let uri: Uri = format!("https://{addr}").parse().unwrap();
         let start = Instant::now();
         let err = Http2Connection::builder()
-            .handshake_timeout(Duration::from_millis(150))
+            .establishment_timeout(Duration::from_millis(150))
             .connect_tls(uri, tls_config)
             .await
             .unwrap_err();
@@ -1535,12 +1611,12 @@ mod tests {
             err.message
                 .as_deref()
                 .unwrap()
-                .contains("handshake did not complete"),
+                .contains("establishment did not complete"),
             "expected a handshake-timeout message, got: {err:?}"
         );
         assert!(
             elapsed < Duration::from_secs(2),
-            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}"
+            "establishment_timeout(150ms) should fire within ~2s, took {elapsed:?}"
         );
 
         server.abort();
@@ -1548,7 +1624,7 @@ mod tests {
 
     #[cfg(feature = "client-tls")]
     #[tokio::test]
-    async fn handshake_timeout_applies_with_custom_h2_settings() {
+    async fn establishment_timeout_applies_with_custom_h2_settings() {
         use std::time::Instant;
 
         // Same stalled-TLS scenario, but constructed via the proxied keep-alive
@@ -1573,7 +1649,7 @@ mod tests {
         let err = Http2Connection::builder()
             .keep_alive_interval(Duration::from_secs(30))
             .keep_alive_while_idle(true)
-            .handshake_timeout(Duration::from_millis(150))
+            .establishment_timeout(Duration::from_millis(150))
             .connect_tls(uri, tls_config)
             .await
             .unwrap_err();
@@ -1584,22 +1660,22 @@ mod tests {
             err.message
                 .as_deref()
                 .unwrap()
-                .contains("handshake did not complete"),
+                .contains("establishment did not complete"),
             "expected a handshake-timeout message, got: {err:?}"
         );
         assert!(
             elapsed < Duration::from_secs(2),
-            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}"
+            "establishment_timeout(150ms) should fire within ~2s, took {elapsed:?}"
         );
 
         server.abort();
     }
 
     #[tokio::test]
-    async fn handshake_timeout_bounds_custom_connector_dial() {
+    async fn establishment_timeout_bounds_custom_connector_dial() {
         use std::time::Instant;
 
-        // A connector that never resolves — handshake_timeout must bound the
+        // A connector that never resolves — establishment_timeout must bound the
         // caller's dial, not just the h2 preface, so this fires.
         let never = tower::service_fn(|_uri: Uri| async move {
             std::future::pending::<()>().await;
@@ -1608,7 +1684,7 @@ mod tests {
         });
         let start = Instant::now();
         let err = Http2Connection::builder()
-            .handshake_timeout(Duration::from_millis(150))
+            .establishment_timeout(Duration::from_millis(150))
             .connect_with_connector(never, "http://localhost".parse().unwrap())
             .await
             .unwrap_err();
@@ -1619,12 +1695,12 @@ mod tests {
             err.message
                 .as_deref()
                 .unwrap()
-                .contains("handshake did not complete"),
+                .contains("establishment did not complete"),
             "expected a handshake-timeout message, got: {err:?}"
         );
         assert!(
             elapsed < Duration::from_secs(2),
-            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}"
+            "establishment_timeout(150ms) should fire within ~2s, took {elapsed:?}"
         );
     }
 
@@ -1632,7 +1708,7 @@ mod tests {
     #[tokio::test]
     async fn handshake_succeeds_within_generous_bound() {
         // A real h2c server completes the preface promptly, so a generous
-        // handshake_timeout must not interfere with normal establishment.
+        // establishment_timeout must not interfere with normal establishment.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
@@ -1656,8 +1732,8 @@ mod tests {
 
         let uri: Uri = format!("http://{addr}").parse().unwrap();
         let conn = Http2Connection::builder()
-            .connect_timeout(Duration::from_secs(5))
-            .handshake_timeout(Duration::from_secs(5))
+            .tcp_connect_timeout(Duration::from_secs(5))
+            .establishment_timeout(Duration::from_secs(5))
             .connect_plaintext(uri)
             .await
             .expect("establishment should succeed within a generous bound");

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -330,6 +330,7 @@ impl Http2Connection {
     ///     "http://localhost".parse().unwrap(),
     /// );
     /// ```
+    #[must_use]
     pub fn lazy_with_connector<C>(connector: C, authority: Uri) -> Self
     where
         C: tower::Service<Uri> + Send + 'static,
@@ -337,16 +338,12 @@ impl Http2Connection {
         C::Error: Into<BoxError>,
         C::Future: Send + 'static,
     {
-        Self {
-            inner: Reconnect::new(
-                MakeSendRequest::new_custom(box_connector(connector)),
-                authority,
-                true,
-            ),
-        }
+        Self::builder().lazy_with_connector(connector, authority)
     }
 
     /// Eagerly establish an h2c connection using a **caller-supplied connector**.
+    ///
+    /// # Errors
     ///
     /// Returns an error if the connector or h2 handshake fails. See
     /// [`lazy_with_connector`](Self::lazy_with_connector) for details.
@@ -360,17 +357,9 @@ impl Http2Connection {
         C::Error: Into<BoxError>,
         C::Future: Send + 'static,
     {
-        let mut conn = Self {
-            inner: Reconnect::new(
-                MakeSendRequest::new_custom(box_connector(connector)),
-                authority,
-                false,
-            ),
-        };
-        std::future::poll_fn(|cx| conn.inner.poll_ready(cx))
+        Self::builder()
+            .connect_with_connector(connector, authority)
             .await
-            .map_err(|e| ConnectError::unavailable(format!("connect failed: {e}")))?;
-        Ok(conn)
     }
 
     /// Create an h2c connection over a **Unix domain socket** that
@@ -385,11 +374,14 @@ impl Http2Connection {
     /// generally doesn't validate it.
     #[cfg(unix)]
     #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[must_use]
     pub fn lazy_unix(path: impl Into<std::path::PathBuf>, authority: Uri) -> Self {
-        Self::lazy_with_connector(unix_connector(path.into()), authority)
+        Self::builder().lazy_unix(path, authority)
     }
 
     /// Eagerly establish an h2c connection over a **Unix domain socket**.
+    ///
+    /// # Errors
     ///
     /// Returns an error if the socket path doesn't exist or the h2
     /// handshake fails. See [`lazy_unix`](Self::lazy_unix) for details.
@@ -399,7 +391,7 @@ impl Http2Connection {
         path: impl Into<std::path::PathBuf>,
         authority: Uri,
     ) -> Result<Self, ConnectError> {
-        Self::connect_with_connector(unix_connector(path.into()), authority).await
+        Self::builder().connect_unix(path, authority).await
     }
 
     /// Create a **TLS** h2 connection that establishes lazily on first
@@ -483,12 +475,16 @@ impl Http2Connection {
 ///
 /// # Scope
 ///
-/// The builder covers the **plaintext** and **TLS** transports (the ones that
-/// dial through the built-in connector). HTTP/2 keep-alive and flow-control
-/// knobs are proxied directly; for hyper settings not surfaced here use
-/// [`h2_settings`](Self::h2_settings). The custom-connector and Unix-socket
-/// constructors on [`Http2Connection`] own their own dialing and are not
-/// reachable through this builder, so they establish without these bounds.
+/// The builder covers every [`Http2Connection`] transport: plaintext, TLS,
+/// caller-supplied connectors, and Unix sockets. HTTP/2 keep-alive and
+/// flow-control knobs are proxied directly; for hyper settings not surfaced
+/// here use [`h2_settings`](Self::h2_settings). [`connect_timeout`] is the
+/// per-address TCP bound on the built-in connector and is ignored by the
+/// custom-connector / Unix-socket terminals — use [`handshake_timeout`] there
+/// as the establishment bound.
+///
+/// [`connect_timeout`]: Self::connect_timeout
+/// [`handshake_timeout`]: Self::handshake_timeout
 ///
 /// [`CallOptions::with_timeout`]: super::CallOptions::with_timeout
 #[derive(Debug, Clone)]
@@ -524,7 +520,9 @@ impl Http2ConnectionBuilder {
     /// `connect(2)` call (per resolved address — the budget is divided across
     /// the address set). It does **not** cover DNS resolution, the TLS
     /// handshake, or the HTTP/2 preface — set
-    /// [`handshake_timeout`](Self::handshake_timeout) too to bound those.
+    /// [`handshake_timeout`](Self::handshake_timeout) too to bound those — and
+    /// is **ignored** by the custom-connector / Unix-socket terminals (which
+    /// have no built-in `HttpConnector` to apply it to).
     ///
     /// Unset (the default) means TCP connect is governed by the kernel's
     /// `tcp_syn_retries` (typically ~130s on Linux).
@@ -636,15 +634,16 @@ impl Http2ConnectionBuilder {
     ///
     /// This is the escape hatch for hyper knobs not proxied above. It
     /// **replaces** any prior keep-alive / window-size settings on this
-    /// builder, and the caller takes ownership of timer setup — set
-    /// `.timer(hyper_util::rt::TokioTimer::new())` on the passed builder if
-    /// enabling keep-alive (hyper panics at handshake time otherwise). Prefer
-    /// the individual setters above for the common cases.
+    /// builder, so call it before the individual setters if you use both. A
+    /// [`TokioTimer`](hyper_util::rt::TokioTimer) is re-applied to the passed
+    /// builder so keep-alive works without the caller wiring one. Prefer the
+    /// individual setters above for the common cases.
     #[must_use]
     pub fn h2_settings(
         mut self,
-        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
+        mut builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
     ) -> Self {
+        builder.timer(hyper_util::rt::TokioTimer::new());
         self.h2_builder = builder;
         self
     }
@@ -708,6 +707,83 @@ impl Http2ConnectionBuilder {
         Ok(conn)
     }
 
+    /// Finish as a lazily-established connection over a **caller-supplied
+    /// connector**. See [`Http2Connection::lazy_with_connector`].
+    ///
+    /// `handshake_timeout` bounds the connector's dial *and* the HTTP/2 preface
+    /// as one wall-clock budget — the same semantics as the built-in
+    /// transports. `connect_timeout` is the per-address TCP bound on the
+    /// built-in connector and is **ignored** here; to bound the dial separately
+    /// from the preface, wrap the connector in `tower::timeout::Timeout`.
+    #[must_use]
+    pub fn lazy_with_connector<C>(self, connector: C, authority: Uri) -> Http2Connection
+    where
+        C: tower::Service<Uri> + Send + 'static,
+        C::Response: hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static,
+        C::Error: Into<BoxError>,
+        C::Future: Send + 'static,
+    {
+        Http2Connection {
+            inner: Reconnect::new(self.make_custom(box_connector(connector)), authority, true),
+        }
+    }
+
+    /// Finish by eagerly establishing a connection over a **caller-supplied
+    /// connector**. See [`Http2Connection::connect_with_connector`] and
+    /// [`lazy_with_connector`](Self::lazy_with_connector) for the timeout
+    /// semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connector or h2 handshake fails (including
+    /// exceeding a configured `handshake_timeout`).
+    pub async fn connect_with_connector<C>(
+        self,
+        connector: C,
+        authority: Uri,
+    ) -> Result<Http2Connection, ConnectError>
+    where
+        C: tower::Service<Uri> + Send + 'static,
+        C::Response: hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static,
+        C::Error: Into<BoxError>,
+        C::Future: Send + 'static,
+    {
+        let mut conn = Http2Connection {
+            inner: Reconnect::new(self.make_custom(box_connector(connector)), authority, false),
+        };
+        drive_connect(&mut conn, "connect failed").await?;
+        Ok(conn)
+    }
+
+    /// Finish as a lazily-established connection over a **Unix domain socket**.
+    /// See [`Http2Connection::lazy_unix`] and
+    /// [`lazy_with_connector`](Self::lazy_with_connector) for the timeout
+    /// semantics.
+    #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[must_use]
+    pub fn lazy_unix(self, path: impl Into<std::path::PathBuf>, authority: Uri) -> Http2Connection {
+        self.lazy_with_connector(unix_connector(path.into()), authority)
+    }
+
+    /// Finish by eagerly establishing a connection over a **Unix domain
+    /// socket**. See [`Http2Connection::connect_unix`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the socket path doesn't exist or the h2 handshake
+    /// fails (including exceeding a configured `handshake_timeout`).
+    #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    pub async fn connect_unix(
+        self,
+        path: impl Into<std::path::PathBuf>,
+        authority: Uri,
+    ) -> Result<Http2Connection, ConnectError> {
+        self.connect_with_connector(unix_connector(path.into()), authority)
+            .await
+    }
+
     fn make_plaintext(self) -> MakeSendRequest {
         MakeSendRequest::with_builder(self.h2_builder)
             .with_timeouts(self.connect_timeout, self.handshake_timeout)
@@ -717,6 +793,12 @@ impl Http2ConnectionBuilder {
     fn make_tls(self, tls_config: Arc<rustls::ClientConfig>) -> MakeSendRequest {
         MakeSendRequest::with_builder_tls(self.h2_builder, tls_config)
             .with_timeouts(self.connect_timeout, self.handshake_timeout)
+    }
+
+    fn make_custom(self, conn: BoxedConnector) -> MakeSendRequest {
+        // `connect_timeout` is intentionally dropped: it's the per-address TCP
+        // bound on the built-in `HttpConnector`, which is not in play here.
+        MakeSendRequest::new_custom(self.h2_builder, conn, self.handshake_timeout)
     }
 }
 
@@ -893,20 +975,20 @@ impl MakeSendRequest {
         }
     }
 
-    fn new_custom(conn: BoxedConnector) -> Self {
-        // `connector` is unused when `custom` is Some — `call()` branches
-        // to the custom connector before touching it. Kept to avoid
-        // restructuring the shared struct; HttpConnector::new() is cheap.
-        let connector = hyper_util::client::legacy::connect::HttpConnector::new();
-        let builder =
-            hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
+    fn new_custom(
+        builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
+        conn: BoxedConnector,
+        handshake_timeout: Option<Duration>,
+    ) -> Self {
         Self {
-            connector,
+            // Unused when `custom` is Some — `call()` branches to the custom
+            // connector before touching it. `HttpConnector::new()` is cheap.
+            connector: hyper_util::client::legacy::connect::HttpConnector::new(),
             builder,
             #[cfg(feature = "client-tls")]
             tls: None,
             custom: Some(conn),
-            handshake_timeout: None,
+            handshake_timeout,
         }
     }
 
@@ -928,8 +1010,10 @@ impl MakeSendRequest {
     }
 
     /// Apply connection-establishment bounds. `connect_timeout` is pushed into
-    /// the built-in `HttpConnector` (TCP connect); `handshake_timeout` is stored
-    /// and applied around the TLS handshake and HTTP/2 preface in `call()`.
+    /// the built-in `HttpConnector` (per-address TCP connect);
+    /// `handshake_timeout` is stored and applied around the whole
+    /// establishment future (DNS, TCP, TLS handshake, HTTP/2 preface) in
+    /// `call()`.
     fn with_timeouts(
         mut self,
         connect_timeout: Option<Duration>,
@@ -961,11 +1045,13 @@ impl tower::Service<Uri> for MakeSendRequest {
             let builder = self.builder.clone();
             let handshake_timeout = self.handshake_timeout;
             return Box::pin(async move {
-                let io = io_fut.await?;
-                // The caller owns the dial, so only the HTTP/2 preface is
-                // bounded here (there is no TLS handshake we control).
-                let handshake = builder.handshake(io);
-                let (send_request, conn) = run_handshake(handshake, handshake_timeout).await?;
+                // Dial + HTTP/2 preface as one wall-clock budget — same
+                // semantics as the built-in branch's `establish` block below.
+                let establish = async move {
+                    let io = io_fut.await?;
+                    builder.handshake(io).await.map_err(BoxError::from)
+                };
+                let (send_request, conn) = run_handshake(establish, handshake_timeout).await?;
                 tokio::spawn(async move {
                     if let Err(e) = conn.await {
                         tracing::debug!("h2 connection task exited with error: {e}");
@@ -1549,6 +1635,39 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn handshake_timeout_bounds_custom_connector_dial() {
+        use std::time::Instant;
+
+        // A connector that never resolves — handshake_timeout must bound the
+        // caller's dial, not just the h2 preface, so this fires.
+        let never = tower::service_fn(|_uri: Uri| async move {
+            std::future::pending::<()>().await;
+            // Unreachable; concrete type for inference.
+            Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(tokio::io::duplex(1).0))
+        });
+        let start = Instant::now();
+        let err = Http2Connection::builder()
+            .handshake_timeout(Duration::from_millis(150))
+            .connect_with_connector(never, "http://localhost".parse().unwrap())
+            .await
+            .unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
+        assert!(
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("handshake did not complete"),
+            "expected a handshake-timeout message, got: {err:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}"
+        );
     }
 
     #[cfg(feature = "server")]

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -267,6 +267,9 @@ pub use http2::Http2ConnectionBuilder;
 #[cfg(feature = "client")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use http2::SharedHttp2Connection;
+#[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
+pub use http2::{DEFAULT_ESTABLISHMENT_TIMEOUT, DEFAULT_TCP_CONNECT_TIMEOUT};
 
 /// General-purpose HTTP client supporting both HTTP/1.1 and HTTP/2.
 ///
@@ -319,7 +322,7 @@ impl std::fmt::Debug for HttpClient {
 /// Inner hyper client, parameterized over connector type via an enum.
 ///
 /// Both connectors are wrapped in [`TimeoutConnector`] so an optional
-/// `handshake_timeout` can bound the whole connector establishment. When no
+/// `establishment_timeout` can bound the whole connector establishment. When no
 /// timeout is set the wrapper forwards each connect unchanged (a single boxed
 /// future per *connection*, not per request — negligible).
 #[cfg(feature = "client")]
@@ -382,7 +385,7 @@ where
     fn call(&mut self, uri: Uri) -> Self::Future {
         let fut = self.inner.call(uri);
         let timeout = self.timeout;
-        Box::pin(http2::run_handshake(fut, timeout))
+        Box::pin(http2::run_establishment(fut, timeout))
     }
 }
 
@@ -475,10 +478,24 @@ impl HttpClient {
 /// here, so `HttpClient::plaintext()` is exactly `HttpClient::builder().plaintext()`.
 #[cfg(feature = "client")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct HttpClientBuilder {
     connect_timeout: Option<Duration>,
-    handshake_timeout: Option<Duration>,
+    establishment_timeout: Option<Duration>,
+}
+
+#[cfg(feature = "client")]
+impl Default for HttpClientBuilder {
+    /// A fresh builder with [`DEFAULT_ESTABLISHMENT_TIMEOUT`] /
+    /// [`DEFAULT_TCP_CONNECT_TIMEOUT`] applied, so a hung server cannot stall
+    /// connection establishment indefinitely. Pass `Duration::MAX` to either
+    /// setter to opt out.
+    fn default() -> Self {
+        Self {
+            connect_timeout: Some(DEFAULT_TCP_CONNECT_TIMEOUT),
+            establishment_timeout: Some(DEFAULT_ESTABLISHMENT_TIMEOUT),
+        }
+    }
 }
 
 #[cfg(feature = "client")]
@@ -491,15 +508,13 @@ impl HttpClientBuilder {
     /// covers only the TCP `connect(2)` call (per resolved address — hyper
     /// divides the timeout evenly across the address set). It does **not**
     /// cover DNS resolution or, for [`with_tls`](Self::with_tls), the TLS
-    /// handshake — set [`handshake_timeout`](Self::handshake_timeout) too to
+    /// handshake — set [`establishment_timeout`](Self::establishment_timeout) too to
     /// bound those. Use a per-request timeout (e.g.
     /// [`CallOptions::with_timeout`]) to bound DNS+connect+TLS+request as a
     /// whole.
     ///
-    /// Unset (the default) means no explicit bound: TCP connect is governed by
-    /// the kernel's `tcp_syn_retries` (typically ~130s on Linux). Set this when
-    /// the network path can silently drop SYNs and you'd rather fail fast than
-    /// stall on kernel retransmits.
+    /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. Pass `Duration::MAX` to
+    /// effectively disable.
     ///
     /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
     #[must_use]
@@ -530,10 +545,11 @@ impl HttpClientBuilder {
     /// [`ErrorCode::Unavailable`] (the connect is retryable); the message names
     /// the establishment phase.
     ///
-    /// Unset (the default) means the connector establishment is unbounded.
+    /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. Pass `Duration::MAX` to
+    /// effectively disable.
     #[must_use]
-    pub fn handshake_timeout(mut self, dur: Duration) -> Self {
-        self.handshake_timeout = Some(dur);
+    pub fn establishment_timeout(mut self, dur: Duration) -> Self {
+        self.establishment_timeout = Some(dur);
         self
     }
 
@@ -544,11 +560,11 @@ impl HttpClientBuilder {
         connector
     }
 
-    /// Wrap a connector so `handshake_timeout` (if set) bounds its establishment.
+    /// Wrap a connector so `establishment_timeout` (if set) bounds its establishment.
     fn wrap<C>(&self, connector: C) -> TimeoutConnector<C> {
         TimeoutConnector {
             inner: connector,
-            timeout: self.handshake_timeout,
+            timeout: self.establishment_timeout,
         }
     }
 
@@ -3928,15 +3944,15 @@ mod tests {
 
     #[cfg(feature = "client")]
     #[tokio::test]
-    async fn http_client_handshake_timeout_bounds_plaintext_connector() {
+    async fn http_client_establishment_timeout_bounds_plaintext_connector() {
         use std::time::Instant;
 
-        // The handshake_timeout wrapper bounds the whole connector. For
+        // The establishment_timeout wrapper bounds the whole connector. For
         // plaintext that's just the TCP connect, so an unroutable TEST-NET-1
         // address must fail fast rather than stall on kernel SYN retransmits.
         let target = "http://192.0.2.1:9/";
         let http = HttpClient::builder()
-            .handshake_timeout(Duration::from_millis(100))
+            .establishment_timeout(Duration::from_millis(100))
             .plaintext();
         let req = http::Request::builder()
             .method(http::Method::POST)
@@ -3950,17 +3966,17 @@ mod tests {
 
         assert!(
             elapsed < Duration::from_secs(2),
-            "handshake_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err}"
+            "establishment_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err}"
         );
     }
 
     #[cfg(feature = "client-tls")]
     #[tokio::test]
-    async fn http_client_handshake_timeout_bounds_stalled_tls() {
+    async fn http_client_establishment_timeout_bounds_stalled_tls() {
         use std::time::Instant;
 
         // A listener that accepts the TCP connection but never performs the TLS
-        // handshake. The TCP connect succeeds, so only handshake_timeout (which
+        // handshake. The TCP connect succeeds, so only establishment_timeout (which
         // covers TCP + TLS for the connector) can release the stalled connect.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -3977,7 +3993,7 @@ mod tests {
                 .with_no_client_auth(),
         );
         let http = HttpClient::builder()
-            .handshake_timeout(Duration::from_millis(150))
+            .establishment_timeout(Duration::from_millis(150))
             .with_tls(tls_config);
         let req = http::Request::builder()
             .method(http::Method::POST)
@@ -3991,7 +4007,7 @@ mod tests {
 
         assert!(
             elapsed < Duration::from_secs(2),
-            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}: {err}"
+            "establishment_timeout(150ms) should fire within ~2s, took {elapsed:?}: {err}"
         );
 
         server.abort();

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -531,9 +531,9 @@ impl HttpClientBuilder {
     ///
     /// Because `HttpClient` pools connections through hyper's legacy client, the
     /// HTTP/2 preface runs *inside* the pool and is not separately observable
-    /// here — this bound covers **TCP and TLS, not the h2 preface**.
-    /// [`Http2Connection`]'s handshake bound additionally covers the h2 preface
-    /// (and DNS resolution). Use a per-request timeout (e.g.
+    /// here — this bound covers **DNS, TCP and TLS, not the h2 preface**.
+    /// [`Http2Connection`]'s handshake bound additionally covers the h2
+    /// preface. Use a per-request timeout (e.g.
     /// [`CallOptions::with_timeout`]) for a true end-to-end bound. For a
     /// transport that bounds the h2 preface too, use [`Http2Connection`].
     ///

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -364,7 +364,7 @@ struct TimeoutConnector<C> {
 impl<C> tower::Service<Uri> for TimeoutConnector<C>
 where
     C: tower::Service<Uri>,
-    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     C::Future: Send + 'static,
     C::Response: Send + 'static,
 {
@@ -382,18 +382,7 @@ where
     fn call(&mut self, uri: Uri) -> Self::Future {
         let fut = self.inner.call(uri);
         let timeout = self.timeout;
-        Box::pin(async move {
-            match timeout {
-                Some(dur) => match tokio::time::timeout(dur, fut).await {
-                    Ok(res) => res.map_err(Into::into),
-                    Err(_) => Err(ConnectError::unavailable(format!(
-                        "connection establishment did not complete within {dur:?}"
-                    ))
-                    .into()),
-                },
-                None => fut.await.map_err(Into::into),
-            }
-        })
+        Box::pin(http2::run_handshake(fut, timeout))
     }
 }
 

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -514,12 +514,12 @@ impl HttpClientBuilder {
     /// whole.
     ///
     /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// effectively disable.
+    /// disable.
     ///
     /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
     #[must_use]
     pub fn connect_timeout(mut self, dur: Duration) -> Self {
-        self.connect_timeout = Some(dur);
+        self.connect_timeout = http2::finite(dur);
         self
     }
 
@@ -546,10 +546,10 @@ impl HttpClientBuilder {
     /// the establishment phase.
     ///
     /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// effectively disable.
+    /// disable.
     #[must_use]
     pub fn establishment_timeout(mut self, dur: Duration) -> Self {
-        self.establishment_timeout = Some(dur);
+        self.establishment_timeout = http2::finite(dur);
         self
     }
 

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -263,6 +263,9 @@ mod http2;
 pub use http2::Http2Connection;
 #[cfg(feature = "client")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
+pub use http2::Http2ConnectionBuilder;
+#[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use http2::SharedHttp2Connection;
 
 /// General-purpose HTTP client supporting both HTTP/1.1 and HTTP/2.
@@ -315,16 +318,17 @@ impl std::fmt::Debug for HttpClient {
 
 /// Inner hyper client, parameterized over connector type via an enum.
 ///
-/// This keeps the plaintext case exactly as before (zero cost) while
-/// allowing the TLS variant to use a different connector type without
-/// leaking generics into the public `HttpClient` signature.
+/// Both connectors are wrapped in [`TimeoutConnector`] so an optional
+/// `handshake_timeout` can bound the whole connector establishment. When no
+/// timeout is set the wrapper forwards each connect unchanged (a single boxed
+/// future per *connection*, not per request — negligible).
 #[cfg(feature = "client")]
 #[derive(Clone)]
 enum HttpClientInner {
     /// Plaintext HTTP (http:// only). Rejects https:// at send-time.
     Plain(
         hyper_util::client::legacy::Client<
-            hyper_util::client::legacy::connect::HttpConnector,
+            TimeoutConnector<hyper_util::client::legacy::connect::HttpConnector>,
             ClientBody,
         >,
     ),
@@ -333,10 +337,64 @@ enum HttpClientInner {
     #[cfg(feature = "client-tls")]
     Tls(
         hyper_util::client::legacy::Client<
-            hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+            TimeoutConnector<
+                hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+            >,
             ClientBody,
         >,
     ),
+}
+
+/// A `tower::Service<Uri>` connector wrapper that bounds connection
+/// establishment with an optional timeout.
+///
+/// Wraps the built-in `HttpConnector` (plaintext) or hyper-rustls's
+/// `HttpsConnector` (TLS). When `timeout` is `Some`, a connect that doesn't
+/// resolve in time is cancelled (dropping the in-flight TCP/TLS work) and
+/// surfaced as a `deadline_exceeded` error. When `None`, the inner connector's
+/// future is awaited unchanged.
+#[cfg(feature = "client")]
+#[derive(Clone)]
+struct TimeoutConnector<C> {
+    inner: C,
+    timeout: Option<Duration>,
+}
+
+#[cfg(feature = "client")]
+impl<C> tower::Service<Uri> for TimeoutConnector<C>
+where
+    C: tower::Service<Uri>,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    C::Future: Send + 'static,
+    C::Response: Send + 'static,
+{
+    type Response = C::Response;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future = BoxFuture<'static, Result<C::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        let fut = self.inner.call(uri);
+        let timeout = self.timeout;
+        Box::pin(async move {
+            match timeout {
+                Some(dur) => match tokio::time::timeout(dur, fut).await {
+                    Ok(res) => res.map_err(Into::into),
+                    Err(_) => Err(ConnectError::deadline_exceeded(format!(
+                        "connection establishment did not complete within {dur:?}"
+                    ))
+                    .into()),
+                },
+                None => fut.await.map_err(Into::into),
+            }
+        })
+    }
 }
 
 #[cfg(feature = "client")]
@@ -348,6 +406,7 @@ impl HttpClient {
     /// `HttpClient::plaintext()` is equivalent to
     /// `HttpClient::builder().plaintext()`, and likewise for the other
     /// constructors.
+    #[must_use]
     pub fn builder() -> HttpClientBuilder {
         HttpClientBuilder::default()
     }
@@ -430,6 +489,7 @@ impl HttpClient {
 #[derive(Debug, Default, Clone)]
 pub struct HttpClientBuilder {
     connect_timeout: Option<Duration>,
+    handshake_timeout: Option<Duration>,
 }
 
 #[cfg(feature = "client")]
@@ -452,8 +512,39 @@ impl HttpClientBuilder {
     /// stall on kernel retransmits.
     ///
     /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
+    #[must_use]
     pub fn connect_timeout(mut self, dur: Duration) -> Self {
         self.connect_timeout = Some(dur);
+        self
+    }
+
+    /// Bound the whole connector establishment: the TCP connect plus, for
+    /// [`with_tls`](Self::with_tls), the TLS handshake.
+    ///
+    /// Unlike [`connect_timeout`](Self::connect_timeout) (which bounds only the
+    /// per-address TCP `connect(2)` call), this is a single wall-clock bound on
+    /// everything the connector does to produce a usable stream — so on the TLS
+    /// transport the two bounds overlap on the TCP phase.
+    ///
+    /// # What it does and does not cover
+    ///
+    /// Because `HttpClient` pools connections through hyper's legacy client, the
+    /// HTTP/2 preface runs *inside* the pool and is not separately observable
+    /// here — this bound covers **TCP and TLS, not the h2 preface**. This
+    /// differs from [`Http2Connection`], whose handshake bound covers the TLS
+    /// handshake *and* the h2 preface while bounding TCP separately via its own
+    /// `connect_timeout`. Use a per-request timeout (e.g.
+    /// [`CallOptions::with_timeout`]) for a true end-to-end bound. For a
+    /// transport that bounds the h2 preface too, use [`Http2Connection`].
+    ///
+    /// Exceeding this bound surfaces as a [`ConnectError`] with
+    /// [`ErrorCode::Unavailable`] (the connect is retryable); the message names
+    /// the establishment phase.
+    ///
+    /// Unset (the default) means the connector establishment is unbounded.
+    #[must_use]
+    pub fn handshake_timeout(mut self, dur: Duration) -> Self {
+        self.handshake_timeout = Some(dur);
         self
     }
 
@@ -464,12 +555,22 @@ impl HttpClientBuilder {
         connector
     }
 
+    /// Wrap a connector so `handshake_timeout` (if set) bounds its establishment.
+    fn wrap<C>(&self, connector: C) -> TimeoutConnector<C> {
+        TimeoutConnector {
+            inner: connector,
+            timeout: self.handshake_timeout,
+        }
+    }
+
     /// Finish building as a plaintext client. See [`HttpClient::plaintext`].
+    #[must_use]
     pub fn plaintext(self) -> HttpClient {
         use hyper_util::client::legacy::Client;
         use hyper_util::rt::TokioExecutor;
 
-        let client = Client::builder(TokioExecutor::new()).build(self.http_connector());
+        let connector = self.wrap(self.http_connector());
+        let client = Client::builder(TokioExecutor::new()).build(connector);
         HttpClient {
             inner: HttpClientInner::Plain(client),
         }
@@ -477,13 +578,15 @@ impl HttpClientBuilder {
 
     /// Finish building as an h2c-only plaintext client. See
     /// [`HttpClient::plaintext_http2_only`].
+    #[must_use]
     pub fn plaintext_http2_only(self) -> HttpClient {
         use hyper_util::client::legacy::Client;
         use hyper_util::rt::TokioExecutor;
 
+        let connector = self.wrap(self.http_connector());
         let client = Client::builder(TokioExecutor::new())
             .http2_only(true)
-            .build(self.http_connector());
+            .build(connector);
         HttpClient {
             inner: HttpClientInner::Plain(client),
         }
@@ -492,6 +595,7 @@ impl HttpClientBuilder {
     /// Finish building as a TLS client. See [`HttpClient::with_tls`].
     #[cfg(feature = "client-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
+    #[must_use]
     pub fn with_tls(self, tls_config: std::sync::Arc<rustls::ClientConfig>) -> HttpClient {
         use hyper_util::client::legacy::Client;
         use hyper_util::rt::TokioExecutor;
@@ -518,7 +622,8 @@ impl HttpClientBuilder {
             .enable_all_versions()
             .wrap_connector(http);
 
-        let client = Client::builder(TokioExecutor::new()).build(https);
+        let connector = self.wrap(https);
+        let client = Client::builder(TokioExecutor::new()).build(connector);
         HttpClient {
             inner: HttpClientInner::Tls(client),
         }
@@ -3830,6 +3935,77 @@ mod tests {
             elapsed < Duration::from_secs(2),
             "connect_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err}"
         );
+    }
+
+    #[cfg(feature = "client")]
+    #[tokio::test]
+    async fn http_client_handshake_timeout_bounds_plaintext_connector() {
+        use std::time::Instant;
+
+        // The handshake_timeout wrapper bounds the whole connector. For
+        // plaintext that's just the TCP connect, so an unroutable TEST-NET-1
+        // address must fail fast rather than stall on kernel SYN retransmits.
+        let target = "http://192.0.2.1:9/";
+        let http = HttpClient::builder()
+            .handshake_timeout(Duration::from_millis(100))
+            .plaintext();
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(target)
+            .body(full_body(Bytes::new()))
+            .unwrap();
+
+        let start = Instant::now();
+        let err = http.send(req).await.expect_err("connect must fail");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "handshake_timeout(100ms) should abort within ~2s, took {elapsed:?}: {err}"
+        );
+    }
+
+    #[cfg(feature = "client-tls")]
+    #[tokio::test]
+    async fn http_client_handshake_timeout_bounds_stalled_tls() {
+        use std::time::Instant;
+
+        // A listener that accepts the TCP connection but never performs the TLS
+        // handshake. The TCP connect succeeds, so only handshake_timeout (which
+        // covers TCP + TLS for the connector) can release the stalled connect.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let tls_config = std::sync::Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let http = HttpClient::builder()
+            .handshake_timeout(Duration::from_millis(150))
+            .with_tls(tls_config);
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!("https://{addr}/"))
+            .body(full_body(Bytes::new()))
+            .unwrap();
+
+        let start = Instant::now();
+        let err = http.send(req).await.expect_err("stalled TLS must fail");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "handshake_timeout(150ms) should fire within ~2s, took {elapsed:?}: {err}"
+        );
+
+        server.abort();
     }
 
     #[test]

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -398,7 +398,6 @@ impl HttpClient {
     /// `HttpClient::plaintext()` is equivalent to
     /// `HttpClient::builder().plaintext()`, and likewise for the other
     /// constructors.
-    #[must_use]
     pub fn builder() -> HttpClientBuilder {
         HttpClientBuilder::default()
     }
@@ -411,6 +410,10 @@ impl HttpClient {
     /// The client uses connection pooling and supports HTTP/1.1 and HTTP/2
     /// over cleartext. TCP_NODELAY is enabled to avoid Nagle + delayed ACK
     /// latency on small messages.
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`]
+    /// (and [`DEFAULT_TCP_CONNECT_TIMEOUT`] per address); use
+    /// [`builder()`](Self::builder) to adjust or opt out.
     pub fn plaintext() -> Self {
         Self::builder().plaintext()
     }
@@ -428,6 +431,10 @@ impl HttpClient {
     /// **Note:** For gRPC, prefer [`SharedHttp2Connection`] over this —
     /// it has honest `poll_ready` and composes with `tower::balance`. This
     /// method pins you to one connection per host with no way to scale out.
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`]
+    /// (and [`DEFAULT_TCP_CONNECT_TIMEOUT`] per address); use
+    /// [`builder()`](Self::builder) to adjust or opt out.
     pub fn plaintext_http2_only() -> Self {
         Self::builder().plaintext_http2_only()
     }
@@ -464,6 +471,10 @@ impl HttpClient {
     /// let http = HttpClient::with_tls(tls_config);
     /// let client = GreetServiceClient::new(http, config);
     /// ```
+    ///
+    /// Connection establishment is bounded by [`DEFAULT_ESTABLISHMENT_TIMEOUT`]
+    /// (and [`DEFAULT_TCP_CONNECT_TIMEOUT`] per address); use
+    /// [`builder()`](Self::builder) to adjust or opt out.
     #[cfg(feature = "client-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-tls")))]
     pub fn with_tls(tls_config: std::sync::Arc<rustls::ClientConfig>) -> Self {
@@ -479,8 +490,9 @@ impl HttpClient {
 #[cfg(feature = "client")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 #[derive(Debug, Clone)]
+#[must_use = "call a terminal (plaintext / plaintext_http2_only / with_tls) to build the client"]
 pub struct HttpClientBuilder {
-    connect_timeout: Option<Duration>,
+    tcp_connect_timeout: Option<Duration>,
     establishment_timeout: Option<Duration>,
 }
 
@@ -488,11 +500,13 @@ pub struct HttpClientBuilder {
 impl Default for HttpClientBuilder {
     /// A fresh builder with [`DEFAULT_ESTABLISHMENT_TIMEOUT`] /
     /// [`DEFAULT_TCP_CONNECT_TIMEOUT`] applied, so a hung server cannot stall
-    /// connection establishment indefinitely. Pass `Duration::MAX` to either
-    /// setter to opt out.
+    /// connection establishment indefinitely. Use
+    /// [`no_establishment_timeout`](HttpClientBuilder::no_establishment_timeout) /
+    /// [`no_tcp_connect_timeout`](HttpClientBuilder::no_tcp_connect_timeout) to
+    /// opt out.
     fn default() -> Self {
         Self {
-            connect_timeout: Some(DEFAULT_TCP_CONNECT_TIMEOUT),
+            tcp_connect_timeout: Some(DEFAULT_TCP_CONNECT_TIMEOUT),
             establishment_timeout: Some(DEFAULT_ESTABLISHMENT_TIMEOUT),
         }
     }
@@ -513,20 +527,34 @@ impl HttpClientBuilder {
     /// [`CallOptions::with_timeout`]) to bound DNS+connect+TLS+request as a
     /// whole.
     ///
-    /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// disable.
+    /// Defaults to [`DEFAULT_TCP_CONNECT_TIMEOUT`]. To disable, use
+    /// [`no_tcp_connect_timeout`](Self::no_tcp_connect_timeout). Passing
+    /// `Duration::ZERO` causes every per-address connect to fail immediately.
     ///
     /// [hyper-ct]: hyper_util::client::legacy::connect::HttpConnector::set_connect_timeout
-    #[must_use]
-    pub fn connect_timeout(mut self, dur: Duration) -> Self {
-        self.connect_timeout = http2::finite(dur);
+    #[doc(alias = "connect_timeout")]
+    pub fn tcp_connect_timeout(mut self, dur: Duration) -> Self {
+        self.tcp_connect_timeout = http2::finite(dur);
+        self
+    }
+
+    /// Alias for [`tcp_connect_timeout`](Self::tcp_connect_timeout).
+    pub fn connect_timeout(self, dur: Duration) -> Self {
+        self.tcp_connect_timeout(dur)
+    }
+
+    /// Disable the per-address TCP connect bound (the
+    /// [`DEFAULT_TCP_CONNECT_TIMEOUT`] default). The whole-connector
+    /// [`establishment_timeout`](Self::establishment_timeout) still applies.
+    pub fn no_tcp_connect_timeout(mut self) -> Self {
+        self.tcp_connect_timeout = None;
         self
     }
 
     /// Bound the whole connector establishment: DNS resolution, the TCP connect,
     /// and, for [`with_tls`](Self::with_tls), the TLS handshake.
     ///
-    /// Unlike [`connect_timeout`](Self::connect_timeout) (which bounds only the
+    /// Unlike [`tcp_connect_timeout`](Self::tcp_connect_timeout) (which bounds only the
     /// per-address TCP `connect(2)` call), this is a single wall-clock bound on
     /// everything the connector does to produce a usable stream — so on the TLS
     /// transport the two bounds overlap on the TCP phase.
@@ -545,18 +573,28 @@ impl HttpClientBuilder {
     /// [`ErrorCode::Unavailable`] (the connect is retryable); the message names
     /// the establishment phase.
     ///
-    /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. Pass `Duration::MAX` to
-    /// disable.
-    #[must_use]
+    /// Defaults to [`DEFAULT_ESTABLISHMENT_TIMEOUT`]. To disable, use
+    /// [`no_establishment_timeout`](Self::no_establishment_timeout). Passing
+    /// `Duration::ZERO` causes every establishment to fail immediately.
     pub fn establishment_timeout(mut self, dur: Duration) -> Self {
         self.establishment_timeout = http2::finite(dur);
+        self
+    }
+
+    /// Disable the wall-clock connector-establishment bound (the
+    /// [`DEFAULT_ESTABLISHMENT_TIMEOUT`] default). With both this and
+    /// [`no_tcp_connect_timeout`](Self::no_tcp_connect_timeout), a hung server
+    /// can stall connection establishment indefinitely — the pre-0.8.0
+    /// behaviour.
+    pub fn no_establishment_timeout(mut self) -> Self {
+        self.establishment_timeout = None;
         self
     }
 
     fn http_connector(&self) -> hyper_util::client::legacy::connect::HttpConnector {
         let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
         connector.set_nodelay(true);
-        connector.set_connect_timeout(self.connect_timeout);
+        connector.set_connect_timeout(self.tcp_connect_timeout);
         connector
     }
 
@@ -3916,10 +3954,11 @@ mod tests {
     async fn http_client_connect_timeout_bounds_tcp_connect() {
         use std::time::Instant;
 
-        // RFC 5737 TEST-NET-1: guaranteed unroutable. SYNs are dropped, so an
-        // unbounded connect would stall on kernel retransmits (~130s on Linux
-        // defaults). With a 100ms connect timeout, hyper aborts the connect
-        // future and surfaces the failure promptly.
+        // RFC 5737 TEST-NET-1: reserved for documentation. Most hosts drop
+        // SYNs to it (so an unbounded connect stalls on kernel retransmits,
+        // ~130s on Linux defaults), but RFC 5737 doesn't mandate that — some
+        // CI hosts actively reject. The assertion that matters is the upper
+        // bound: a 100ms timeout must abort well before the kernel retry floor.
         let target = "http://192.0.2.1:9/";
         let timeout = Duration::from_millis(100);
 
@@ -3931,8 +3970,15 @@ mod tests {
             .unwrap();
 
         let start = Instant::now();
-        let err = http.send(req).await.expect_err("connect must fail");
+        // Outer timeout guards a transparent-proxy host that accepts the
+        // connect (so the bound under test never fires) and then never answers
+        // the HTTP/1.1 request — without this the test would hang.
+        let result = tokio::time::timeout(Duration::from_secs(3), http.send(req)).await;
         let elapsed = start.elapsed();
+        let Ok(Err(err)) = result else {
+            eprintln!("skipping: TEST-NET-1 reachable on this host (proxy?) in {elapsed:?}");
+            return;
+        };
 
         // Generous slack for CI scheduling jitter — but well under the
         // multi-second kernel SYN-retry floor we'd hit without the bound.
@@ -3961,8 +4007,15 @@ mod tests {
             .unwrap();
 
         let start = Instant::now();
-        let err = http.send(req).await.expect_err("connect must fail");
+        // Outer timeout guards a transparent-proxy host that accepts the
+        // connect (so the bound under test never fires) and then never answers
+        // the HTTP/1.1 request — without this the test would hang.
+        let result = tokio::time::timeout(Duration::from_secs(3), http.send(req)).await;
         let elapsed = start.elapsed();
+        let Ok(Err(err)) = result else {
+            eprintln!("skipping: TEST-NET-1 reachable on this host (proxy?) in {elapsed:?}");
+            return;
+        };
 
         assert!(
             elapsed < Duration::from_secs(2),

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -351,7 +351,7 @@ enum HttpClientInner {
 /// Wraps the built-in `HttpConnector` (plaintext) or hyper-rustls's
 /// `HttpsConnector` (TLS). When `timeout` is `Some`, a connect that doesn't
 /// resolve in time is cancelled (dropping the in-flight TCP/TLS work) and
-/// surfaced as a `deadline_exceeded` error. When `None`, the inner connector's
+/// surfaced as an `unavailable` error. When `None`, the inner connector's
 /// future is awaited unchanged.
 #[cfg(feature = "client")]
 #[derive(Clone)]
@@ -386,7 +386,7 @@ where
             match timeout {
                 Some(dur) => match tokio::time::timeout(dur, fut).await {
                     Ok(res) => res.map_err(Into::into),
-                    Err(_) => Err(ConnectError::deadline_exceeded(format!(
+                    Err(_) => Err(ConnectError::unavailable(format!(
                         "connection establishment did not complete within {dur:?}"
                     ))
                     .into()),
@@ -502,7 +502,8 @@ impl HttpClientBuilder {
     /// covers only the TCP `connect(2)` call (per resolved address — hyper
     /// divides the timeout evenly across the address set). It does **not**
     /// cover DNS resolution or, for [`with_tls`](Self::with_tls), the TLS
-    /// handshake. Use a per-request timeout (e.g.
+    /// handshake — set [`handshake_timeout`](Self::handshake_timeout) too to
+    /// bound those. Use a per-request timeout (e.g.
     /// [`CallOptions::with_timeout`]) to bound DNS+connect+TLS+request as a
     /// whole.
     ///
@@ -518,8 +519,8 @@ impl HttpClientBuilder {
         self
     }
 
-    /// Bound the whole connector establishment: the TCP connect plus, for
-    /// [`with_tls`](Self::with_tls), the TLS handshake.
+    /// Bound the whole connector establishment: DNS resolution, the TCP connect,
+    /// and, for [`with_tls`](Self::with_tls), the TLS handshake.
     ///
     /// Unlike [`connect_timeout`](Self::connect_timeout) (which bounds only the
     /// per-address TCP `connect(2)` call), this is a single wall-clock bound on
@@ -530,10 +531,9 @@ impl HttpClientBuilder {
     ///
     /// Because `HttpClient` pools connections through hyper's legacy client, the
     /// HTTP/2 preface runs *inside* the pool and is not separately observable
-    /// here — this bound covers **TCP and TLS, not the h2 preface**. This
-    /// differs from [`Http2Connection`], whose handshake bound covers the TLS
-    /// handshake *and* the h2 preface while bounding TCP separately via its own
-    /// `connect_timeout`. Use a per-request timeout (e.g.
+    /// here — this bound covers **TCP and TLS, not the h2 preface**.
+    /// [`Http2Connection`]'s handshake bound additionally covers the h2 preface
+    /// (and DNS resolution). Use a per-request timeout (e.g.
     /// [`CallOptions::with_timeout`]) for a true end-to-end bound. For a
     /// transport that bounds the h2 preface too, use [`Http2Connection`].
     ///

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1388,6 +1388,24 @@ A `plaintext()` client refuses `https://` URIs and a `with_tls()`
 client refuses `http://` URIs - this catches misconfiguration loudly
 rather than silently downgrading.
 
+### Connection-establishment bounds and keep-alive
+
+Both `HttpClient` and `Http2Connection` bound connection establishment by default: a 20-second wall-clock budget on the whole DNS + TCP + TLS chain (`DEFAULT_ESTABLISHMENT_TIMEOUT`) with an additional 5-second per-address TCP bound (`DEFAULT_TCP_CONNECT_TIMEOUT`). Exceeding either surfaces as `ErrorCode::Unavailable`, so a server that accepts the TCP connection but stalls the TLS handshake cannot park `poll_ready` indefinitely. To adjust or opt out, use the `builder()` entry point on either transport:
+
+```rust
+use std::time::Duration;
+use connectrpc::client::Http2Connection;
+
+let conn = Http2Connection::builder()
+    .establishment_timeout(Duration::from_secs(10))
+    .keep_alive_interval(Duration::from_secs(30))
+    .keep_alive_while_idle(true)
+    .connect_tls(uri, tls_config)
+    .await?;
+```
+
+`Http2ConnectionBuilder` also proxies hyper's HTTP/2 keep-alive and flow-control knobs (`keep_alive_interval`, `keep_alive_timeout`, `keep_alive_while_idle`, `initial_stream_window_size`, `initial_connection_window_size`, `adaptive_window`), with a `TokioTimer` pre-wired so the keep-alive setters work without further plumbing. The `h2_settings(|b| ...)` escape hatch exposes the underlying hyper builder for knobs not surfaced directly. To restore the unbounded pre-0.8.0 behaviour, chain `.no_establishment_timeout().no_tcp_connect_timeout()`.
+
 ### ClientConfig
 
 `ClientConfig` carries the base URI and per-call defaults that apply


### PR DESCRIPTION
## What

Makes `Http2Connection` (and `HttpClient`) bound connection establishment by default, so a hung or half-open server cannot stall `poll_ready` indefinitely. Surfaces the common HTTP/2 settings (keep-alive, window sizes) directly on the new builder so callers don't have to construct a `hyper::client::conn::http2::Builder` by hand.

This carries the first commit from #187 and reshapes the API in four further commits. It is an alternative to #187; one of the two should land.

## Why

Issue #137: the `Reconnect` state machine's `Connecting` future runs DNS → TCP → TLS → h2 preface serially with no time bound on any step. A server that accepts the TCP connection but never completes the TLS handshake (e.g. a draining pod whose kernel backlog still accepts) parks that future forever, which parks `poll_ready` for every caller sharing the connection. h2 keep-alive can't help because the h2 layer doesn't exist yet.

#187 added the timeout knobs but left them opt-in (default unbounded), left DNS uncovered by either knob, and gave callers who set h2 keep-alive (the `with_builder_tls` path) no way to reach them.

## API

`Http2ConnectionBuilder` (via `Http2Connection::builder()`) is now the single config surface for every transport — plaintext, TLS, caller-supplied connector, Unix socket. Every existing `Http2Connection` constructor delegates through it.

- `establishment_timeout(Duration)` — wall-clock bound on DNS + TCP + TLS + h2 preface as one budget. **Defaults to `DEFAULT_ESTABLISHMENT_TIMEOUT` (20s)**, matching grpc-go's `MinConnectTimeout`. Exceeding it surfaces as `ErrorCode::Unavailable`. Pass `Duration::MAX` to opt out.
- `tcp_connect_timeout(Duration)` — per-address TCP `connect(2)` budget on the built-in connector, divided across the resolved address set, so the connector moves on to the next address rather than burning the whole establishment budget on one blackholed peer. **Defaults to `DEFAULT_TCP_CONNECT_TIMEOUT` (5s).** Ignored on the custom-connector / Unix-socket terminals (no built-in connector there).
- `keep_alive_interval` / `keep_alive_timeout` / `keep_alive_while_idle` / `initial_stream_window_size` / `initial_connection_window_size` / `adaptive_window` — proxied hyper h2 setters, matching `tonic::Endpoint`. A `TokioTimer` is pre-wired so the keep-alive setters work without hyper's "supply a timer" panic.
- `h2_settings(Builder)` — escape hatch for hyper knobs not proxied above; replaces prior h2 settings wholesale.
- Terminals: `lazy_plaintext` / `connect_plaintext` / `lazy_tls` / `connect_tls` / `lazy_with_connector` / `connect_with_connector` / `lazy_unix` / `connect_unix`.

`HttpClientBuilder` gains `establishment_timeout(Duration)` (DNS + TCP + TLS via a `TimeoutConnector` wrapper; the h2 preface runs inside hyper's pool and is not separately observable). `connect_timeout` keeps its shipped name. Both default on with the same constants.

