### PR TITLE
client: take an async Stream for client-streaming requests

### DIFF
--- a/.changes/unreleased/Changed-20260709-102954.yaml
+++ b/.changes/unreleased/Changed-20260709-102954.yaml
@@ -1,0 +1,16 @@
+kind: Changed
+body: |-
+  **Breaking: client-streaming calls take an async `Stream` of requests** instead
+  of a synchronous iterator. `call_client_stream` and the generated client
+  methods accept `impl Stream<Item = Req> + Send + 'static`, so request
+  messages can be produced as they become available — without buffering the
+  upload or blocking a thread. The stream backs the HTTP request body
+  directly: the transport polls it as it is able to send, so backpressure is
+  HTTP/2 flow control and a server that ends the RPC mid-upload no longer
+  goes unnoticed while the stream is idle. The `Stream` trait and a
+  `stream_iter` adapter (`futures::stream::iter`) are re-exported from
+  `connectrpc::client`, so migrating a ready collection is
+  `client.sum(connectrpc::client::stream_iter(requests))` with no new
+  dependency. Because the stream backs the request body, it must be
+  `Send + 'static`: streams that borrow local data must be made owning.
+time: 2026-07-09T17:29:54.497133719Z

--- a/.changes/unreleased/Changed-20260709-102954.yaml
+++ b/.changes/unreleased/Changed-20260709-102954.yaml
@@ -11,8 +11,11 @@ body: |-
   control and a server that ends the RPC mid-upload no longer goes
   unnoticed while the stream is idle. The `Stream` trait and a
   `stream_iter` adapter (`futures::stream::iter`) are re-exported from
-  `connectrpc::client`, so migrating a ready collection is
-  `client.sum(connectrpc::client::stream_iter(requests))` with no new
+  `connectrpc::client`, with `stream_iter` also at the crate root, so
+  migrating a ready collection is
+  `client.sum(connectrpc::stream_iter(requests))` with no new
   dependency. Because the stream backs the request body, it must be
   `Send + 'static`: streams that borrow local data must be made owning.
+  Note that dropping a client-streaming call now cancels it: messages the
+  stream had not yet yielded are never delivered.
 time: 2026-07-09T17:29:54.497133719Z

--- a/.changes/unreleased/Changed-20260709-102954.yaml
+++ b/.changes/unreleased/Changed-20260709-102954.yaml
@@ -1,13 +1,15 @@
 kind: Changed
 body: |-
-  **Breaking: client-streaming calls take an async `Stream` of requests** instead
-  of a synchronous iterator. `call_client_stream` and the generated client
-  methods accept `impl Stream<Item = Req> + Send + 'static`, so request
-  messages can be produced as they become available — without buffering the
-  upload or blocking a thread. The stream backs the HTTP request body
-  directly: the transport polls it as it is able to send, so backpressure is
-  HTTP/2 flow control and a server that ends the RPC mid-upload no longer
-  goes unnoticed while the stream is idle. The `Stream` trait and a
+  **Breaking: client-streaming calls take an async `Stream` of requests**
+  instead of a synchronous iterator. `call_client_stream` and the generated
+  client methods accept `impl ClientRequestStream<Req>` — a sealed trait
+  implemented automatically for every `Stream<Item = Req> + Send + 'static`,
+  carrying tailored compiler diagnostics — so request messages can be
+  produced as they become available, without buffering the upload or
+  blocking a thread. The stream backs the HTTP request body directly: the
+  transport polls it as it is able to send, so backpressure is HTTP/2 flow
+  control and a server that ends the RPC mid-upload no longer goes
+  unnoticed while the stream is idle. The `Stream` trait and a
   `stream_iter` adapter (`futures::stream::iter`) are re-exported from
   `connectrpc::client`, so migrating a ready collection is
   `client.sum(connectrpc::client::stream_iter(requests))` with no new

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio-stream = "0.1"
 tokio-util = "0.7"
 futures = "0.3"
 pin-project = "1"
+sync_wrapper = "1"
 async-trait = "0.1"
 
 # Protobuf. The 0.8 floor matches the regen baseline for the checked-in

