### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ with the [Rust 0.x convention](https://doc.rust-lang.org/cargo/reference/semver.
 breaking changes increment the minor version (0.2 → 0.3), additive changes
 increment the patch version.
 
-## [Unreleased]
+## [0.8.0] - 2026-07-01
 
 ### Added
 
@@ -100,6 +100,22 @@ increment the patch version.
   `with_http2_initial_connection_window_size` set fixed windows (supplying a
   fixed window turns adaptive sizing off, mirroring grpc-go). The new default
   is exposed as the `DEFAULT_HTTP2_ADAPTIVE_WINDOW` constant.
+
+- **Connection-level HTTP/1.1 header read timeout** ([#135]). The built-in
+  `Server`/`BoundServer` and the axum `serve_tls` path now install a
+  `TokioTimer` on every accepted connection and apply a header read timeout,
+  configurable via `with_header_read_timeout(Option<Duration>)` (default
+  `DEFAULT_HEADER_READ_TIMEOUT`, 30 seconds; pass `None` to disable). The
+  timeout bounds how long the server waits to read a complete request header
+  block, measured from when hyper begins reading a new request; on a keep-alive
+  connection it also bounds the idle wait between requests. A peer that opens a
+  connection — or finishes one request — and then stalls without sending the
+  next request's headers is now disconnected instead of holding a task and file
+  descriptor open indefinitely, which mitigates slowloris-style
+  connection-exhaustion attacks. Previously no timer was installed, so hyper's
+  built-in header read timeout never took effect; the default is now active.
+  Applies to HTTP/1.1 only — HTTP/2 connection liveness (keep-alive pings) and
+  idle-connection reaping are tracked separately.
 
 ### Changed
 
@@ -229,32 +245,6 @@ increment the patch version.
   an unsupported `grpc-encoding`. Clients that branch on grpc-status will
   observe 13 → 12 for this case on upgrade.
 
-### Deprecated
-
-- `Http2Connection::with_builder_plaintext` / `with_builder_tls` ([#197]). Use
-  `Http2Connection::builder()` and configure via the proxied keep-alive /
-  window-size setters or `h2_settings(|b| ...)`. The old names collide with the
-  new `builder()` entry point, where "builder" now means
-  `Http2ConnectionBuilder` rather than hyper's HTTP/2 builder.
-
-- **Connection-level HTTP/1.1 header read timeout** ([#135]). The built-in
-  `Server`/`BoundServer` and the axum `serve_tls` path now install a
-  `TokioTimer` on every accepted connection and apply a header read timeout,
-  configurable via `with_header_read_timeout(Option<Duration>)` (default
-  `DEFAULT_HEADER_READ_TIMEOUT`, 30 seconds; pass `None` to disable). The
-  timeout bounds how long the server waits to read a complete request header
-  block, measured from when hyper begins reading a new request; on a keep-alive
-  connection it also bounds the idle wait between requests. A peer that opens a
-  connection — or finishes one request — and then stalls without sending the
-  next request's headers is now disconnected instead of holding a task and file
-  descriptor open indefinitely, which mitigates slowloris-style
-  connection-exhaustion attacks. Previously no timer was installed, so hyper's
-  built-in header read timeout never took effect; the default is now active.
-  Applies to HTTP/1.1 only — HTTP/2 connection liveness (keep-alive pings) and
-  idle-connection reaping are tracked separately.
-
-### Changed
-
 - **The built-in server now closes idle/stalled HTTP/1.1 connections by
   default** ([#135]). Because a connection timer is now installed (see the
   Added entry above), the 30-second header read timeout is active by default
@@ -265,6 +255,16 @@ increment the patch version.
   an HTTP/1.1 client that pools a connection across long idle gaps must
   reconnect. Raise the duration with `with_header_read_timeout(Some(d))` or
   disable it with `with_header_read_timeout(None)`.
+
+### Deprecated
+
+- `Http2Connection::with_builder_plaintext` / `with_builder_tls` ([#197]). Use
+  `Http2Connection::builder()` and configure via the proxied keep-alive /
+  window-size setters or `h2_settings(|b| ...)`. The old names collide with the
+  new `builder()` entry point, where "builder" now means
+  `Http2ConnectionBuilder` rather than hyper's HTTP/2 builder.
+
+
 
 ### Fixed
 
@@ -296,25 +296,25 @@ increment the patch version.
   a truncated response was indistinguishable from a complete one. It now
   returns `Err(internal)` (see [#168]); complete responses are unchanged.
 
-[#135]: https://github.com/anthropics/connect-rust/issues/135
-[#137]: https://github.com/anthropics/connect-rust/issues/137
-[#145]: https://github.com/anthropics/connect-rust/issues/145
-[#205]: https://github.com/anthropics/connect-rust/pull/205
-[#151]: https://github.com/anthropics/connect-rust/issues/151
-[#163]: https://github.com/anthropics/connect-rust/pull/163
-[#164]: https://github.com/anthropics/connect-rust/pull/164
-[#167]: https://github.com/anthropics/connect-rust/pull/167
-[#168]: https://github.com/anthropics/connect-rust/pull/168
-[#172]: https://github.com/anthropics/connect-rust/pull/172
-[#178]: https://github.com/anthropics/connect-rust/issues/178
-[#180]: https://github.com/anthropics/connect-rust/issues/180
-[#181]: https://github.com/anthropics/connect-rust/issues/181
-[#192]: https://github.com/anthropics/connect-rust/pull/192
-[#194]: https://github.com/anthropics/connect-rust/pull/194
-[#197]: https://github.com/anthropics/connect-rust/pull/197
-[#199]: https://github.com/anthropics/connect-rust/pull/199
-[#200]: https://github.com/anthropics/connect-rust/pull/200
-[#201]: https://github.com/anthropics/connect-rust/pull/201
+[#135]: https://github.com/connectrpc/connect-rust/issues/135
+[#137]: https://github.com/connectrpc/connect-rust/issues/137
+[#145]: https://github.com/connectrpc/connect-rust/issues/145
+[#205]: https://github.com/connectrpc/connect-rust/pull/205
+[#151]: https://github.com/connectrpc/connect-rust/issues/151
+[#163]: https://github.com/connectrpc/connect-rust/pull/163
+[#164]: https://github.com/connectrpc/connect-rust/pull/164
+[#167]: https://github.com/connectrpc/connect-rust/pull/167
+[#168]: https://github.com/connectrpc/connect-rust/pull/168
+[#172]: https://github.com/connectrpc/connect-rust/pull/172
+[#178]: https://github.com/connectrpc/connect-rust/issues/178
+[#180]: https://github.com/connectrpc/connect-rust/issues/180
+[#181]: https://github.com/connectrpc/connect-rust/issues/181
+[#192]: https://github.com/connectrpc/connect-rust/pull/192
+[#194]: https://github.com/connectrpc/connect-rust/pull/194
+[#197]: https://github.com/connectrpc/connect-rust/pull/197
+[#199]: https://github.com/connectrpc/connect-rust/pull/199
+[#200]: https://github.com/connectrpc/connect-rust/pull/200
+[#201]: https://github.com/connectrpc/connect-rust/pull/201
 [#209]: https://github.com/connectrpc/connect-rust/issues/209
 [connectrpc/conformance#1104]: https://github.com/connectrpc/conformance/pull/1104
 
@@ -532,18 +532,18 @@ regenerate with this release's toolchain and buffa ≥ 0.7.0.**
   intended behavior change beyond [#159]; the streaming contract tests'
   assertions are unchanged.
 
-[#127]: https://github.com/anthropics/connect-rust/pull/127
-[#128]: https://github.com/anthropics/connect-rust/pull/128
-[#136]: https://github.com/anthropics/connect-rust/issues/136
-[#139]: https://github.com/anthropics/connect-rust/issues/139
-[#140]: https://github.com/anthropics/connect-rust/issues/140
-[#141]: https://github.com/anthropics/connect-rust/pull/141
-[#143]: https://github.com/anthropics/connect-rust/pull/143
-[#147]: https://github.com/anthropics/connect-rust/pull/147
-[#150]: https://github.com/anthropics/connect-rust/pull/150
-[#157]: https://github.com/anthropics/connect-rust/pull/157
-[#159]: https://github.com/anthropics/connect-rust/pull/159
-[#160]: https://github.com/anthropics/connect-rust/pull/160
+[#127]: https://github.com/connectrpc/connect-rust/pull/127
+[#128]: https://github.com/connectrpc/connect-rust/pull/128
+[#136]: https://github.com/connectrpc/connect-rust/issues/136
+[#139]: https://github.com/connectrpc/connect-rust/issues/139
+[#140]: https://github.com/connectrpc/connect-rust/issues/140
+[#141]: https://github.com/connectrpc/connect-rust/pull/141
+[#143]: https://github.com/connectrpc/connect-rust/pull/143
+[#147]: https://github.com/connectrpc/connect-rust/pull/147
+[#150]: https://github.com/connectrpc/connect-rust/pull/150
+[#157]: https://github.com/connectrpc/connect-rust/pull/157
+[#159]: https://github.com/connectrpc/connect-rust/pull/159
+[#160]: https://github.com/connectrpc/connect-rust/pull/160
 
 ## [0.6.1] - 2026-05-27
 
@@ -579,10 +579,10 @@ now 1.6.
 
 - The minimum supported `bytes` version is now 1.6 ([#132]).
 
-[#130]: https://github.com/anthropics/connect-rust/pull/130
-[#131]: https://github.com/anthropics/connect-rust/pull/131
-[#132]: https://github.com/anthropics/connect-rust/pull/132
-[#133]: https://github.com/anthropics/connect-rust/pull/133
+[#130]: https://github.com/connectrpc/connect-rust/pull/130
+[#131]: https://github.com/connectrpc/connect-rust/pull/131
+[#132]: https://github.com/connectrpc/connect-rust/pull/132
+[#133]: https://github.com/connectrpc/connect-rust/pull/133
 
 ## [0.6.0] - 2026-05-20
 
@@ -718,19 +718,19 @@ rebuilds `OUT_DIR` automatically.
   register interceptors without dropping down to
   `Server::from_service(ConnectRpcService::new(...).with_interceptor(...))`.
 
-[#87]: https://github.com/anthropics/connect-rust/issues/87
-[#105]: https://github.com/anthropics/connect-rust/pull/105
-[#110]: https://github.com/anthropics/connect-rust/issues/110
-[#112]: https://github.com/anthropics/connect-rust/pull/112
-[#113]: https://github.com/anthropics/connect-rust/pull/113
-[#114]: https://github.com/anthropics/connect-rust/pull/114
-[#116]: https://github.com/anthropics/connect-rust/pull/116
-[#117]: https://github.com/anthropics/connect-rust/pull/117
-[#118]: https://github.com/anthropics/connect-rust/pull/118
-[#119]: https://github.com/anthropics/connect-rust/pull/119
-[#120]: https://github.com/anthropics/connect-rust/pull/120
-[#121]: https://github.com/anthropics/connect-rust/pull/121
-[#123]: https://github.com/anthropics/connect-rust/pull/123
+[#87]: https://github.com/connectrpc/connect-rust/issues/87
+[#105]: https://github.com/connectrpc/connect-rust/pull/105
+[#110]: https://github.com/connectrpc/connect-rust/issues/110
+[#112]: https://github.com/connectrpc/connect-rust/pull/112
+[#113]: https://github.com/connectrpc/connect-rust/pull/113
+[#114]: https://github.com/connectrpc/connect-rust/pull/114
+[#116]: https://github.com/connectrpc/connect-rust/pull/116
+[#117]: https://github.com/connectrpc/connect-rust/pull/117
+[#118]: https://github.com/connectrpc/connect-rust/pull/118
+[#119]: https://github.com/connectrpc/connect-rust/pull/119
+[#120]: https://github.com/connectrpc/connect-rust/pull/120
+[#121]: https://github.com/connectrpc/connect-rust/pull/121
+[#123]: https://github.com/connectrpc/connect-rust/pull/123
 [`Spec`]: https://docs.rs/connectrpc/latest/connectrpc/spec/struct.Spec.html
 [`Payload`]: https://docs.rs/connectrpc/latest/connectrpc/payload/struct.Payload.html
 [`AnyMessage`]: https://docs.rs/connectrpc/latest/connectrpc/payload/trait.AnyMessage.html
@@ -987,15 +987,15 @@ mechanical: direct field reads become accessor calls (`ctx.headers` →
   The directives are now suppressed in Buf mode, completing the fix #56
   applied to `Precompiled` mode. Manual `protoc` mode is unchanged.
 
-[#59]: https://github.com/anthropics/connect-rust/pull/59
-[#98]: https://github.com/anthropics/connect-rust/pull/98
-[#100]: https://github.com/anthropics/connect-rust/pull/100
-[#101]: https://github.com/anthropics/connect-rust/pull/101
-[#103]: https://github.com/anthropics/connect-rust/pull/103
-[#105]: https://github.com/anthropics/connect-rust/pull/105
-[#108]: https://github.com/anthropics/connect-rust/pull/108
-[#109]: https://github.com/anthropics/connect-rust/pull/109
-[#111]: https://github.com/anthropics/connect-rust/pull/111
+[#59]: https://github.com/connectrpc/connect-rust/pull/59
+[#98]: https://github.com/connectrpc/connect-rust/pull/98
+[#100]: https://github.com/connectrpc/connect-rust/pull/100
+[#101]: https://github.com/connectrpc/connect-rust/pull/101
+[#103]: https://github.com/connectrpc/connect-rust/pull/103
+[#105]: https://github.com/connectrpc/connect-rust/pull/105
+[#108]: https://github.com/connectrpc/connect-rust/pull/108
+[#109]: https://github.com/connectrpc/connect-rust/pull/109
+[#111]: https://github.com/connectrpc/connect-rust/pull/111
 [@Yong-yuan-X]: https://github.com/Yong-yuan-X
 [@hobostay]: https://github.com/hobostay
 
@@ -1246,13 +1246,13 @@ rebuilds `OUT_DIR` automatically.
   `build.rs` context (e.g. from a Bazel genrule or standalone host tool).
   Default remains `true`.
 
-[#80]: https://github.com/anthropics/connect-rust/pull/80
-[#7]: https://github.com/anthropics/connect-rust/issues/7
-[#34]: https://github.com/anthropics/connect-rust/issues/34
-[#50]: https://github.com/anthropics/connect-rust/issues/50
-[#55]: https://github.com/anthropics/connect-rust/pull/55
-[#61]: https://github.com/anthropics/connect-rust/issues/61
-[#63]: https://github.com/anthropics/connect-rust/pull/63
+[#80]: https://github.com/connectrpc/connect-rust/pull/80
+[#7]: https://github.com/connectrpc/connect-rust/issues/7
+[#34]: https://github.com/connectrpc/connect-rust/issues/34
+[#50]: https://github.com/connectrpc/connect-rust/issues/50
+[#55]: https://github.com/connectrpc/connect-rust/pull/55
+[#61]: https://github.com/connectrpc/connect-rust/issues/61
+[#63]: https://github.com/connectrpc/connect-rust/pull/63
 [buffa#22]: https://github.com/anthropics/buffa/pull/22
 [buffa#55]: https://github.com/anthropics/buffa/pull/55
 [buffa#62]: https://github.com/anthropics/buffa/pull/62
@@ -1285,10 +1285,10 @@ rebuilds `OUT_DIR` automatically.
 - New `examples/streaming-tour` and `examples/middleware` crates,
   plus a user guide under `docs/guide.md` ([#46], [#48]).
 
-[#44]: https://github.com/anthropics/connect-rust/pull/44
-[#46]: https://github.com/anthropics/connect-rust/pull/46
-[#48]: https://github.com/anthropics/connect-rust/pull/48
-[#56]: https://github.com/anthropics/connect-rust/pull/56
+[#44]: https://github.com/connectrpc/connect-rust/pull/44
+[#46]: https://github.com/connectrpc/connect-rust/pull/46
+[#48]: https://github.com/connectrpc/connect-rust/pull/48
+[#56]: https://github.com/connectrpc/connect-rust/pull/56
 
 ## [0.3.2] - 2026-04-03
 
@@ -1328,10 +1328,10 @@ rebuilds `OUT_DIR` automatically.
   Currently exercises unary calls without deadlines; timeouts and
   streaming require additional setup beyond the example.
 
-[#16]: https://github.com/anthropics/connect-rust/pull/16
-[#19]: https://github.com/anthropics/connect-rust/pull/19
-[#32]: https://github.com/anthropics/connect-rust/pull/32
-[#37]: https://github.com/anthropics/connect-rust/pull/37
+[#16]: https://github.com/connectrpc/connect-rust/pull/16
+[#19]: https://github.com/connectrpc/connect-rust/pull/19
+[#32]: https://github.com/connectrpc/connect-rust/pull/32
+[#37]: https://github.com/connectrpc/connect-rust/pull/37
 
 ## [0.3.1] - 2026-04-02
 
@@ -1346,7 +1346,7 @@ rebuilds `OUT_DIR` automatically.
   `no_register_fn` parameter for path-compat with the unified `connectrpc-build`
   flow.
 
-[#35]: https://github.com/anthropics/connect-rust/pull/35
+[#35]: https://github.com/connectrpc/connect-rust/pull/35
 
 ## [0.3.0] - 2026-04-02
 
@@ -1399,14 +1399,14 @@ rebuilds `OUT_DIR` automatically.
   trait is suffixed to `Self_`; the `SelfExt` / `SelfClient` / `SelfServer`
   derivatives are unaffected since the suffix already de-keywords them.
 
-[#15]: https://github.com/anthropics/connect-rust/pull/15
-[#22]: https://github.com/anthropics/connect-rust/pull/22
-[#23]: https://github.com/anthropics/connect-rust/issues/23
-[#24]: https://github.com/anthropics/connect-rust/pull/24
-[#26]: https://github.com/anthropics/connect-rust/pull/26
-[#27]: https://github.com/anthropics/connect-rust/pull/27
-[#28]: https://github.com/anthropics/connect-rust/pull/28
-[#31]: https://github.com/anthropics/connect-rust/pull/31
+[#15]: https://github.com/connectrpc/connect-rust/pull/15
+[#22]: https://github.com/connectrpc/connect-rust/pull/22
+[#23]: https://github.com/connectrpc/connect-rust/issues/23
+[#24]: https://github.com/connectrpc/connect-rust/pull/24
+[#26]: https://github.com/connectrpc/connect-rust/pull/26
+[#27]: https://github.com/connectrpc/connect-rust/pull/27
+[#28]: https://github.com/connectrpc/connect-rust/pull/28
+[#31]: https://github.com/connectrpc/connect-rust/pull/31
 
 ## [0.2.1] - 2026-03-18
 
@@ -1429,14 +1429,14 @@ rebuilds `OUT_DIR` automatically.
   `readme = "../README.md"`, so the crates.io page for 0.2.0 shows the
   stale version; this release updates it.
 
-[#1]: https://github.com/anthropics/connect-rust/issues/1
-[#2]: https://github.com/anthropics/connect-rust/issues/2
-[#3]: https://github.com/anthropics/connect-rust/pull/3
-[#4]: https://github.com/anthropics/connect-rust/pull/4
+[#1]: https://github.com/connectrpc/connect-rust/issues/1
+[#2]: https://github.com/connectrpc/connect-rust/issues/2
+[#3]: https://github.com/connectrpc/connect-rust/pull/3
+[#4]: https://github.com/connectrpc/connect-rust/pull/4
 
 ## [0.2.0] - 2026-03-17
 
-First release from the [anthropics/connect-rust](https://github.com/anthropics/connect-rust)
+First release from the [anthropics/connect-rust](https://github.com/connectrpc/connect-rust)
 repository. This is a complete from-scratch implementation — not a continuation
 of the 0.1.x releases previously published under the `connectrpc` crate name,
 which have been superseded.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
-repository = "https://github.com/anthropics/connect-rust"
+repository = "https://github.com/connectrpc/connect-rust"
 keywords = ["connectrpc", "grpc", "rpc", "protobuf", "tower"]
 categories = ["network-programming", "web-programming::http-server", "web-programming::http-client"]
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![crates.io](https://img.shields.io/crates/v/connectrpc.svg)](https://crates.io/crates/connectrpc)
 [![docs.rs](https://img.shields.io/docsrs/connectrpc)](https://docs.rs/connectrpc)
-[![CI](https://github.com/anthropics/connect-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/anthropics/connect-rust/actions/workflows/ci.yml)
+[![CI](https://github.com/connectrpc/connect-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/connectrpc/connect-rust/actions/workflows/ci.yml)
 [![MSRV](https://img.shields.io/crates/msrv/connectrpc)](Cargo.toml)
-[![deps.rs](https://deps.rs/repo/github/anthropics/connect-rust/status.svg)](https://deps.rs/repo/github/anthropics/connect-rust)
+[![deps.rs](https://deps.rs/repo/github/connectrpc/connect-rust/status.svg)](https://deps.rs/repo/github/connectrpc/connect-rust)
 [![License](https://img.shields.io/crates/l/connectrpc)](LICENSE)
 
 A [Tower](https://docs.rs/tower/latest/tower/)-based Rust implementation of [ConnectRPC](https://connectrpc.com/), serving Connect, gRPC, and gRPC-Web clients over HTTP with binary or JSON protobuf messages.
@@ -82,7 +82,7 @@ ship Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows
 ```sh
 VERSION=v0.8.0
 PLATFORM=linux-x86_64        # or darwin-aarch64, etc.
-BASE=https://github.com/anthropics/connect-rust/releases/download/${VERSION}
+BASE=https://github.com/connectrpc/connect-rust/releases/download/${VERSION}
 BIN=protoc-gen-connect-rust-${VERSION}-${PLATFORM}
 
 curl -fSL -o "${BIN}"        "${BASE}/${BIN}"
@@ -94,13 +94,13 @@ curl -fSL -o checksums-sha256.txt "${BASE}/checksums-sha256.txt"
 grep " ${BIN}\$" checksums-sha256.txt | sha256sum -c -
 
 # Verify the GitHub-native attestation (no .sig/.pem download needed).
-gh attestation verify "${BIN}" --repo anthropics/connect-rust
+gh attestation verify "${BIN}" --repo connectrpc/connect-rust
 
 # Or verify the cosign signature directly.
 cosign verify-blob \
   --certificate "${BIN}.pem" \
   --signature "${BIN}.sig" \
-  --certificate-identity "https://github.com/anthropics/connect-rust/.github/workflows/release.yml@refs/tags/${VERSION}" \
+  --certificate-identity "https://github.com/connectrpc/connect-rust/.github/workflows/release.yml@refs/tags/${VERSION}" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   "${BIN}"
 
@@ -116,7 +116,7 @@ cargo install --locked connectrpc-codegen
 ```
 
 **3. Buf Schema Registry remote plugin (planned).** Once accepted upstream
-the plugin will be runnable as `remote: buf.build/anthropics/connect-rust`
+the plugin will be runnable as `remote: buf.build/connectrpc/connect-rust`
 in `buf.gen.yaml`, with no local install step.
 
 ```yaml

--- a/connectrpc-build/Cargo.toml
+++ b/connectrpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-build"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -10,7 +10,7 @@ keywords = ["connectrpc", "grpc", "protobuf", "build", "codegen"]
 categories = ["development-tools::build-utils"]
 
 [dependencies]
-connectrpc-codegen = { path = "../connectrpc-codegen", version = "0.7" }
+connectrpc-codegen = { path = "../connectrpc-codegen", version = "0.8" }
 buffa = { workspace = true }
 buffa-codegen = { workspace = true }
 tempfile = { workspace = true }

--- a/connectrpc-codegen/Cargo.toml
+++ b/connectrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-codegen"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/connectrpc-health/Cargo.toml
+++ b/connectrpc-health/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-health"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ default = ["client"]
 client = ["connectrpc/client"]
 
 [dependencies]
-connectrpc = { path = "../connectrpc", version = "0.7", features = ["server"] }
+connectrpc = { path = "../connectrpc", version = "0.8", features = ["server"] }
 
 # Protobuf + serde (pulled in by the generated module paths)
 buffa = { workspace = true }

--- a/connectrpc-reflection/Cargo.toml
+++ b/connectrpc-reflection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc-reflection"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ default = ["client"]
 client = ["connectrpc/client"]
 
 [dependencies]
-connectrpc = { path = "../connectrpc", version = "0.7", features = ["server"] }
+connectrpc = { path = "../connectrpc", version = "0.8", features = ["server"] }
 
 # Protobuf + serde (pulled in by the generated module paths)
 buffa = { workspace = true }

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/examples/bazel/Cargo.toml
+++ b/examples/bazel/Cargo.toml
@@ -16,8 +16,8 @@ publish = false
 path = "stub.rs"
 
 [dependencies]
-buffa = { version = "0.7.0", features = ["json"] }
-connectrpc = { version = "0.7.0", default-features = false, features = ["server", "client"] }
+buffa = { version = "0.8.1", features = ["json"] }
+connectrpc = { version = "0.8.0", default-features = false, features = ["server", "client"] }
 futures = "0.3"
 http-body = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Cuts the 0.8.0 release: all five crates move 0.7.0 → 0.8.0, the changelog gains its `[0.8.0] - 2026-07-01` section, and repository metadata moves to the connectrpc GitHub org.

## What's in the commit

- **Version bumps**: `connectrpc`, `connectrpc-codegen`, `connectrpc-build`, `connectrpc-health`, `connectrpc-reflection` to 0.8.0, with inner dependency floors (`connectrpc-codegen = "0.8"` in -build, `connectrpc = "0.8"` in -health/-reflection) and the standalone bazel example to connectrpc 0.8.0 / buffa 0.8.1.
- **Changelog cut and repair**: the `[Unreleased]` section becomes `[0.8.0] - 2026-07-01`; the `#135` header-read-timeout entry is refiled from `### Deprecated` (where it was misfiled) into `### Added`, and the duplicated `### Changed` sections are merged.
- **Org re-point**: `workspace.package.repository`, README badges, the cosign/attestation verification identities (which will match v0.8.0 artifacts signed under the new org path), the planned BSR remote-plugin path, and all changelog issue/PR links now reference `connectrpc/connect-rust`. This is what makes the crates.io pages show the connectrpc umbrella — crates.io renders the `repository` field from the published manifest, so the old URL persists there until this release ships. buffa links intentionally stay under `anthropics`.

## Semver posture vs published 0.7.0

`cargo semver-checks -p connectrpc --baseline-version 0.7.0`: the only lint fired is `inherent_method_now_doc_hidden` on the `Router::route*` family (an intentional 0.8-line change; the methods still exist). The headline API story for 0.8.0 is in the changelog: buffa 0.8.1 adoption with **infallible owned-message conversion across the whole public surface**, client stream items unified on `StreamMessage`, and the pre-release ergonomics fixes (root-export cleanup, `ErrorDetail::from_message`, `http_body` re-export, testing constructors, `InboundStream`).

## Release mechanics after merge

Pushing the signed `v0.8.0` tag triggers `release.yml` (plugin binaries + checksums + Sigstore signatures + GitHub release) and `publish-crates.yml` (crates.io publish in dependency order via OIDC Trusted Publishing — re-pointed to this repo and verified for all five crates; stale trust entries deleted).
