### PR TITLE
client: stop the client-stream transport task when the call is abandoned

### DIFF
--- a/.changes/unreleased/Fixed-20260709-051015.yaml
+++ b/.changes/unreleased/Fixed-20260709-051015.yaml
@@ -3,7 +3,10 @@ body: |-
   **`call_client_stream` now stops its background transport send when the call
   is abandoned** ([#224]). Dropping the call future or hitting its deadline
   while the transport is still waiting for response headers no longer leaves the
-  detached send task polling the transport indefinitely.
+  detached send task polling the transport indefinitely. Note that abandonment
+  now cancels the underlying request: a request that was still being sent when
+  the call was abandoned may never reach the server, so a caller that needs
+  the request delivered must drive the call to completion.
 
   [#224]: https://github.com/connectrpc/connect-rust/issues/224
 time: 2026-07-09T05:10:15.451894063-04:00

--- a/.changes/unreleased/Fixed-20260709-051015.yaml
+++ b/.changes/unreleased/Fixed-20260709-051015.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |-
+  **`call_client_stream` now stops its background transport send when the call
+  is abandoned** ([#224]). Dropping the call future or hitting its deadline
+  while the transport is still waiting for response headers no longer leaves the
+  detached send task polling the transport indefinitely.
+
+  [#224]: https://github.com/connectrpc/connect-rust/issues/224
+time: 2026-07-09T05:10:15.451894063-04:00

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -24,7 +24,10 @@ bytes = { workspace = true }
 # Tower service abstraction (the foundation)
 tower = { workspace = true }
 
-# Async runtime (minimal features for core)
+# Async runtime (minimal features for core). `macros` is load-bearing for
+# `tokio::select!` in both the always-compiled client-stream path and the
+# `server` accept loop; CI's `--all-targets` would hide its removal via
+# dev-dep unification while breaking downstream `server`-only builds.
 tokio = { workspace = true, features = ["rt", "io-util", "sync", "time", "macros"] }
 futures = { workspace = true }
 pin-project = { workspace = true }
@@ -127,10 +130,6 @@ server = [
     "dep:libc",
     "dep:tower-http",
     "tokio/net",
-    # The accept loop uses `tokio::select!`. Surfaced only when downstream
-    # consumers enable `server` without also enabling `tokio/macros`
-    # themselves; `--all-targets` (CI) hides it via dev-dep unification.
-    "tokio/macros",
 ]
 
 # HTTP client with connection pooling

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { workspace = true }
 tower = { workspace = true }
 
 # Async runtime (minimal features for core)
-tokio = { workspace = true, features = ["rt", "io-util", "sync", "time"] }
+tokio = { workspace = true, features = ["rt", "io-util", "sync", "time", "macros"] }
 futures = { workspace = true }
 pin-project = { workspace = true }
 async-trait = { workspace = true }

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2755,6 +2755,12 @@ where
 ///
 /// Errors that occur during the stream (e.g., in gRPC trailers or the
 /// END_STREAM envelope) are returned by [`ServerStream::message()`].
+///
+/// # Cancellation
+///
+/// Dropping the returned future or hitting its deadline drops the in-flight
+/// transport send with it, so a request that had not finished sending may
+/// never reach the server.
 pub async fn call_server_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
@@ -3433,9 +3439,11 @@ where
 /// # Cancellation
 ///
 /// Dropping the returned future (caller cancellation) or letting its deadline
-/// expire stops the in-flight transport send, even if the transport is still
-/// waiting for response headers — the background send does not outlive the
-/// abandoned call.
+/// expire promptly stops the in-flight transport send, even if the transport
+/// is still waiting for response headers — the background send task stops
+/// instead of outliving the call. As a consequence, a request that was still
+/// being sent when the call was abandoned may never reach the server; a
+/// caller that needs the request delivered must drive the call to completion.
 pub async fn call_client_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
@@ -3508,11 +3516,10 @@ where
     let (mut resp_tx, resp_rx) =
         tokio::sync::oneshot::channel::<Result<Response<T::ResponseBody>, ConnectError>>();
     let _ = crate::spawn_detached(async move {
-        // If the caller's future is cancelled or the call deadline fires,
-        // `resp_rx` is dropped. Race the send against the receiver closing so
-        // that, the next time this task is polled, the closed branch wins and
-        // `response_fut` is dropped — stopping the transport work instead of
-        // leaving it running in a detached task.
+        // Race the send against the receiver closing (see the `resp_rx`
+        // ownership note above): once the caller stops waiting, the closed
+        // branch wins on this task's next poll and `response_fut` is dropped,
+        // stopping the transport work instead of leaving it running detached.
         let maybe_result = tokio::select! {
             result = response_fut => {
                 Some(result.map_err(|e| map_transport_send_error(e, "request failed")))
@@ -5741,8 +5748,9 @@ mod tests {
 
     // When the caller drops the `call_client_stream` future (cancellation)
     // while the transport is still waiting for response headers, the background
-    // send task must likewise stop polling the transport send. A deadline-only
-    // fix would leave this path leaking, so this is the load-bearing test.
+    // send task must likewise stop polling the transport send. Cancellation is
+    // a distinct path from deadline expiry — no deadline machinery fires here,
+    // so dropping the call future must stop the in-flight send on its own.
     #[cfg(feature = "client")]
     #[tokio::test]
     async fn client_stream_cancellation_cancels_transport_send_task() {
@@ -5828,8 +5836,9 @@ mod tests {
             .expect("drop signal sender vanished without firing");
     }
 
-    // The abandonment fix must not disturb the success path: a well-formed
-    // Connect client-streaming response still decodes normally.
+    // Success path: with the send raced against caller abandonment in a
+    // background task, a well-formed Connect client-streaming response still
+    // decodes normally.
     #[cfg(feature = "client")]
     #[tokio::test]
     async fn client_stream_transport_task_still_returns_response() {
@@ -5890,8 +5899,9 @@ mod tests {
         assert_eq!(response.view().value, "ok");
     }
 
-    // A transport send failure must still surface through the existing
-    // `map_transport_send_error(e, "request failed")` branch unchanged.
+    // A transport send failure surfaces through the
+    // `map_transport_send_error(e, "request failed")` branch even though the
+    // send runs in a background task raced against caller abandonment.
     #[cfg(feature = "client")]
     #[tokio::test]
     async fn client_stream_transport_send_error_still_surfaces() {

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -3429,6 +3429,13 @@ where
 /// is ready instead of waiting for the iterator to be fully drained, so peak
 /// memory stays around `channel_depth * envelope_size` rather than the full
 /// concatenated body.
+///
+/// # Cancellation
+///
+/// Dropping the returned future (caller cancellation) or letting its deadline
+/// expire stops the in-flight transport send, even if the transport is still
+/// waiting for response headers — the background send does not outlive the
+/// abandoned call.
 pub async fn call_client_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
@@ -3492,14 +3499,29 @@ where
     // would not read from the channel until awaited, deadlocking once the
     // channel filled. The response is bridged back via a oneshot so the
     // awaitee is uniform across architectures.
+    //
+    // `resp_rx` is owned solely by the `with_deadline` block below and only
+    // consumed by `resp_rx.await`, so it is dropped exactly when the caller has
+    // stopped waiting (call future dropped, or deadline fired). The spawned
+    // task relies on that invariant to know when to abandon the send.
     let response_fut = transport.send(http_request);
-    let (resp_tx, resp_rx) =
+    let (mut resp_tx, resp_rx) =
         tokio::sync::oneshot::channel::<Result<Response<T::ResponseBody>, ConnectError>>();
     let _ = crate::spawn_detached(async move {
-        let result = response_fut
-            .await
-            .map_err(|e| map_transport_send_error(e, "request failed"));
-        let _ = resp_tx.send(result);
+        // If the caller's future is cancelled or the call deadline fires,
+        // `resp_rx` is dropped. Race the send against the receiver closing so
+        // that, the next time this task is polled, the closed branch wins and
+        // `response_fut` is dropped — stopping the transport work instead of
+        // leaving it running in a detached task.
+        let maybe_result = tokio::select! {
+            result = response_fut => {
+                Some(result.map_err(|e| map_transport_send_error(e, "request failed")))
+            }
+            () = resp_tx.closed() => None,
+        };
+        if let Some(result) = maybe_result {
+            let _ = resp_tx.send(result);
+        }
     });
 
     // Enforce client-side deadline on send + parse.
@@ -5574,6 +5596,338 @@ mod tests {
         .expect_err("transport config error must surface from client stream");
         assert_eq!(err.code, ErrorCode::InvalidArgument);
         assert!(err.message.as_deref().unwrap().contains("with_tls"));
+    }
+
+    // A transport whose `send()` future never resolves. It signals when it is
+    // first polled and again when it is dropped, so a test can assert that
+    // abandoning `call_client_stream` actually drops the in-flight transport
+    // send future rather than leaking it in a detached task.
+    #[cfg(feature = "client")]
+    #[derive(Clone)]
+    struct PendingSendTransport {
+        started: std::sync::Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+        dropped: std::sync::Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+    }
+
+    #[cfg(feature = "client")]
+    struct PendingSendFuture {
+        // Hold the request (and thus the request-body receiver) without ever
+        // reading it, so a caller draining into the body channel eventually
+        // parks on `tx.send(...)` backpressure rather than seeing the receiver
+        // drop. Dropping this future drops the request too.
+        _request: Request<ClientBody>,
+        started: Option<tokio::sync::oneshot::Sender<()>>,
+        dropped: Option<tokio::sync::oneshot::Sender<()>>,
+    }
+
+    #[cfg(feature = "client")]
+    impl std::future::Future for PendingSendFuture {
+        type Output = Result<Response<Full<Bytes>>, std::io::Error>;
+
+        fn poll(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            if let Some(tx) = self.started.take() {
+                let _ = tx.send(());
+            }
+            std::task::Poll::Pending
+        }
+    }
+
+    #[cfg(feature = "client")]
+    impl Drop for PendingSendFuture {
+        fn drop(&mut self) {
+            if let Some(tx) = self.dropped.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    #[cfg(feature = "client")]
+    impl ClientTransport for PendingSendTransport {
+        type ResponseBody = Full<Bytes>;
+        type Error = std::io::Error;
+
+        fn send(
+            &self,
+            request: Request<ClientBody>,
+        ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
+            // Single-shot: the streaming call paths invoke `send` exactly once.
+            // Panic loudly rather than silently swallow the started/dropped
+            // signals if that ever stops holding, which would otherwise hang the
+            // test.
+            let started = Some(
+                self.started
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("PendingSendTransport::send called more than once"),
+            );
+            let dropped = Some(
+                self.dropped
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("PendingSendTransport::send called more than once"),
+            );
+            Box::pin(PendingSendFuture {
+                _request: request,
+                started,
+                dropped,
+            })
+        }
+    }
+
+    #[cfg(feature = "client")]
+    fn pending_send_transport() -> (
+        PendingSendTransport,
+        tokio::sync::oneshot::Receiver<()>,
+        tokio::sync::oneshot::Receiver<()>,
+    ) {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
+        let transport = PendingSendTransport {
+            started: std::sync::Arc::new(std::sync::Mutex::new(Some(started_tx))),
+            dropped: std::sync::Arc::new(std::sync::Mutex::new(Some(dropped_tx))),
+        };
+        (transport, started_rx, dropped_rx)
+    }
+
+    // When the call deadline fires while the transport is still waiting for
+    // response headers, the background send task must stop polling the
+    // transport send (dropping its future) instead of leaking.
+    #[cfg(feature = "client")]
+    #[tokio::test(start_paused = true)]
+    async fn client_stream_deadline_cancels_transport_send_task() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let (transport, started_rx, dropped_rx) = pending_send_transport();
+        let config = ClientConfig::new("http://localhost:8080".parse().unwrap());
+
+        let mut call = Box::pin(
+            call_client_stream::<_, StringValue, StringValueView<'static>>(
+                &transport,
+                &config,
+                "test.Service",
+                "ClientStream",
+                std::iter::empty::<StringValue>(),
+                CallOptions::default().with_timeout(Duration::from_millis(100)),
+            ),
+        );
+
+        // Drive the call until the transport send future is actually polled, so
+        // the drop we assert below is provably the deadline path abandoning an
+        // in-flight send rather than an unpolled future.
+        tokio::select! {
+            res = &mut call => panic!("call resolved before the transport was polled: {res:?}"),
+            started = started_rx => started.expect("transport send future was never polled"),
+        }
+
+        // Now let the deadline fire.
+        let err = call
+            .await
+            .expect_err("deadline must fire while the transport waits for headers");
+        assert_eq!(err.code, ErrorCode::DeadlineExceeded);
+
+        // The transport send future must be dropped now that the caller has
+        // stopped waiting.
+        tokio::time::timeout(Duration::from_secs(5), dropped_rx)
+            .await
+            .expect("transport send future was not dropped after the deadline fired")
+            .expect("drop signal sender vanished without firing");
+    }
+
+    // When the caller drops the `call_client_stream` future (cancellation)
+    // while the transport is still waiting for response headers, the background
+    // send task must likewise stop polling the transport send. A deadline-only
+    // fix would leave this path leaking, so this is the load-bearing test.
+    #[cfg(feature = "client")]
+    #[tokio::test]
+    async fn client_stream_cancellation_cancels_transport_send_task() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let (transport, started_rx, dropped_rx) = pending_send_transport();
+        let config = ClientConfig::new("http://localhost:8080".parse().unwrap());
+
+        let mut call = Box::pin(
+            call_client_stream::<_, StringValue, StringValueView<'static>>(
+                &transport,
+                &config,
+                "test.Service",
+                "ClientStream",
+                std::iter::empty::<StringValue>(),
+                CallOptions::default(),
+            ),
+        );
+
+        // Drive the call until the transport send future is polled, then
+        // abandon it. `call` completing here would be a bug (the transport
+        // never resolves), so treat that as a failure.
+        tokio::select! {
+            _ = &mut call => panic!("call completed though the transport never responded"),
+            started = started_rx => started.expect("transport send future was never polled"),
+        }
+        drop(call);
+
+        tokio::time::timeout(Duration::from_secs(5), dropped_rx)
+            .await
+            .expect("transport send future was not dropped after caller cancellation")
+            .expect("drop signal sender vanished without firing");
+    }
+
+    // The earlier abandonment tests park the caller at `resp_rx.await` (empty
+    // request iterator). This one abandons the caller while it is still parked
+    // *inside* the drain loop on `tx.send(...)` backpressure — the transport
+    // holds the request body but never reads it, so the depth-32 channel fills.
+    // Proves the deadline reaches through the drain phase and still drops the
+    // in-flight send.
+    #[cfg(feature = "client")]
+    #[tokio::test(start_paused = true)]
+    async fn client_stream_deadline_cancels_transport_send_while_draining() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let (transport, started_rx, dropped_rx) = pending_send_transport();
+        let config = ClientConfig::new("http://localhost:8080".parse().unwrap());
+
+        // Far more than the depth-32 request channel holds, so the drain loop
+        // cannot finish and parks on `tx.send(...)`.
+        let requests: Vec<StringValue> = (0..256)
+            .map(|i| StringValue::from(format!("m{i}")))
+            .collect();
+
+        let mut call = Box::pin(
+            call_client_stream::<_, StringValue, StringValueView<'static>>(
+                &transport,
+                &config,
+                "test.Service",
+                "ClientStream",
+                requests,
+                CallOptions::default().with_timeout(Duration::from_millis(100)),
+            ),
+        );
+
+        // Drive the call until the transport send future is polled: by now the
+        // caller is parked mid-drain on channel backpressure.
+        tokio::select! {
+            res = &mut call => panic!("call resolved before the transport was polled: {res:?}"),
+            started = started_rx => started.expect("transport send future was never polled"),
+        }
+
+        let err = call
+            .await
+            .expect_err("deadline must fire while the caller is draining");
+        assert_eq!(err.code, ErrorCode::DeadlineExceeded);
+
+        tokio::time::timeout(Duration::from_secs(5), dropped_rx)
+            .await
+            .expect("transport send future was not dropped after the deadline fired mid-drain")
+            .expect("drop signal sender vanished without firing");
+    }
+
+    // The abandonment fix must not disturb the success path: a well-formed
+    // Connect client-streaming response still decodes normally.
+    #[cfg(feature = "client")]
+    #[tokio::test]
+    async fn client_stream_transport_task_still_returns_response() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        #[derive(Clone)]
+        struct FixedResponseTransport {
+            body: Bytes,
+        }
+
+        impl ClientTransport for FixedResponseTransport {
+            type ResponseBody = Full<Bytes>;
+            type Error = std::io::Error;
+
+            fn send(
+                &self,
+                _request: Request<ClientBody>,
+            ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
+                let body = self.body.clone();
+                Box::pin(async move {
+                    let response = Response::builder()
+                        .status(http::StatusCode::OK)
+                        .header(http::header::CONTENT_TYPE, "application/connect+proto")
+                        .body(Full::new(body))
+                        .unwrap();
+                    Ok(response)
+                })
+            }
+        }
+
+        // DATA envelope carrying the response message, then an END_STREAM
+        // envelope with empty (`{}`) trailers — the Connect client-stream
+        // terminus.
+        let data =
+            crate::envelope::Envelope::data(Bytes::from(StringValue::from("ok").encode_to_vec()))
+                .encode();
+        let end = crate::envelope::Envelope::end_stream(Bytes::from_static(b"{}")).encode();
+        let mut body = BytesMut::new();
+        body.extend_from_slice(&data);
+        body.extend_from_slice(&end);
+        let transport = FixedResponseTransport {
+            body: body.freeze(),
+        };
+        let config = ClientConfig::new("http://localhost:8080".parse().unwrap());
+
+        let response = call_client_stream::<_, StringValue, StringValueView<'static>>(
+            &transport,
+            &config,
+            "test.Service",
+            "ClientStream",
+            [StringValue::from("req")],
+            CallOptions::default(),
+        )
+        .await
+        .expect("well-formed client-streaming response must decode");
+        assert_eq!(response.view().value, "ok");
+    }
+
+    // A transport send failure must still surface through the existing
+    // `map_transport_send_error(e, "request failed")` branch unchanged.
+    #[cfg(feature = "client")]
+    #[tokio::test]
+    async fn client_stream_transport_send_error_still_surfaces() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        #[derive(Clone)]
+        struct FailingTransport;
+
+        impl ClientTransport for FailingTransport {
+            type ResponseBody = Full<Bytes>;
+            type Error = std::io::Error;
+
+            fn send(
+                &self,
+                _request: Request<ClientBody>,
+            ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
+                Box::pin(async { Err(std::io::Error::other("boom")) })
+            }
+        }
+
+        let config = ClientConfig::new("http://localhost:8080".parse().unwrap());
+        let err = call_client_stream::<_, StringValue, StringValueView<'static>>(
+            &FailingTransport,
+            &config,
+            "test.Service",
+            "ClientStream",
+            [StringValue::from("req")],
+            CallOptions::default(),
+        )
+        .await
+        .expect_err("transport send failure must surface");
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        let message = err.message.as_deref().unwrap_or_default();
+        assert!(message.contains("request failed"), "unexpected: {message}");
+        assert!(message.contains("boom"), "unexpected: {message}");
     }
 
     #[cfg(feature = "client")]


### PR DESCRIPTION
## What this does

Abandoning a `call_client_stream` call (dropping its future or hitting the deadline) while the transport is still awaiting response headers leaves the background `transport.send(...)` running indefinitely: the detached task driving it only checks the receiver after the send resolves.

**Fix:** the spawned task now stops the send when the caller stops waiting (future dropped or deadline fired). The response and transport-error paths are unchanged.

Note that this is also a behavior change, not only a leak fix: abandonment now cancels the underlying request, so a request that was still being sent may never reach the server. The `# Cancellation` docs and the changelog entry call this out, matching the equivalent `BidiStream` documentation from #221.

## Verification

Unpatched, the abandonment tests time out: the transport send future is never dropped.

| Check | Result |
| --- | --- |
| abandon: deadline / cancel / mid-drain | unpatched: send never dropped; patched: dropped |
| success, transport-error paths | unchanged |
| `fmt`, `clippy -D warnings`, `test` | clean / 562 passed |

## Review map

- `call_client_stream`: the spawned send task selects `transport.send(...)` against `resp_tx.closed()`, so a dropped receiver (cancellation or deadline) stops the send instead of leaving it detached.
- `connectrpc/Cargo.toml`: the always-compiled `call_client_stream` now uses `tokio::select!`, so the base tokio dep gains `macros`; the `server` feature's own `tokio/macros` entry is dropped as redundant, with a note on the base dependency explaining why `macros` is load-bearing.
- tests: pin both abandonment paths dropping the send future (with mid-drain backpressure), and preserve the success and transport-error paths.
- maintainer fixup (`6f67559`): documents the delivery caveat in the rustdoc and changelog, adds a `# Cancellation` note to `call_server_stream`, and consolidates the `tokio/macros` feature declaration.

Fixes #224
