### PR TITLE
signatures: preserve the historical CLA record on main

### DIFF
--- a/signatures/README.md
+++ b/signatures/README.md
@@ -1,0 +1,7 @@
+# Historical CLA signatures
+
+This directory is the historical record of contributors who signed the Contributor License Agreement (CLA) while connect-rust was still an Anthropic-managed project, before it joined the connectrpc organization.
+
+Until [#207](https://github.com/connectrpc/connect-rust/pull/207) replaced the CLA with the Developer Certificate of Origin sign-off used across connectrpc projects, contributions required a CLA signature, collected by CLA Assistant on each contributor's first pull request. External contributions made before that change are covered by the signatures recorded in `cla.json`; commits made after it carry their own `Signed-off-by` lines. The text of the agreement is preserved in git history as `CLA.md`, which was removed in the same pull request.
+
+CLA Assistant originally wrote this record to the `cla-signatures` branch. This copy freezes it on `main` so that the record is preserved alongside the code it covers.

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,3 +1,220 @@
 {
-   "signedContributors": []
+  "signedContributors": [
+    {
+      "name": "iantay-ant",
+      "id": 232680153,
+      "comment_id": 4130405832,
+      "created_at": "2026-03-25T23:08:41Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 15
+    },
+    {
+      "name": "paikend",
+      "id": 26214518,
+      "comment_id": 4139068076,
+      "created_at": "2026-03-26T23:49:06Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 16
+    },
+    {
+      "name": "washanhanzi",
+      "id": 56581242,
+      "comment_id": 4140256867,
+      "created_at": "2026-03-27T05:13:21Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 17
+    },
+    {
+      "name": "tannaurus",
+      "id": 25316168,
+      "comment_id": 4148260778,
+      "created_at": "2026-03-28T15:26:15Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 19
+    },
+    {
+      "name": "windsornguyen",
+      "id": 93564933,
+      "comment_id": 4174228434,
+      "created_at": "2026-04-02T02:34:38Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 32
+    },
+    {
+      "name": "InboraStudio",
+      "id": 96738915,
+      "comment_id": 4220010353,
+      "created_at": "2026-04-10T03:31:15Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 53
+    },
+    {
+      "name": "siketyan",
+      "id": 12772118,
+      "comment_id": 4266988409,
+      "created_at": "2026-04-17T09:51:38Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 55
+    },
+    {
+      "name": "sharma-uday",
+      "id": 35044053,
+      "comment_id": 4269991219,
+      "created_at": "2026-04-17T17:23:37Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 56
+    },
+    {
+      "name": "rpb-ant",
+      "id": 218844675,
+      "comment_id": 4277978572,
+      "created_at": "2026-04-20T05:15:09Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 58
+    },
+    {
+      "name": "connyay",
+      "id": 597300,
+      "comment_id": 4330014041,
+      "created_at": "2026-04-27T19:54:36Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 63
+    },
+    {
+      "name": "tejas-dharani",
+      "id": 12762152,
+      "comment_id": 4372359636,
+      "created_at": "2026-05-04T15:36:25Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 76
+    },
+    {
+      "name": "tejas-dharani",
+      "id": 12762152,
+      "comment_id": 4372372399,
+      "created_at": "2026-05-04T15:38:09Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 76
+    },
+    {
+      "name": "jportner-ant",
+      "id": 263973075,
+      "comment_id": 4384183717,
+      "created_at": "2026-05-06T00:23:15Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 81
+    },
+    {
+      "name": "hobostay",
+      "id": 110803307,
+      "comment_id": 4384996215,
+      "created_at": "2026-05-06T04:03:41Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 59
+    },
+    {
+      "name": "Yong-yuan-X",
+      "id": 129142497,
+      "comment_id": 4470258945,
+      "created_at": "2026-05-17T10:17:24Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 109
+    },
+    {
+      "name": "aknott-ant",
+      "id": 272944338,
+      "comment_id": 4480739086,
+      "created_at": "2026-05-18T18:33:29Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 112
+    },
+    {
+      "name": "azdagron",
+      "id": 7400314,
+      "comment_id": 4488597749,
+      "created_at": "2026-05-19T14:09:11Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 117
+    },
+    {
+      "name": "DevExzh",
+      "id": 25602131,
+      "comment_id": 4494709327,
+      "created_at": "2026-05-20T05:08:57Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 125
+    },
+    {
+      "name": "Dev-X25874",
+      "id": 283057883,
+      "comment_id": 4496136238,
+      "created_at": "2026-05-20T08:18:20Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 127
+    },
+    {
+      "name": "torkelrogstad",
+      "id": 16610775,
+      "comment_id": 4507471818,
+      "created_at": "2026-05-21T10:57:43Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 128
+    },
+    {
+      "name": "christopherwxyz",
+      "id": 362387,
+      "comment_id": 4557406917,
+      "created_at": "2026-05-27T18:23:35Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 141
+    },
+    {
+      "name": "jeet-dekivadia",
+      "id": 176027117,
+      "comment_id": 4582169938,
+      "created_at": "2026-05-30T07:54:26Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 147
+    },
+    {
+      "name": "EffortlessSteven",
+      "id": 15812269,
+      "comment_id": 4629934023,
+      "created_at": "2026-06-05T09:10:02Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 150
+    },
+    {
+      "name": "Jaksenc",
+      "id": 46287095,
+      "comment_id": 4721476589,
+      "created_at": "2026-06-16T17:27:09Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 165
+    },
+    {
+      "name": "macalinao",
+      "id": 401263,
+      "comment_id": 4749660485,
+      "created_at": "2026-06-19T08:03:16Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 172
+    },
+    {
+      "name": "fallintoplace",
+      "id": 38443830,
+      "comment_id": 4770944265,
+      "created_at": "2026-06-22T17:16:11Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 192
+    },
+    {
+      "name": "bickfordb",
+      "id": 2729,
+      "comment_id": 4785555354,
+      "created_at": "2026-06-24T03:16:33Z",
+      "repoId": 1172812784,
+      "pullRequestNo": 196
+    }
+  ]
 }


### PR DESCRIPTION
CLA Assistant wrote contributor signatures to the `cla-signatures` branch, so the `signatures/cla.json` on `main` has always been an empty placeholder. Now that #207 has replaced the CLA with DCO sign-off, this PR freezes the real signature record (27 signed contributors, 2026-03-25 through 2026-06-24) onto `main`:

- `signatures/cla.json`: copied verbatim from the `cla-signatures` branch.
- `signatures/README.md`: explains that this is the historical record of contributors who signed the CLA while connect-rust was an Anthropic-managed project, covering external contributions that predate the DCO requirement.

The `cla-signatures` branch should be retained as the original record, but with this copy on `main` the signature history survives alongside the code it covers even if branch rulesets change in the future.
