### PR TITLE
release: v0.8.1

### DIFF
--- a/.changes/0.8.1.md
+++ b/.changes/0.8.1.md
@@ -1,0 +1,7 @@
+## [0.8.1] - 2026-07-02
+
+### Fixed
+
+- Client stream `message()` futures are `Send` again with concrete generated view types ([#214]). 0.8.0's bound shape on `ServerStream::message`/`BidiStream::message` (projecting `RespView::Owned` in the where-clause) tripped rustc's coroutine-witness auto-trait check on monomorphization, so a server-stream could not be consumed inside `tokio::spawn`; the bound is reshaped as an output type parameter (`RespView: MessageView<'static, Owned = M>`), which is equivalent for every caller and restores `Send`. Call sites are unaffected — `M` is inferred.
+  
+  [#214]: https://github.com/connectrpc/connect-rust/issues/214

--- a/.changes/unreleased/Fixed-20260702-090031.yaml
+++ b/.changes/unreleased/Fixed-20260702-090031.yaml
@@ -1,6 +1,0 @@
-kind: Fixed
-body: |-
-    Client stream `message()` futures are `Send` again with concrete generated view types ([#214]). 0.8.0's bound shape on `ServerStream::message`/`BidiStream::message` (projecting `RespView::Owned` in the where-clause) tripped rustc's coroutine-witness auto-trait check on monomorphization, so a server-stream could not be consumed inside `tokio::spawn`; the bound is reshaped as an output type parameter (`RespView: MessageView<'static, Owned = M>`), which is equivalent for every caller and restores `Send`. Call sites are unaffected — `M` is inferred.
-
-    [#214]: https://github.com/connectrpc/connect-rust/issues/214
-time: 2026-07-02T09:00:31.44759722-07:00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Entries for unreleased changes live as fragment files under
 one. This file is assembled from `.changes/` at release time — do not edit it
 directly.
 
+## [0.8.1] - 2026-07-02
+
+### Fixed
+
+- Client stream `message()` futures are `Send` again with concrete generated view types ([#214]). 0.8.0's bound shape on `ServerStream::message`/`BidiStream::message` (projecting `RespView::Owned` in the where-clause) tripped rustc's coroutine-witness auto-trait check on monomorphization, so a server-stream could not be consumed inside `tokio::spawn`; the bound is reshaped as an output type parameter (`RespView: MessageView<'static, Owned = M>`), which is equivalent for every caller and restores `Send`. Call sites are unaffected — `M` is inferred.
+  
+  [#214]: https://github.com/connectrpc/connect-rust/issues/214
+
 ## [0.8.0] - 2026-07-01
 
 ### Added

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connectrpc"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Cuts the 0.8.1 patch release: `connectrpc` moves to 0.8.1 carrying the #214/#215 fix (client stream `message()` futures are `Send` again with concrete generated view types). The four companion crates are unchanged and stay at 0.8.0 — the publish workflow skips already-published versions.

First release through the changie fragment workflow: the unreleased fragment is batched into `.changes/0.8.1.md` via `task changelog-batch -- 0.8.1` and `CHANGELOG.md` regenerated with `changelog-merge`, so `check-changelog` verifies the assembly.

Semver note (carried from #215): `cargo semver-checks` flags the added generic parameter on `message()` as formally major; the waiver rationale is in #215's description — the formal break surface is turbofish that cannot exist against 0.8.0, weighed against the real regression of streaming clients being unusable in `tokio::spawn`.

After merge: signed `v0.8.1` tag → `release.yml` (binaries; the plugin is unchanged, so v0.8.1 assets carry the 0.8.0-versioned binary) + `publish-crates.yml` (crates.io via the re-pointed Trusted Publishing).
