### PR TITLE
client: make BidiStream receive initialization cancellation-safe

### DIFF
--- a/.changes/unreleased/Fixed-20260706-203937.yaml
+++ b/.changes/unreleased/Fixed-20260706-203937.yaml
@@ -1,0 +1,8 @@
+kind: Fixed
+body: |-
+  **Initial `BidiStream::message()` cancellation no longer breaks the receive side**.
+  Dropping the first receive while it is waiting for response headers or Connect
+  error-body parsing now leaves initialization pending for the next `message()`
+  call, while real transport, deadline, and protocol failures stay terminal and
+  sticky.
+time: 2026-07-06T20:39:37.361463737-04:00

--- a/.changes/unreleased/Fixed-20260706-203937.yaml
+++ b/.changes/unreleased/Fixed-20260706-203937.yaml
@@ -4,5 +4,12 @@ body: |-
   Dropping the first receive while it is waiting for response headers or Connect
   error-body parsing now leaves initialization pending for the next `message()`
   call, while real transport, deadline, and protocol failures stay terminal and
-  sticky.
+  sticky. Dropping the `BidiStream` (or failing the call at its deadline) now
+  aborts the in-flight initialization task instead of detaching it: a stalled
+  server can no longer pin an abandoned call's resources, and dropping the
+  stream cancels the call outright rather than flushing buffered request
+  messages in the background — callers that need the request delivered must
+  drive the call via `message()` before dropping. `message()` now requires
+  `B: 'static` and the view type to be `'static`, which every transport and
+  generated view type already satisfies.
 time: 2026-07-06T20:39:37.361463737-04:00

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2989,19 +2989,22 @@ impl Body for ChannelBody {
 /// read) would buffer into the 32-deep mpsc with nobody draining it, and
 /// deadlock on the 33rd send.
 ///
-/// The response HEADERS future (what the spawned task resolves to) is still
-/// awaited lazily on the first `message()` call, so servers that wait for
-/// the first request message before sending HEADERS don't deadlock either.
+/// Response initialization is still lazy: `message()` first awaits response
+/// HEADERS, then constructs the [`ServerStream`]. Both pending operations stay
+/// in this state machine while awaited, so cancelling `message()` does not
+/// discard either the response task or a suspended construction step such as
+/// Connect error-body parsing.
 enum RecvState<B, RespView> {
     /// Request initiated in a spawned task; response HEADERS not yet
     /// received. Awaiting the handle yields the [`Response`] once hyper
     /// reads the HEADERS frame.
-    Pending(tokio::task::JoinHandle<Result<Response<B>, ConnectError>>),
+    AwaitingHeaders(tokio::task::JoinHandle<Result<Response<B>, ConnectError>>),
+    /// HEADERS received; response-side stream construction is in progress.
+    Constructing(tokio::task::JoinHandle<Result<Box<ServerStream<B, RespView>>, ConnectError>>),
     /// HEADERS received; response-side decoding delegates to [`ServerStream`].
     Ready(Box<ServerStream<B, RespView>>),
-    /// Transport error or make_server_stream error stored on self.construct_err.
-    /// Terminal state.
-    Failed,
+    /// Transport error, deadline, or make_server_stream error. Terminal state.
+    Failed(ConnectError),
 }
 
 /// A bidirectional streaming RPC in progress.
@@ -3036,33 +3039,36 @@ pub struct BidiStream<B, Req, RespView> {
     encoder: crate::envelope::EnvelopeEncoder,
     codec_format: CodecFormat,
 
-    // Receive side — state machine: Pending -> Ready or Failed
+    // Receive side — state machine: AwaitingHeaders -> Constructing -> Ready or Failed
     recv: RecvState<B, RespView>,
     /// Config snapshot for constructing ServerStream when headers arrive.
     /// Captured by value (not &) because the stream outlives call_bidi_stream.
     stream_config: StreamConfig,
-    /// Error from transport.send or make_server_stream. Terminal.
-    construct_err: Option<ConnectError>,
 
     _req: PhantomData<Req>,
 }
 
 // Manual impl: the body type inside `ServerStream` typically isn't `Debug`,
 // and the JoinHandle's inner type wouldn't format usefully anyway. Print
-// send-channel state, recv-state discriminant, and any construction error.
+// send-channel state, recv-state discriminant, and any receive error.
 impl<B, Req, RespView> std::fmt::Debug for BidiStream<B, Req, RespView> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let recv_state = match &self.recv {
-            RecvState::Pending(_) => "Pending",
+            RecvState::AwaitingHeaders(_) => "AwaitingHeaders",
+            RecvState::Constructing(_) => "Constructing",
             RecvState::Ready(_) => "Ready",
-            RecvState::Failed => "Failed",
+            RecvState::Failed(_) => "Failed",
+        };
+        let recv_error = match &self.recv {
+            RecvState::Failed(err) => Some(err),
+            _ => None,
         };
         f.debug_struct("BidiStream")
             .field("send_closed", &self.tx.is_none())
             .field("recv_state", &recv_state)
             .field("protocol", &self.stream_config.protocol)
             .field("codec_format", &self.stream_config.codec_format)
-            .field("construct_err", &self.construct_err)
+            .field("recv_error", &recv_error)
             .finish_non_exhaustive()
     }
 }
