### PR TITLE
Tighten gRPC response content-type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,19 @@ increment the patch version.
 
 ### Fixed
 
+- **gRPC unary response content-type validation is protocol- and
+  codec-aware** ([#200]). The client previously accepted any response
+  `content-type` starting with `application/grpc`, so a gRPC client could
+  accept gRPC-Web framing, and a proto-configured client could try to decode
+  JSON bytes as proto. Validation now mirrors connect-go's
+  `grpcValidateResponseContentType`: the exact configured subtype and the
+  bare family type (`application/grpc` / `application/grpc-web`, which imply
+  proto and are what proxies such as Envoy send on trailers-only error
+  replies) are accepted, with `; parameter` suffixes stripped; a same-family
+  codec mismatch is rejected as `internal` and anything else as `unknown`,
+  with the expected content type named in the error message. A missing
+  `content-type` header remains accepted. This also covers gRPC / gRPC-Web
+  client-streaming responses, which share the unary parse path.
 - **Malformed Connect END_STREAM JSON now returns `internal`** ([#192],
   [#201]). A streaming Connect response whose END_STREAM envelope body was not
   valid JSON was silently treated as a clean `Ok(None)` close (the parse error
@@ -193,6 +206,7 @@ increment the patch version.
 [#194]: https://github.com/anthropics/connect-rust/pull/194
 [#197]: https://github.com/anthropics/connect-rust/pull/197
 [#199]: https://github.com/anthropics/connect-rust/pull/199
+[#200]: https://github.com/anthropics/connect-rust/pull/200
 [#201]: https://github.com/anthropics/connect-rust/pull/201
 [connectrpc/conformance#1104]: https://github.com/connectrpc/conformance/pull/1104
 

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1970,18 +1970,7 @@ where
         return Err(err);
     }
 
-    // Validate response content-type starts with application/grpc
-    if let Some(ct) = resp_headers.get(http::header::CONTENT_TYPE) {
-        let ct_str = ct.to_str().unwrap_or("");
-        if !ct_str.starts_with("application/grpc") {
-            let mut err = ConnectError::new(
-                ErrorCode::Unknown,
-                format!("unexpected content-type: {ct_str}"),
-            );
-            err.set_response_headers(resp_headers);
-            return Err(err);
-        }
-    }
+    validate_grpc_response_content_type(&resp_headers, config)?;
 
     // Check for unsupported compression before reading the body
     let response_encoding = resp_headers
@@ -2173,6 +2162,44 @@ where
         body: message,
         trailers: grpc_trailers,
     })
+}
+
+fn validate_grpc_response_content_type(
+    resp_headers: &http::HeaderMap,
+    config: &ClientConfig,
+) -> Result<(), ConnectError> {
+    debug_assert!(
+        matches!(config.protocol, Protocol::Grpc | Protocol::GrpcWeb),
+        "gRPC response content-type validation is only for gRPC/gRPC-Web"
+    );
+
+    let Some(resp_content_type) = resp_headers.get(http::header::CONTENT_TYPE) else {
+        return Ok(());
+    };
+
+    let ct = resp_content_type.to_str().unwrap_or("");
+    let ct_normalized = ct.split(';').next().unwrap_or(ct).trim();
+    let expected = config
+        .protocol
+        .response_content_type(config.codec_format, false);
+    let bare_proto_default = match (config.protocol, config.codec_format) {
+        (Protocol::Grpc, CodecFormat::Proto) => Some("application/grpc"),
+        (Protocol::GrpcWeb, CodecFormat::Proto) => Some("application/grpc-web"),
+        _ => None,
+    };
+
+    if ct_normalized == expected || bare_proto_default == Some(ct_normalized) {
+        return Ok(());
+    }
+
+    let code = if ct_normalized.starts_with("application/grpc") {
+        ErrorCode::Internal
+    } else {
+        ErrorCode::Unknown
+    };
+    let mut err = ConnectError::new(code, format!("unexpected content-type: {ct}"));
+    err.set_response_headers(resp_headers.clone());
+    Err(err)
 }
 
 /// Terminal record for a client stream: why it ended and what trailing
@@ -5479,6 +5506,94 @@ mod tests {
         assert_eq!(
             response.trailers().get("grpc-status").unwrap(),
             http::HeaderValue::from_static("0")
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_accepts_bare_application_grpc_with_parameters() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        let data = Envelope::data(StringValue::from("hi").encode_to_bytes()).encode();
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "0".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(Frame::data(data)), Ok(Frame::trailers(trailers))];
+
+        let response = Response::builder()
+            .header(
+                http::header::CONTENT_TYPE,
+                "application/grpc; charset=utf-8",
+            )
+            .body(StreamBody::new(futures::stream::iter(frames)))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let response = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect("bare application/grpc must be accepted as proto");
+        assert_eq!(response.view().value, "hi");
+        assert_eq!(response.trailers().get("grpc-status").unwrap(), "0");
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_rejects_grpc_web_content_type() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc-web+proto")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("gRPC client must reject gRPC-Web content type");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("unexpected content-type: application/grpc-web+proto")
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_rejects_mismatched_codec_content_type() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc+json")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("gRPC client must reject mismatched response codec");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("unexpected content-type: application/grpc+json")
         );
     }
 

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2164,6 +2164,19 @@ where
     })
 }
 
+/// Validate the `content-type` of a gRPC / gRPC-Web response against the
+/// client's configured protocol and codec, mirroring connect-go's
+/// `grpcValidateResponseContentType`.
+///
+/// Parameters (`; charset=...`) are stripped before comparison. The bare
+/// family types `application/grpc` / `application/grpc-web` are accepted for
+/// any codec, because the bare type means "proto by default" and proxies that
+/// synthesize trailers-only error responses (such as Envoy local replies)
+/// send it regardless of the request's subtype. A missing `content-type`
+/// header is also accepted, preserving this client's previous leniency. A
+/// same-family subtype that doesn't match the configured codec is rejected as
+/// `internal` (a broken server or intermediary); anything else is `unknown`
+/// (not a gRPC response at all), matching connect-go's classification.
 fn validate_grpc_response_content_type(
     resp_headers: &http::HeaderMap,
     config: &ClientConfig,
@@ -2178,26 +2191,34 @@ fn validate_grpc_response_content_type(
     };
 
     let ct = resp_content_type.to_str().unwrap_or("");
-    let ct_normalized = ct.split(';').next().unwrap_or(ct).trim();
+    let ct_normalized = ct
+        .split_once(';')
+        .map_or(ct, |(media_type, _params)| media_type)
+        .trim();
     let expected = config
         .protocol
         .response_content_type(config.codec_format, false);
-    let bare_proto_default = match (config.protocol, config.codec_format) {
-        (Protocol::Grpc, CodecFormat::Proto) => Some("application/grpc"),
-        (Protocol::GrpcWeb, CodecFormat::Proto) => Some("application/grpc-web"),
-        _ => None,
+    let (bare, family_prefix) = match config.protocol {
+        Protocol::Grpc => ("application/grpc", "application/grpc+"),
+        Protocol::GrpcWeb => ("application/grpc-web", "application/grpc-web+"),
+        // Unreachable per the debug_assert above; treat as valid rather than
+        // misclassify a Connect response in release builds.
+        Protocol::Connect => return Ok(()),
     };
 
-    if ct_normalized == expected || bare_proto_default == Some(ct_normalized) {
+    if ct_normalized == expected || ct_normalized == bare {
         return Ok(());
     }
 
-    let code = if ct_normalized.starts_with("application/grpc") {
+    let code = if ct_normalized.starts_with(family_prefix) {
         ErrorCode::Internal
     } else {
         ErrorCode::Unknown
     };
-    let mut err = ConnectError::new(code, format!("unexpected content-type: {ct}"));
+    let mut err = ConnectError::new(
+        code,
+        format!("unexpected content-type: {ct} (expected {expected})"),
+    );
     err.set_response_headers(resp_headers.clone());
     Err(err)
 }
@@ -5564,10 +5585,15 @@ mod tests {
         )
         .await
         .expect_err("gRPC client must reject gRPC-Web content type");
-        assert_eq!(err.code, ErrorCode::Internal);
+        // Cross-family mismatches are `unknown` (not a gRPC response at all),
+        // matching connect-go; only same-family codec mismatches are
+        // `internal`.
+        assert_eq!(err.code, ErrorCode::Unknown);
         assert_eq!(
             err.message.as_deref(),
-            Some("unexpected content-type: application/grpc-web+proto")
+            Some(
+                "unexpected content-type: application/grpc-web+proto (expected application/grpc+proto)"
+            )
         );
     }
 
@@ -5593,7 +5619,88 @@ mod tests {
         assert_eq!(err.code, ErrorCode::Internal);
         assert_eq!(
             err.message.as_deref(),
-            Some("unexpected content-type: application/grpc+json")
+            Some(
+                "unexpected content-type: application/grpc+json (expected application/grpc+proto)"
+            )
+        );
+    }
+
+    #[test]
+    fn grpc_response_content_type_rejects_non_grpc_as_unknown() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::CONTENT_TYPE, "text/html".parse().unwrap());
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = validate_grpc_response_content_type(&headers, &config)
+            .expect_err("non-gRPC content type must be rejected");
+        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("unexpected content-type: text/html (expected application/grpc+proto)")
+        );
+        assert!(
+            err.response_headers()
+                .contains_key(http::header::CONTENT_TYPE)
+        );
+    }
+
+    #[test]
+    fn grpc_response_content_type_accepts_missing_header() {
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+        validate_grpc_response_content_type(&http::HeaderMap::new(), &config)
+            .expect("missing content-type must remain accepted");
+    }
+
+    #[test]
+    fn grpc_response_content_type_accepts_bare_for_json_codec() {
+        // Proxies that synthesize trailers-only error replies (e.g. Envoy)
+        // send bare `application/grpc` regardless of the request subtype, so
+        // the bare type must be accepted for every codec, as in connect-go.
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/grpc".parse().unwrap(),
+        );
+        let config = ClientConfig::new("http://localhost".parse().unwrap())
+            .with_protocol(Protocol::Grpc)
+            .with_codec_format(CodecFormat::Json);
+        validate_grpc_response_content_type(&headers, &config)
+            .expect("bare application/grpc must be accepted for a json-codec client");
+    }
+
+    #[test]
+    fn grpc_web_response_content_type_accepts_bare() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/grpc-web".parse().unwrap(),
+        );
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
+        validate_grpc_response_content_type(&headers, &config)
+            .expect("bare application/grpc-web must be accepted as proto");
+    }
+
+    #[test]
+    fn grpc_web_response_content_type_rejects_grpc_as_unknown() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/grpc+proto".parse().unwrap(),
+        );
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
+
+        let err = validate_grpc_response_content_type(&headers, &config)
+            .expect_err("gRPC-Web client must reject plain gRPC content type");
+        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(
+            err.message.as_deref(),
+            Some(
+                "unexpected content-type: application/grpc+proto (expected application/grpc-web+proto)"
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- replace the gRPC unary response `content-type` prefix check with strict protocol-and-codec-aware validation
- allow the bare proto defaults (`application/grpc` and `application/grpc-web`) while still stripping parameters
- add regressions for rejecting gRPC-Web on a gRPC client, rejecting mismatched response codecs, and accepting `application/grpc; charset=utf-8`

## Why
The previous `starts_with("application/grpc")` check accepted `application/grpc-web*` and never verified that the response codec matched the client configuration. That let a gRPC client accept gRPC-Web framing and could let a proto-configured client try to decode JSON bytes as proto.

## Impact
- gRPC unary responses now require an exact allowed content type for the configured protocol and codec
- `application/grpc` remains accepted as the default proto subtype, even with parameters
- gRPC-family mismatches are rejected before body parsing starts

## Validation
- `cargo test -p connectrpc grpc_unary_`
- `cargo test -p connectrpc grpc_web_unary_stops_reading_after_trailer_frame`
