### PR TITLE
client: preserve headers on malformed end streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,13 +164,15 @@ increment the patch version.
 
 ### Fixed
 
-- **Malformed Connect END_STREAM JSON now returns `internal`** ([#192]).
-  A streaming Connect response whose END_STREAM envelope body was not valid
-  JSON was silently treated as a clean `Ok(None)` close (the parse error fell
-  through `unwrap_or_default()`). It now returns `Err(internal)` with the
+- **Malformed Connect END_STREAM JSON now returns `internal`** ([#192],
+  [#201]). A streaming Connect response whose END_STREAM envelope body was not
+  valid JSON was silently treated as a clean `Ok(None)` close (the parse error
+  fell through `unwrap_or_default()`). It now returns `Err(internal)` with the
   serde error in the message, matching connect-go's behaviour for the same
-  case. Well-formed END_STREAM payloads (including the `null-error`,
-  `missing-code`, and unknown-field conformance shapes) are unchanged.
+  case, and the error carries the response headers on both the
+  server-streaming and client-streaming paths. Well-formed END_STREAM payloads
+  (including the `null-error`, `missing-code`, and unknown-field conformance
+  shapes) are unchanged.
 - **Connect client-streaming responses require the END_STREAM envelope**
   ([#163]). A response that ended after its single data message but before
   the END_STREAM envelope was accepted as a success with empty trailers, so
@@ -191,6 +193,7 @@ increment the patch version.
 [#194]: https://github.com/anthropics/connect-rust/pull/194
 [#197]: https://github.com/anthropics/connect-rust/pull/197
 [#199]: https://github.com/anthropics/connect-rust/pull/199
+[#201]: https://github.com/anthropics/connect-rust/pull/201
 [connectrpc/conformance#1104]: https://github.com/connectrpc/conformance/pull/1104
 
 ## [0.7.0] - 2026-06-10

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2639,7 +2639,10 @@ where
 
         let end_stream = match parse_connect_end_stream(&end_stream_data) {
             Ok(end_stream) => end_stream,
-            Err(e) => return e.into(),
+            Err(mut e) => {
+                e.set_response_headers(self.headers.clone());
+                return e.into();
+            }
         };
 
         let trailers = end_stream.metadata.map(|metadata| {
@@ -4427,8 +4430,11 @@ mod tests {
         );
         body.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"not json")).encode());
 
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
+
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
-            headers: http::HeaderMap::new(),
+            headers,
             body: Full::new(body.freeze()),
             buf: BytesMut::new(),
             encoding: None,
@@ -4459,12 +4465,17 @@ mod tests {
                 .contains("malformed Connect END_STREAM JSON"),
             "unexpected error: {err}"
         );
+        assert_eq!(err.response_headers().get("x-from-headers").unwrap(), "yes");
 
         let again = stream
             .message()
             .await
             .expect_err("malformed END_STREAM error must be sticky");
         assert_eq!(again.code, ErrorCode::Internal);
+        assert_eq!(
+            again.response_headers().get("x-from-headers").unwrap(),
+            "yes"
+        );
     }
 
     /// Same contract for gRPC: an error in HTTP/2 trailers is a failed RPC


### PR DESCRIPTION
## Summary
Preserve response headers when a server-streaming Connect response ends with malformed `END_STREAM` JSON.

## Why
In `#192`, the client-streaming parse-error path started attaching response headers to malformed `END_STREAM` errors, but the server-streaming path still dropped them. The maintainer review on that PR called out the asymmetry as a good follow-up to make the two paths uniform.

## What changed
- attach `self.headers` before converting a malformed Connect `END_STREAM` parse error into the terminal `StreamEnd`
- extend the existing server-stream malformed-`END_STREAM` regression to assert the headers are preserved on the first error and on the sticky replay

## Validation
- `cargo test -p connectrpc malformed_end_stream_json`
- `cargo test -p connectrpc`
