### PR TITLE
ci: derive the MSRV check's toolchain from Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,24 @@ jobs:
       - run: cargo check --workspace --all-features --all-targets
 
   msrv-check:
-    name: MSRV (1.88)
+    name: MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      # The MSRV is declared once, in the workspace Cargo.toml; this job
+      # derives its toolchain from it so the declaration and the check can
+      # never drift apart.
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: |
+          version=$(sed -n 's/^rust-version = "\(.*\)"$/\1/p' Cargo.toml)
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "MSRV: $version"
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.88'
+          toolchain: ${{ steps.msrv.outputs.version }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 (sha-pinned)
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0 (sha-pinned)
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ $ git commit -s -m "your commit message"
 
 ## Prerequisites
 
-- **Rust 1.88+** (MSRV; the codebase uses let-chains).
+- **Rust 1.88+** (MSRV; source of truth is `rust-version` in the workspace
+  `Cargo.toml` — the codebase uses let-chains).
 - **`protoc` v27+** — the test and example protos use editions syntax
   (`edition = "2023"`). Ubuntu's apt `protobuf-compiler` (v21) is too old;
   install from the [protobuf releases] page or via `arduino/setup-protoc`
@@ -181,7 +182,8 @@ GitHub Actions CI (`.github/workflows/ci.yml`) runs on every push to
 - **Check generated code** — runs `task generate:all` and verifies the
   checked-in generated directories have no diff
 - **Documentation** — `cargo doc` with broken-intra-doc-links denied
-- **MSRV (1.88)** — `cargo check` on the pinned minimum toolchain
+- **MSRV** — `cargo check` on the minimum toolchain, read from `rust-version`
+  in the workspace `Cargo.toml` so the declaration and the check cannot drift
 - **Examples** — builds and runs the example crates
 - **Minimal features** — `cargo check -p connectrpc --no-default-features`
 - **Wasm** — `wasm32-unknown-unknown` build of the client example

--- a/examples/bazel/Cargo.toml
+++ b/examples/bazel/Cargo.toml
@@ -7,6 +7,9 @@
 name = "connectrpc-bazel-example-deps"
 version = "0.0.0"
 edition = "2021"
+# Kept in sync with the workspace rust-version by hand: this manifest is
+# standalone (excluded from the workspace) so it cannot inherit it.
+rust-version = "1.88"
 publish = false
 
 # crates_universe needs a [package] target. We point at a stub source so


### PR DESCRIPTION
The MSRV was declared consistently (workspace `rust-version`, inherited by every member; README/guide/CONTRIBUTING all say 1.88) but enforced from a second, independent copy: the CI job hardcoded `1.88` in both its display name and its toolchain input. Bumping either source without the other would silently pass the wrong check. The job now reads `rust-version` from the workspace manifest and is renamed to plain **MSRV** so the name doesn't embed a third copy.

Also: CONTRIBUTING names the manifest as the source of truth, and `examples/bazel`'s standalone manifest (excluded from the workspace, so it can't inherit) gains an explicit `rust-version`.

**Separate finding for the ruleset (not in this diff):** the MSRV job — along with `Check generated code`, `Check changelog`, and `Wasm` — is not in the main branch's required status checks, so it runs but cannot block a merge. A staged ruleset update adds all four; it must be applied **after** this PR lands (it requires the new `MSRV` context name).