### PR TITLE
codegen: advertise proto edition 2024

### DIFF
--- a/.changes/unreleased/Added-20260717-153147.yaml
+++ b/.changes/unreleased/Added-20260717-153147.yaml
@@ -1,0 +1,11 @@
+kind: Added
+body: |-
+  **`protoc-gen-connect-rust` now advertises proto edition 2024** as its
+  maximum supported edition ([#229]). Previously `protoc` refused to run the
+  generator against an `edition = "2024"` file at all. Generated stubs are
+  unchanged: the features edition 2024 introduced, `enforce_naming_style`
+  and `default_symbol_visibility`, are enforced by `protoc` while compiling
+  and do not affect the service descriptors the generator reads.
+
+  [#229]: https://github.com/connectrpc/connect-rust/issues/229
+time: 2026-07-17T15:31:47.376852992-07:00

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -18,6 +18,7 @@ use quote::format_ident;
 use quote::quote;
 
 use buffa_codegen::generated::descriptor::DescriptorProto;
+use buffa_codegen::generated::descriptor::Edition;
 use buffa_codegen::generated::descriptor::FileDescriptorProto;
 use buffa_codegen::generated::descriptor::MethodDescriptorProto;
 use buffa_codegen::generated::descriptor::ServiceDescriptorProto;
@@ -695,8 +696,8 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
 
     Ok(CodeGeneratorResponse {
         supported_features: Some(feature_flags()),
-        minimum_edition: Some(EDITION_2023),
-        maximum_edition: Some(EDITION_2023),
+        minimum_edition: Some(Edition::EDITION_2023 as i32),
+        maximum_edition: Some(Edition::EDITION_2024 as i32),
         file: files,
         ..Default::default()
     })
@@ -709,10 +710,6 @@ fn feature_flags() -> u64 {
     const FEATURE_SUPPORTS_EDITIONS: u64 = 2;
     FEATURE_PROTO3_OPTIONAL | FEATURE_SUPPORTS_EDITIONS
 }
-
-/// Edition 2023 numeric value. buffa-codegen handles proto2/proto3/edition-2023;
-/// we declare 2023 as both min and max.
-const EDITION_2023: i32 = 1000;
 
 /// Format a TokenStream into a Rust source string via prettyplease.
 fn format_token_stream(tokens: &TokenStream) -> Result<String> {
@@ -4814,5 +4811,16 @@ mod tests {
 
         let chat = render(&consts[3]);
         assert!(chat.contains("StreamType::BidiStream"), "{chat}");
+    }
+
+    #[test]
+    fn declares_edition_2024_support() {
+        // protoc refuses to run a generator against a file whose edition
+        // falls outside the advertised range, so this declaration is the
+        // whole of edition support for a service generator.
+        let response = generate(&CodeGeneratorRequest::default())
+            .expect("an empty request still yields a response carrying the edition range");
+        assert_eq!(response.minimum_edition, Some(Edition::EDITION_2023 as i32));
+        assert_eq!(response.maximum_edition, Some(Edition::EDITION_2024 as i32));
     }
 }


### PR DESCRIPTION
## Summary

`protoc-gen-connect-rust` advertised `maximum_edition: EDITION_2023`, and protoc refuses to run a generator against a file whose edition falls outside the advertised range. An `edition = "2024"` proto therefore failed before this crate saw it:

```
svc.proto: is a file using edition 2024, which isn't supported by code
generator protoc-gen-connect-rust.  Please ask the owner of this code
generator to add support or switch back to a maximum of edition 2023.
```

Raising the declared ceiling is the whole of the fix.

## Why nothing else needs to change

Edition 2024 introduced exactly two features, `enforce_naming_style` and `default_symbol_visibility`. Both are enforced by protoc while compiling, and neither reaches the service descriptors this crate reads — method names, input and output types resolved by fully-qualified name, the streaming booleans, idempotency level, and source-code comments all mean the same thing under either edition. Message and field codegen belongs to buffa, which has handled edition 2024 since its first release.

Verified rather than assumed:

- **Red/green.** With the old ceiling protoc fails as above; with the new one, a service exercising all four RPC shapes generates 768 lines of correct stubs.
- **Byte-identical output.** The same service written as `edition = "2023"` generates byte-identical stubs, and byte-identical buffa messages and views.
- **Nested types.** A nested message used as an RPC input and output still resolves, which is the one place `default_symbol_visibility` (whose 2024 default is `EXPORT_TOP_LEVEL`) could plausibly have bitten.
- **No regeneration drift.** `task generate:all` leaves the checked-in generated directories unchanged, confirming the change is response metadata only.

## Also here

The declared editions now come from the descriptor `Edition` enum instead of a hand-written `const EDITION_2023: i32 = 1000`, matching what the buffa plugins do. The enum carries the canonical values (`EDITION_2023 = 1000`, `EDITION_2024 = 1001`), so the minimum is unchanged and the ceiling moves by one.

## Testing

`task lint` and the full workspace suite pass. The new `declares_edition_2024_support` test pins the advertised range so a future ceiling change has to be deliberate.

Worth being explicit about what that test does *not* do: it asserts the declared values, so it is a tripwire rather than functional coverage. The evidence that an edition-2024 descriptor actually generates correctly is the manual verification above, not CI. Closing that gap properly would mean checking in a binary edition-2024 descriptor fixture or hand-building a `FileDescriptorProto` with resolved features; given the repo's own protos are edition 2023 and message-level edition handling is buffa's responsibility, that did not seem proportionate here. Happy to add it if a reviewer disagrees.

Fixes #229
