### PR TITLE
docs: BSR remote plugin is now published

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ship Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows
 (`.sig` + `.pem`), and a GitHub-native build provenance attestation.
 
 ```sh
-VERSION=v0.8.0
+VERSION=v0.8.1
 PLATFORM=linux-x86_64        # or darwin-aarch64, etc.
 BASE=https://github.com/connectrpc/connect-rust/releases/download/${VERSION}
 BIN=protoc-gen-connect-rust-${VERSION}-${PLATFORM}
@@ -115,9 +115,13 @@ install -m 0755 "${BIN}" /usr/local/bin/protoc-gen-connect-rust
 cargo install --locked connectrpc-codegen
 ```
 
-**3. Buf Schema Registry remote plugin (planned).** Once accepted upstream
-the plugin will be runnable as `remote: buf.build/connectrpc/connect-rust`
-in `buf.gen.yaml`, with no local install step.
+**3. Buf Schema Registry remote plugin.** The plugin is published on the
+Buf Schema Registry as
+[`buf.build/connectrpc/rust`](https://buf.build/connectrpc/rust), with
+versions tracking connect-rust releases. No local install of
+`protoc-gen-connect-rust` is needed: replace the
+`local: protoc-gen-connect-rust` entry below with
+`remote: buf.build/connectrpc/rust:v0.8.0`.
 
 ```yaml
 # buf.gen.yaml


### PR DESCRIPTION
The `protoc-gen-connect-rust` remote plugin is now live on the Buf Schema Registry as [`buf.build/connectrpc/rust`](https://buf.build/connectrpc/rust), with versions tracking connect-rust releases (currently `v0.8.0`).

This updates the README's plugin installation section:

- Option 3 no longer describes the BSR remote plugin as "(planned)" and now points at the published plugin name, showing the `remote: buf.build/connectrpc/rust:v0.8.0` form as a drop-in replacement for the `local:` entry in the adjacent `buf.gen.yaml` example.
- The binary-download example's `VERSION` is bumped from `v0.8.0` to the current `v0.8.1` GitHub release. (The BSR plugin's latest curated version is `v0.8.0`, so the remote example keeps that pin.)

Docs-only change; no code or generated output affected.