### PR TITLE
Add The Connect Authors copyright notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -177,6 +177,7 @@
    END OF TERMS AND CONDITIONS
 
    Copyright 2026 Anthropic, PBC
+   Copyright 2026 The Connect Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Following the repository's transfer to the connectrpc organization, add the standard `Copyright 2026 The Connect Authors` notice to the LICENSE appendix alongside the existing Anthropic notice. Both notices are retained per Apache-2.0 §4(c).