@@ -3138,6 +3144,9 @@ where
     /// The first call awaits response headers (lazily, so full-duplex
     /// servers that wait for a request before sending headers don't deadlock).
     /// Subsequent calls decode envelopes from the response body stream.
+    /// If this future is dropped while response initialization is still pending,
+    /// the initialization remains in the stream and the next `message()` call
+    /// resumes it. Actual initialization failures remain terminal and sticky.
     ///
     /// Returns `Ok(None)` only when the server finished **cleanly**; a
     /// server error carried in the termination metadata is returned as
@@ -3146,70 +3155,84 @@ where
     pub async fn message<M>(&mut self) -> Result<Option<crate::StreamMessage<M>>, ConnectError>
     where
         // Same output-parameter shape as `ServerStream::message` — see the
-        // bound comment there (#214).
-        RespView: MessageView<'static, Owned = M>,
+        // bound comment there (#214). `B` and `RespView` must also be
+        // `'static` because response-side construction is retained in a
+        // spawned task while the caller's `message()` future may be dropped.
+        B: 'static,
+        RespView: MessageView<'static, Owned = M> + 'static,
         M: HasMessageView<View<'static> = RespView>,
     {
-        // If we already failed during construction or first await, return that.
-        if let Some(ref err) = self.construct_err {
-            return Err(err.clone());
-        }
-
-        // Transition Pending -> Ready on first call.
-        if matches!(self.recv, RecvState::Pending(_)) {
-            // Take the handle out so we can await it (borrow check).
-            let RecvState::Pending(handle) = std::mem::replace(&mut self.recv, RecvState::Failed)
-            else {
-                unreachable!()
-            };
-
-            // Bound the response-HEADERS wait by the whole-call deadline.
-            // A server that never sends headers shouldn't block forever.
-            // The spawned task either resolves or is cancelled: if we hit the
-            // deadline here and drop the handle, the task detaches — but the
-            // dropped tx (on BidiStream drop) will end the body stream, which
-            // ends the request, which completes the detached task naturally.
-            let awaited = async move {
-                handle.await.map_err(|e| {
-                    ConnectError::internal(format!("transport send task panicked: {e}"))
-                })?
-            };
-            match with_deadline(self.stream_config.deadline, awaited).await {
-                Ok(response) => {
-                    let cfg = &self.stream_config;
-                    match make_server_stream(
-                        response,
-                        cfg.protocol,
-                        &cfg.compression,
-                        cfg.codec_format,
-                        cfg.max_message_size,
-                        cfg.deadline,
-                    )
+        loop {
+            match &mut self.recv {
+                RecvState::AwaitingHeaders(task) => {
+                    // Bound the response-HEADERS wait by the whole-call
+                    // deadline. The JoinHandle stays in `self.recv` while it
+                    // is pending, so cancelling this `message()` future does
+                    // not detach the task or lose its eventual response.
+                    let response = match with_deadline(self.stream_config.deadline, async {
+                        task.await.map_err(|e| {
+                            ConnectError::internal(format!("transport send task panicked: {e}"))
+                        })?
+                    })
                     .await
                     {
-                        Ok(stream) => self.recv = RecvState::Ready(Box::new(stream)),
+                        Ok(response) => response,
                         Err(e) => {
-                            self.construct_err = Some(e.clone());
+                            self.recv = RecvState::Failed(e.clone());
+                            return Err(e);
+                        }
+                    };
+
+                    let protocol = self.stream_config.protocol;
+                    let codec_format = self.stream_config.codec_format;
+                    let compression = self.stream_config.compression.clone();
+                    let max_message_size = self.stream_config.max_message_size;
+                    let deadline = self.stream_config.deadline;
+
+                    let construct_task = tokio::spawn(async move {
+                        // `make_server_stream` can await while collecting a
+                        // non-200 Connect error body, before a `ServerStream`
+                        // exists to enforce the call deadline.
+                        let stream = with_deadline(
+                            deadline,
+                            make_server_stream(
+                                response,
+                                protocol,
+                                &compression,
+                                codec_format,
+                                max_message_size,
+                                deadline,
+                            ),
+                        )
+                        .await?;
+
+                        Ok(Box::new(stream))
+                    });
+
+                    self.recv = RecvState::Constructing(construct_task);
+                }
+                RecvState::Constructing(task) => {
+                    // The construction task stays in `self.recv` while it is
+                    // pending, so cancellation during Connect error-body
+                    // collection can be resumed by the next `message()` call.
+                    let result = match task.await {
+                        Ok(result) => result,
+                        Err(e) => Err(ConnectError::internal(format!(
+                            "response stream construction task panicked: {e}"
+                        ))),
+                    };
+
+                    match result {
+                        Ok(stream) => self.recv = RecvState::Ready(stream),
+                        Err(e) => {
+                            self.recv = RecvState::Failed(e.clone());
                             return Err(e);
                         }
                     }
                 }
-                Err(e) => {
-                    self.construct_err = Some(e.clone());
-                    return Err(e);
-                }
+                RecvState::Ready(stream) => return stream.message().await,
+                RecvState::Failed(e) => return Err(e.clone()),
             }
-        }
-
-        match &mut self.recv {
-            RecvState::Ready(stream) => stream.message().await,
-            RecvState::Failed => {
-                // construct_err is set above; checked at top of fn.
-                // This branch is only reachable if recv is Failed but
-                // construct_err was cleared (which we never do).
-                Err(ConnectError::internal("stream in failed state"))
-            }
-            RecvState::Pending(_) => unreachable!("transitioned above"),
         }
     }
 
@@ -3243,7 +3266,8 @@ where
     pub fn error(&self) -> Option<&ConnectError> {
         match &self.recv {
             RecvState::Ready(s) => s.error(),
-            _ => self.construct_err.as_ref(),
+            RecvState::Failed(e) => Some(e),
+            _ => None,
         }
     }
 }
@@ -3330,7 +3354,7 @@ where
     // this avoids.
     //
     // Uses tokio::spawn directly (not spawn_detached) because
-    // RecvState::Pending needs JoinHandle<Result<...>>. If wasm32+client
+    // RecvState::AwaitingHeaders needs JoinHandle<Result<...>>. If wasm32+client
     // becomes supported, factor this into a spawn_with_result helper that
     // bridges via oneshot on wasm.
     let response_fut = transport.send(http_request);
@@ -3344,7 +3368,7 @@ where
         tx: Some(tx),
         encoder,
         codec_format: config.codec_format,
-        recv: RecvState::Pending(response_task),
+        recv: RecvState::AwaitingHeaders(response_task),
         stream_config: StreamConfig {
             protocol: config.protocol,
             codec_format: config.codec_format,
@@ -3352,7 +3376,6 @@ where
             max_message_size: options.max_message_size,
             deadline,
         },
-        construct_err: None,
         _req: PhantomData,
     })
 }