--- a/benches/rpc/benches/cross_impl_bench.rs
+++ b/benches/rpc/benches/cross_impl_bench.rs
@@ -292,7 +292,7 @@ fn bench_client_stream_grpc(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(impl_name), |b| {
             b.to_async(&rt).iter(|| async {
                 client
-                    .client_stream(messages.clone())
+                    .client_stream(futures::stream::iter(messages.clone()))
                     .await
                     .expect("client_stream failed")
             });

--- a/benches/rpc/benches/rpc_bench.rs
+++ b/benches/rpc/benches/rpc_bench.rs
@@ -216,7 +216,7 @@ fn bench_client_stream(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(protocol), |b| {
             b.to_async(&rt).iter(|| async {
                 client
-                    .client_stream(messages.clone())
+                    .client_stream(futures::stream::iter(messages.clone()))
                     .await
                     .expect("client_stream failed")
             });

--- a/benches/rpc/benches/rpc_bench.rs
+++ b/benches/rpc/benches/rpc_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use pprof::criterion::{Output, PProfProfiler};
 
 use connectrpc::client::{HttpClient, full_body};
@@ -225,6 +225,66 @@ fn bench_client_stream(c: &mut Criterion) {
     group.finish();
 }
 
+/// Sustained client-streaming: enough messages per call that the per-message
+/// path (stream poll, encode, frame emission) dominates call setup/teardown.
+fn bench_client_stream_many_small(c: &mut Criterion) {
+    const MANY: i32 = 1000;
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (addr, _handle) = rt.block_on(start_server());
+
+    let mut group = c.benchmark_group("client_stream_many_small");
+    group.throughput(Throughput::Elements(MANY as u64));
+    group.sample_size(30);
+    let messages: Vec<BenchRequest> = (0..MANY).map(|_| small_request()).collect();
+    for protocol in PROTOCOLS {
+        let client = make_client(addr, protocol, CodecFormat::Proto);
+        group.bench_function(BenchmarkId::from_parameter(protocol), |b| {
+            // iter_batched keeps the 1000-message clone out of the timing.
+            b.to_async(&rt).iter_batched(
+                || messages.clone(),
+                |msgs| async {
+                    client
+                        .client_stream(futures::stream::iter(msgs))
+                        .await
+                        .expect("client_stream failed")
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// Large-message client-streaming: per-message encode/copy cost is
+/// significant relative to the wire, so where the encode runs matters.
+fn bench_client_stream_large(c: &mut Criterion) {
+    const LARGE_COUNT: i32 = 10;
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (addr, _handle) = rt.block_on(start_server());
+
+    let mut group = c.benchmark_group("client_stream_large");
+    group.throughput(Throughput::Elements(LARGE_COUNT as u64));
+    group.sample_size(20);
+    let messages: Vec<BenchRequest> = (0..LARGE_COUNT).map(|_| large_request()).collect();
+    for protocol in PROTOCOLS {
+        let client = make_client(addr, protocol, CodecFormat::Proto);
+        group.bench_function(BenchmarkId::from_parameter(protocol), |b| {
+            // iter_batched keeps the 10 MiB clone out of the timing.
+            b.to_async(&rt).iter_batched(
+                || messages.clone(),
+                |msgs| async {
+                    client
+                        .client_stream(futures::stream::iter(msgs))
+                        .await
+                        .expect("client_stream failed")
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
 fn bench_bidi_stream(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let (addr, _handle) = rt.block_on(start_server());
@@ -292,6 +352,8 @@ criterion_group! {
         bench_unary_large,
         bench_server_stream,
         bench_client_stream,
+        bench_client_stream_many_small,
+        bench_client_stream_large,
         bench_bidi_stream,
 }
 criterion_main!(benches);

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -934,16 +934,17 @@ where
     }
     /// Call the ClientStream RPC. Sends a request to /bench.v1.BenchService/ClientStream.
     ///
-    /// `requests` is an asynchronous stream; messages are sent as the
-    /// stream yields them. It must be `Send + 'static` (it backs the
-    /// request body), so yield owned messages or feed the call from a
+    /// `requests` is any `Stream<Item = ...> + Send + 'static` of
+    /// request messages (the `ClientRequestStream` bound); messages
+    /// are sent as the stream yields them. It backs the request
+    /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
     /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream(
         &self,
-        requests: impl ::connectrpc::client::Stream<
-            Item = crate::proto::bench::v1::BenchRequest,
-        > + Send + 'static,
+        requests: impl ::connectrpc::client::ClientRequestStream<
+            crate::proto::bench::v1::BenchRequest,
+        >,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<
             ::buffa::view::OwnedView<
@@ -960,16 +961,17 @@ where
     }
     /// Call the ClientStream RPC with explicit per-call options. Options override [`ClientConfig`](::connectrpc::client::ClientConfig) defaults.
     ///
-    /// `requests` is an asynchronous stream; messages are sent as the
-    /// stream yields them. It must be `Send + 'static` (it backs the
-    /// request body), so yield owned messages or feed the call from a
+    /// `requests` is any `Stream<Item = ...> + Send + 'static` of
+    /// request messages (the `ClientRequestStream` bound); messages
+    /// are sent as the stream yields them. It backs the request
+    /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
     /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream_with_options(
         &self,
-        requests: impl ::connectrpc::client::Stream<
-            Item = crate::proto::bench::v1::BenchRequest,
-        > + Send + 'static,
+        requests: impl ::connectrpc::client::ClientRequestStream<
+            crate::proto::bench::v1::BenchRequest,
+        >,
         options: ::connectrpc::client::CallOptions,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -933,9 +933,17 @@ where
             .await
     }
     /// Call the ClientStream RPC. Sends a request to /bench.v1.BenchService/ClientStream.
+    ///
+    /// `requests` is an asynchronous stream; messages are sent as the
+    /// stream yields them. It must be `Send + 'static` (it backs the
+    /// request body), so yield owned messages or feed the call from a
+    /// channel-backed stream. For a collection that is already in
+    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream(
         &self,
-        requests: impl IntoIterator<Item = crate::proto::bench::v1::BenchRequest>,
+        requests: impl ::connectrpc::client::Stream<
+            Item = crate::proto::bench::v1::BenchRequest,
+        > + Send + 'static,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<
             ::buffa::view::OwnedView<
@@ -951,9 +959,17 @@ where
             .await
     }
     /// Call the ClientStream RPC with explicit per-call options. Options override [`ClientConfig`](::connectrpc::client::ClientConfig) defaults.
+    ///
+    /// `requests` is an asynchronous stream; messages are sent as the
+    /// stream yields them. It must be `Send + 'static` (it backs the
+    /// request body), so yield owned messages or feed the call from a
+    /// channel-backed stream. For a collection that is already in
+    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream_with_options(
         &self,
-        requests: impl IntoIterator<Item = crate::proto::bench::v1::BenchRequest>,
+        requests: impl ::connectrpc::client::Stream<
+            Item = crate::proto::bench::v1::BenchRequest,
+        > + Send + 'static,
         options: ::connectrpc::client::CallOptions,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -939,7 +939,13 @@ where
     /// are sent as the stream yields them. It backs the request
     /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
-    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
+    /// hand, wrap it with `::connectrpc::stream_iter(...)`.
+    ///
+    /// Dropping the returned future cancels the call: the request
+    /// body is dropped along with it, so messages the stream had
+    /// not yet yielded are never delivered. A caller that needs the
+    /// request delivered must drive the call to completion rather
+    /// than, say, wrapping it in a `timeout`.
     pub async fn client_stream(
         &self,
         requests: impl ::connectrpc::client::ClientRequestStream<
@@ -966,7 +972,13 @@ where
     /// are sent as the stream yields them. It backs the request
     /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
-    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
+    /// hand, wrap it with `::connectrpc::stream_iter(...)`.
+    ///
+    /// Dropping the returned future cancels the call: the request
+    /// body is dropped along with it, so messages the stream had
+    /// not yet yielded are never delivered. A caller that needs the
+    /// request delivered must drive the call to completion rather
+    /// than, say, wrapping it in a `timeout`.
     pub async fn client_stream_with_options(
         &self,
         requests: impl ::connectrpc::client::ClientRequestStream<

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -1039,7 +1039,12 @@ async fn do_client_stream_call(
     // Make the call
     let call_future = async {
         let resp = call_client_stream::<_, ClientStreamRequest, ClientStreamResponseView<'static>>(
-            &transport, &config, service, method, requests, options,
+            &transport,
+            &config,
+            service,
+            method,
+            futures::stream::iter(requests),
+            options,
         )
         .await?;
         let (headers, message, trailers) = resp.into_owned_parts();

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -1179,11 +1179,17 @@ where
             .await
     }
     /// Call the ClientStream RPC. Sends a request to /connectrpc.conformance.v1.ConformanceService/ClientStream.
+    ///
+    /// `requests` is an asynchronous stream; messages are sent as the
+    /// stream yields them. It must be `Send + 'static` (it backs the
+    /// request body), so yield owned messages or feed the call from a
+    /// channel-backed stream. For a collection that is already in
+    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream(
         &self,
-        requests: impl IntoIterator<
+        requests: impl ::connectrpc::client::Stream<
             Item = crate::proto::connectrpc::conformance::v1::ClientStreamRequest,
-        >,
+        > + Send + 'static,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<
             ::buffa::view::OwnedView<
@@ -1201,11 +1207,17 @@ where
             .await
     }
     /// Call the ClientStream RPC with explicit per-call options. Options override [`ClientConfig`](::connectrpc::client::ClientConfig) defaults.
+    ///
+    /// `requests` is an asynchronous stream; messages are sent as the
+    /// stream yields them. It must be `Send + 'static` (it backs the
+    /// request body), so yield owned messages or feed the call from a
+    /// channel-backed stream. For a collection that is already in
+    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream_with_options(
         &self,
-        requests: impl IntoIterator<
+        requests: impl ::connectrpc::client::Stream<
             Item = crate::proto::connectrpc::conformance::v1::ClientStreamRequest,
-        >,
+        > + Send + 'static,
         options: ::connectrpc::client::CallOptions,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -1185,7 +1185,13 @@ where
     /// are sent as the stream yields them. It backs the request
     /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
-    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
+    /// hand, wrap it with `::connectrpc::stream_iter(...)`.
+    ///
+    /// Dropping the returned future cancels the call: the request
+    /// body is dropped along with it, so messages the stream had
+    /// not yet yielded are never delivered. A caller that needs the
+    /// request delivered must drive the call to completion rather
+    /// than, say, wrapping it in a `timeout`.
     pub async fn client_stream(
         &self,
         requests: impl ::connectrpc::client::ClientRequestStream<
@@ -1214,7 +1220,13 @@ where
     /// are sent as the stream yields them. It backs the request
     /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
-    /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
+    /// hand, wrap it with `::connectrpc::stream_iter(...)`.
+    ///
+    /// Dropping the returned future cancels the call: the request
+    /// body is dropped along with it, so messages the stream had
+    /// not yet yielded are never delivered. A caller that needs the
+    /// request delivered must drive the call to completion rather
+    /// than, say, wrapping it in a `timeout`.
     pub async fn client_stream_with_options(
         &self,
         requests: impl ::connectrpc::client::ClientRequestStream<

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -1180,16 +1180,17 @@ where
     }
     /// Call the ClientStream RPC. Sends a request to /connectrpc.conformance.v1.ConformanceService/ClientStream.
     ///
-    /// `requests` is an asynchronous stream; messages are sent as the
-    /// stream yields them. It must be `Send + 'static` (it backs the
-    /// request body), so yield owned messages or feed the call from a
+    /// `requests` is any `Stream<Item = ...> + Send + 'static` of
+    /// request messages (the `ClientRequestStream` bound); messages
+    /// are sent as the stream yields them. It backs the request
+    /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
     /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream(
         &self,
-        requests: impl ::connectrpc::client::Stream<
-            Item = crate::proto::connectrpc::conformance::v1::ClientStreamRequest,
-        > + Send + 'static,
+        requests: impl ::connectrpc::client::ClientRequestStream<
+            crate::proto::connectrpc::conformance::v1::ClientStreamRequest,
+        >,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<
             ::buffa::view::OwnedView<
@@ -1208,16 +1209,17 @@ where
     }
     /// Call the ClientStream RPC with explicit per-call options. Options override [`ClientConfig`](::connectrpc::client::ClientConfig) defaults.
     ///
-    /// `requests` is an asynchronous stream; messages are sent as the
-    /// stream yields them. It must be `Send + 'static` (it backs the
-    /// request body), so yield owned messages or feed the call from a
+    /// `requests` is any `Stream<Item = ...> + Send + 'static` of
+    /// request messages (the `ClientRequestStream` bound); messages
+    /// are sent as the stream yields them. It backs the request
+    /// body, so yield owned messages or feed the call from a
     /// channel-backed stream. For a collection that is already in
     /// hand, wrap it with `::connectrpc::client::stream_iter(...)`.
     pub async fn client_stream_with_options(
         &self,
-        requests: impl ::connectrpc::client::Stream<
-            Item = crate::proto::connectrpc::conformance::v1::ClientStreamRequest,
-        > + Send + 'static,
+        requests: impl ::connectrpc::client::ClientRequestStream<
+            crate::proto::connectrpc::conformance::v1::ClientStreamRequest,
+        >,
         options: ::connectrpc::client::CallOptions,
     ) -> Result<
         ::connectrpc::client::UnaryResponse<

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -2254,7 +2254,13 @@ fn generate_client_method(
             #[doc = " are sent as the stream yields them. It backs the request"]
             #[doc = " body, so yield owned messages or feed the call from a"]
             #[doc = " channel-backed stream. For a collection that is already in"]
-            #[doc = " hand, wrap it with `::connectrpc::client::stream_iter(...)`."]
+            #[doc = " hand, wrap it with `::connectrpc::stream_iter(...)`."]
+            #[doc = ""]
+            #[doc = " Dropping the returned future cancels the call: the request"]
+            #[doc = " body is dropped along with it, so messages the stream had"]
+            #[doc = " not yet yielded are never delivered. A caller that needs the"]
+            #[doc = " request delivered must drive the call to completion rather"]
+            #[doc = " than, say, wrapping it in a `timeout`."]
         };
         ret_ty = quote! {
             Result<

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -2249,9 +2249,10 @@ fn generate_client_method(
         // Client-stream
         extra_doc = quote! {
             #[doc = ""]
-            #[doc = " `requests` is an asynchronous stream; messages are sent as the"]
-            #[doc = " stream yields them. It must be `Send + 'static` (it backs the"]
-            #[doc = " request body), so yield owned messages or feed the call from a"]
+            #[doc = " `requests` is any `Stream<Item = ...> + Send + 'static` of"]
+            #[doc = " request messages (the `ClientRequestStream` bound); messages"]
+            #[doc = " are sent as the stream yields them. It backs the request"]
+            #[doc = " body, so yield owned messages or feed the call from a"]
             #[doc = " channel-backed stream. For a collection that is already in"]
             #[doc = " hand, wrap it with `::connectrpc::client::stream_iter(...)`."]
         };
@@ -2268,8 +2269,9 @@ fn generate_client_method(
                 requests, options,
             ).await
         };
-        short_args = quote! { requests: impl ::connectrpc::client::Stream<Item = #input_type> + Send + 'static };
-        opts_args = quote! { requests: impl ::connectrpc::client::Stream<Item = #input_type> + Send + 'static, options: ::connectrpc::client::CallOptions };
+        short_args =
+            quote! { requests: impl ::connectrpc::client::ClientRequestStream<#input_type> };
+        opts_args = quote! { requests: impl ::connectrpc::client::ClientRequestStream<#input_type>, options: ::connectrpc::client::CallOptions };
         short_delegate_args = quote! { requests, ::connectrpc::client::CallOptions::default() };
     } else if client_streaming && server_streaming {
         // Bidi

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -2242,9 +2242,19 @@ fn generate_client_method(
     let short_args: TokenStream; // args to the no-opts convenience method
     let opts_args: TokenStream; // args to the _with_options method
     let short_delegate_args: TokenStream; // how short delegates to opts
+    // Extra doc lines appended to both methods (client-stream input contract).
+    let mut extra_doc = quote! {};
 
     if client_streaming && !server_streaming {
         // Client-stream
+        extra_doc = quote! {
+            #[doc = ""]
+            #[doc = " `requests` is an asynchronous stream; messages are sent as the"]
+            #[doc = " stream yields them. It must be `Send + 'static` (it backs the"]
+            #[doc = " request body), so yield owned messages or feed the call from a"]
+            #[doc = " channel-backed stream. For a collection that is already in"]
+            #[doc = " hand, wrap it with `::connectrpc::client::stream_iter(...)`."]
+        };
         ret_ty = quote! {
             Result<
                 ::connectrpc::client::UnaryResponse<::buffa::view::OwnedView<#output_view_type<'static>>>,
@@ -2258,8 +2268,8 @@ fn generate_client_method(
                 requests, options,
             ).await
         };
-        short_args = quote! { requests: impl IntoIterator<Item = #input_type> };
-        opts_args = quote! { requests: impl IntoIterator<Item = #input_type>, options: ::connectrpc::client::CallOptions };
+        short_args = quote! { requests: impl ::connectrpc::client::Stream<Item = #input_type> + Send + 'static };
+        opts_args = quote! { requests: impl ::connectrpc::client::Stream<Item = #input_type> + Send + 'static, options: ::connectrpc::client::CallOptions };
         short_delegate_args = quote! { requests, ::connectrpc::client::CallOptions::default() };
     } else if client_streaming && server_streaming {
         // Bidi
@@ -2320,11 +2330,13 @@ fn generate_client_method(
 
     Ok(quote! {
         #[doc = #doc]
+        #extra_doc
         pub async fn #method_snake(&self, #short_args) -> #ret_ty {
             self.#method_with_opts(#short_delegate_args).await
         }
 
         #[doc = #doc_opts]
+        #extra_doc
         pub async fn #method_with_opts(&self, #opts_args) -> #ret_ty {
             #call_body
         }

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -28,6 +28,7 @@ tower = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "sync", "time"] }
 futures = { workspace = true }
 pin-project = { workspace = true }
+sync_wrapper = { workspace = true }
 async-trait = { workspace = true }
 
 # Protobuf.

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -119,14 +119,40 @@ use buffa::view::MessageView;
 use buffa::view::OwnedView;
 use buffa::view::ViewReborrow;
 /// Re-export of [`futures::Stream`] (the `futures` 0.3 / `futures-core` 0.3
-/// trait), the request-stream bound for client-streaming calls. Re-exported
-/// so generated code and callers can name the bound without a direct
-/// `futures` dependency.
+/// trait), which [`ClientRequestStream`] builds on. Re-exported so generic
+/// code can name the trait without a direct `futures` dependency.
 pub use futures::Stream;
 /// Re-export of [`futures::stream::iter`]: adapts a collection that is
 /// already in hand into a request stream for a client-streaming call,
 /// without a direct `futures` dependency.
 pub use futures::stream::iter as stream_iter;
+
+mod sealed {
+    pub trait Sealed {}
+    impl<S> Sealed for S where S: super::Stream + Send + 'static {}
+}
+
+/// The request-stream bound for client-streaming calls.
+///
+/// Implemented automatically for every `Stream<Item = Req> + Send + 'static`
+/// — it cannot (and never needs to) be implemented by hand. The trait exists
+/// so the compiler can point at the two usual fixes when the bound is not
+/// met: wrap a ready collection with [`stream_iter`], and make a borrowing
+/// stream yield owned messages (the stream backs the request body, which can
+/// outlive the call frame and move across threads — hence `Send + 'static`).
+///
+/// Not to be confused with the server-side
+/// [`dispatcher::RequestStream`](crate::dispatcher::RequestStream), a boxed
+/// stream of raw request bytes.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` cannot be used as the request stream of a client-streaming call",
+    label = "expected an async `Stream<Item = {Req}> + Send + 'static`",
+    note = "for a collection that is already in hand, wrap it with `connectrpc::client::stream_iter(...)`",
+    note = "the stream backs the request body, so it must be `Send + 'static`: yield owned messages (no borrows of local data) or feed the call from a channel-backed stream"
+)]
+pub trait ClientRequestStream<Req>: sealed::Sealed + Stream<Item = Req> + Send + 'static {}
+
+impl<S, Req> ClientRequestStream<Req> for S where S: Stream<Item = Req> + Send + 'static {}
 
 use crate::codec::CodecFormat;
 use crate::codec::content_type;
@@ -3525,10 +3551,11 @@ where
 ///
 /// `requests` is an asynchronous [`Stream`], so messages can be produced as
 /// they become available (paced by timers, read from sockets, forwarded from
-/// channels) without buffering the whole request up front. The stream must
-/// be `Send + 'static` because it backs the request body, which can outlive
-/// the call frame and move across threads — yield owned messages (no borrows
-/// of local data), or feed the call from a channel-backed stream. For a
+/// channels) without buffering the whole request up front. The
+/// [`ClientRequestStream`] bound additionally requires `Send + 'static`
+/// because the stream backs the request body, which can outlive the call
+/// frame and move across threads — yield owned messages (no borrows of
+/// local data), or feed the call from a channel-backed stream. For a
 /// collection that is already in hand, wrap it with [`stream_iter`]:
 ///
 /// ```rust,ignore
@@ -3556,7 +3583,7 @@ pub async fn call_client_stream<T, Req, RespView>(
     config: &ClientConfig,
     service: &str,
     method: &str,
-    requests: impl Stream<Item = Req> + Send + 'static,
+    requests: impl ClientRequestStream<Req>,
     options: CallOptions,
 ) -> Result<UnaryResponse<OwnedView<RespView>>, ConnectError>
 where

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -144,10 +144,22 @@ mod sealed {
 /// Not to be confused with the server-side
 /// [`dispatcher::RequestStream`](crate::dispatcher::RequestStream), a boxed
 /// stream of raw request bytes.
+///
+/// # Panics in `poll_next`
+///
+/// The stream backs the request body, so it is polled on the task driving
+/// the HTTP request rather than on the caller's. A panic in `poll_next`
+/// therefore does not propagate to the caller: it surfaces as a generic
+/// transport error, and where that driver task is shared between calls
+/// (such as [`SharedHttp2Connection`]) it can fault every RPC on that
+/// connection, not just this one. The stream yields `Req`, not a
+/// `Result`, so it has no channel for reporting its own failure: end the
+/// stream early instead of panicking, and surface the reason through your
+/// own application protocol.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` cannot be used as the request stream of a client-streaming call",
     label = "expected an async `Stream<Item = {Req}> + Send + 'static`",
-    note = "for a collection that is already in hand, wrap it with `connectrpc::client::stream_iter(...)`",
+    note = "for a collection that is already in hand, wrap it with `connectrpc::stream_iter(...)`",
     note = "the stream backs the request body, so it must be `Send + 'static`: yield owned messages (no borrows of local data) or feed the call from a channel-backed stream"
 )]
 pub trait ClientRequestStream<Req>: sealed::Sealed + Stream<Item = Req> + Send + 'static {}
@@ -3567,7 +3579,7 @@ where
 /// ```rust,ignore
 /// let resp = call_client_stream(
 ///     &transport, &config, "svc", "Method",
-///     connectrpc::client::stream_iter(vec![req1, req2]),
+///     connectrpc::stream_iter(vec![req1, req2]),
 ///     CallOptions::default(),
 /// ).await?;
 /// ```
@@ -3692,6 +3704,12 @@ where
     // the precise encode error instead of the generic transport failure —
     // unconditionally, because a server's early response can race the abort
     // and produce an `Ok` result for a truncated, encode-aborted upload.
+    //
+    // The race runs the other way too, and that direction is left alone on
+    // purpose: with the body driven in the background, an encode failure can
+    // land after this check and is then never read, so the call reports the
+    // server's `Ok`. That is the intended outcome — the server had already
+    // produced a complete response, so the truncated tail did not affect it.
     if let Some(err) = encode_error
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -118,6 +118,15 @@ use buffa::view::HasMessageView;
 use buffa::view::MessageView;
 use buffa::view::OwnedView;
 use buffa::view::ViewReborrow;
+/// Re-export of [`futures::Stream`] (the `futures` 0.3 / `futures-core` 0.3
+/// trait), the request-stream bound for client-streaming calls. Re-exported
+/// so generated code and callers can name the bound without a direct
+/// `futures` dependency.
+pub use futures::Stream;
+/// Re-export of [`futures::stream::iter`]: adapts a collection that is
+/// already in hand into a request stream for a client-streaming call,
+/// without a direct `futures` dependency.
+pub use futures::stream::iter as stream_iter;
 
 use crate::codec::CodecFormat;
 use crate::codec::content_type;
@@ -2955,7 +2964,7 @@ where
 
 /// A request body that pulls envelope-encoded frames from an mpsc channel.
 ///
-/// Used as the request body for bidirectional and client-streaming calls.
+/// Used as the request body for bidirectional streaming calls.
 /// [`BidiStream::send`] pushes encoded envelopes to the channel's sender half;
 /// dropping the sender (via [`BidiStream::close_send`]) closes the body,
 /// signalling EOF to the server.
@@ -2974,6 +2983,90 @@ impl Body for ChannelBody {
         self.rx
             .poll_recv(cx)
             .map(|opt| opt.map(|r| r.map(http_body::Frame::data)))
+    }
+}
+
+/// A request body that lazily encodes messages from the caller's stream
+/// into envelope frames as the transport polls for body data.
+///
+/// Used by [`call_client_stream`]: making the stream *be* the body hands
+/// upload liveness to the HTTP layer. The transport polls for the next
+/// frame only while it can send (backpressure is HTTP/2 flow control), a
+/// server that ends the RPC early makes the transport stop polling and
+/// drop the body, and a server that sends response headers early while
+/// still reading the upload keeps receiving frames — none of which needs a
+/// library-side pump loop.
+///
+/// The stream is held in a [`sync_wrapper::SyncWrapper`] so the body is
+/// `Sync` (as [`ClientBody`]'s boxing requires) without demanding `Sync`
+/// of the caller's stream — the wrapper only ever hands out `&mut` access.
+#[pin_project::pin_project]
+struct EncodingBody<S> {
+    #[pin]
+    stream: sync_wrapper::SyncWrapper<S>,
+    encoder: crate::envelope::EnvelopeEncoder,
+    codec_format: CodecFormat,
+    /// Mirror of an encode error also emitted through the body, letting the
+    /// call report the precise error instead of a transport-level failure.
+    error: std::sync::Arc<std::sync::Mutex<Option<ConnectError>>>,
+    /// Set on an encode error or stream exhaustion; the body then reports
+    /// end-of-stream without polling the (possibly non-fused) stream again.
+    done: bool,
+}
+
+impl<S, Req> Body for EncodingBody<S>
+where
+    S: Stream<Item = Req>,
+    Req: buffa::Message + crate::codec::JsonSerialize,
+{
+    type Data = Bytes;
+    type Error = ConnectError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<http_body::Frame<Bytes>, ConnectError>>> {
+        use std::task::Poll;
+
+        let this = self.project();
+        if *this.done {
+            return Poll::Ready(None);
+        }
+
+        let Some(request) = std::task::ready!(this.stream.get_pin_mut().poll_next(cx)) else {
+            // `Stream` gives no post-`None` guarantee, so never poll the
+            // (possibly non-fused) stream again.
+            *this.done = true;
+            return Poll::Ready(None);
+        };
+
+        let mut record_error = |err: &ConnectError| {
+            *this.done = true;
+            *this
+                .error
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(err.clone());
+        };
+
+        let msg_bytes = match this.codec_format {
+            CodecFormat::Proto => request.encode_to_bytes(),
+            CodecFormat::Json => match encode_json(&request) {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    record_error(&err);
+                    return Poll::Ready(Some(Err(err)));
+                }
+            },
+        };
+
+        let mut envelope_buf = BytesMut::new();
+        match tokio_util::codec::Encoder::encode(this.encoder, msg_bytes, &mut envelope_buf) {
+            Ok(()) => Poll::Ready(Some(Ok(http_body::Frame::data(envelope_buf.freeze())))),
+            Err(err) => {
+                record_error(&err);
+                Poll::Ready(Some(Err(err)))
+            }
+        }
     }
 }
 
@@ -3423,18 +3516,47 @@ where
 /// envelope-framed response with END_STREAM. Returns a [`UnaryResponse`] containing
 /// the decoded response message along with headers and trailers.
 ///
-/// The request body is streamed: each item from the iterator is encoded into
-/// an envelope and pushed to a bounded mpsc channel that backs the HTTP
-/// request body. The transport begins sending as soon as the first envelope
-/// is ready instead of waiting for the iterator to be fully drained, so peak
-/// memory stays around `channel_depth * envelope_size` rather than the full
-/// concatenated body.
+/// The request body IS the stream: each item yielded by `requests` is
+/// encoded into an envelope frame as the transport asks for the next chunk
+/// of body data. The transport begins sending as soon as the first message
+/// is available, backpressure is the HTTP layer's own flow control, and
+/// peak memory stays around one envelope rather than the full concatenated
+/// body.
+///
+/// `requests` is an asynchronous [`Stream`], so messages can be produced as
+/// they become available (paced by timers, read from sockets, forwarded from
+/// channels) without buffering the whole request up front. The stream must
+/// be `Send + 'static` because it backs the request body, which can outlive
+/// the call frame and move across threads — yield owned messages (no borrows
+/// of local data), or feed the call from a channel-backed stream. For a
+/// collection that is already in hand, wrap it with [`stream_iter`]:
+///
+/// ```rust,ignore
+/// let resp = call_client_stream(
+///     &transport, &config, "svc", "Method",
+///     connectrpc::client::stream_iter(vec![req1, req2]),
+///     CallOptions::default(),
+/// ).await?;
+/// ```
+///
+/// Because the transport owns the polling of `requests`, upload liveness
+/// follows HTTP semantics: a server that ends the RPC while `requests` is
+/// still pending (for example, rejecting the call partway through the
+/// upload) produces a response and the call returns without draining the
+/// stream, while a server that merely sends response headers early and
+/// keeps consuming the upload keeps receiving messages.
+///
+/// # Errors
+///
+/// Returns an error if a request message cannot be encoded, the transport
+/// fails, the whole-call deadline expires, the server responds with an
+/// error, or the response cannot be decoded.
 pub async fn call_client_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
     service: &str,
     method: &str,
-    requests: impl IntoIterator<Item = Req>,
+    requests: impl Stream<Item = Req> + Send + 'static,
     options: CallOptions,
 ) -> Result<UnaryResponse<OwnedView<RespView>>, ConnectError>
 where
@@ -3454,21 +3576,31 @@ where
         .parse()
         .map_err(|e| ConnectError::internal(format!("invalid URI: {e}")))?;
 
-    // Channel-backed request body. Depth 32 matches `call_bidi_stream` and
-    // gives natural backpressure on HTTP/2 flow control.
-    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, ConnectError>>(32);
-    let body: ClientBody = ChannelBody { rx }.boxed();
-
     let compression_for_encoder = config.request_compression.as_ref().map(|enc| {
         (
             std::sync::Arc::new(config.compression.clone()),
             enc.as_str(),
         )
     });
-    let mut encoder = crate::envelope::EnvelopeEncoder::new(
+    let encoder = crate::envelope::EnvelopeEncoder::new(
         compression_for_encoder,
         config.compression_policy.with_override(options.compress),
     );
+
+    // The stream backs the request body directly: the transport polls it for
+    // the next frame as it is able to send. An encode failure is reported
+    // through the body (aborting the request) and stashed here so the call
+    // can surface the precise error instead of a generic transport failure.
+    let encode_error: std::sync::Arc<std::sync::Mutex<Option<ConnectError>>> =
+        std::sync::Arc::default();
+    let body: ClientBody = EncodingBody {
+        stream: sync_wrapper::SyncWrapper::new(requests),
+        encoder,
+        codec_format: config.codec_format,
+        error: encode_error.clone(),
+        done: false,
+    }
+    .boxed();
 
     // Compute deadline BEFORE sending, matching Go's ctx.Deadline() semantics
     let deadline = client_deadline(options.timeout, config.protocol);
@@ -3487,51 +3619,16 @@ where
         .body(body)
         .map_err(|e| ConnectError::internal(format!("failed to build request: {e}")))?;
 
-    // Drive the transport send concurrently with the iterator drain below.
-    // Without this, a transport whose send() future contains the actual I/O
-    // would not read from the channel until awaited, deadlocking once the
-    // channel filled. The response is bridged back via a oneshot so the
-    // awaitee is uniform across architectures.
-    let response_fut = transport.send(http_request);
-    let (resp_tx, resp_rx) =
-        tokio::sync::oneshot::channel::<Result<Response<T::ResponseBody>, ConnectError>>();
-    let _ = crate::spawn_detached(async move {
-        let result = response_fut
+    // Enforce the client-side deadline on send + parse. The transport polls
+    // the request body (and therefore the caller's stream) while this send
+    // future — or, for connection-driver transports, their background task —
+    // makes progress; there is no library-side pump that could hang on an
+    // idle stream or cut off an upload the server is still consuming.
+    let result = with_deadline(deadline, async {
+        let response = transport
+            .send(http_request)
             .await
-            .map_err(|e| map_transport_send_error(e, "request failed"));
-        let _ = resp_tx.send(result);
-    });
-
-    // Enforce client-side deadline on send + parse.
-    with_deadline(deadline, async {
-        // Drain the iterator, encoding each request and pushing its envelope
-        // into the channel. The iterator is synchronous, so the only awaits
-        // here are tx.send(...), which provides backpressure via the channel
-        // depth.
-        for request in requests {
-            let msg_bytes = match config.codec_format {
-                CodecFormat::Proto => request.encode_to_bytes(),
-                CodecFormat::Json => encode_json(&request)?,
-            };
-
-            let mut envelope_buf = BytesMut::new();
-            tokio_util::codec::Encoder::encode(&mut encoder, msg_bytes, &mut envelope_buf)?;
-
-            if tx.send(Ok(envelope_buf.freeze())).await.is_err() {
-                // Receiver dropped: the spawned send task has finished, either
-                // because the transport failed or the server responded before
-                // we finished sending. Stop draining and let the response
-                // task surface the actual error/result.
-                break;
-            }
-        }
-
-        drop(tx);
-
-        // Await the response now that the request body has been fully sent.
-        let response = resp_rx.await.map_err(|_| {
-            ConnectError::internal("transport send task dropped without producing a response")
-        })??;
+            .map_err(|e| map_transport_send_error(e, "request failed"))?;
 
         // For gRPC, the response is envelope-framed like a unary gRPC response
         // (single data envelope + trailers). Reuse parse_grpc_unary_response.
@@ -3544,7 +3641,20 @@ where
             }
         }
     })
-    .await
+    .await;
+
+    // An encode failure aborts the request at the transport level; surface
+    // the precise encode error instead of the generic transport failure —
+    // unconditionally, because a server's early response can race the abort
+    // and produce an `Ok` result for a truncated, encode-aborted upload.
+    if let Some(err) = encode_error
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+    {
+        return Err(err);
+    }
+    result
 }
 
 /// Parse a Connect protocol client-streaming response.
@@ -5567,7 +5677,7 @@ mod tests {
             &config,
             "test.Service",
             "ClientStream",
-            [StringValue::from("hello")],
+            futures::stream::iter([StringValue::from("hello")]),
             CallOptions::default(),
         )
         .await

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -329,6 +329,10 @@ pub use client::BidiStream;
 pub use client::ServerStream;
 pub use client::UnaryResponse;
 
+// Request-side adapter for client-streaming calls. Re-exported at the root
+// because adapting a ready collection is the common call site.
+pub use client::stream_iter;
+
 // ============================================================================
 // Codec exports
 // ============================================================================

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -742,8 +742,29 @@ while let Some(msg) = stream.message().await? {
     println!("{}", msg.view().value.unwrap_or_default());
 }
 
-// Client streaming - takes a Vec
-let resp = client.sum(vec![req1, req2, req3]).await?;
+// Client streaming - takes an async `Stream` of requests, so messages
+// can be produced as they become available without buffering the whole
+// upload. A ready collection is adapted with `stream_iter` (a re-export
+// of `futures::stream::iter`, so no direct `futures` dependency needed):
+let resp = client
+    .sum(connectrpc::client::stream_iter(vec![req1, req2, req3]))
+    .await?;
+
+// ...or feed the call from a live producer through a channel-backed
+// stream (add the `tokio-stream` crate for the wrapper). The stream backs
+// the request body, so it must be `Send + 'static`: yield owned messages
+// rather than borrows of local data.
+let (tx, rx) = tokio::sync::mpsc::channel(16);
+tokio::spawn(async move {
+    while let Some(chunk) = source.recv().await {
+        if tx.send(request_for(chunk)).await.is_err() {
+            break; // call ended — stop producing
+        }
+    }
+});
+let resp = client
+    .sum(tokio_stream::wrappers::ReceiverStream::new(rx))
+    .await?;
 
 // Bidi - received items are `StreamMessage`s too
 let mut bidi = client.running_sum().await?;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -751,9 +751,10 @@ let resp = client
     .await?;
 
 // ...or feed the call from a live producer through a channel-backed
-// stream (add the `tokio-stream` crate for the wrapper). The stream backs
-// the request body, so it must be `Send + 'static`: yield owned messages
-// rather than borrows of local data.
+// stream (add the `tokio-stream` crate for the wrapper). The generated
+// bound, `ClientRequestStream<T>`, is `Stream<Item = T> + Send + 'static`:
+// the stream backs the request body, so yield owned messages rather than
+// borrows of local data.
 let (tx, rx) = tokio::sync::mpsc::channel(16);
 tokio::spawn(async move {
     while let Some(chunk) = source.recv().await {

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -747,7 +747,7 @@ while let Some(msg) = stream.message().await? {
 // upload. A ready collection is adapted with `stream_iter` (a re-export
 // of `futures::stream::iter`, so no direct `futures` dependency needed):
 let resp = client
-    .sum(connectrpc::client::stream_iter(vec![req1, req2, req3]))
+    .sum(connectrpc::stream_iter(vec![req1, req2, req3]))
     .await?;
 
 // ...or feed the call from a live producer through a channel-backed
@@ -781,6 +781,12 @@ server finished cleanly, and a terminal RPC error — including a
 gRPC/gRPC-Web stream that ends without a usable `grpc-status` — comes
 back as `Err`, sticky across calls. The `error()` and `trailers()`
 accessors remain available afterwards for post-hoc inspection.
+
+Dropping a client-streaming call cancels it: the request body is dropped
+with the future, so messages the stream had not yet yielded never reach
+the server. Wrapping such a call in a `timeout` therefore abandons the
+upload rather than truncating it cleanly — drive the call to completion
+whenever the request must be delivered.
 
 Both `streaming-tour/src/client.rs` and the eliza example show these
 patterns end-to-end.

--- a/examples/streaming-tour/README.md
+++ b/examples/streaming-tour/README.md
@@ -51,9 +51,10 @@ cargo test -p streaming-tour-example
   request type changes: unary takes `OwnedView<RequestView<'static>>`,
   client/bidi take a `Pin<Box<dyn Stream<Item = Result<OwnedView<...>>>>>`.
 - **`src/client.rs`** - generated-client invocation patterns. The
-  client-streaming `Sum` takes a `Vec<SumRequest>`; the bidi
-  `RunningSum` returns a stream you `.send()` to and `.message()` from
-  interleaved.
+  client-streaming `Sum` takes an async `Stream<Item = SumRequest>`
+  (a ready collection is adapted with `connectrpc::client::stream_iter`);
+  the bidi `RunningSum` returns a stream you `.send()` to and
+  `.message()` from interleaved.
 
 ## Where to go next
 

--- a/examples/streaming-tour/README.md
+++ b/examples/streaming-tour/README.md
@@ -52,7 +52,7 @@ cargo test -p streaming-tour-example
   client/bidi take a `Pin<Box<dyn Stream<Item = Result<OwnedView<...>>>>>`.
 - **`src/client.rs`** - generated-client invocation patterns. The
   client-streaming `Sum` takes an async `Stream<Item = SumRequest>`
-  (a ready collection is adapted with `connectrpc::client::stream_iter`);
+  (a ready collection is adapted with `connectrpc::stream_iter`);
   the bidi `RunningSum` returns a stream you `.send()` to and
   `.message()` from interleaved.
 

--- a/examples/streaming-tour/src/client.rs
+++ b/examples/streaming-tour/src/client.rs
@@ -51,14 +51,14 @@ async fn main() -> Result<(), BoxError> {
     println!("]");
 
     // --- Client streaming ---
+    // `sum` takes an async stream of requests; adapt the in-hand array
+    // with `stream_iter` (a live producer would pass a channel-backed
+    // stream instead).
     let inputs = [3, 5, 7, 9];
-    let messages: Vec<SumRequest> = inputs
-        .iter()
-        .map(|&v| SumRequest {
-            value: Some(v),
-            ..Default::default()
-        })
-        .collect();
+    let messages = connectrpc::client::stream_iter(inputs.map(|v| SumRequest {
+        value: Some(v),
+        ..Default::default()
+    }));
     let resp = client.sum(messages).await?;
     println!(
         "Sum({inputs:?}) -> {}",

--- a/examples/streaming-tour/src/client.rs
+++ b/examples/streaming-tour/src/client.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), BoxError> {
     // with `stream_iter` (a live producer would pass a channel-backed
     // stream instead).
     let inputs = [3, 5, 7, 9];
-    let messages = connectrpc::client::stream_iter(inputs.map(|v| SumRequest {
+    let messages = connectrpc::stream_iter(inputs.map(|v| SumRequest {
         value: Some(v),
         ..Default::default()
     }));

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -144,13 +144,10 @@ async fn server_stream_range() {
 async fn client_stream_sum() {
     let addr = start_server().await;
     let client = make_client(addr);
-    let messages: Vec<SumRequest> = [3, 5, 7, 9]
-        .iter()
-        .map(|&v| SumRequest {
-            value: Some(v),
-            ..Default::default()
-        })
-        .collect();
+    let messages = connectrpc::client::stream_iter([3, 5, 7, 9].map(|v| SumRequest {
+        value: Some(v),
+        ..Default::default()
+    }));
     let resp = client.sum(messages).await.unwrap();
     assert_eq!(resp.view().total, Some(24));
 }

--- a/examples/streaming-tour/tests/e2e.rs
+++ b/examples/streaming-tour/tests/e2e.rs
@@ -144,7 +144,7 @@ async fn server_stream_range() {
 async fn client_stream_sum() {
     let addr = start_server().await;
     let client = make_client(addr);
-    let messages = connectrpc::client::stream_iter([3, 5, 7, 9].map(|v| SumRequest {
+    let messages = connectrpc::stream_iter([3, 5, 7, 9].map(|v| SumRequest {
         value: Some(v),
         ..Default::default()
     }));

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -347,7 +347,10 @@ mod tests {
             })
             .collect();
 
-        let resp = client.client_stream(messages).await.unwrap();
+        let resp = client
+            .client_stream(futures::stream::iter(messages))
+            .await
+            .unwrap();
 
         let msg = resp.into_view();
         assert_eq!(msg.reborrow().sequence, 5);
@@ -360,7 +363,7 @@ mod tests {
         let client = make_client(addr);
 
         let resp = client
-            .client_stream(Vec::<EchoRequest>::new())
+            .client_stream(futures::stream::empty::<EchoRequest>())
             .await
             .unwrap();
 
@@ -371,8 +374,8 @@ mod tests {
 
     /// Regression: `call_client_stream` must stream the request body
     /// frame-by-frame instead of buffering the whole concatenated payload
-    /// into a single Frame. Each iterator item should produce its own body
-    /// frame (one envelope per channel push).
+    /// into a single Frame. Each stream item should produce its own body
+    /// frame (one envelope per message).
     #[tokio::test]
     async fn client_stream_request_body_is_streamed() {
         use bytes::Bytes;
@@ -430,9 +433,10 @@ mod tests {
             })
             .collect();
 
-        // Expected to fail with the forced transport error. call_client_stream
-        // awaits the oneshot internally, so frames are fully captured by return.
-        let _ = client.client_stream(messages).await;
+        // Expected to fail with the forced transport error. The transport's
+        // send future (which reads the whole body) completes before the call
+        // returns, so frames are fully captured by then.
+        let _ = client.client_stream(futures::stream::iter(messages)).await;
 
         let captured = frames.lock().unwrap().clone();
         assert_eq!(
@@ -448,6 +452,271 @@ mod tests {
                 "envelope frame too small ({size} bytes) — header alone is 5 bytes",
             );
         }
+    }
+
+    /// End-to-end: the client-stream request source is an async stream, so
+    /// messages produced *after* the call starts — here by a separate task
+    /// pacing itself with sleeps — are sent as they become available, and
+    /// the call completes once the stream ends.
+    #[tokio::test]
+    async fn client_stream_async_producer() {
+        let (addr, _server) = start_server().await;
+        let client = make_client(addr);
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<EchoRequest>(1);
+        let producer = tokio::spawn(async move {
+            for i in 0..4 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                tx.send(EchoRequest {
+                    sequence: i,
+                    data: format!("async-{i}"),
+                    ..Default::default()
+                })
+                .await
+                .expect("request body should keep draining the channel");
+            }
+            // Dropping tx ends the stream, which ends the request body.
+        });
+
+        let resp = client
+            .client_stream(tokio_stream::wrappers::ReceiverStream::new(rx))
+            .await
+            .unwrap();
+
+        let msg = resp.into_view();
+        assert_eq!(msg.reborrow().sequence, 4);
+        assert_eq!(msg.reborrow().data, "async-0,async-1,async-2,async-3");
+        producer.await.unwrap();
+    }
+
+    /// Regression: a transport whose response resolves *before* the request
+    /// stream is drained — a server sending response headers early while it
+    /// keeps consuming the upload is a legitimate HTTP/2 pattern — must NOT
+    /// cut the upload short. Every request message must still reach the
+    /// transport; only the request body being dropped ends the drain.
+    #[tokio::test]
+    async fn client_stream_early_response_headers_do_not_truncate_upload() {
+        use bytes::{BufMut, Bytes, BytesMut};
+        use connectrpc::client::{BoxFuture, ClientBody, ClientTransport};
+        use http::{Request, Response};
+        use http_body::Body;
+        use std::sync::Mutex;
+
+        /// Resolves with a complete, valid Connect client-stream response
+        /// immediately, while a spawned task keeps consuming the request
+        /// body until EOF, recording each frame.
+        #[derive(Clone)]
+        struct EarlyResponseTransport {
+            frames: Arc<Mutex<Vec<usize>>>,
+        }
+
+        impl ClientTransport for EarlyResponseTransport {
+            type ResponseBody = http_body_util::Full<Bytes>;
+            type Error = ConnectError;
+
+            fn send(
+                &self,
+                request: Request<ClientBody>,
+            ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
+                let frames = self.frames.clone();
+                // Keep the body alive and drain it in the background — the
+                // signal a real transport gives while the server is still
+                // reading the upload.
+                tokio::spawn(async move {
+                    let mut body = request.into_body();
+                    while let Some(frame) =
+                        std::future::poll_fn(|cx| std::pin::Pin::new(&mut body).poll_frame(cx))
+                            .await
+                    {
+                        if let Ok(Ok(data)) = frame.map(http_body::Frame::into_data) {
+                            frames.lock().unwrap().push(data.len());
+                        }
+                    }
+                });
+
+                // Envelope-framed unary response + END_STREAM, ready at once.
+                let mut body = BytesMut::new();
+                let msg = buffa::Message::encode_to_vec(&EchoResponse {
+                    sequence: 42,
+                    ..Default::default()
+                });
+                body.put_u8(0);
+                body.put_u32(msg.len() as u32);
+                body.extend_from_slice(&msg);
+                body.put_u8(0x02); // END_STREAM
+                body.put_u32(2);
+                body.extend_from_slice(b"{}");
+                let response = Response::builder()
+                    .status(200)
+                    .header("content-type", "application/connect+proto")
+                    .body(http_body_util::Full::new(body.freeze()))
+                    .unwrap();
+                Box::pin(async move { Ok(response) })
+            }
+        }
+
+        let frames: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+        let transport = EarlyResponseTransport {
+            frames: frames.clone(),
+        };
+        let config = ClientConfig::new("http://localhost/".parse().unwrap());
+        let client = EchoServiceClient::new(transport, config);
+
+        // A paced producer: every item is momentarily unavailable, so a
+        // drain loop that (wrongly) stopped as soon as the response
+        // resolved would truncate the upload.
+        let (req_tx, req_rx) = tokio::sync::mpsc::channel::<EchoRequest>(1);
+        tokio::spawn(async move {
+            for i in 0..5 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                if req_tx
+                    .send(EchoRequest {
+                        sequence: i,
+                        ..Default::default()
+                    })
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        });
+
+        let resp = client
+            .client_stream(tokio_stream::wrappers::ReceiverStream::new(req_rx))
+            .await
+            .unwrap();
+        assert_eq!(resp.view().sequence, 42);
+
+        // The consumer task races the call's return for the tail frames;
+        // give it a moment to observe body EOF before asserting.
+        for _ in 0..200 {
+            if frames.lock().unwrap().len() >= 5 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            frames.lock().unwrap().len(),
+            5,
+            "all request messages must be sent even though the response resolved first",
+        );
+    }
+
+    /// Regression: an encode failure in the request body must surface as the
+    /// call's error even when the transport still produces a successful
+    /// response (the abort and an early server response can race). Without
+    /// the unconditional encode-error check, this call would return `Ok`
+    /// for a truncated, encode-aborted upload.
+    #[tokio::test]
+    async fn client_stream_encode_error_beats_ok_response() {
+        use bytes::{BufMut, Bytes, BytesMut};
+        use connectrpc::client::{BoxFuture, ClientBody, ClientTransport};
+        use http::{Request, Response};
+        use http_body::Body;
+
+        /// Reads the request body until EOF or the first body error, then
+        /// returns a complete, valid response regardless.
+        #[derive(Clone)]
+        struct SwallowingTransport;
+
+        impl ClientTransport for SwallowingTransport {
+            type ResponseBody = http_body_util::Full<Bytes>;
+            type Error = ConnectError;
+
+            fn send(
+                &self,
+                request: Request<ClientBody>,
+            ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
+                Box::pin(async move {
+                    let mut body = request.into_body();
+                    while let Some(frame) =
+                        std::future::poll_fn(|cx| std::pin::Pin::new(&mut body).poll_frame(cx))
+                            .await
+                    {
+                        if frame.is_err() {
+                            break;
+                        }
+                    }
+
+                    let mut body = BytesMut::new();
+                    let msg = buffa::Message::encode_to_vec(&EchoResponse::default());
+                    body.put_u8(0);
+                    body.put_u32(msg.len() as u32);
+                    body.extend_from_slice(&msg);
+                    body.put_u8(0x02); // END_STREAM
+                    body.put_u32(2);
+                    body.extend_from_slice(b"{}");
+                    Ok(Response::builder()
+                        .status(200)
+                        .header("content-type", "application/connect+proto")
+                        .body(http_body_util::Full::new(body.freeze()))
+                        .unwrap())
+                })
+            }
+        }
+
+        // An unregistered request compression makes envelope encoding fail
+        // (the message must exceed the compression min-size to be attempted).
+        let config =
+            ClientConfig::new("http://localhost/".parse().unwrap()).compress_requests("bogus");
+        let client = EchoServiceClient::new(SwallowingTransport, config);
+
+        let err = client
+            .client_stream(connectrpc::client::stream_iter([EchoRequest {
+                data: "x".repeat(8 * 1024),
+                ..Default::default()
+            }]))
+            .await
+            .expect_err("encode failure must surface despite the 200 response");
+        assert_eq!(err.code, connectrpc::ErrorCode::Unimplemented);
+        assert!(
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("unsupported compression"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// Regression: a server that ends the RPC while the request stream is
+    /// still pending must surface its response instead of waiting for the
+    /// next request message. The transport owns the polling of the
+    /// stream-backed request body, so when the call ends it simply stops
+    /// polling; a library-side pump loop awaiting the next item would hang
+    /// this call forever (no timeout is set).
+    #[tokio::test]
+    async fn client_stream_early_server_response_unblocks_pending_stream() {
+        use bytes::Bytes;
+        use connectrpc::client::{BoxFuture, ClientBody, ClientTransport};
+        use http::{Request, Response};
+
+        /// Fails the call immediately, without consuming the request body —
+        /// the shape of a server rejecting the RPC mid-upload.
+        #[derive(Clone)]
+        struct ImmediateErrorTransport;
+
+        impl ClientTransport for ImmediateErrorTransport {
+            type ResponseBody = http_body_util::Empty<Bytes>;
+            type Error = ConnectError;
+
+            fn send(
+                &self,
+                _request: Request<ClientBody>,
+            ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
+                Box::pin(async { Err(ConnectError::unavailable("rejected mid-upload")) })
+            }
+        }
+
+        let config = ClientConfig::new("http://localhost/".parse().unwrap());
+        let client = EchoServiceClient::new(ImmediateErrorTransport, config);
+
+        let call = client.client_stream(futures::stream::pending::<EchoRequest>());
+        let err = tokio::time::timeout(Duration::from_secs(5), call)
+            .await
+            .expect("call must return once the transport responds, not await the stream")
+            .expect_err("transport error must surface");
+        assert_eq!(err.code, connectrpc::ErrorCode::Unavailable);
     }
 
     /// Tests bidi streaming at the server level by sending envelope-framed
@@ -573,7 +842,10 @@ mod tests {
                 ..Default::default()
             })
             .collect();
-        let resp = client.client_stream(messages).await.unwrap();
+        let resp = client
+            .client_stream(futures::stream::iter(messages))
+            .await
+            .unwrap();
         assert_eq!(resp.view().sequence, 4);
 
         // NotFound — wrong path should produce Unimplemented, not panic.
@@ -1395,7 +1667,10 @@ mod tests {
                 ..Default::default()
             })
             .collect();
-        let resp = client.client_stream(messages).await.unwrap();
+        let resp = client
+            .client_stream(futures::stream::iter(messages))
+            .await
+            .unwrap();
         assert_eq!(
             resp.headers().get("x-stream-intercepted").unwrap(),
             "/test.echo.v1.EchoService/ClientStream"
@@ -1490,7 +1765,7 @@ mod tests {
         // Client streaming: the response is unary-shaped over a streaming
         // wire, so the error surfaces from the call itself.
         let err = client
-            .client_stream(vec![EchoRequest::default()])
+            .client_stream(futures::stream::iter(vec![EchoRequest::default()]))
             .await
             .expect_err("expected deny");
         assert_eq!(err.code, connectrpc::ErrorCode::PermissionDenied);

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -663,7 +663,7 @@ mod tests {
         let client = EchoServiceClient::new(SwallowingTransport, config);
 
         let err = client
-            .client_stream(connectrpc::client::stream_iter([EchoRequest {
+            .client_stream(connectrpc::stream_iter([EchoRequest {
                 data: "x".repeat(8 * 1024),
                 ..Default::default()
             }]))


### PR DESCRIPTION
## Summary

Client-streaming calls now take an async `Stream` of requests instead of a synchronous iterator.

`call_client_stream` and the generated client-streaming methods accept `impl ClientRequestStream<Req>` — a sealed trait implemented automatically for every `Stream<Item = Req> + Send + 'static` — so request messages can be produced as they become available — paced by timers, read from sockets, forwarded from channels — without buffering the whole upload or blocking a thread. The synchronous-iterator shape could not express this: there was no way to await between messages, which ruled out pump-style uploads (e.g. forwarding chunks under a per-chunk idle deadline).

**Breaking change**, targeted at 0.9.0. Migration for a ready collection is one line, with no new dependency:

```rust
// before
client.sum(requests).await?;
// after
client.sum(connectrpc::client::stream_iter(requests)).await?;
```

`Stream` (the `futures` 0.3 trait) and `stream_iter` (`futures::stream::iter`) are re-exported from `connectrpc::client`, and every generated client-streaming method carries the migration hint in its rustdoc. The bound trait carries `#[diagnostic::on_unimplemented]`, so passing a collection directly produces compiler output that names `stream_iter` and explains the `Send + 'static` requirement, rather than a bare unmet-trait error.

## Design: the stream is the request body

The stream is not pumped by a library-side drain loop — it backs the HTTP request body directly (`EncodingBody`, which envelope-encodes each message in `poll_frame`). The transport polls for the next frame only while it can send, so:

- backpressure is HTTP/2 flow control (peak memory ~one envelope, previously a 32-envelope channel);
- a server that ends the RPC mid-upload produces a response and the call returns, even while the caller's stream is idle — previously unobservable until the deadline;
- a server that sends response headers early while continuing to read the upload keeps receiving messages (a drain loop racing the response future would truncate here — caught by review and pinned with a regression test).

An encode failure is emitted through the body (aborting the request) and mirrored into the call's return value so the caller sees the precise error. The stream is held in a `sync_wrapper::SyncWrapper` (new tiny zero-dep dependency, the axum pattern) so the boxed body is `Sync` without requiring `Sync` of the caller's stream. The previous channel + detached-send-task machinery for client-streaming is deleted; bidi is unchanged (its push-style `send()` API keeps the channel).

## Changes

- `connectrpc/src/client/mod.rs`: signature, `EncodingBody`, `Stream`/`stream_iter` re-exports, rewritten docs with `# Errors`.
- `connectrpc-codegen/src/codegen.rs`: generated arg type + doc hint; checked-in generated dirs regenerated.
- Call sites updated: conformance client, benches, streaming-tour example, e2e tests; `docs/guide.md` shows both `stream_iter` and a channel-backed producer.
- New e2e tests: async producer paced by a channel; early-response-headers-do-not-truncate-upload; early-server-response-unblocks-pending-stream.

## Testing

- `task lint` / `task test` green; clippy all-targets `-D warnings` clean; docs with broken-links denied; MSRV (1.88), wasm32, and minimal-features checks pass.
- Conformance client suites: Connect 2580, gRPC 1454, gRPC-Web 2838 — all passing.
- Live socket drives (HTTP/1.1 and HTTP/2): a producer pacing 3 messages 100 ms apart aggregates correctly (elapsed ≥ 300 ms proves incremental sending); a handler rejecting without draining returns in ~2 ms against a never-yielding stream (previously an unbounded hang).
- `cargo semver-checks` vs 0.8.1 passes (the break is in an `impl Trait` argument bound, outside its lint coverage); declared in the changelog fragment.
