### PR TITLE
build: carry proto comments into generated docs via --include_source_info

### DIFF
--- a/.changes/unreleased/Fixed-20260708-203246.yaml
+++ b/.changes/unreleased/Fixed-20260708-203246.yaml
@@ -1,0 +1,12 @@
+kind: Fixed
+body: |-
+  `connectrpc-build` now passes `--include_source_info` to `protoc`, so proto
+  comments are carried into the generated Rust documentation ([#222]). Users of
+  `Config::descriptor_set` must add `--include_source_info` to their own
+  `protoc` invocation to get the same benefit; `buf`-built sets already
+  include source info. The set written by `Config::emit_descriptor_set` now
+  has `SourceCodeInfo` stripped for the protoc and buf sources — reflection
+  does not need it, and stripping keeps embedded descriptor bytes lean and
+  proto comments out of shipped binaries (precompiled sets are still written
+  through unchanged).
+time: 2026-07-08T20:32:46.262831531-07:00

--- a/.changes/unreleased/Fixed-20260708-203246.yaml
+++ b/.changes/unreleased/Fixed-20260708-203246.yaml
@@ -8,5 +8,14 @@ body: |-
   has `SourceCodeInfo` stripped for the protoc and buf sources — reflection
   does not need it, and stripping keeps embedded descriptor bytes lean and
   proto comments out of shipped binaries (precompiled sets are still written
-  through unchanged).
+  through unchanged). Service and method comments are now sanitized for
+  rustdoc the same way buffa sanitizes message and field comments: markdown
+  and HTML metacharacters are escaped, bare URLs are autolinked, indented
+  blocks and code fences without a language annotation are rendered as
+  text, and unterminated fences are closed, so arbitrary proto comments
+  cannot break a consumer's `cargo doc` or be picked up as doctests.
+  Paragraph breaks and continuation-line indentation in service and method
+  comments are also preserved instead of being flattened.
+
+  [#222]: https://github.com/connectrpc/connect-rust/issues/222
 time: 2026-07-08T20:32:46.262831531-07:00

--- a/.changes/unreleased/Fixed-20260708-203246.yaml
+++ b/.changes/unreleased/Fixed-20260708-203246.yaml
@@ -11,9 +11,13 @@ body: |-
   through unchanged). Service and method comments are now sanitized for
   rustdoc the same way buffa sanitizes message and field comments: markdown
   and HTML metacharacters are escaped, bare URLs are autolinked, indented
-  blocks and code fences without a language annotation are rendered as
-  text, and unterminated fences are closed, so arbitrary proto comments
-  cannot break a consumer's `cargo doc` or be picked up as doctests.
+  blocks are rendered as text, and unterminated fences are closed, so
+  arbitrary proto comments cannot break a consumer's `cargo doc`. Code
+  fences in proto comments are also made inert — an unannotated fence
+  becomes `text` and any other gains `ignore` (keeping its language, so a
+  `rust` fence is still syntax-highlighted) — because rustdoc would
+  otherwise compile a fence's contents as a doctest in the consuming crate,
+  where a proto comment's example has no imports and names proto types.
   Paragraph breaks and continuation-line indentation in service and method
   comments are also preserved instead of being flattened.
 

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -38,6 +38,7 @@ pub const BLOAT_ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec:
 /// repeated strings, a string map, two singular sub-messages, and a
 /// repeated sub-message — the field-shape mix where view→view encode
 /// (zero string allocations) is expected to win biggest.
+///
 /// Target encoded size: ~2-3 KB.
 ///
 /// # Implementing handlers

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -285,6 +285,7 @@ pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC: ::connectrpc::Spec = ::conn
 /// The service implemented by conformance test servers. This is implemented by
 /// the reference servers, used to test clients, and is expected to be implemented
 /// by test servers, since this is the service used by reference clients.
+///
 /// Test servers must implement the service as described.
 ///
 /// # Implementing handlers
@@ -338,12 +339,15 @@ pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC: ::connectrpc::Spec = ::conn
 pub trait ConformanceService: Send + Sync + 'static {
     /// A unary operation. The request indicates the response headers and trailers
     /// and also indicates either a response message or an error to send back.
+    ///
     /// Response message data is specified as bytes. The service should echo back
     /// request properties in the ConformancePayload and then include the message
     /// data in the data field.
+    ///
     /// If the response_delay_ms duration is specified, the server should wait the
     /// given duration after reading the request before sending the corresponding
     /// response.
+    ///
     /// Servers should allow the response definition to be unset in the request and
     /// if it is, set no response headers or trailers and return no response data.
     /// The returned payload should only contain the request info.
@@ -373,13 +377,16 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// response messages, trailers, and an optional error to send back. The
     /// response data should be sent in the order indicated, and the server should
     /// wait between sending response messages as indicated.
+    ///
     /// Response message data is specified as bytes. The service should echo back
     /// request properties in the first ConformancePayload, and then include the
     /// message data in the data field. Subsequent messages after the first one
     /// should contain only the data field.
+    ///
     /// Servers should immediately send response headers on the stream before sleeping
     /// for any specified response delay and/or sending the first message so that
     /// clients can be unblocked reading response headers.
+    ///
     /// If a response definition is not specified OR is specified, but response data
     /// is empty, the server should skip sending anything on the stream. When there
     /// are no responses to send, servers should throw an error if one is provided
@@ -411,14 +418,18 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// A client-streaming operation. The first request indicates the response
     /// headers and trailers and also indicates either a response message or an
     /// error to send back.
+    ///
     /// Response message data is specified as bytes. The service should echo back
     /// request properties, including all request messages in the order they were
     /// received, in the ConformancePayload and then include the message data in
     /// the data field.
+    ///
     /// If the input stream is empty, the server's response will include no data,
     /// only the request properties (headers, timeout).
+    ///
     /// Servers should only read the response definition from the first message in
     /// the stream and should ignore any definition set in subsequent messages.
+    ///
     /// Servers should allow the response definition to be unset in the request and
     /// if it is, set no response headers or trailers and return no response data.
     /// The returned payload should only contain the request info.
@@ -446,38 +457,49 @@ pub trait ConformanceService: Send + Sync + 'static {
     /// headers, response messages, trailers, and an optional error to send back.
     /// The response data should be sent in the order indicated, and the server
     /// should wait between sending response messages as indicated.
+    ///
     /// Response message data is specified as bytes and should be included in the
     /// data field of the ConformancePayload in each response.
+    ///
     /// Servers should send responses indicated according to the rules of half duplex
     /// vs. full duplex streams. Once all responses are sent, the server should either
     /// return an error if specified or close the stream without error.
+    ///
     /// Servers should immediately send response headers on the stream before sleeping
     /// for any specified response delay and/or sending the first message so that
     /// clients can be unblocked reading response headers.
+    ///
     /// If a response definition is not specified OR is specified, but response data
     /// is empty, the server should skip sending anything on the stream. Stream
     /// headers and trailers should always be set on the stream if provided
     /// regardless of whether a response is sent or an error is thrown.
+    ///
     /// If the full_duplex field is true:
     /// - the handler should read one request and then send back one response, and
-    /// then alternate, reading another request and then sending back another response, etc.
+    ///   then alternate, reading another request and then sending back another response, etc.
+    ///
     /// - if the server receives a request and has no responses to send, it
-    /// should throw the error specified in the request.
+    ///   should throw the error specified in the request.
+    ///
     /// - the service should echo back all request properties in the first response
-    /// including the last received request. Subsequent responses should only
-    /// echo back the last received request.
+    ///   including the last received request. Subsequent responses should only
+    ///   echo back the last received request.
+    ///
     /// - if the response_delay_ms duration is specified, the server should wait the given
-    /// duration after reading the request before sending the corresponding
-    /// response.
+    ///   duration after reading the request before sending the corresponding
+    ///   response.
+    ///
     /// If the full_duplex field is false:
     /// - the handler should read all requests until the client is done sending.
-    /// Once all requests are read, the server should then send back any responses
-    /// specified in the response definition.
+    ///   Once all requests are read, the server should then send back any responses
+    ///   specified in the response definition.
+    ///
     /// - the server should echo back all request properties, including all request
-    /// messages in the order they were received, in the first response. Subsequent
-    /// responses should only include the message data in the data field.
+    ///   messages in the order they were received, in the first response. Subsequent
+    ///   responses should only include the message data in the data field.
+    ///
     /// - if the response_delay_ms duration is specified, the server should wait that
-    /// long in between sending each response message.
+    ///   long in between sending each response message.
     ///
     /// Each `requests` item is a [`StreamMessage`](::connectrpc::StreamMessage):
     /// it owns its buffer, is `Send + 'static`, and exposes zero-copy

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -4,7 +4,11 @@
 //! build time. It shells out to `protoc` (or `buf`, or reads a precompiled
 //! `FileDescriptorSet`) to obtain descriptors, then runs
 //! [`connectrpc_codegen`] to emit buffa message types plus ConnectRPC
-//! service traits and clients into `$OUT_DIR`.
+//! service traits and clients into `$OUT_DIR`. Comments in the `.proto`
+//! source are carried into the generated Rust as doc comments, as long as
+//! the descriptors carry source info — the protoc and buf sources always
+//! do, but a precompiled set must be built with it (see
+//! [`Config::descriptor_set`]).
 //!
 //! # Example
 //!
@@ -268,7 +272,8 @@ impl Config {
     /// and `buf.yaml` configuration; [`Config::includes`] is ignored. When
     /// using buf, [`Config::files`] must contain proto-relative names as
     /// they appear in the buf module (e.g. `"my/service.proto"`), not
-    /// filesystem paths.
+    /// filesystem paths. buf includes source info by default, so proto
+    /// comments become generated doc comments, same as the protoc source.
     #[must_use]
     pub fn use_buf(mut self) -> Self {
         self.descriptor_source = DescriptorSource::Buf;
@@ -280,7 +285,9 @@ impl Config {
     ///
     /// Produce the file once with `protoc --descriptor_set_out=... --include_imports`
     /// or `buf build --as-file-descriptor-set -o ...`, then ship it with
-    /// your source.
+    /// your source. Add `--include_source_info` to the `protoc` invocation
+    /// if you want proto comments carried into the generated Rust docs
+    /// (buf includes source info by default).
     ///
     /// [`Config::files`] selects which files in the set to generate code for.
     /// **These must be the proto-relative names as they appear in the
@@ -318,6 +325,12 @@ impl Config {
     /// The inverse of [`Config::descriptor_set`], which *reads* a precompiled
     /// set; this *writes* the one connectrpc-build already computed, so build
     /// scripts no longer need a second `protoc --descriptor_set_out` pass.
+    ///
+    /// For the protoc and buf sources, `SourceCodeInfo` (proto comments and
+    /// spans) is stripped from the emitted set — reflection does not need it,
+    /// and stripping keeps the embedded bytes lean and proto comments out of
+    /// shipped binaries. A precompiled set is written through byte-for-byte;
+    /// use that source if you need the emitted set to carry source info.
     #[must_use]
     pub fn emit_descriptor_set(mut self, name: impl Into<String>) -> Self {
         self.emit_descriptor_set = Some(name.into());
@@ -398,7 +411,7 @@ impl Config {
                 (bytes, proto_relative_names(&self.files))
             }
         };
-        let fds = FileDescriptorSet::decode_from_slice(&descriptor_bytes)
+        let mut fds = FileDescriptorSet::decode_from_slice(&descriptor_bytes)
             .map_err(|e| anyhow!("failed to decode FileDescriptorSet: {e}"))?;
 
         // 3. Generate.
@@ -411,9 +424,9 @@ impl Config {
         std::fs::create_dir_all(&out_dir)
             .with_context(|| format!("failed to create out_dir '{}'", out_dir.display()))?;
 
-        // Emit the parsed descriptor set for gRPC server reflection, if requested.
-        // `descriptor_bytes` already carries the full import closure for every
-        // descriptor source, so the written set is reflection-ready as-is.
+        // Emit the descriptor set for gRPC server reflection, if requested.
+        // The decoded set carries the full import closure for every
+        // descriptor source, so the written set is reflection-ready.
         if let Some(name) = &self.emit_descriptor_set {
             // `<out_dir>/<name>` is the documented contract; a separator or
             // absolute path would silently escape it via `Path::join`.
@@ -424,7 +437,22 @@ impl Config {
                 );
             }
             let target = out_dir.join(name);
-            write_if_changed(&target, &descriptor_bytes)
+            // For the sets this crate builds itself, strip `SourceCodeInfo`
+            // before writing: reflection never needs it, and passing it
+            // through would bloat the embedded bytes and leak proto comments
+            // into consumer binaries. A precompiled set is user-curated, so
+            // it is written through byte-for-byte. Codegen has already run,
+            // so mutating `fds` here is safe.
+            let emit_bytes = match &self.descriptor_source {
+                DescriptorSource::Protoc | DescriptorSource::Buf => {
+                    for file in &mut fds.file {
+                        file.source_code_info = Default::default();
+                    }
+                    fds.encode_to_vec()
+                }
+                DescriptorSource::Precompiled(_) => descriptor_bytes,
+            };
+            write_if_changed(&target, &emit_bytes)
                 .with_context(|| format!("failed to write descriptor set {}", target.display()))?;
         }
 
@@ -504,6 +532,9 @@ fn run_protoc(files: &[PathBuf], includes: &[PathBuf]) -> Result<Vec<u8>> {
 
     let mut cmd = Command::new(&protoc);
     cmd.arg("--include_imports");
+    // Without this, the descriptor set carries no `SourceCodeInfo` and proto
+    // comments never reach the generated Rust docs.
+    cmd.arg("--include_source_info");
     cmd.arg(format!("--descriptor_set_out={}", out_path.display()));
     for inc in includes {
         cmd.arg(format!("--proto_path={}", inc.display()));
@@ -873,6 +904,74 @@ mod tests {
             "default emission must not emit any cfg attr — external \
              consumers should not need to declare a `client` Cargo \
              feature unless they opt in. Got:\n{ungated}"
+        );
+    }
+
+    /// Protoc mode must pass `--include_source_info` so proto comments
+    /// survive into the generated Rust as doc comments (issue #222).
+    /// Unlike the fixture-driven tests above, this one requires `protoc`
+    /// on PATH — a documented prerequisite of the workspace test suite.
+    #[test]
+    fn protoc_mode_preserves_proto_comments() {
+        let proto_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            proto_dir.path().join("commented.proto"),
+            r#"syntax = "proto3";
+package commented;
+
+// DistinctiveMessageComment documents the Note message.
+message Note {
+  // DistinctiveFieldComment documents the text field.
+  string text = 1;
+}
+"#,
+        )
+        .unwrap();
+
+        let out = tempfile::tempdir().unwrap();
+        Config::new()
+            .files(&[proto_dir.path().join("commented.proto")])
+            .includes(&[proto_dir.path()])
+            .out_dir(out.path())
+            .emit_rerun_directives(false)
+            .emit_descriptor_set("commented.bin")
+            .compile()
+            .expect("compile in protoc mode");
+
+        let generated =
+            std::fs::read_to_string(out.path().join("commented.rs")).expect("read commented.rs");
+        for marker in ["DistinctiveMessageComment", "DistinctiveFieldComment"] {
+            assert!(
+                generated.contains(&format!("/// {marker}")),
+                "expected proto comment `{marker}` as a doc comment in the \
+                 generated Rust — was the descriptor built without \
+                 --include_source_info?\n{generated}"
+            );
+        }
+
+        // The emitted reflection set must NOT carry the source info codegen
+        // consumed: reflection doesn't need it, and it would leak proto
+        // comments into consumer binaries. The rest of the descriptor
+        // content must survive the strip's decode→re-encode round trip.
+        let bytes = std::fs::read(out.path().join("commented.bin")).unwrap();
+        let emitted = FileDescriptorSet::decode_from_slice(&bytes).unwrap();
+        assert!(
+            emitted
+                .file
+                .iter()
+                .all(|f| f.source_code_info.as_option().is_none()),
+            "emitted descriptor set must have SourceCodeInfo stripped"
+        );
+        let file = emitted
+            .file
+            .iter()
+            .find(|f| f.name.as_deref() == Some("commented.proto"))
+            .expect("emitted set must retain commented.proto");
+        assert!(
+            file.message_type
+                .iter()
+                .any(|m| m.name.as_deref() == Some("Note")),
+            "emitted set must retain the Note message"
         );
     }
 

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -924,6 +924,12 @@ message Note {
   // DistinctiveFieldComment documents the text field.
   string text = 1;
 }
+
+// DistinctiveServiceComment: see [Note] and map<string, int32>.
+service NoteService {
+  // DistinctiveMethodComment: docs at http://example.com/notes here.
+  rpc GetNote(Note) returns (Note);
+}
 "#,
         )
         .unwrap();
@@ -946,6 +952,23 @@ message Note {
                 "expected proto comment `{marker}` as a doc comment in the \
                  generated Rust — was the descriptor built without \
                  --include_source_info?\n{generated}"
+            );
+        }
+
+        // Service and method comments flow through connectrpc-codegen's
+        // sanitizer: markdown/HTML metacharacters must be escaped and bare
+        // URLs autolinked so hostile proto comments can't break a
+        // consumer's rustdoc build.
+        let connect = std::fs::read_to_string(out.path().join("commented.__connect.rs"))
+            .expect("read commented.__connect.rs");
+        for expected in [
+            r"/// DistinctiveServiceComment: see \[Note\] and map\<string, int32\>.",
+            "/// DistinctiveMethodComment: docs at <http://example.com/notes> here.",
+        ] {
+            assert!(
+                connect.contains(expected),
+                "expected sanitized doc comment `{expected}` in generated \
+                 service code\n{connect}"
             );
         }
 

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -2386,15 +2386,20 @@ fn find_comment(source_info: &SourceCodeInfo, target_path: &[i32]) -> Option<Str
                 .as_ref()
                 .or(location.trailing_comments.as_ref())?;
 
-            // Trim each line; blank lines are dropped (protoc's convention
-            // uses a leading space we don't need here — `doc_attrs` adds
-            // its own uniform leading space for prettyplease rendering).
-            let cleaned: String = comment
+            // protoc strips the `//` marker but keeps the space that follows
+            // it; drop that one space per line while preserving deeper
+            // indentation (code blocks) and blank lines (paragraph breaks).
+            // `doc_attrs` adds its own uniform leading space for
+            // prettyplease rendering.
+            let normalized: String = comment
                 .lines()
-                .map(|line| line.trim())
-                .filter(|line| !line.is_empty())
+                .map(|line| line.strip_prefix(' ').unwrap_or(line).trim_end())
                 .collect::<Vec<_>>()
                 .join("\n");
+
+            // Escape markdown/HTML metacharacters so arbitrary proto
+            // comments can't break the consumer's rustdoc build.
+            let cleaned = crate::comments::sanitize_comment(normalized.trim_matches('\n'));
 
             if !cleaned.is_empty() {
                 return Some(cleaned);

--- a/connectrpc-codegen/src/comments.rs
+++ b/connectrpc-codegen/src/comments.rs
@@ -1,0 +1,518 @@
+//! Sanitization of proto source comments for rustdoc emission.
+//!
+//! Ported from buffa-codegen's crate-private comment sanitizer (as of buffa
+//! v0.8.1, `buffa-codegen/src/comments.rs`) so that service and method
+//! comments get the same treatment buffa gives message and field comments:
+//! user-written markdown fences pass through, indented blocks are fenced as
+//! `text`, and markdown/HTML metacharacters in prose are escaped so
+//! arbitrary proto comments cannot break a consumer's `cargo doc`
+//! (intra-doc-link and HTML-tag lints) or inadvertently become doctests.
+//! Several deliberate divergences harden on buffa's behavior: fences
+//! without a language annotation default to `text` (rustdoc would
+//! otherwise compile their content as a Rust doctest), an unterminated
+//! fence is closed at the end of the comment, and fence open/close
+//! detection follows CommonMark (closers need matching tick counts and no
+//! info string; markers indented 4+ spaces are code, not fences). This
+//! module is transitional: if buffa exports an equivalently hardened
+//! sanitizer publicly, this fork should be deleted in favor of it.
+//! Proto cross-reference resolution
+//! (`[display][ref]`) is not ported — connect codegen has no proto→Rust
+//! type map in service scope — so bracketed refs fall back to escaped
+//! literal text, which is also buffa's fallback for unresolvable refs.
+
+/// Sanitize a proto comment for embedding in `#[doc]` attributes.
+///
+/// Line-oriented text transform: the output is joined with `\n` and carries
+/// no leading-space normalization — `doc_attrs` adds the uniform single
+/// space prettyplease needs. Handles, in priority order per line:
+///
+/// - user-written ``` fences: content passes through unescaped; an opener
+///   with no language annotation gains `text`, and an unterminated fence
+///   is closed at the end of the comment;
+/// - indented blocks (4 spaces / tab): wrapped in a ```` ```text ````
+///   fence and de-indented, so protoc-style examples render as code and
+///   can never be run as doctests;
+/// - blank lines: preserved (paragraph breaks);
+/// - prose: escaped via [`sanitize_line`].
+pub(crate) fn sanitize_comment(text: &str) -> String {
+    let raw_lines: Vec<&str> = text.lines().collect();
+    let mut lines: Vec<String> = Vec::with_capacity(raw_lines.len());
+    let mut in_code_block = false;
+    let mut in_user_fence = false;
+    let mut user_fence_ticks = 0;
+
+    for (idx, line) in raw_lines.iter().enumerate() {
+        if in_user_fence {
+            // Per CommonMark, only a run of at least the opener's tick
+            // count with no info string closes the fence; anything else
+            // (shorter runs, ```lang lines) is fence content.
+            if let Some((ticks, info)) = fence_marker(line)
+                && ticks >= user_fence_ticks
+                && info.trim().is_empty()
+            {
+                in_user_fence = false;
+            }
+            lines.push((*line).to_string());
+            continue;
+        }
+
+        if in_code_block {
+            if is_indented(line) {
+                lines.push(strip_indent(line));
+                continue;
+            }
+            // A blank line inside an indented block only closes it when no
+            // more indented content follows.
+            if line.is_empty() {
+                let next_is_indented = raw_lines[idx + 1..]
+                    .iter()
+                    .find(|l| !l.is_empty())
+                    .is_some_and(|l| is_indented(l));
+                if next_is_indented {
+                    lines.push(String::new());
+                    continue;
+                }
+            }
+            lines.push("```".to_string());
+            in_code_block = false;
+            // Fall through: this line still needs classifying.
+        }
+
+        if let Some((ticks, info)) = fence_marker(line) {
+            in_user_fence = true;
+            user_fence_ticks = ticks;
+            if info.trim().is_empty() {
+                // rustdoc treats a fence with no info string as a Rust
+                // doctest; default it to `text` so arbitrary comment
+                // content is never compiled by a consumer's `cargo test`.
+                lines.push(format!("{}text", line.trim_end()));
+            } else {
+                lines.push((*line).to_string());
+            }
+        } else if is_indented(line) {
+            lines.push("```text".to_string());
+            in_code_block = true;
+            lines.push(strip_indent(line));
+        } else {
+            lines.push(sanitize_line(line));
+        }
+    }
+
+    if in_code_block {
+        lines.push("```".to_string());
+    }
+    if in_user_fence {
+        // An unterminated fence would swallow the rest of the doc block
+        // (including any generator-authored text appended after the proto
+        // comment); close it with a matching-length fence.
+        lines.push("`".repeat(user_fence_ticks));
+    }
+
+    lines.join("\n")
+}
+
+/// An indented-code-block line: 4+ spaces or a tab (CommonMark).
+fn is_indented(line: &str) -> bool {
+    line.starts_with("    ") || line.starts_with('\t')
+}
+
+/// Remove one level of code-block indentation, but keep it on a line that
+/// would otherwise read as a fence marker — inside the synthetic ```text
+/// fence a de-indented ``` run would close it early, while CommonMark
+/// ignores fence markers indented 4+ spaces.
+fn strip_indent(line: &str) -> String {
+    let stripped = line
+        .strip_prefix("    ")
+        .or_else(|| line.strip_prefix('\t'))
+        .unwrap_or(line);
+    if stripped.trim_start().starts_with("```") {
+        (*line).to_string()
+    } else {
+        stripped.to_string()
+    }
+}
+
+/// If `line` is a fence marker (an optionally ≤3-space-indented run of 3+
+/// backticks), return the run length and the info string after it. Lines
+/// indented 4+ spaces are indented code, not fences (CommonMark).
+fn fence_marker(line: &str) -> Option<(usize, &str)> {
+    if is_indented(line) {
+        return None;
+    }
+    let trimmed = line.trim_start();
+    let info = trimmed.trim_start_matches('`');
+    let ticks = trimmed.len() - info.len();
+    (ticks >= 3).then_some((ticks, info))
+}
+
+/// Escape one prose line for rustdoc.
+///
+/// Backtick code spans pass through verbatim; complete inline links
+/// (`[text](url)`) and autolinks (`<http(s)://…>`) are preserved; bare
+/// `http(s)://` URLs are wrapped in `<…>` (rustdoc's `bare_urls` lint);
+/// everything else that rustdoc would interpret — `[`, `]`, `<`, `>`,
+/// `\` — is escaped.
+fn sanitize_line(line: &str) -> String {
+    let bytes = line.as_bytes();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b == b'`' {
+            let run_start = i;
+            while i < bytes.len() && bytes[i] == b'`' {
+                i += 1;
+            }
+            let run_len = i - run_start;
+            if let Some(close_end) = find_backtick_closer(bytes, i, run_len) {
+                out.push_str(&line[run_start..close_end]);
+                i = close_end;
+            } else {
+                out.push_str(&line[run_start..i]);
+            }
+            continue;
+        }
+
+        match b {
+            b'\\' => {
+                // The comment author is escaping the next char; pass the
+                // pair through verbatim.
+                out.push('\\');
+                i += 1;
+                if i < bytes.len() {
+                    i += push_char_at(&mut out, line, i);
+                }
+            }
+            b'[' => {
+                if let Some(end) = find_inline_link_end(bytes, i) {
+                    out.push_str(&line[i..=end]);
+                    i = end + 1;
+                } else {
+                    out.push_str("\\[");
+                    i += 1;
+                }
+            }
+            b']' => {
+                out.push_str("\\]");
+                i += 1;
+            }
+            b'<' => {
+                if let Some(end) = find_autolink_end(bytes, i) {
+                    out.push_str(&line[i..=end]);
+                    i = end + 1;
+                } else {
+                    out.push_str("\\<");
+                    i += 1;
+                }
+            }
+            b'>' => {
+                out.push_str("\\>");
+                i += 1;
+            }
+            b'h' => {
+                if let Some(end) = find_bare_url_end(bytes, i) {
+                    out.push('<');
+                    out.push_str(&line[i..end]);
+                    out.push('>');
+                    i = end;
+                } else {
+                    out.push('h');
+                    i += 1;
+                }
+            }
+            _ => {
+                i += push_char_at(&mut out, line, i);
+            }
+        }
+    }
+    out
+}
+
+/// Push the UTF-8 char at byte index `i` of `s` into `out`, returning its
+/// byte length. `i` must be a char boundary and `< s.len()`.
+fn push_char_at(out: &mut String, s: &str, i: usize) -> usize {
+    let ch = s[i..]
+        .chars()
+        .next()
+        .expect("i is in bounds and on a char boundary");
+    out.push(ch);
+    ch.len_utf8()
+}
+
+/// Starting at `from` (just past an opening run of `run_len` backticks),
+/// return the past-the-end index of the matching closing run, or `None`.
+fn find_backtick_closer(bytes: &[u8], from: usize, run_len: usize) -> Option<usize> {
+    let mut i = from;
+    while i < bytes.len() {
+        if bytes[i] == b'`' {
+            let start = i;
+            while i < bytes.len() && bytes[i] == b'`' {
+                i += 1;
+            }
+            if i - start == run_len {
+                return Some(i);
+            }
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// If `bytes[start..]` is a complete `[text](url)`, return the index of the
+/// closing `)`. Nested `(`/`)` inside the URL are balanced one level deep so
+/// fragments like `…#method()` survive.
+fn find_inline_link_end(bytes: &[u8], start: usize) -> Option<usize> {
+    debug_assert_eq!(bytes[start], b'[');
+    let mut j = start + 1;
+    while j < bytes.len() && bytes[j] != b']' {
+        if bytes[j] == b'[' {
+            return None;
+        }
+        j += 1;
+    }
+    if j + 1 >= bytes.len() || bytes[j + 1] != b'(' {
+        return None;
+    }
+    let mut depth = 1i32;
+    let mut k = j + 2;
+    while k < bytes.len() {
+        match bytes[k] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(k);
+                }
+            }
+            _ => {}
+        }
+        k += 1;
+    }
+    None
+}
+
+/// Does `rest` begin with an `http(s)://` scheme?
+fn has_url_scheme(rest: &[u8]) -> bool {
+    rest.starts_with(b"http://") || rest.starts_with(b"https://")
+}
+
+/// If `bytes[start..]` is `<http(s)://…>`, return the index of the `>`.
+fn find_autolink_end(bytes: &[u8], start: usize) -> Option<usize> {
+    debug_assert_eq!(bytes[start], b'<');
+    let rest = &bytes[start + 1..];
+    if !has_url_scheme(rest) {
+        return None;
+    }
+    rest.iter().position(|&b| b == b'>').map(|p| start + 1 + p)
+}
+
+/// If `bytes[start..]` begins a bare `http(s)://` URL, return the
+/// past-the-end byte index. The URL ends at whitespace, `)`, or an angle
+/// bracket (which would corrupt the `<…>` autolink wrapper), and trailing
+/// sentence punctuation is treated as prose rather than URL.
+fn find_bare_url_end(bytes: &[u8], start: usize) -> Option<usize> {
+    if !has_url_scheme(&bytes[start..]) {
+        return None;
+    }
+    let mut j = start;
+    while j < bytes.len()
+        && !bytes[j].is_ascii_whitespace()
+        && !matches!(bytes[j], b')' | b'<' | b'>')
+    {
+        j += 1;
+    }
+    while j > start && matches!(bytes[j - 1], b'.' | b',' | b';' | b':' | b'!' | b'?') {
+        j -= 1;
+    }
+    Some(j)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn brackets_escaped() {
+        assert_eq!(
+            sanitize_line("see [Note] for details"),
+            "see \\[Note\\] for details"
+        );
+    }
+
+    #[test]
+    fn angle_brackets_escaped() {
+        assert_eq!(
+            sanitize_line("a map<string, int32> field"),
+            "a map\\<string, int32\\> field"
+        );
+    }
+
+    #[test]
+    fn author_escapes_pass_through() {
+        assert_eq!(sanitize_line(r"a \[not a link\]"), r"a \[not a link\]");
+        assert_eq!(sanitize_line(r"trailing \"), r"trailing \");
+    }
+
+    #[test]
+    fn code_spans_pass_through() {
+        assert_eq!(
+            sanitize_line("use `[T; N]` or `<T>`"),
+            "use `[T; N]` or `<T>`"
+        );
+    }
+
+    #[test]
+    fn unmatched_backtick_run_passes_through() {
+        assert_eq!(sanitize_line("stray ` tick [x]"), "stray ` tick \\[x\\]");
+    }
+
+    #[test]
+    fn inline_links_preserved() {
+        assert_eq!(
+            sanitize_line("see [docs](https://example.com/a#m()) here"),
+            "see [docs](https://example.com/a#m()) here"
+        );
+    }
+
+    #[test]
+    fn autolinks_preserved() {
+        assert_eq!(
+            sanitize_line("visit <https://example.com> now"),
+            "visit <https://example.com> now"
+        );
+    }
+
+    #[test]
+    fn bare_urls_wrapped() {
+        assert_eq!(
+            sanitize_line("docs at https://example.com/x, see there"),
+            "docs at <https://example.com/x>, see there"
+        );
+        assert_eq!(
+            sanitize_line("(https://example.com)"),
+            "(<https://example.com>)"
+        );
+        assert_eq!(
+            sanitize_line("see https://example.com."),
+            "see <https://example.com>."
+        );
+    }
+
+    #[test]
+    fn ref_style_link_falls_back_to_escaping() {
+        assert_eq!(
+            sanitize_line("see [Note][commented.Note]"),
+            "see \\[Note\\]\\[commented.Note\\]"
+        );
+    }
+
+    #[test]
+    fn user_fences_pass_through() {
+        let input = "Example:\n```json\n{\"a\": [1]}\n```\ndone [x]";
+        let expected = "Example:\n```json\n{\"a\": [1]}\n```\ndone \\[x\\]";
+        assert_eq!(sanitize_comment(input), expected);
+    }
+
+    #[test]
+    fn bare_fence_defaults_to_text() {
+        let input = "Example:\n```\n{\"a\": 1}\n```\ndone";
+        let expected = "Example:\n```text\n{\"a\": 1}\n```\ndone";
+        assert_eq!(sanitize_comment(input), expected);
+    }
+
+    #[test]
+    fn unterminated_fence_closed() {
+        let input = "para\n```\nstuff";
+        assert_eq!(sanitize_comment(input), "para\n```text\nstuff\n```");
+    }
+
+    #[test]
+    fn longer_fence_closed_with_matching_ticks() {
+        let input = "````\nnested ``` inside";
+        assert_eq!(sanitize_comment(input), "````text\nnested ``` inside\n````");
+    }
+
+    #[test]
+    fn four_tick_fence_keeps_inner_three_tick_line() {
+        let input = "````\n```\ncode\n````";
+        assert_eq!(sanitize_comment(input), "````text\n```\ncode\n````");
+    }
+
+    #[test]
+    fn info_string_line_inside_fence_is_content() {
+        let input = "```json\n{}\n```rust\nx\n```";
+        assert_eq!(sanitize_comment(input), input);
+    }
+
+    #[test]
+    fn fence_directly_after_indented_block_is_tracked() {
+        let input = "    x = 1\n```\nnot rust\n```";
+        assert_eq!(
+            sanitize_comment(input),
+            "```text\nx = 1\n```\n```text\nnot rust\n```"
+        );
+    }
+
+    #[test]
+    fn indented_fence_marker_is_code_not_fence() {
+        let input = "    ```\n    x";
+        assert_eq!(sanitize_comment(input), "```text\n    ```\nx\n```");
+    }
+
+    #[test]
+    fn fence_line_inside_indented_block_keeps_indent() {
+        let input = "    code\n    ```\n    more";
+        assert_eq!(sanitize_comment(input), "```text\ncode\n    ```\nmore\n```");
+    }
+
+    #[test]
+    fn url_with_angle_bracket_stops_at_bracket() {
+        assert_eq!(
+            sanitize_line("see http://example.com/a>b"),
+            "see <http://example.com/a>\\>b"
+        );
+    }
+
+    #[test]
+    fn indented_block_fenced_as_text() {
+        let input = "Usage:\n    req = Note{}\n    send(req)\nDone.";
+        let expected = "Usage:\n```text\nreq = Note{}\nsend(req)\n```\nDone.";
+        assert_eq!(sanitize_comment(input), expected);
+    }
+
+    #[test]
+    fn blank_line_inside_indented_block_kept_open() {
+        let input = "    a\n\n    b\nprose";
+        let expected = "```text\na\n\nb\n```\nprose";
+        assert_eq!(sanitize_comment(input), expected);
+    }
+
+    #[test]
+    fn trailing_indented_block_closed() {
+        let input = "text\n    code";
+        assert_eq!(sanitize_comment(input), "text\n```text\ncode\n```");
+    }
+
+    #[test]
+    fn multibyte_chars_survive_around_metachars() {
+        assert_eq!(
+            sanitize_line("émoji 🦀 <T> — done"),
+            "émoji 🦀 \\<T\\> — done"
+        );
+        assert_eq!(
+            sanitize_line("précis at https://例え.jp/パス end"),
+            "précis at <https://例え.jp/パス> end"
+        );
+    }
+
+    #[test]
+    fn blank_lines_preserved() {
+        assert_eq!(
+            sanitize_comment("para one\n\npara two"),
+            "para one\n\npara two"
+        );
+    }
+}

--- a/connectrpc-codegen/src/comments.rs
+++ b/connectrpc-codegen/src/comments.rs
@@ -39,19 +39,16 @@ pub(crate) fn sanitize_comment(text: &str) -> String {
     let raw_lines: Vec<&str> = text.lines().collect();
     let mut lines: Vec<String> = Vec::with_capacity(raw_lines.len());
     let mut in_code_block = false;
-    let mut in_user_fence = false;
-    let mut user_fence_ticks = 0;
+    // The character and run length of the author's fence we are inside, if
+    // any — a closer must match both.
+    let mut open_fence: Option<(char, usize)> = None;
 
     for (idx, line) in raw_lines.iter().enumerate() {
-        if in_user_fence {
-            // Per CommonMark, only a run of at least the opener's tick
-            // count with no info string closes the fence; anything else
-            // (shorter runs, ```lang lines) is fence content.
-            if let Some((ticks, info)) = fence_marker(line)
-                && ticks >= user_fence_ticks
-                && info.trim().is_empty()
-            {
-                in_user_fence = false;
+        if let Some(open) = open_fence {
+            // Anything that does not close the fence (a shorter run, a
+            // ```lang line, the other fence character) is fence content.
+            if fence_marker(line).is_some_and(|f| f.closes(open)) {
+                open_fence = None;
             }
             lines.push((*line).to_string());
             continue;
@@ -79,12 +76,10 @@ pub(crate) fn sanitize_comment(text: &str) -> String {
             // Fall through: this line still needs classifying.
         }
 
-        if let Some((ticks, info)) = fence_marker(line) {
-            in_user_fence = true;
-            user_fence_ticks = ticks;
-            let indent = &line[..line.len() - line.trim_start().len()];
-            let ticks_str = "`".repeat(ticks);
-            lines.push(format!("{indent}{ticks_str}{}", fence_info(info)));
+        if let Some(fence) = fence_marker(line) {
+            open_fence = Some((fence.ch, fence.len));
+            let run = fence.ch.to_string().repeat(fence.len);
+            lines.push(format!("{}{run}{}", fence.indent, fence_info(fence.info)));
         } else if is_indented(line) {
             lines.push("```text".to_string());
             in_code_block = true;
@@ -97,11 +92,11 @@ pub(crate) fn sanitize_comment(text: &str) -> String {
     if in_code_block {
         lines.push("```".to_string());
     }
-    if in_user_fence {
+    if let Some((ch, len)) = open_fence {
         // An unterminated fence would swallow the rest of the doc block
         // (including any generator-authored text appended after the proto
-        // comment); close it with a matching-length fence.
-        lines.push("`".repeat(user_fence_ticks));
+        // comment); close it with a matching fence.
+        lines.push(ch.to_string().repeat(len));
     }
 
     lines.join("\n")
@@ -181,17 +176,57 @@ fn strip_indent(line: &str) -> String {
     }
 }
 
-/// If `line` is a fence marker (an optionally ≤3-space-indented run of 3+
-/// backticks), return the run length and the info string after it. Lines
-/// indented 4+ spaces are indented code, not fences (CommonMark).
-fn fence_marker(line: &str) -> Option<(usize, &str)> {
+/// A fenced-code-block marker line.
+struct Fence<'a> {
+    /// The 0–3 spaces before the run.
+    indent: &'a str,
+    /// The fence character: a backtick or a tilde.
+    ch: char,
+    /// How many of them the run has. A closer needs at least as many.
+    len: usize,
+    /// Whatever follows the run — the language, plus any rustdoc attributes.
+    info: &'a str,
+}
+
+impl Fence<'_> {
+    /// Whether this marker closes `open` — same character, a run at least as
+    /// long, and nothing but spaces or tabs after it (CommonMark).
+    fn closes(&self, open: (char, usize)) -> bool {
+        self.ch == open.0 && self.len >= open.1 && self.info.chars().all(|c| c == ' ' || c == '\t')
+    }
+}
+
+/// If `line` is a fence marker — an optionally ≤3-space-indented run of 3+
+/// backticks *or* tildes — describe it. rustdoc's markdown parser treats
+/// `~~~` exactly like ` ``` `, so both must be inerted.
+///
+/// Only spaces may precede the run, and only 3 of them: 4+ spaces or a tab
+/// make the line indented code, and any other leading whitespace (an NBSP,
+/// say) is prose. A backtick fence's info string may not itself contain a
+/// backtick. In each of those cases CommonMark says this is not a fence, so
+/// neither does this — misreading one as a fence would leave the *real*
+/// fence rustdoc sees unguarded.
+fn fence_marker(line: &str) -> Option<Fence<'_>> {
     if is_indented(line) {
         return None;
     }
-    let trimmed = line.trim_start();
-    let info = trimmed.trim_start_matches('`');
-    let ticks = trimmed.len() - info.len();
-    (ticks >= 3).then_some((ticks, info))
+    let indent_len = line.len() - line.trim_start_matches(' ').len();
+    let (indent, rest) = line.split_at(indent_len);
+    let ch = rest.chars().next()?;
+    if ch != '`' && ch != '~' {
+        return None;
+    }
+    let info = rest.trim_start_matches(ch);
+    let len = rest.len() - info.len();
+    if len < 3 || (ch == '`' && info.contains('`')) {
+        return None;
+    }
+    Some(Fence {
+        indent,
+        ch,
+        len,
+        info,
+    })
 }
 
 /// Escape one prose line for rustdoc.
@@ -532,6 +567,64 @@ mod tests {
                 "info string: {info}"
             );
         }
+    }
+
+    #[test]
+    fn tilde_fences_are_inerted_too() {
+        // rustdoc's markdown parser treats ~~~ exactly like ``` — a tilde
+        // fence's body is compiled as a doctest just the same.
+        assert_eq!(
+            sanitize_comment("~~~rust\nlet x = 1;\n~~~"),
+            "~~~rust,ignore\nlet x = 1;\n~~~"
+        );
+        assert_eq!(
+            sanitize_comment("~~~\n{\"a\": 1}\n~~~"),
+            "~~~text\n{\"a\": 1}\n~~~"
+        );
+        // A tilde fence is not closed by a backtick run, and vice versa.
+        assert_eq!(sanitize_comment("~~~\nx\n```"), "~~~text\nx\n```\n~~~");
+    }
+
+    #[test]
+    fn exotic_leading_whitespace_is_not_a_fence() {
+        // Only spaces (0-3) may precede a fence marker. rustdoc reads an
+        // NBSP- or tab-prefixed run as prose, and so must we — otherwise we
+        // "close" a fence rustdoc never opened and leave the run it *does*
+        // treat as an opener (the trailing one here) unguarded.
+        for lead in ["\u{a0}", " \t"] {
+            let out = sanitize_comment(&format!("{lead}```\nlet x = 1;\n```"));
+            assert!(
+                out.starts_with(&format!("{lead}```\n")),
+                "opener-lookalike must stay prose: {out:?}"
+            );
+            assert!(
+                out.ends_with("```text\n```"),
+                "the run rustdoc treats as the real opener must be inerted \
+                 and closed: {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn closer_may_only_trail_spaces_or_tabs() {
+        // rustdoc allows only spaces/tabs after a closing run, so an
+        // NBSP-trailing run is content, and the fence stays open — and must
+        // therefore be force-closed.
+        let out = sanitize_comment("```\nx\n```\u{a0}");
+        assert!(
+            out.ends_with("\n```"),
+            "unclosed fence must be force-closed: {out:?}"
+        );
+    }
+
+    #[test]
+    fn backtick_in_info_string_is_not_a_fence() {
+        // CommonMark: a backtick fence's info string may not contain a
+        // backtick, so rustdoc reads this line as prose, not an opener.
+        // Treating it as a fence would desync us from rustdoc and let the
+        // *next* ``` open an unannotated (Rust) block.
+        let out = sanitize_comment("```rust```\nx");
+        assert!(!out.contains("ignore"), "not treated as a fence: {out}");
     }
 
     #[test]

--- a/connectrpc-codegen/src/comments.rs
+++ b/connectrpc-codegen/src/comments.rs
@@ -7,12 +7,12 @@
 //! `text`, and markdown/HTML metacharacters in prose are escaped so
 //! arbitrary proto comments cannot break a consumer's `cargo doc`
 //! (intra-doc-link and HTML-tag lints) or inadvertently become doctests.
-//! Several deliberate divergences harden on buffa's behavior: fences
-//! without a language annotation default to `text` (rustdoc would
-//! otherwise compile their content as a Rust doctest), an unterminated
-//! fence is closed at the end of the comment, and fence open/close
-//! detection follows CommonMark (closers need matching tick counts and no
-//! info string; markers indented 4+ spaces are code, not fences). This
+//! Several deliberate divergences harden on buffa's behavior: every code
+//! fence is made inert so rustdoc can never compile comment content as a
+//! doctest (see [`fence_info`]), an unterminated fence is closed at the end
+//! of the comment, and fence open/close detection follows CommonMark
+//! (closers need matching tick counts and no info string; markers indented
+//! 4+ spaces are code, not fences). This
 //! module is transitional: if buffa exports an equivalently hardened
 //! sanitizer publicly, this fork should be deleted in favor of it.
 //! Proto cross-reference resolution
@@ -26,9 +26,10 @@
 /// no leading-space normalization — `doc_attrs` adds the uniform single
 /// space prettyplease needs. Handles, in priority order per line:
 ///
-/// - user-written ``` fences: content passes through unescaped; an opener
-///   with no language annotation gains `text`, and an unterminated fence
-///   is closed at the end of the comment;
+/// - user-written ``` fences: content passes through unescaped, while the
+///   opener's info string is rewritten by [`fence_info`] so rustdoc never
+///   compiles it; an unterminated fence is closed at the end of the
+///   comment;
 /// - indented blocks (4 spaces / tab): wrapped in a ```` ```text ````
 ///   fence and de-indented, so protoc-style examples render as code and
 ///   can never be run as doctests;
@@ -81,14 +82,9 @@ pub(crate) fn sanitize_comment(text: &str) -> String {
         if let Some((ticks, info)) = fence_marker(line) {
             in_user_fence = true;
             user_fence_ticks = ticks;
-            if info.trim().is_empty() {
-                // rustdoc treats a fence with no info string as a Rust
-                // doctest; default it to `text` so arbitrary comment
-                // content is never compiled by a consumer's `cargo test`.
-                lines.push(format!("{}text", line.trim_end()));
-            } else {
-                lines.push((*line).to_string());
-            }
+            let indent = &line[..line.len() - line.trim_start().len()];
+            let ticks_str = "`".repeat(ticks);
+            lines.push(format!("{indent}{ticks_str}{}", fence_info(info)));
         } else if is_indented(line) {
             lines.push("```text".to_string());
             in_code_block = true;
@@ -109,6 +105,59 @@ pub(crate) fn sanitize_comment(text: &str) -> String {
     }
 
     lines.join("\n")
+}
+
+/// The info string to emit for a fence opener, so that rustdoc never
+/// *compiles* the fence body. Proto comments are untrusted input: their
+/// examples have no imports, name proto types rather than Rust ones, and
+/// would be compiled — and run — by the consumer's `cargo test --doc`.
+///
+/// Deciding "is this Rust?" the way rustdoc does is a trap: an explicit
+/// `rust` keeps the block Rust even beside an unknown word
+/// (`rust,noplayground`), error-code tokens (`compile_fail,E0277`) and
+/// `{class=…}` attributes keep it Rust too, and the verdict is even
+/// order-dependent. So this does not classify at all — it makes every
+/// fence inert:
+///
+/// - `ignore-<target>` tokens are dropped. rustdoc reads them as a target
+///   *list* that replaces a plain `ignore`, so the block would still be
+///   compiled for every other target.
+/// - a bare `ignore` is then ensured. It is the only attribute that
+///   reliably stops compilation: `no_run` still type-checks,
+///   `should_panic` runs, and `compile_fail` merely inverts the verdict.
+///
+/// The author's language annotation is preserved, so a ` ```rust ` fence
+/// still gets Rust syntax highlighting as ` ```rust,ignore `. An `ignore`
+/// on a non-Rust fence is inert, and an unannotated fence becomes `text`
+/// rather than guessing a language — rustdoc highlights nothing but Rust,
+/// so identifying JSON or YAML would buy no rendering benefit.
+///
+/// (Every claim above was verified against rustdoc directly.)
+fn fence_info(info: &str) -> String {
+    let mut dropped_target_ignore = false;
+    let mut tokens: Vec<&str> = Vec::new();
+    for tok in info.split([',', ' ', '\t']).filter(|t| !t.is_empty()) {
+        if tok.starts_with("ignore-") {
+            dropped_target_ignore = true;
+        } else {
+            tokens.push(tok);
+        }
+    }
+
+    if tokens.is_empty() {
+        // A fence annotated only with `ignore-<target>` was Rust, so keep
+        // it highlighted; an unannotated one is language-agnostic.
+        return if dropped_target_ignore {
+            "rust,ignore".to_string()
+        } else {
+            "text".to_string()
+        };
+    }
+
+    if !tokens.contains(&"ignore") {
+        tokens.push("ignore");
+    }
+    tokens.join(",")
 }
 
 /// An indented-code-block line: 4+ spaces or a tab (CommonMark).
@@ -411,8 +460,10 @@ mod tests {
 
     #[test]
     fn user_fences_pass_through() {
+        // Fence *content* is never escaped; only the info string gains the
+        // `ignore` that keeps rustdoc from compiling it.
         let input = "Example:\n```json\n{\"a\": [1]}\n```\ndone [x]";
-        let expected = "Example:\n```json\n{\"a\": [1]}\n```\ndone \\[x\\]";
+        let expected = "Example:\n```json,ignore\n{\"a\": [1]}\n```\ndone \\[x\\]";
         assert_eq!(sanitize_comment(input), expected);
     }
 
@@ -436,6 +487,70 @@ mod tests {
     }
 
     #[test]
+    fn rust_fence_is_marked_ignore_but_keeps_highlighting() {
+        // `rust,ignore` is still syntax-highlighted by rustdoc, but never
+        // compiled — a proto comment's Rust example has no imports and
+        // would fail in the consumer's `cargo test --doc`.
+        let input = "```rust\nlet x = Note::default();\n```";
+        assert_eq!(
+            sanitize_comment(input),
+            "```rust,ignore\nlet x = Note::default();\n```"
+        );
+    }
+
+    /// Every one of these still reaches rustdoc's compiler without an
+    /// `ignore`: `no_run` type-checks, `should_panic` runs, `compile_fail`
+    /// inverts the verdict, an error code or an mdBook-style word keeps the
+    /// block Rust, and `ignore-<target>` compiles on every other target —
+    /// even when a plain `ignore` sits beside it, because rustdoc lets the
+    /// target list replace it. All verified against rustdoc directly.
+    #[test]
+    fn every_fence_is_made_inert() {
+        let cases = [
+            ("rust", "rust,ignore"),
+            ("no_run", "no_run,ignore"),
+            ("should_panic", "should_panic,ignore"),
+            ("compile_fail", "compile_fail,ignore"),
+            ("compile_fail,E0277", "compile_fail,E0277,ignore"),
+            ("rust,noplayground", "rust,noplayground,ignore"),
+            ("edition2018", "edition2018,ignore"),
+            // `ignore-<target>` is dropped, not kept alongside `ignore`.
+            ("ignore-wasm32", "rust,ignore"),
+            ("rust,ignore-wasm32", "rust,ignore"),
+            ("ignore-wasm32,ignore", "ignore"),
+            // Non-Rust fences keep their language; the added `ignore` is
+            // inert for them, and uniformity beats classifying.
+            ("json", "json,ignore"),
+            ("proto", "proto,ignore"),
+            // Whitespace-separated info strings normalize to commas.
+            ("rust no_run", "rust,no_run,ignore"),
+        ];
+        for (info, expected) in cases {
+            assert_eq!(
+                sanitize_comment(&format!("```{info}\nbody\n```")),
+                format!("```{expected}\nbody\n```"),
+                "info string: {info}"
+            );
+        }
+    }
+
+    #[test]
+    fn already_ignored_fences_are_untouched() {
+        for info in ["rust,ignore", "ignore", "ignore,json"] {
+            let input = format!("```{info}\nbody\n```");
+            assert_eq!(sanitize_comment(&input), input, "info string: {info}");
+        }
+    }
+
+    #[test]
+    fn indented_fence_opener_keeps_indent() {
+        assert_eq!(
+            sanitize_comment("  ```rust\n  x\n  ```"),
+            "  ```rust,ignore\n  x\n  ```"
+        );
+    }
+
+    #[test]
     fn four_tick_fence_keeps_inner_three_tick_line() {
         let input = "````\n```\ncode\n````";
         assert_eq!(sanitize_comment(input), "````text\n```\ncode\n````");
@@ -443,8 +558,13 @@ mod tests {
 
     #[test]
     fn info_string_line_inside_fence_is_content() {
+        // The inner ```rust line is fence content, not a closer, so it is
+        // left alone; only the opener is rewritten.
         let input = "```json\n{}\n```rust\nx\n```";
-        assert_eq!(sanitize_comment(input), input);
+        assert_eq!(
+            sanitize_comment(input),
+            "```json,ignore\n{}\n```rust\nx\n```"
+        );
     }
 
     #[test]

--- a/connectrpc-codegen/src/lib.rs
+++ b/connectrpc-codegen/src/lib.rs
@@ -37,6 +37,7 @@
 //! ```
 
 pub mod codegen;
+mod comments;
 pub mod plugin;
 
 pub use codegen::CodeGenConfig;

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -125,11 +125,13 @@ pub trait Health: Send + Sync + 'static {
     /// The server will immediately send back a message indicating the current
     /// serving status. It will then subsequently send a new message whenever
     /// the service's serving status changes.
+    ///
     /// If the requested service is unknown when the call is received, the
     /// server will send a message setting the serving status to SERVICE_UNKNOWN
     /// but will *not* terminate the call. If at some future point, the serving
     /// status of the service becomes known, the server will send a new message
     /// with the service's serving status.
+    ///
     /// If the call terminates with status UNIMPLEMENTED, then the client should
     /// assume this method is not supported and should not retry the call. If
     /// the call terminates with any other status (including OK), then the


### PR DESCRIPTION
Fixes #222.

`connectrpc-build` invoked `protoc` with `--include_imports` but not `--include_source_info`, so the resulting `FileDescriptorSet` carried no `SourceCodeInfo` and proto comments never reached the generated Rust documentation. This adds the flag, matching buf's default behavior (and prost-build's), and updates `Config::descriptor_set` docs to note that precompiled sets need `--include_source_info` on the caller's own `protoc` invocation to get generated docs.

One deliberate companion change: the set written by `Config::emit_descriptor_set` now has `SourceCodeInfo` stripped for the protoc and buf sources. Reflection never needs source info, and passing it through would have grown every embedded descriptor blob (source info is commonly a multiple of the semantic descriptor payload) and leaked proto comments into shipped binaries and reflection responses. Precompiled sets are still written through byte-for-byte, which doubles as the escape hatch for anyone who wants source info in the emitted set. The strip's decode→re-encode round trip preserves unknown fields (custom options), verified against buffa 0.8.1's `__buffa_unknown_fields` retention.

The regression test compiles a proto with distinctive message and field comments through the real protoc pipeline, asserts both surface as `///` doc comments, and asserts the emitted descriptor set is source-info-free while retaining the file and message. Verified the test fails without the flag. This is the first unit test in the crate that requires `protoc` on PATH; CONTRIBUTING already lists protoc v27+ as a prerequisite and the CI Test job installs it.