@@ -4380,6 +4403,312 @@ mod tests {
         // Transports — manual impls that print mode/connection state.
         #[cfg(feature = "client")]
         assert_debug::<HttpClient>();
+    }
+
+    #[test]
+    fn bidi_stream_auto_traits() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        fn assert_unpin<T: Unpin>() {}
+
+        type TestBidi = BidiStream<http_body_util::Empty<Bytes>, (), ()>;
+
+        assert_send::<TestBidi>();
+        assert_sync::<TestBidi>();
+        assert_unpin::<TestBidi>();
+    }
+
+    fn connect_success_body(message: &str) -> Bytes {
+        use buffa::Message;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut body = BytesMut::new();
+        body.extend_from_slice(
+            &Envelope::data(StringValue::from(message).encode_to_bytes()).encode(),
+        );
+        body.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"{}")).encode());
+        body.freeze()
+    }
+
+    fn connect_response<B>(status: http::StatusCode, body: B) -> Response<B> {
+        Response::builder().status(status).body(body).unwrap()
+    }
+
+    fn bidi_stream_with_response_task<B>(
+        response_task: tokio::task::JoinHandle<Result<Response<B>, ConnectError>>,
+        deadline: Option<std::time::Instant>,
+    ) -> BidiStream<
+        B,
+        buffa_types::google::protobuf::StringValue,
+        buffa_types::google::protobuf::__buffa::view::StringValueView<'static>,
+    > {
+        BidiStream {
+            tx: None,
+            encoder: crate::envelope::EnvelopeEncoder::uncompressed(),
+            codec_format: CodecFormat::Proto,
+            recv: RecvState::AwaitingHeaders(response_task),
+            stream_config: StreamConfig {
+                protocol: Protocol::Connect,
+                codec_format: CodecFormat::Proto,
+                compression: CompressionRegistry::new(),
+                max_message_size: Some(1024),
+                deadline,
+            },
+            _req: PhantomData,
+        }
+    }
+
+    struct GatedBody {
+        shared: std::sync::Arc<std::sync::Mutex<GatedBodyState>>,
+    }
+
+    struct GatedBodyRelease {
+        shared: std::sync::Arc<std::sync::Mutex<GatedBodyState>>,
+    }
+
+    struct GatedBodyState {
+        first_poll: Option<tokio::sync::oneshot::Sender<()>>,
+        released: Option<Bytes>,
+        done: bool,
+        waker: Option<std::task::Waker>,
+    }
+
+    impl GatedBody {
+        fn new() -> (Self, tokio::sync::oneshot::Receiver<()>, GatedBodyRelease) {
+            let (first_poll_tx, first_poll_rx) = tokio::sync::oneshot::channel();
+            let shared = std::sync::Arc::new(std::sync::Mutex::new(GatedBodyState {
+                first_poll: Some(first_poll_tx),
+                released: None,
+                done: false,
+                waker: None,
+            }));
+
+            (
+                Self {
+                    shared: shared.clone(),
+                },
+                first_poll_rx,
+                GatedBodyRelease { shared },
+            )
+        }
+    }
+
+    impl GatedBodyRelease {
+        fn release(self, bytes: Bytes) {
+            let mut state = self.shared.lock().unwrap();
+            state.released = Some(bytes);
+            if let Some(waker) = state.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+
+    impl Body for GatedBody {
+        type Data = Bytes;
+        type Error = ConnectError;
+
+        fn poll_frame(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Result<http_body::Frame<Bytes>, ConnectError>>> {
+            let mut state = self.shared.lock().unwrap();
+            if let Some(first_poll) = state.first_poll.take() {
+                let _ = first_poll.send(());
+            }
+
+            if state.done {
+                return std::task::Poll::Ready(None);
+            }
+
+            if let Some(bytes) = state.released.take() {
+                state.done = true;
+                return std::task::Poll::Ready(Some(Ok(http_body::Frame::data(bytes))));
+            }
+
+            state.waker = Some(cx.waker().clone());
+            std::task::Poll::Pending
+        }
+    }
+
+    #[tokio::test]
+    async fn bidi_message_cancel_before_headers_resumes() {
+        use buffa_types::google::protobuf::StringValue;
+
+        let (response_tx, response_rx) =
+            tokio::sync::oneshot::channel::<Result<Response<Full<Bytes>>, ConnectError>>();
+        let response_task = tokio::spawn(async move {
+            response_rx
+                .await
+                .expect("test response sender should stay alive")
+        });
+        let mut stream = bidi_stream_with_response_task(response_task, None);
+
+        let mut first_message = Box::pin(stream.message::<StringValue>());
+        assert!(matches!(
+            futures::poll!(&mut first_message),
+            std::task::Poll::Pending
+        ));
+        drop(first_message);
+
+        assert!(stream.error().is_none());
+        assert!(stream.headers().is_none());
+
+        response_tx
+            .send(Ok(connect_response(
+                http::StatusCode::OK,
+                Full::new(connect_success_body("hello")),
+            )))
+            .expect("detached response task should still receive headers");
+
+        let msg = stream
+            .message::<StringValue>()
+            .await
+            .expect("cancelled header wait should resume")
+            .expect("stream should yield first response message");
+        assert_eq!(msg.view().value, "hello");
+        assert!(stream.message::<StringValue>().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn bidi_message_cancel_during_connect_error_body_resumes() {
+        use buffa_types::google::protobuf::StringValue;
+
+        let (body, body_polled, body_release) = GatedBody::new();
+        let (response_ready_tx, response_ready_rx) = tokio::sync::oneshot::channel();
+        let response_task = tokio::spawn(async move {
+            let response = connect_response(http::StatusCode::BAD_REQUEST, body);
+            let _ = response_ready_tx.send(());
+            Ok(response)
+        });
+        response_ready_rx
+            .await
+            .expect("response task should have prepared headers");
+        let mut stream = bidi_stream_with_response_task(response_task, None);
+
+        let mut first_message = Box::pin(stream.message::<StringValue>());
+        assert!(matches!(
+            futures::poll!(&mut first_message),
+            std::task::Poll::Pending
+        ));
+        body_polled
+            .await
+            .expect("Connect error body should be polled");
+        drop(first_message);
+
+        assert!(stream.error().is_none());
+        assert!(stream.headers().is_none());
+
+        body_release.release(Bytes::from_static(
+            br#"{"code":"invalid_argument","message":"bad request"}"#,
+        ));
+
+        let err = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("server Connect error should be preserved");
+        assert_eq!(err.code, ErrorCode::InvalidArgument);
+        assert_eq!(err.message.as_deref(), Some("bad request"));
+        let again = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("initialization error should be sticky");
+        assert_eq!(again.code, ErrorCode::InvalidArgument);
+        assert_eq!(stream.error().unwrap().code, ErrorCode::InvalidArgument);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn bidi_message_deadline_before_headers_stays_sticky() {
+        use buffa_types::google::protobuf::StringValue;
+
+        let (_response_tx, response_rx) =
+            tokio::sync::oneshot::channel::<Result<Response<Full<Bytes>>, ConnectError>>();
+        let response_task = tokio::spawn(async move {
+            response_rx
+                .await
+                .expect("test intentionally keeps response pending")
+        });
+        let deadline = std::time::Instant::now() + Duration::from_millis(100);
+        let mut stream = bidi_stream_with_response_task(response_task, Some(deadline));
+
+        let err = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("deadline should fail receive initialization");
+        assert_eq!(err.code, ErrorCode::DeadlineExceeded);
+
+        let again = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("deadline failure should be sticky");
+        assert_eq!(again.code, ErrorCode::DeadlineExceeded);
+        assert_eq!(stream.error().unwrap().code, ErrorCode::DeadlineExceeded);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn bidi_message_deadline_during_connect_error_body_stays_sticky() {
+        use buffa_types::google::protobuf::StringValue;
+
+        let (body, body_polled, _body_release) = GatedBody::new();
+        let (response_ready_tx, response_ready_rx) = tokio::sync::oneshot::channel();
+        let response_task = tokio::spawn(async move {
+            let response = connect_response(http::StatusCode::BAD_REQUEST, body);
+            let _ = response_ready_tx.send(());
+            Ok(response)
+        });
+        response_ready_rx
+            .await
+            .expect("response task should have prepared headers");
+
+        let deadline = std::time::Instant::now() + Duration::from_millis(100);
+        let mut stream = bidi_stream_with_response_task(response_task, Some(deadline));
+
+        let mut first_message = Box::pin(stream.message::<StringValue>());
+        assert!(matches!(
+            futures::poll!(&mut first_message),
+            std::task::Poll::Pending
+        ));
+        body_polled
+            .await
+            .expect("Connect error body should be polled");
+
+        // Keep `_body_release` alive and unused so the gated body remains
+        // pending until the call deadline fires.
+        let err = first_message
+            .await
+            .expect_err("deadline should fail response construction");
+        assert_eq!(err.code, ErrorCode::DeadlineExceeded);
+
+        let again = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("construction deadline should be sticky");
+        assert_eq!(again.code, ErrorCode::DeadlineExceeded);
+        assert_eq!(stream.error().unwrap().code, ErrorCode::DeadlineExceeded);
+    }
+
+    #[tokio::test]
+    async fn bidi_message_transport_failure_is_sticky() {
+        use buffa_types::google::protobuf::StringValue;
+
+        let response_task = tokio::spawn(async {
+            Err::<Response<Full<Bytes>>, _>(ConnectError::unavailable("request failed: boom"))
+        });
+        let mut stream = bidi_stream_with_response_task(response_task, None);
+
+        let err = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("transport failure should fail receive initialization");
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.message.as_deref(), Some("request failed: boom"));
+
+        let again = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("transport failure should be sticky");
+        assert_eq!(again.code, ErrorCode::Unavailable);
+        assert_eq!(again.message.as_deref(), Some("request failed: boom"));
+        assert_eq!(stream.error().unwrap().code, ErrorCode::Unavailable);
     }
 
     #[tokio::test]

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2993,7 +2993,8 @@ impl Body for ChannelBody {
 /// HEADERS, then constructs the [`ServerStream`]. Both pending operations stay
 /// in this state machine while awaited, so cancelling `message()` does not
 /// discard either the response task or a suspended construction step such as
-/// Connect error-body parsing.
+/// Connect error-body parsing. Dropping the whole [`BidiStream`] (or failing
+/// the call at its deadline) aborts the in-flight task instead.
 enum RecvState<B, RespView> {
     /// Request initiated in a spawned task; response HEADERS not yet
     /// received. Awaiting the handle yields the [`Response`] once hyper
@@ -3019,6 +3020,16 @@ enum RecvState<B, RespView> {
 /// HTTP/2. This type does not distinguish — it's the caller's responsibility to
 /// respect the protocol in use. On HTTP/1.1, calling `message()` before
 /// `close_send()` will block until the request body is complete.
+///
+/// # Cancellation
+///
+/// Dropping the `BidiStream` cancels the call: any in-flight initialization
+/// task is aborted, which resets the underlying transport stream. Request
+/// messages accepted by [`send()`](Self::send) but not yet transmitted may
+/// never reach the server — a caller that needs the request delivered must
+/// drive the call to completion via [`message()`](Self::message) before
+/// dropping. Cancelling an individual `message()` future is safe and
+/// resumable — see [`message()`](Self::message).
 ///
 /// # Example
 ///
@@ -3053,15 +3064,11 @@ pub struct BidiStream<B, Req, RespView> {
 // send-channel state, recv-state discriminant, and any receive error.
 impl<B, Req, RespView> std::fmt::Debug for BidiStream<B, Req, RespView> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let recv_state = match &self.recv {
-            RecvState::AwaitingHeaders(_) => "AwaitingHeaders",
-            RecvState::Constructing(_) => "Constructing",
-            RecvState::Ready(_) => "Ready",
-            RecvState::Failed(_) => "Failed",
-        };
-        let recv_error = match &self.recv {
-            RecvState::Failed(err) => Some(err),
-            _ => None,
+        let (recv_state, recv_error) = match &self.recv {
+            RecvState::AwaitingHeaders(_) => ("AwaitingHeaders", None),
+            RecvState::Constructing(_) => ("Constructing", None),
+            RecvState::Ready(_) => ("Ready", None),
+            RecvState::Failed(err) => ("Failed", Some(err)),
         };
         f.debug_struct("BidiStream")
             .field("send_closed", &self.tx.is_none())
@@ -3070,6 +3077,22 @@ impl<B, Req, RespView> std::fmt::Debug for BidiStream<B, Req, RespView> {
             .field("codec_format", &self.stream_config.codec_format)
             .field("recv_error", &recv_error)
             .finish_non_exhaustive()
+    }
+}
+
+// Dropping the stream aborts any in-flight initialization task. Without
+// this, a task left in `AwaitingHeaders` or `Constructing` would detach on
+// drop and — absent a call deadline — could be pinned indefinitely by a
+// server that stalls response HEADERS or a Connect error body without ever
+// ending the stream. Abandoning the stream abandons the RPC, so nothing can
+// consume the task's result anyway.
+impl<B, Req, RespView> Drop for BidiStream<B, Req, RespView> {
+    fn drop(&mut self) {
+        match &self.recv {
+            RecvState::AwaitingHeaders(task) => task.abort(),
+            RecvState::Constructing(task) => task.abort(),
+            RecvState::Ready(_) | RecvState::Failed(_) => {}
+        }
     }
 }
 
@@ -3170,14 +3193,23 @@ where
                     // is pending, so cancelling this `message()` future does
                     // not detach the task or lose its eventual response.
                     let response = match with_deadline(self.stream_config.deadline, async {
-                        task.await.map_err(|e| {
-                            ConnectError::internal(format!("transport send task panicked: {e}"))
+                        // Reborrow rather than move so `task` stays usable
+                        // for the abort in the failure arm below.
+                        (&mut *task).await.map_err(|e| {
+                            // JoinError's Display already distinguishes
+                            // panic from cancellation.
+                            ConnectError::internal(format!("transport send task failed: {e}"))
                         })?
                     })
                     .await
                     {
                         Ok(response) => response,
                         Err(e) => {
+                            // Deadline (or join) failure is terminal: abort
+                            // the response task rather than detaching it —
+                            // the RPC is dead, so nothing will ever consume
+                            // its result. No-op if the task already finished.
+                            task.abort();
                             self.recv = RecvState::Failed(e.clone());
                             return Err(e);
                         }
@@ -3218,7 +3250,7 @@ where
                     let result = match task.await {
                         Ok(result) => result,
                         Err(e) => Err(ConnectError::internal(format!(
-                            "response stream construction task panicked: {e}"
+                            "response stream construction task failed: {e}"
                         ))),
                     };
 
@@ -3237,7 +3269,8 @@ where
     }
 
     /// Response headers. `None` until the first [`message()`](Self::message)
-    /// call resolves them (i.e. until the response HEADERS frame arrives).
+    /// call completes response initialization (a cancelled first `message()`
+    /// can leave this `None` even after the HEADERS frame arrived).
     #[must_use]
     pub fn headers(&self) -> Option<&http::HeaderMap> {
         match &self.recv {
@@ -3261,7 +3294,10 @@ where
     /// decode/transport/deadline failure. [`message()`](Self::message)
     /// already returns this same error, so most callers never need this
     /// accessor; it exists for post-hoc inspection alongside
-    /// [`trailers()`](Self::trailers).
+    /// [`trailers()`](Self::trailers). Returns `None` while response
+    /// initialization is still in progress — including after a cancelled
+    /// first `message()` call whose retained initialization has since
+    /// failed; call `message()` again to surface that error.
     #[must_use]
     pub fn error(&self) -> Option<&ConnectError> {
         match &self.recv {
@@ -3354,9 +3390,10 @@ where
     // this avoids.
     //
     // Uses tokio::spawn directly (not spawn_detached) because
-    // RecvState::AwaitingHeaders needs JoinHandle<Result<...>>. If wasm32+client
-    // becomes supported, factor this into a spawn_with_result helper that
-    // bridges via oneshot on wasm.
+    // RecvState::AwaitingHeaders needs JoinHandle<Result<...>>. There is a
+    // second such site: `message()` spawns the RecvState::Constructing task.
+    // If wasm32+client becomes supported, factor both into a
+    // spawn_with_result helper that bridges via oneshot on wasm.
     let response_fut = transport.send(http_request);
     let response_task = tokio::spawn(async move {
         response_fut
@@ -4709,6 +4746,92 @@ mod tests {
         assert_eq!(again.code, ErrorCode::Unavailable);
         assert_eq!(again.message.as_deref(), Some("request failed: boom"));
         assert_eq!(stream.error().unwrap().code, ErrorCode::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn bidi_drop_aborts_headers_task() {
+        let (guard_tx, guard_rx) = tokio::sync::oneshot::channel::<()>();
+        let (_never_tx, never_rx) =
+            tokio::sync::oneshot::channel::<Result<Response<Full<Bytes>>, ConnectError>>();
+        let response_task = tokio::spawn(async move {
+            let _guard = guard_tx;
+            never_rx.await.expect("test never resolves the response")
+        });
+        let stream = bidi_stream_with_response_task(response_task, None);
+        drop(stream);
+
+        // The abort drops the task and with it `_guard`, erroring the
+        // receiver. Without the abort the task stays parked and this times out.
+        tokio::time::timeout(Duration::from_secs(5), guard_rx)
+            .await
+            .expect("dropped BidiStream should abort the headers task")
+            .expect_err("guard sender should be dropped by the abort");
+    }
+
+    #[tokio::test]
+    async fn bidi_drop_aborts_pending_construction() {
+        use buffa_types::google::protobuf::StringValue;
+
+        let (body, body_polled, body_release) = GatedBody::new();
+        let (response_ready_tx, response_ready_rx) = tokio::sync::oneshot::channel();
+        let response_task = tokio::spawn(async move {
+            let response = connect_response(http::StatusCode::BAD_REQUEST, body);
+            let _ = response_ready_tx.send(());
+            Ok(response)
+        });
+        response_ready_rx
+            .await
+            .expect("response task should have prepared headers");
+        let mut stream = bidi_stream_with_response_task(response_task, None);
+
+        let mut first_message = Box::pin(stream.message::<StringValue>());
+        assert!(matches!(
+            futures::poll!(&mut first_message),
+            std::task::Poll::Pending
+        ));
+        body_polled
+            .await
+            .expect("Connect error body should be polled");
+        drop(first_message);
+        drop(stream);
+
+        // Aborting the construction task drops the gated response body; the
+        // release handle then holds the only reference to the shared state.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while std::sync::Arc::strong_count(&body_release.shared) > 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped BidiStream should abort construction and drop the body");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn bidi_deadline_aborts_headers_task() {
+        use buffa_types::google::protobuf::StringValue;
+
+        let (guard_tx, guard_rx) = tokio::sync::oneshot::channel::<()>();
+        let (_never_tx, never_rx) =
+            tokio::sync::oneshot::channel::<Result<Response<Full<Bytes>>, ConnectError>>();
+        let response_task = tokio::spawn(async move {
+            let _guard = guard_tx;
+            never_rx.await.expect("test never resolves the response")
+        });
+        let deadline = std::time::Instant::now() + Duration::from_millis(100);
+        let mut stream = bidi_stream_with_response_task(response_task, Some(deadline));
+
+        let err = stream
+            .message::<StringValue>()
+            .await
+            .expect_err("deadline should fail receive initialization");
+        assert_eq!(err.code, ErrorCode::DeadlineExceeded);
+
+        // Failing the call at the deadline aborts (not detaches) the headers
+        // task, dropping `_guard`.
+        tokio::time::timeout(Duration::from_secs(5), guard_rx)
+            .await
+            .expect("deadline failure should abort the headers task")
+            .expect_err("guard sender should be dropped by the abort");
     }
 
     #[tokio::test]

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -887,7 +887,7 @@ mod tests {
     /// Regression test for the half-duplex deadlock on `SharedHttp2Connection`.
     ///
     /// Before the fix, `call_bidi_stream` stored the transport's `send()`
-    /// future unpolled in `RecvState::Pending`, so the HTTP request never
+    /// future unpolled in the receive state machine, so the HTTP request never
     /// initiated until the first `message()` call. `BidiStream::send()`
     /// would buffer into the 32-deep mpsc with nobody draining it, and the
     /// 33rd send would hang forever. After the fix, the send future is


### PR DESCRIPTION
## What this does

Cancelling the initial `BidiStream::message()` could leave `RecvState` failed without a real error while response initialization was still pending. Later reads returned `internal("stream in failed state")` even when the server completed normally.

This is the `BidiStream::message()` cancellation-safety follow-up called out in connectrpc/connect-rust#159.

**Fix:** keep response initialization in `RecvState` while awaiting response headers and `ServerStream` construction. Dropping the `message()` future leaves the active stage resumable; real transport, deadline, and protocol failures become sticky `Failed(ConnectError)` states.

## Verification

| Check | Result |
| --- | --- |
| initialization cancellation | before headers and during Connect error-body parsing: unpatched `stream in failed state`, patched resumes or returns the server error |
| sticky failures | deadline before headers, deadline during construction, and transport failure stay sticky |
| preservation coverage | auto traits and half-duplex send-before-read behavior preserved |
| local package gates | `connectrpc` all-features, no-default-features, clippy, fmt, docs, and workspace check clean |

## Review map

- `RecvState`: replace `Pending` and `Failed` + `construct_err` with `AwaitingHeaders`, `Constructing`, `Ready`, and `Failed(ConnectError)`. Pending initialization now stays in the state while awaited, and terminal initialization failures carry their actual error.
- `BidiStream::message`: poll retained header and construction handles in place under the call deadline, then transition only after completion to `Ready` or `Failed(error)`.
- `call_bidi_stream`: still spawns `transport.send(...)` immediately, preserving half-duplex send-before-read behavior.
- `error()` / `Debug`: read terminal initialization failures from `RecvState::Failed`.