### PR TITLE
server: pass large response payloads through by refcount instead of copying

### DIFF
--- a/.changes/unreleased/Changed-20260706-155026.yaml
+++ b/.changes/unreleased/Changed-20260706-155026.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: |-
+    Large response messages are no longer copied into the framing buffer on the server. Uncompressed (and compressed) payloads of at least 16 KiB are emitted as their own HTTP body data frame by reference count, so encoding a streaming or gRPC unary response costs one payload copy instead of two. Envelope wire bytes are unchanged — only HTTP-level frame boundaries differ (the 5-byte envelope header may arrive in a separate frame from its payload, which the protocol has always permitted).
+time: 2026-07-06T15:50:26.107887272Z

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -28,6 +28,17 @@ pub mod flags {
 /// Size of the envelope header in bytes.
 pub const HEADER_SIZE: usize = 5;
 
+/// Minimum payload size for chaining a payload as its own body frame
+/// instead of copying it into the contiguous framing buffer.
+///
+/// The trade-off is a payload-sized memcpy (tens of GiB/s) against the cost
+/// of an extra body frame: one more `poll_frame` cycle, a 9-byte HTTP/2
+/// frame header for the 5-byte envelope-header frame, and refcount
+/// bookkeeping. The crossover is low (single-digit KiB); 16 KiB is
+/// conservative and matches h2's default `max_frame_size`, above which the
+/// transport splits the payload into multiple DATA frames anyway.
+pub(crate) const MIN_CHAIN_SIZE: usize = 16 * 1024;
+
 /// An envelope-framed message.
 #[derive(Debug, Clone)]
 pub struct Envelope {
@@ -84,6 +95,28 @@ impl Envelope {
         write_envelope(self.flags, &self.data, &mut buf)
             .expect("envelope payload exceeds u32::MAX");
         buf.freeze()
+    }
+
+    /// Encode this envelope as a head segment plus an optionally chained
+    /// payload.
+    ///
+    /// Payloads of at least `min_chain` bytes return `(header, Some(payload))`
+    /// — the 5-byte header alone, with the payload passed through by refcount
+    /// for the caller to emit as its own body frame. Smaller payloads return
+    /// the full contiguous encoding and `None`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the payload exceeds `u32::MAX` bytes, like
+    /// [`encode`](Self::encode).
+    pub(crate) fn encode_parts(self, min_chain: usize) -> (Bytes, Option<Bytes>) {
+        if self.data.len() < min_chain {
+            return (self.encode(), None);
+        }
+        let mut head = BytesMut::with_capacity(HEADER_SIZE);
+        write_envelope_header(self.flags, self.data.len(), &mut head)
+            .expect("envelope payload exceeds u32::MAX");
+        (head.freeze(), Some(self.data))
     }
 
     /// Decode an envelope from bytes.
@@ -297,34 +330,77 @@ impl EnvelopeEncoder {
     ) -> Result<(), ConnectError> {
         write_envelope(flags::END_STREAM, &data, dst)
     }
+
+    /// Encode a data envelope, avoiding the payload copy for large messages.
+    ///
+    /// When the on-wire payload (post-compression, if negotiated) is at
+    /// least `min_chain` bytes, only the 5-byte envelope header is written
+    /// into `dst` and the payload is returned for the caller to emit as its
+    /// own body frame — a refcount move instead of a payload-sized memcpy.
+    /// Smaller payloads are written contiguously into `dst` and `None` is
+    /// returned.
+    ///
+    /// This is the single implementation of the envelope-encode policy —
+    /// the [`Encoder`](tokio_util::codec::Encoder) impl delegates here with
+    /// `min_chain = usize::MAX` (never chain) — so the compression decision
+    /// and the chaining decision cannot drift apart.
+    ///
+    /// gRPC/Connect envelope framing is independent of HTTP-level frame
+    /// boundaries, so splitting the header and payload across body frames
+    /// does not change the wire protocol.
+    pub(crate) fn encode_chained(
+        &mut self,
+        data: Bytes,
+        dst: &mut BytesMut,
+        min_chain: usize,
+    ) -> Result<Option<Bytes>, ConnectError> {
+        let (flag, payload) = if let Some((ref comp, ref encoding)) = self.compression
+            && self.policy.should_compress(data.len())
+        {
+            (flags::COMPRESSED, comp.compress(encoding, &data)?)
+        } else {
+            (flags::DATA, data)
+        };
+        if payload.len() < min_chain {
+            write_envelope(flag, &payload, dst)?;
+            return Ok(None);
+        }
+        write_envelope_header(flag, payload.len(), dst)?;
+        Ok(Some(payload))
+    }
 }
 
 impl tokio_util::codec::Encoder<Bytes> for EnvelopeEncoder {
     type Error = ConnectError;
 
     fn encode(&mut self, data: Bytes, dst: &mut BytesMut) -> Result<(), ConnectError> {
-        if let Some((ref comp, ref encoding)) = self.compression
-            && self.policy.should_compress(data.len())
-        {
-            let compressed = comp.compress(encoding, &data)?;
-            return write_envelope(flags::COMPRESSED, &compressed, dst);
-        }
-        write_envelope(flags::DATA, &data, dst)
+        // `usize::MAX` threshold: the contiguous entry point never chains.
+        let chained = self.encode_chained(data, dst, usize::MAX)?;
+        debug_assert!(chained.is_none(), "usize::MAX threshold cannot chain");
+        Ok(())
     }
 }
 
 /// Write a single envelope (header + payload) into a `BytesMut` buffer.
+/// The length is validated (via [`write_envelope_header`]) before any
+/// buffer growth, so an oversized payload errors without allocating.
 fn write_envelope(flag: u8, data: &[u8], dst: &mut BytesMut) -> Result<(), ConnectError> {
-    if data.len() > u32::MAX as usize {
+    write_envelope_header(flag, data.len(), dst)?;
+    dst.put_slice(data);
+    Ok(())
+}
+
+/// Write only the 5-byte envelope header (flag + big-endian length) into
+/// `dst`, for callers that emit the payload as its own body frame.
+fn write_envelope_header(flag: u8, len: usize, dst: &mut BytesMut) -> Result<(), ConnectError> {
+    if len > u32::MAX as usize {
         return Err(ConnectError::resource_exhausted(format!(
-            "envelope payload {} bytes exceeds u32::MAX",
-            data.len()
+            "envelope payload {len} bytes exceeds u32::MAX"
         )));
     }
-    dst.reserve(HEADER_SIZE + data.len());
+    dst.reserve(HEADER_SIZE);
     dst.put_u8(flag);
-    dst.put_u32(data.len() as u32);
-    dst.put_slice(data);
+    dst.put_u32(len as u32);
     Ok(())
 }
 
@@ -344,6 +420,69 @@ mod tests {
     }
 
     // ── Envelope tests ──────────────────────────────────────────────
+
+    #[test]
+    fn encode_parts_chains_large_payload_by_refcount() {
+        let payload = Bytes::from(vec![7u8; 64]);
+        let ptr = payload.as_ptr();
+        let (head, chained) = Envelope::data(payload.clone()).encode_parts(64);
+        assert_eq!(head.len(), HEADER_SIZE);
+        let chained = chained.expect("payload at threshold must chain");
+        assert!(std::ptr::eq(chained.as_ptr(), ptr), "must not copy");
+
+        // Reassembled bytes are identical to the contiguous encoding.
+        let mut reassembled = BytesMut::from(&head[..]);
+        reassembled.put_slice(&chained);
+        assert_eq!(
+            reassembled.freeze(),
+            Envelope::data(payload).encode(),
+            "chained wire bytes must match contiguous encoding"
+        );
+    }
+
+    /// A payload that compresses is chained on the COMPRESSED payload's
+    /// size, with the COMPRESSED flag in the header segment.
+    #[test]
+    #[cfg(feature = "gzip")]
+    fn encode_chained_chains_large_compressed_payload() {
+        let registry = Arc::new(CompressionRegistry::default());
+        let mut enc = EnvelopeEncoder::new(
+            Some((Arc::clone(&registry), "gzip")),
+            CompressionPolicy::default().min_size(0),
+        );
+        // Incompressible-ish random-ish payload so the compressed form stays
+        // above the chain threshold.
+        let data: Vec<u8> = (0..64 * 1024u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 13) as u8)
+            .collect();
+        let mut dst = BytesMut::new();
+        let chained = enc
+            .encode_chained(Bytes::from(data), &mut dst, 1024)
+            .unwrap()
+            .expect("large compressed payload must chain");
+
+        assert_eq!(dst.len(), HEADER_SIZE);
+        assert_eq!(dst[0], flags::COMPRESSED);
+        assert_eq!(
+            u32::from_be_bytes([dst[1], dst[2], dst[3], dst[4]]) as usize,
+            chained.len()
+        );
+
+        // Reassembled envelope decodes back to the original payload.
+        let mut wire = dst;
+        wire.put_slice(&chained);
+        let mut dec = EnvelopeDecoder::new(1024 * 1024, Some("gzip".to_owned()), registry);
+        let decoded = Decoder::decode(&mut dec, &mut wire).unwrap().unwrap();
+        assert_eq!(decoded.len(), 64 * 1024);
+    }
+
+    #[test]
+    fn encode_parts_small_payload_stays_contiguous() {
+        let payload = Bytes::from_static(b"tiny");
+        let (head, chained) = Envelope::data(payload.clone()).encode_parts(64);
+        assert!(chained.is_none());
+        assert_eq!(head, Envelope::data(payload).encode());
+    }
 
     #[test]
     fn test_envelope_roundtrip() {

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -943,7 +943,8 @@ struct BatchingEnvelopeStream {
     finalizer: StreamFinalizer,
     /// Finalizer frame staged for the next poll (when buf was non-empty at end).
     pending_final: Option<Frame<Bytes>>,
-    /// Large uncompressed payload staged for the next poll: emitted as its
+    /// Large payload (post-compression, when negotiated) staged for the next
+    /// poll: emitted as its
     /// own data frame (refcount clone) right after the header flush, instead
     /// of being copied into `buf`. See [`EnvelopeEncoder::encode_chained`].
     ///
@@ -1066,7 +1067,7 @@ impl Stream for BatchingEnvelopeStream {
                             }
                         }
                         Ok(Some(payload)) => {
-                            // Large uncompressed payload: `buf` now ends with
+                            // Large payload: `buf` now ends with
                             // its 5-byte envelope header. Flush the buffer and
                             // stage the payload as the next frame, unmoved.
                             self.pending_payload = Some(payload);
@@ -1321,7 +1322,8 @@ impl<D: Dispatcher> ConnectRpcService<D> {
 /// `EnvelopeEncoder` for the common unary case.
 pub struct GrpcUnaryBody {
     data: Option<Bytes>,
-    /// Large uncompressed message payload emitted as its own data frame
+    /// Large message payload (post-compression, when negotiated) emitted as
+    /// its own data frame
     /// after `data` (which then carries only the 5-byte envelope header),
     /// so the payload is passed through by refcount instead of copied.
     payload: Option<Bytes>,
@@ -2124,7 +2126,7 @@ where
     );
 
     // Encode response into a gRPC envelope (5-byte header + payload). Large
-    // uncompressed payloads are chained (header segment + payload by
+    // payloads are chained (header segment + payload by
     // refcount) rather than copied into a contiguous buffer.
     let effective_policy = compression_policy.with_override(resp.compress);
     let min_chain = crate::envelope::MIN_CHAIN_SIZE;
@@ -3305,7 +3307,7 @@ pub mod axum_integration {
 mod tests {
     use super::*;
 
-    /// A payload at or above `STREAM_BATCH_THRESHOLD` must reach the body
+    /// A payload at or above `envelope::MIN_CHAIN_SIZE` must reach the body
     /// frames by refcount, not by copy: the emitted data frame references
     /// the handler's original allocation. Small envelopes (the 5-byte
     /// header) still batch into the framing buffer.
@@ -3313,7 +3315,7 @@ mod tests {
     async fn streaming_large_payload_is_chained_not_copied() {
         use futures::StreamExt as _;
 
-        let payload = Bytes::from(vec![0x42u8; STREAM_BATCH_THRESHOLD]);
+        let payload = Bytes::from(vec![0x42u8; crate::envelope::MIN_CHAIN_SIZE]);
         let original_ptr = payload.as_ptr();
         let source = futures::stream::iter([Ok::<_, ConnectError>(payload.clone())]).boxed();
         let mut stream = std::pin::pin!(create_grpc_envelope_stream(
@@ -3346,7 +3348,7 @@ mod tests {
         assert!(stream.next().await.is_none());
     }
 
-    /// Payloads below the chaining threshold keep today's behavior: one
+    /// Payloads below the chaining threshold are emitted as one
     /// contiguous data frame containing header + payload.
     #[tokio::test]
     async fn streaming_small_payload_stays_contiguous() {
@@ -3376,7 +3378,7 @@ mod tests {
     async fn streaming_chained_frames_reassemble_to_same_wire_bytes() {
         use futures::StreamExt as _;
 
-        let large = Bytes::from(vec![0x5Au8; STREAM_BATCH_THRESHOLD + 7]);
+        let large = Bytes::from(vec![0x5Au8; crate::envelope::MIN_CHAIN_SIZE + 7]);
         let small = Bytes::from_static(b"tail");
         let items = [
             Ok::<_, ConnectError>(small.clone()),

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -943,6 +943,12 @@ struct BatchingEnvelopeStream {
     finalizer: StreamFinalizer,
     /// Finalizer frame staged for the next poll (when buf was non-empty at end).
     pending_final: Option<Frame<Bytes>>,
+    /// Large uncompressed payload staged for the next poll: emitted as its
+    /// own data frame (refcount clone) right after the header flush, instead
+    /// of being copied into `buf`. See [`EnvelopeEncoder::encode_chained`].
+    ///
+    /// [`EnvelopeEncoder::encode_chained`]: crate::envelope::EnvelopeEncoder::encode_chained
+    pending_payload: Option<Bytes>,
     /// Fused-done flag.
     done: bool,
 }
@@ -962,6 +968,7 @@ impl BatchingEnvelopeStream {
             trailers,
             finalizer,
             pending_final: None,
+            pending_payload: None,
             done: false,
         }
     }
@@ -977,10 +984,15 @@ impl Stream for BatchingEnvelopeStream {
     type Item = Result<Frame<Bytes>, Infallible>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
-        use tokio_util::codec::Encoder;
-
         if self.done {
             return Poll::Ready(None);
+        }
+
+        // Staged large payload from a prior poll — its envelope header was
+        // already flushed, so this must precede everything else (including
+        // a staged finalizer).
+        if let Some(payload) = self.pending_payload.take() {
+            return Poll::Ready(Some(Ok(Frame::data(payload))));
         }
 
         // Staged finalizer from a prior poll (buf was non-empty at stream end).
@@ -1031,22 +1043,36 @@ impl Stream for BatchingEnvelopeStream {
                 }
                 Poll::Ready(Some(Ok(data))) => {
                     let me = &mut *self;
-                    if let Err(err) = me.encoder.encode(data, &mut me.buf) {
-                        // Envelope encoding/compression failed mid-stream.
-                        // The buffer may contain prior successfully-encoded
-                        // envelopes — don't drop them.
-                        tracing::debug!(
-                            error = %err,
-                            "streaming response: envelope encoding failed"
-                        );
-                        let final_frame = self.finalizer.error(&err, &self.trailers);
-                        if self.buf.is_empty() {
-                            self.done = true;
-                            return Poll::Ready(Some(Ok(final_frame)));
-                        } else {
-                            self.pending_final = Some(final_frame);
+                    match me.encoder.encode_chained(
+                        data,
+                        &mut me.buf,
+                        crate::envelope::MIN_CHAIN_SIZE,
+                    ) {
+                        Err(err) => {
+                            // Envelope encoding/compression failed mid-stream.
+                            // The buffer may contain prior successfully-encoded
+                            // envelopes — don't drop them.
+                            tracing::debug!(
+                                error = %err,
+                                "streaming response: envelope encoding failed"
+                            );
+                            let final_frame = self.finalizer.error(&err, &self.trailers);
+                            if self.buf.is_empty() {
+                                self.done = true;
+                                return Poll::Ready(Some(Ok(final_frame)));
+                            } else {
+                                self.pending_final = Some(final_frame);
+                                return Poll::Ready(Some(Ok(self.flush_buf())));
+                            }
+                        }
+                        Ok(Some(payload)) => {
+                            // Large uncompressed payload: `buf` now ends with
+                            // its 5-byte envelope header. Flush the buffer and
+                            // stage the payload as the next frame, unmoved.
+                            self.pending_payload = Some(payload);
                             return Poll::Ready(Some(Ok(self.flush_buf())));
                         }
+                        Ok(None) => {}
                     }
                     if self.buf.len() >= STREAM_BATCH_THRESHOLD {
                         return Poll::Ready(Some(Ok(self.flush_buf())));
@@ -1287,12 +1313,18 @@ impl<D: Dispatcher> ConnectRpcService<D> {
 
 /// A lightweight body for gRPC unary responses.
 ///
-/// Yields exactly two frames: one data frame (the gRPC envelope) and one
-/// trailers frame (for gRPC) or a second data frame (for gRPC-Web trailer encoding).
+/// Yields two or three frames: one data frame carrying the gRPC envelope
+/// (or, for large chained responses, just its 5-byte header followed by a
+/// second data frame with the payload by refcount), then one trailers frame
+/// (for gRPC) or a final data frame (for gRPC-Web trailer encoding).
 /// This avoids the overhead of `Pin<Box<dyn Stream>>` + `stream::unfold` +
 /// `EnvelopeEncoder` for the common unary case.
 pub struct GrpcUnaryBody {
     data: Option<Bytes>,
+    /// Large uncompressed message payload emitted as its own data frame
+    /// after `data` (which then carries only the 5-byte envelope header),
+    /// so the payload is passed through by refcount instead of copied.
+    payload: Option<Bytes>,
     trailers: Option<GrpcUnaryTrailers>,
 }
 
@@ -1315,6 +1347,8 @@ impl Body for GrpcUnaryBody {
         let me = self.get_mut();
         if let Some(data) = me.data.take() {
             Poll::Ready(Some(Ok(Frame::data(data))))
+        } else if let Some(payload) = me.payload.take() {
+            Poll::Ready(Some(Ok(Frame::data(payload))))
         } else if let Some(trailers) = me.trailers.take() {
             match trailers {
                 GrpcUnaryTrailers::Http2(map) => Poll::Ready(Some(Ok(Frame::trailers(map)))),
@@ -1954,11 +1988,13 @@ where
         }
         let body = GrpcUnaryBody {
             data: None,
+            payload: None,
             trailers: Some(trailers),
         };
         response.body(body).unwrap_or_else(|_| {
             Response::new(GrpcUnaryBody {
                 data: None,
+                payload: None,
                 trailers: None,
             })
         })
@@ -2087,17 +2123,20 @@ where
         metadata.streaming_encoding.as_deref(),
     );
 
-    // Encode response into a gRPC envelope (5-byte header + payload)
+    // Encode response into a gRPC envelope (5-byte header + payload). Large
+    // uncompressed payloads are chained (header segment + payload by
+    // refcount) rather than copied into a contiguous buffer.
     let effective_policy = compression_policy.with_override(resp.compress);
-    let encoded_data = if let Some(encoding) = response_encoding
+    let min_chain = crate::envelope::MIN_CHAIN_SIZE;
+    let (encoded_data, chained_payload) = if let Some(encoding) = response_encoding
         && effective_policy.should_compress(resp.body.len())
     {
         match compression.compress(encoding, &resp.body) {
-            Ok(compressed) => Envelope::compressed(compressed).encode(),
-            Err(_) => Envelope::data(resp.body).encode(),
+            Ok(compressed) => Envelope::compressed(compressed).encode_parts(min_chain),
+            Err(_) => Envelope::data(resp.body).encode_parts(min_chain),
         }
     } else {
-        Envelope::data(resp.body).encode()
+        Envelope::data(resp.body).encode_parts(min_chain)
     };
 
     // Build gRPC trailers
@@ -2132,6 +2171,7 @@ where
 
     let body = GrpcUnaryBody {
         data: Some(encoded_data),
+        payload: chained_payload,
         trailers: Some(trailers),
     };
 
@@ -3264,6 +3304,169 @@ pub mod axum_integration {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A payload at or above `STREAM_BATCH_THRESHOLD` must reach the body
+    /// frames by refcount, not by copy: the emitted data frame references
+    /// the handler's original allocation. Small envelopes (the 5-byte
+    /// header) still batch into the framing buffer.
+    #[tokio::test]
+    async fn streaming_large_payload_is_chained_not_copied() {
+        use futures::StreamExt as _;
+
+        let payload = Bytes::from(vec![0x42u8; STREAM_BATCH_THRESHOLD]);
+        let original_ptr = payload.as_ptr();
+        let source = futures::stream::iter([Ok::<_, ConnectError>(payload.clone())]).boxed();
+        let mut stream = std::pin::pin!(create_grpc_envelope_stream(
+            source,
+            http::HeaderMap::new(),
+            None,
+            CompressionPolicy::disabled(),
+        ));
+
+        // Frame 1: the 5-byte envelope header (batched buffer flush).
+        let head = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(head.len(), crate::envelope::HEADER_SIZE);
+        assert_eq!(head[0], crate::envelope::flags::DATA);
+        assert_eq!(
+            u32::from_be_bytes([head[1], head[2], head[3], head[4]]) as usize,
+            payload.len()
+        );
+
+        // Frame 2: the payload, by refcount — same allocation, no copy.
+        let data = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(data.len(), payload.len());
+        assert!(
+            std::ptr::eq(data.as_ptr(), original_ptr),
+            "payload frame must reference the original allocation"
+        );
+
+        // Frame 3: gRPC trailers.
+        let trailers = stream.next().await.unwrap().unwrap();
+        assert!(trailers.is_trailers());
+        assert!(stream.next().await.is_none());
+    }
+
+    /// Payloads below the chaining threshold keep today's behavior: one
+    /// contiguous data frame containing header + payload.
+    #[tokio::test]
+    async fn streaming_small_payload_stays_contiguous() {
+        use futures::StreamExt as _;
+
+        let payload = Bytes::from_static(b"small");
+        let source = futures::stream::iter([Ok::<_, ConnectError>(payload.clone())]).boxed();
+        let mut stream = std::pin::pin!(create_grpc_envelope_stream(
+            source,
+            http::HeaderMap::new(),
+            None,
+            CompressionPolicy::disabled(),
+        ));
+
+        let frame = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(frame.len(), crate::envelope::HEADER_SIZE + payload.len());
+        assert_eq!(&frame[crate::envelope::HEADER_SIZE..], &payload[..]);
+
+        let trailers = stream.next().await.unwrap().unwrap();
+        assert!(trailers.is_trailers());
+        assert!(stream.next().await.is_none());
+    }
+
+    /// The chained split must be invisible to an envelope decoder: bytes
+    /// reassembled from the frames decode identically to the contiguous path.
+    #[tokio::test]
+    async fn streaming_chained_frames_reassemble_to_same_wire_bytes() {
+        use futures::StreamExt as _;
+
+        let large = Bytes::from(vec![0x5Au8; STREAM_BATCH_THRESHOLD + 7]);
+        let small = Bytes::from_static(b"tail");
+        let items = [
+            Ok::<_, ConnectError>(small.clone()),
+            Ok(large.clone()),
+            Ok(small.clone()),
+        ];
+        let source = futures::stream::iter(items).boxed();
+        let mut stream = std::pin::pin!(create_envelope_stream(
+            source,
+            http::HeaderMap::new(),
+            None,
+            CompressionPolicy::disabled(),
+        ));
+
+        let mut wire = bytes::BytesMut::new();
+        while let Some(frame) = stream.next().await {
+            let frame = frame.unwrap();
+            if let Ok(data) = frame.into_data() {
+                wire.extend_from_slice(&data);
+            }
+        }
+
+        // Decode all envelopes back out and compare to the source messages.
+        let mut decoded = Vec::new();
+        while let Some(env) = Envelope::decode(&mut wire).unwrap() {
+            decoded.push(env);
+        }
+        assert_eq!(decoded.len(), 4, "3 data envelopes + 1 end-stream");
+        assert_eq!(decoded[0].data, small);
+        assert_eq!(decoded[1].data, large);
+        assert_eq!(decoded[2].data, small);
+        assert!(decoded[3].is_end_stream());
+    }
+
+    /// A source error right after a chained payload must still emit the
+    /// staged payload before the error finalizer: header frame, payload
+    /// frame, then trailers.
+    #[tokio::test]
+    async fn streaming_error_after_chained_payload_preserves_order() {
+        use futures::StreamExt as _;
+
+        let large = Bytes::from(vec![0x77u8; crate::envelope::MIN_CHAIN_SIZE]);
+        let items = [
+            Ok::<_, ConnectError>(large.clone()),
+            Err(ConnectError::internal("boom")),
+        ];
+        let source = futures::stream::iter(items).boxed();
+        let mut stream = std::pin::pin!(create_grpc_envelope_stream(
+            source,
+            http::HeaderMap::new(),
+            None,
+            CompressionPolicy::disabled(),
+        ));
+
+        let head = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(head.len(), crate::envelope::HEADER_SIZE);
+        let payload = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(payload, large);
+        let trailers = stream.next().await.unwrap().unwrap();
+        let map = trailers.into_trailers().unwrap();
+        assert_eq!(map.get("grpc-status").unwrap(), "13", "internal = 13");
+        assert!(stream.next().await.is_none());
+    }
+
+    /// GrpcUnaryBody with a chained payload yields header, payload, then
+    /// trailers, in that order; the payload frame is the original
+    /// allocation.
+    #[tokio::test]
+    async fn grpc_unary_body_chained_frame_order() {
+        use http_body_util::BodyExt as _;
+
+        let payload = Bytes::from(vec![0x33u8; crate::envelope::MIN_CHAIN_SIZE]);
+        let ptr = payload.as_ptr();
+        let (head, chained) =
+            Envelope::data(payload.clone()).encode_parts(crate::envelope::MIN_CHAIN_SIZE);
+        let mut body = GrpcUnaryBody {
+            data: Some(head.clone()),
+            payload: chained,
+            trailers: Some(GrpcUnaryTrailers::Http2(http::HeaderMap::new())),
+        };
+
+        let f1 = body.frame().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(f1, head);
+        assert_eq!(f1.len(), crate::envelope::HEADER_SIZE);
+        let f2 = body.frame().await.unwrap().unwrap().into_data().unwrap();
+        assert!(std::ptr::eq(f2.as_ptr(), ptr), "payload must not be copied");
+        let f3 = body.frame().await.unwrap().unwrap();
+        assert!(f3.is_trailers());
+        assert!(body.frame().await.is_none());
+    }
 
     #[test]
     fn test_service_creation() {


### PR DESCRIPTION
## Summary

Eliminates the second payload-sized copy in the server's response framing. Today every streaming message (Connect, gRPC, and gRPC-Web) and every gRPC unary response is copied twice between the handler and the socket: once by message encoding, and once more when the envelope layer `put_slice`s the encoded message into the framing buffer. For messages dominated by one large `bytes` field, the second copy doubles encode cost — and hands hyper/h2 nothing they can't already handle without it, since h2 chains any `Buf` payload above 256 bytes and writes it to the socket with vectored I/O.

With this change, payloads of at least 16 KiB on the wire (`envelope::MIN_CHAIN_SIZE`) are emitted as their own HTTP body data frame by reference count: the 5-byte envelope header goes into the framing buffer, and the payload `Bytes` passes through unmoved. Compressed payloads chain on their post-compression size, so enabling compression never makes the copy overhead worse than leaving it off.

The wire bytes are unchanged. gRPC/Connect envelope framing has always been independent of HTTP-level frame boundaries; the only observable difference is that the envelope header may arrive in a separate HTTP/2 DATA frame (or HTTP/1.1 chunk) from its payload.

## Design notes

- `EnvelopeEncoder::encode_chained` is the single implementation of the envelope-encode policy; the `tokio_util::codec::Encoder` impl delegates to it with an infinite chain threshold, so the compression decision and the chaining decision cannot drift apart.
- `BatchingEnvelopeStream` stages the chained payload as `pending_payload`, drained ahead of any staged finalizer — order proven by `streaming_error_after_chained_payload_preserves_order`.
- `GrpcUnaryBody` gains a second data-frame slot fed by `Envelope::encode_parts`.
- The oversized-payload (`> u32::MAX`) check now runs before any buffer growth.

Measured on a dev machine with a chunk-shaped message (one dominant `bytes` field): encode+frame at 512 KiB drops from 25.3 µs to 10.6 µs (the cost of the encode copy alone); at 2 MiB from 1.24 ms to 125 µs, because the eliminated framing buffer was also a fresh multi-megabyte allocation per message.

## Testing

- 8 new unit tests: pointer identity of the chained frame, byte-identical reassembly against the contiguous path (mixed small/large streams), error-after-chained-payload frame ordering, unary three-frame ordering, compressed chaining, sub-threshold behavior unchanged.
- Full server conformance suite: 3600 passed, 0 failed.
- Driven live over a socket (Connect HTTP/1.1 streaming, gzip negotiation, gRPC unary over HTTP/2) with the response bytes parsed envelope-by-envelope.

## Scheduling

Queued for the 0.9.0 release rather than a 0.8.x patch. Client-side request framing has the same second copy; that is a separate follow-up PR.
