### PR TITLE
server: encode view responses without copying their large fields

### DIFF
--- a/.changes/unreleased/Changed-20260717-173621.yaml
+++ b/.changes/unreleased/Changed-20260717-173621.yaml
@@ -1,8 +1,26 @@
 kind: Changed
 body: |-
-    Response bodies can now reach the socket in several reference-counted segments instead of one contiguous buffer. When a handler returns an `OwnedView`, its large borrowed fields are handed to the HTTP body by reference count rather than copied into the encode buffer — the encode then costs the same whatever the payload weighs (measured 1.49us to 421ns at 16 KiB per field, 252us to 421ns at 1 MiB). The wire bytes are unchanged; only the HTTP frame boundaries differ, which gRPC and Connect envelope framing has never depended on.
+  **A gRPC or gRPC-Web unary response whose body is an `OwnedView` no longer
+  copies its large fields when encoding.** A view's fields are slices into the
+  buffer it was decoded from, so they are handed to the HTTP body by reference
+  count and reach the socket as their own data frames. Past the framing
+  threshold the encode stops growing with the payload, because only the
+  framing is still being written.
 
-    Owned-message responses are deliberately unaffected: their fields are `String` and `Vec<u8>`, which cannot be handed over by reference, so segmenting them would only add cost. Small messages are unaffected too — below the framing threshold the encoder stays contiguous.
+  Encoding stays contiguous where segmenting would not pay: responses below
+  the framing threshold, owned-message responses (their `String` and `Vec<u8>`
+  fields cannot be handed over by reference), a response much smaller than the
+  request it borrows from (capturing would keep the whole request buffer alive
+  while the response flushes), Connect-protocol unary, streaming, and any call
+  passing through an interceptor, since an interceptor may replace the body and
+  so needs it whole.
 
-    `EncodedResponse` is now `Response<EncodedBody>` rather than `Response<Bytes>`. This is a breaking change for code implementing the `Dispatcher` trait directly or handling `EncodedResponse` values: construct with `.into()` from `Bytes`, and call `.into_contiguous()` where a single buffer is needed. Interceptors are unaffected — `UnaryResponse` still carries a contiguous `Payload`.
+  **Breaking, for custom dispatch only.** `EncodedResponse` is now
+  `Response<EncodedBody>` rather than `Response<Bytes>`. If you implement the
+  `Dispatcher` trait, or construct or consume `EncodedResponse` values, build
+  one with `Bytes::into()` and recover a single buffer with
+  `EncodedBody::into_contiguous()`. Interceptors are unaffected —
+  `UnaryResponse` still carries a contiguous `Payload`, because an interceptor
+  may replace the whole body — note that this also means a call with an
+  interceptor configured takes the contiguous path.
 time: 2026-07-17T17:36:21.338084808-07:00

--- a/.changes/unreleased/Changed-20260717-173621.yaml
+++ b/.changes/unreleased/Changed-20260717-173621.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: |-
+    Response bodies can now reach the socket in several reference-counted segments instead of one contiguous buffer. When a handler returns an `OwnedView`, its large borrowed fields are handed to the HTTP body by reference count rather than copied into the encode buffer — the encode then costs the same whatever the payload weighs (measured 1.49us to 421ns at 16 KiB per field, 252us to 421ns at 1 MiB). The wire bytes are unchanged; only the HTTP frame boundaries differ, which gRPC and Connect envelope framing has never depended on.
+
+    Owned-message responses are deliberately unaffected: their fields are `String` and `Vec<u8>`, which cannot be handed over by reference, so segmenting them would only add cost. Small messages are unaffected too — below the framing threshold the encoder stays contiguous.
+
+    `EncodedResponse` is now `Response<EncodedBody>` rather than `Response<Bytes>`. This is a breaking change for code implementing the `Dispatcher` trait directly or handling `EncodedResponse` values: construct with `.into()` from `Bytes`, and call `.into_contiguous()` where a single buffer is needed. Interceptors are unaffected — `UnaryResponse` still carries a contiguous `Payload`.
+time: 2026-07-17T17:36:21.338084808-07:00

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ benches/rpc-go/fortune-connect-go
 
 # Tool downloads (changie, etc.) — see Taskfile install-* tasks
 .local/
+
+# Raw output from benchmark harnesses that write into the working tree.
+# These carry host details from whatever machine produced them and are not
+# reproducible artifacts worth tracking.
+metal-bench-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,10 @@ GitHub Actions CI (`.github/workflows/ci.yml`) runs on every push to
 - **MSRV** — `cargo check` on the minimum toolchain, read from `rust-version`
   in the workspace `Cargo.toml` so the declaration and the check cannot drift
 - **Examples** — builds and runs the example crates
-- **Minimal features** — `cargo check -p connectrpc --no-default-features`
+- **Minimal features** — `cargo check` *and* `cargo test`, both
+  `-p connectrpc --no-default-features`. Because the tests run, a test that
+  needs `json`, `gzip`, `zstd` or `streaming` must be
+  `#[cfg(feature = "...")]`-gated or it fails here while passing the
+  default-feature suite
 - **Wasm** — `wasm32-unknown-unknown` build of the client example
 - **Conformance (server)** / **Conformance (client)** — full suites

--- a/benches/rpc/Cargo.toml
+++ b/benches/rpc/Cargo.toml
@@ -72,5 +72,9 @@ harness = false
 name = "filter_handler"
 harness = false
 
+[[bench]]
+name = "view_rope_encode"
+harness = false
+
 [lints]
 workspace = true

--- a/benches/rpc/README.md
+++ b/benches/rpc/README.md
@@ -9,6 +9,7 @@ Benchmark crate for `connectrpc`. `publish = false`; nothing here ships.
 | `rpc_bench` | Full-stack unary/stream RPC over loopback HTTP, Connect/gRPC/gRPC-Web × proto/JSON. Needs a running server (`cargo run --bin echo_server` etc.). | `cargo bench --bench rpc_bench` |
 | `cross_impl_bench` | Cross-implementation comparison vs tonic. | `cargo bench --bench cross_impl_bench` |
 | `echo_bloat` | Codec-layer (no HTTP) `{owned,view}×{decode,encode}` sweep across five payload shapes + a 1→N fanout sweep. Motivates the future view-response handler API. | `cargo bench --bench echo_bloat` |
+| `view_rope_encode` | Encode cost of a response view, contiguous vs a rope backed by the view's own buffer, swept either side of the segment threshold. Shows what the segmented response path buys and what it costs below the threshold. | `cargo bench --bench view_rope_encode` |
 
 Filter by criterion regex: `cargo bench --bench echo_bloat -- fanout` or `-- map_dominated`.
 

--- a/benches/rpc/benches/view_rope_encode.rs
+++ b/benches/rpc/benches/view_rope_encode.rs
@@ -1,0 +1,126 @@
+//! Does encoding a response view through a rope actually pay?
+//!
+//! The response path copies twice today: once when the message is encoded
+//! into a contiguous buffer, and once when that buffer is written into the
+//! envelope framing buffer. buffa 0.9's `Rope` removes the first copy for
+//! payloads it can hand over by reference count — for a *view*, that means
+//! any large field borrowed from the buffer the view was decoded from,
+//! which needs no codegen configuration and so is available to every user.
+//!
+//! Threading segments from the encoder out to the socket is a breaking
+//! change to connect-rust's dispatcher boundary, so this measures the
+//! ceiling first: the encode step alone, contiguous versus rope, across
+//! payload sizes. Everything below the segment threshold should be a wash;
+//! the question is how the curve behaves above it.
+
+use buffa::view::MessageView;
+use buffa::{Rope, ViewEncode};
+use bytes::Bytes;
+use connectrpc::{CodecFormat, Encodable};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rpc_bench::proto::bench::v1::__buffa::view::FewLargeStringsView;
+use rpc_bench::proto::bench::v1::FewLargeStrings;
+
+/// Build a `FewLargeStrings` whose four string fields are `each` bytes, then
+/// return its encoded wire bytes. The view decoded from these borrows each
+/// field directly out of the buffer, which is exactly what a rope backed by
+/// that buffer can capture without copying.
+fn encoded_message(each: usize) -> Bytes {
+    let body = "x".repeat(each);
+    let msg = FewLargeStrings {
+        body_a: body.clone(),
+        body_b: body.clone(),
+        body_c: body.clone(),
+        body_d: body,
+        ts: 1,
+        seq: 2,
+        ..Default::default()
+    };
+    Bytes::from(buffa::Message::encode_to_vec(&msg))
+}
+
+fn bench_view_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("view_encode");
+
+    // Straddle the 16 KiB segment threshold in both directions. At 256 B and
+    // 1 KiB neither the fields nor the whole message reach it, so those rows
+    // should sit at parity with the contiguous path rather than paying for a
+    // rope that cannot capture anything. From 16 KiB up every field is
+    // capturable and the encode should go flat.
+    for each in [256usize, 1024, 16 * 1024, 256 * 1024, 1024 * 1024] {
+        let buffer = encoded_message(each);
+        let view = FewLargeStringsView::decode_view(&buffer).expect("decode view");
+
+        group.throughput(Throughput::Bytes(buffer.len() as u64));
+
+        // Today's path: one contiguous buffer, every field memcpy'd in.
+        group.bench_with_input(BenchmarkId::new("contiguous", each), &view, |b, view| {
+            b.iter(|| std::hint::black_box(view.encode_to_bytes()))
+        });
+
+        // Rope with the decode buffer attached, so a large borrowed field is
+        // captured by reference count instead of copied.
+        group.bench_with_input(BenchmarkId::new("rope_backed", each), &view, |b, view| {
+            b.iter(|| {
+                let mut rope = Rope::new().with_backing(buffer.clone());
+                ViewEncode::encode(view, &mut rope);
+                std::hint::black_box(rope.into_segments())
+            });
+        });
+
+        // What connect-rust actually calls, so the size gate is included:
+        // below one segment it must fall back to contiguous rather than pay
+        // for a rope that cannot capture anything.
+        group.bench_with_input(
+            BenchmarkId::new("encode_view_segments", each),
+            &view,
+            |b, view| {
+                b.iter(|| {
+                    std::hint::black_box(
+                        connectrpc::__codegen::encode_view_body_segments(
+                            view,
+                            &buffer,
+                            CodecFormat::Proto,
+                            16 * 1024,
+                        )
+                        .expect("encode"),
+                    )
+                });
+            },
+        );
+
+        // Owned messages are deliberately NOT routed through a rope: their
+        // `String` / `Vec<u8>` fields cannot be handed over by reference, so
+        // the rope captures nothing and only adds cost. Kept as a measured
+        // control for that decision.
+        let owned: FewLargeStrings = view.to_owned_message().expect("to owned");
+        group.bench_with_input(
+            BenchmarkId::new("owned_contiguous", each),
+            &owned,
+            |b, owned| {
+                b.iter(|| {
+                    std::hint::black_box(
+                        Encodable::<FewLargeStrings>::encode(owned, CodecFormat::Proto)
+                            .expect("encode"),
+                    )
+                });
+            },
+        );
+
+        // Control: a rope with no backing buffer cannot capture anything, so
+        // it should track the contiguous path. This separates "the rope is
+        // cheap" from "the capture is what pays".
+        group.bench_with_input(BenchmarkId::new("rope_unbacked", each), &view, |b, view| {
+            b.iter(|| {
+                let mut rope = Rope::new();
+                ViewEncode::encode(view, &mut rope);
+                std::hint::black_box(rope.into_segments())
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_view_encode);
+criterion_main!(benches);

--- a/benches/rpc/benches/view_rope_encode.rs
+++ b/benches/rpc/benches/view_rope_encode.rs
@@ -1,17 +1,23 @@
-//! Does encoding a response view through a rope actually pay?
+//! What encoding a response view through a rope costs, across payload sizes.
 //!
-//! The response path copies twice today: once when the message is encoded
-//! into a contiguous buffer, and once when that buffer is written into the
-//! envelope framing buffer. buffa 0.9's `Rope` removes the first copy for
-//! payloads it can hand over by reference count — for a *view*, that means
-//! any large field borrowed from the buffer the view was decoded from,
-//! which needs no codegen configuration and so is available to every user.
+//! Encoding a message into one contiguous buffer copies every field into it.
+//! A view's fields are slices into the buffer the view was decoded from, so a
+//! rope backed by that buffer can take a large field by reference instead,
+//! which is what `encode_view_body_segments` does on the response path.
 //!
-//! Threading segments from the encoder out to the socket is a breaking
-//! change to connect-rust's dispatcher boundary, so this measures the
-//! ceiling first: the encode step alone, contiguous versus rope, across
-//! payload sizes. Everything below the segment threshold should be a wash;
-//! the question is how the curve behaves above it.
+//! The arms isolate where the cost goes:
+//!
+//! - `contiguous` — the copy-everything baseline.
+//! - `rope_backed` — the rope with the view's own buffer, so captures engage.
+//! - `encode_view_segments` — the production entry point, including its size
+//!   gate, which is what makes the small sizes match the baseline.
+//! - `owned_contiguous` — an owned message, whose `String` fields cannot be
+//!   captured; this is why owned bodies are left on the contiguous path.
+//! - `rope_unbacked` — a rope with no buffer to capture from. Separates the
+//!   rope's own cost from the saving the capture produces.
+//!
+//! Above the segment threshold the encode is payload-independent: only the
+//! framing is still being written.
 
 use buffa::view::MessageView;
 use buffa::{Rope, ViewEncode};
@@ -42,11 +48,9 @@ fn encoded_message(each: usize) -> Bytes {
 fn bench_view_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("view_encode");
 
-    // Straddle the 16 KiB segment threshold in both directions. At 256 B and
-    // 1 KiB neither the fields nor the whole message reach it, so those rows
-    // should sit at parity with the contiguous path rather than paying for a
-    // rope that cannot capture anything. From 16 KiB up every field is
-    // capturable and the encode should go flat.
+    // Straddle the 16 KiB segment threshold in both directions: at 256 B and
+    // 1 KiB neither the fields nor the whole message reach it, from 16 KiB up
+    // every field clears it.
     for each in [256usize, 1024, 16 * 1024, 256 * 1024, 1024 * 1024] {
         let buffer = encoded_message(each);
         let view = FewLargeStringsView::decode_view(&buffer).expect("decode view");
@@ -68,16 +72,16 @@ fn bench_view_encode(c: &mut Criterion) {
             });
         });
 
-        // What connect-rust actually calls, so the size gate is included:
-        // below one segment it must fall back to contiguous rather than pay
-        // for a rope that cannot capture anything.
+        // The production entry point, so the size gate is included. Below one
+        // segment it falls back to contiguous rather than pay for a rope that
+        // cannot capture anything.
         group.bench_with_input(
             BenchmarkId::new("encode_view_segments", each),
             &view,
             |b, view| {
                 b.iter(|| {
                     std::hint::black_box(
-                        connectrpc::__codegen::encode_view_body_segments(
+                        connectrpc::__codegen::encode_view_body_with_min_segment(
                             view,
                             &buffer,
                             CodecFormat::Proto,
@@ -107,9 +111,8 @@ fn bench_view_encode(c: &mut Criterion) {
             },
         );
 
-        // Control: a rope with no backing buffer cannot capture anything, so
-        // it should track the contiguous path. This separates "the rope is
-        // cheap" from "the capture is what pays".
+        // Control: a rope with no backing buffer has nothing to capture, so
+        // this arm shows the rope's own cost with the saving removed.
         group.bench_with_input(BenchmarkId::new("rope_unbacked", each), &view, |b, view| {
             b.iter(|| {
                 let mut rope = Rope::new();

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -52,13 +52,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -88,13 +86,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -124,13 +120,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -160,13 +154,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -45,6 +45,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<crate::proto::bench::v1::LogResponse>
 for crate::proto::bench::v1::__buffa::view::LogResponseView<'_> {
@@ -64,6 +80,22 @@ for ::buffa::view::OwnedView<
         codec: ::connectrpc::CodecFormat,
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
+    }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
     }
 }
 impl ::connectrpc::Encodable<crate::proto::bench::v1::EchoResponse>
@@ -85,6 +117,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<crate::proto::bench::v1::LogIngestResponse>
 for crate::proto::bench::v1::__buffa::view::LogIngestResponseView<'_> {
@@ -104,6 +152,22 @@ for ::buffa::view::OwnedView<
         codec: ::connectrpc::CodecFormat,
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
+    }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
     }
 }
 /// Full service name for this service.

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -25,6 +25,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.noutf8.v1.LogIngestService";

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -32,13 +32,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -28,13 +28,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -21,6 +21,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const BLOAT_ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.BloatEchoService";

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -21,6 +21,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const FILTER_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.filter.v1.FilterService";

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -28,13 +28,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -25,6 +25,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const FORTUNE_SERVICE_SERVICE_NAME: &str = "fortune.v1.FortuneService";

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -32,13 +32,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -92,13 +92,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -136,13 +134,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -180,13 +176,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -224,13 +218,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -268,13 +260,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -312,13 +302,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -85,6 +85,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<
     crate::proto::connectrpc::conformance::v1::ServerStreamResponse,
@@ -112,6 +128,22 @@ for ::buffa::view::OwnedView<
         codec: ::connectrpc::CodecFormat,
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
+    }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
     }
 }
 impl ::connectrpc::Encodable<
@@ -141,6 +173,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<
     crate::proto::connectrpc::conformance::v1::BidiStreamResponse,
@@ -168,6 +216,22 @@ for ::buffa::view::OwnedView<
         codec: ::connectrpc::CodecFormat,
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
+    }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
     }
 }
 impl ::connectrpc::Encodable<
@@ -197,6 +261,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<
     crate::proto::connectrpc::conformance::v1::IdempotentUnaryResponse,
@@ -224,6 +304,22 @@ for ::buffa::view::OwnedView<
         codec: ::connectrpc::CodecFormat,
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
+    }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
     }
 }
 /// Full service name for this service.

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1210,18 +1210,13 @@ fn encodable_impl_pair(
             /// its large fields can be handed to the response body by
             /// reference count instead of copied. The bare view impl above
             /// cannot do this: it has borrows but no buffer to name.
-            fn encode_segments(
-                &self,
-                codec: ::connectrpc::CodecFormat,
-                min_segment: usize,
-            )
+            fn encode_segments(&self, codec: ::connectrpc::CodecFormat)
                 -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError>
             {
                 ::connectrpc::__codegen::encode_view_body_segments(
                     self.reborrow(),
                     self.bytes(),
                     codec,
-                    min_segment,
                 )
             }
         }

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1205,6 +1205,25 @@ fn encodable_impl_pair(
             {
                 ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
             }
+
+            /// An `OwnedView` still holds the buffer it was decoded from, so
+            /// its large fields can be handed to the response body by
+            /// reference count instead of copied. The bare view impl above
+            /// cannot do this: it has borrows but no buffer to name.
+            fn encode_segments(
+                &self,
+                codec: ::connectrpc::CodecFormat,
+                min_segment: usize,
+            )
+                -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError>
+            {
+                ::connectrpc::__codegen::encode_view_body_segments(
+                    self.reborrow(),
+                    self.bytes(),
+                    codec,
+                    min_segment,
+                )
+            }
         }
     }))
 }
@@ -4354,11 +4373,13 @@ mod tests {
             .iter()
             .find(|f| f.name == "ping.__connect.rs")
             .expect("service companion");
-        // Count impl bodies (one `encode_view_body` call each) rather than
-        // `impl ::connectrpc::Encodable<` — that string also appears in the
-        // trait method's return-position bound.
+        // Count impl bodies rather than `impl ::connectrpc::Encodable<` —
+        // that string also appears in the trait method's return-position
+        // bound. Match `encode_view_body(` with the paren so the
+        // `encode_view_body_segments` override on the OwnedView impl is not
+        // counted as a second body.
         assert_eq!(
-            companion.content.matches("encode_view_body").count(),
+            companion.content.matches("encode_view_body(").count(),
             4,
             "exactly one impl pair per message (PingReq + PingResp), \
              no E0119 duplicates: {}",
@@ -4452,7 +4473,7 @@ mod tests {
         assert_eq!(pkg_mod.kind, GeneratedFileKind::PackageMod);
         assert_eq!(pkg_mod.name, "common.v1.rs");
         assert_eq!(
-            pkg_mod.content.matches("encode_view_body").count(),
+            pkg_mod.content.matches("encode_view_body(").count(),
             2,
             "impl pair inlined into the package file: {}",
             pkg_mod.content
@@ -4496,7 +4517,7 @@ mod tests {
             .find(|f| f.kind == GeneratedFileKind::PackageMod && f.package == "common.v1")
             .expect("PackageMod for common.v1");
         assert_eq!(
-            pkg_mod.content.matches("encode_view_body").count(),
+            pkg_mod.content.matches("encode_view_body(").count(),
             2,
             "impl pair inlined into the package file: {}",
             pkg_mod.content

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -25,6 +25,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const HEALTH_SERVICE_NAME: &str = "grpc.health.v1.Health";

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -32,13 +32,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -35,6 +35,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1.ServerReflection";

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -42,13 +42,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -44,13 +44,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -37,6 +37,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1alpha.ServerReflection";

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -119,6 +119,48 @@ impl Envelope {
         (head.freeze(), Some(self.data))
     }
 
+    /// Frame an already-encoded body, keeping any segments it arrived in.
+    ///
+    /// The generalization of [`encode_parts`](Self::encode_parts) from one
+    /// payload to several. A body that the encoder split — because it could
+    /// hand a large field over by reference count rather than copy it — stays
+    /// split all the way to the socket, one body frame per segment, instead of
+    /// being flattened back into a single buffer here and undoing the saving.
+    ///
+    /// The envelope header still declares the total length across every
+    /// segment, so the framing on the wire is byte-for-byte what a contiguous
+    /// encode would have produced. Envelope framing has never depended on
+    /// HTTP frame boundaries.
+    ///
+    /// A body below `min_chain` is written into the head buffer as before: a
+    /// segment that small would be copied into the framing buffer downstream
+    /// regardless, so splitting it buys nothing and costs a frame.
+    pub(crate) fn encode_body_parts(
+        flags: u8,
+        body: crate::response::EncodedBody,
+        min_chain: usize,
+    ) -> (Bytes, Vec<Bytes>) {
+        let total = body.len();
+        if total < min_chain {
+            let mut buf = BytesMut::with_capacity(HEADER_SIZE + total);
+            write_envelope_header(flags, total, &mut buf)
+                .expect("envelope payload exceeds u32::MAX");
+            for segment in body.segments() {
+                buf.extend_from_slice(segment);
+            }
+            return (buf.freeze(), Vec::new());
+        }
+
+        let mut head = BytesMut::with_capacity(HEADER_SIZE);
+        write_envelope_header(flags, total, &mut head).expect("envelope payload exceeds u32::MAX");
+
+        let segments = match body {
+            crate::response::EncodedBody::Contiguous(bytes) => vec![bytes],
+            crate::response::EncodedBody::Segmented(segments) => segments,
+        };
+        (head.freeze(), segments)
+    }
+
     /// Decode an envelope from bytes.
     ///
     /// Returns `Ok(Some(envelope))` if a complete envelope was decoded,

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -454,7 +454,7 @@ mod tests {
 
         // Reassembled bytes are identical to the contiguous encoding.
         let mut reassembled = BytesMut::from(&head[..]);
-        reassembled.put_slice(&chained);
+        reassembled.put_slice(chained);
         assert_eq!(
             reassembled.freeze(),
             Envelope::data(payload).encode(),

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -97,35 +97,12 @@ impl Envelope {
         buf.freeze()
     }
 
-    /// Encode this envelope as a head segment plus an optionally chained
-    /// payload.
-    ///
-    /// Payloads of at least `min_chain` bytes return `(header, Some(payload))`
-    /// — the 5-byte header alone, with the payload passed through by refcount
-    /// for the caller to emit as its own body frame. Smaller payloads return
-    /// the full contiguous encoding and `None`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the payload exceeds `u32::MAX` bytes, like
-    /// [`encode`](Self::encode).
-    pub(crate) fn encode_parts(self, min_chain: usize) -> (Bytes, Option<Bytes>) {
-        if self.data.len() < min_chain {
-            return (self.encode(), None);
-        }
-        let mut head = BytesMut::with_capacity(HEADER_SIZE);
-        write_envelope_header(self.flags, self.data.len(), &mut head)
-            .expect("envelope payload exceeds u32::MAX");
-        (head.freeze(), Some(self.data))
-    }
-
     /// Frame an already-encoded body, keeping any segments it arrived in.
     ///
-    /// The generalization of [`encode_parts`](Self::encode_parts) from one
-    /// payload to several. A body that the encoder split — because it could
-    /// hand a large field over by reference count rather than copy it — stays
-    /// split all the way to the socket, one body frame per segment, instead of
-    /// being flattened back into a single buffer here and undoing the saving.
+    /// A body that the encoder split — because it could hand a large field
+    /// over by reference count rather than copy it — stays split all the way
+    /// to the socket, one body frame per segment, instead of being flattened
+    /// back into a single buffer here and undoing the saving.
     ///
     /// The envelope header still declares the total length across every
     /// segment, so the framing on the wire is byte-for-byte what a contiguous
@@ -382,10 +359,11 @@ impl EnvelopeEncoder {
     /// Smaller payloads are written contiguously into `dst` and `None` is
     /// returned.
     ///
-    /// This is the single implementation of the envelope-encode policy —
-    /// the [`Encoder`](tokio_util::codec::Encoder) impl delegates here with
-    /// `min_chain = usize::MAX` (never chain) — so the compression decision
-    /// and the chaining decision cannot drift apart.
+    /// The [`Encoder`](tokio_util::codec::Encoder) impl delegates here with
+    /// `min_chain = usize::MAX` (never chain), so the compression decision and
+    /// the chaining decision cannot drift apart on the streaming path.
+    /// Unary responses take [`Envelope::encode_body_parts`], which applies the
+    /// same threshold to an already-encoded body.
     ///
     /// gRPC/Connect envelope framing is independent of HTTP-level frame
     /// boundaries, so splitting the header and payload across body frames
@@ -464,12 +442,14 @@ mod tests {
     // ── Envelope tests ──────────────────────────────────────────────
 
     #[test]
-    fn encode_parts_chains_large_payload_by_refcount() {
+    fn encode_body_parts_chains_large_payload_by_refcount() {
         let payload = Bytes::from(vec![7u8; 64]);
         let ptr = payload.as_ptr();
-        let (head, chained) = Envelope::data(payload.clone()).encode_parts(64);
+        let (head, chained) = Envelope::encode_body_parts(flags::DATA, payload.clone().into(), 64);
         assert_eq!(head.len(), HEADER_SIZE);
-        let chained = chained.expect("payload at threshold must chain");
+        let [chained] = &chained[..] else {
+            panic!("payload at threshold must chain as one segment");
+        };
         assert!(std::ptr::eq(chained.as_ptr(), ptr), "must not copy");
 
         // Reassembled bytes are identical to the contiguous encoding.
@@ -519,11 +499,76 @@ mod tests {
     }
 
     #[test]
-    fn encode_parts_small_payload_stays_contiguous() {
+    fn encode_body_parts_small_payload_stays_contiguous() {
         let payload = Bytes::from_static(b"tiny");
-        let (head, chained) = Envelope::data(payload.clone()).encode_parts(64);
-        assert!(chained.is_none());
+        let (head, chained) = Envelope::encode_body_parts(flags::DATA, payload.clone().into(), 64);
+        assert!(chained.is_empty());
         assert_eq!(head, Envelope::data(payload).encode());
+    }
+
+    /// The property every branch has to hold: the header declares the total
+    /// length across all segments, and concatenating what is emitted equals
+    /// the contiguous envelope. A header that disagreed with the bytes after
+    /// it would desynchronize the peer's framing rather than fail locally, so
+    /// each branch is pinned rather than left to the conformance suite.
+    #[test]
+    fn encode_body_parts_declares_the_length_it_emits() {
+        use crate::response::EncodedBody;
+
+        let cases: Vec<(&str, EncodedBody)> = vec![
+            ("empty", EncodedBody::Contiguous(Bytes::new())),
+            (
+                "sub-threshold contiguous",
+                EncodedBody::Contiguous(Bytes::from_static(b"small")),
+            ),
+            (
+                "sub-threshold segmented",
+                EncodedBody::Segmented(vec![Bytes::from_static(b"ab"), Bytes::from_static(b"cd")]),
+            ),
+            (
+                "over-threshold contiguous",
+                EncodedBody::Contiguous(Bytes::from(vec![9u8; 128])),
+            ),
+            (
+                "over-threshold two segments",
+                EncodedBody::Segmented(vec![
+                    Bytes::from(vec![1u8; 64]),
+                    Bytes::from(vec![2u8; 64]),
+                ]),
+            ),
+            (
+                "over-threshold many segments",
+                EncodedBody::Segmented((0..5).map(|i| Bytes::from(vec![i as u8; 40])).collect()),
+            ),
+        ];
+
+        for (name, body) in cases {
+            let total = body.len();
+            let expected = Envelope::data(body.clone().into_contiguous()).encode();
+
+            let (head, segments) = Envelope::encode_body_parts(flags::DATA, body, 64);
+
+            let declared = u32::from_be_bytes([head[1], head[2], head[3], head[4]]) as usize;
+            assert_eq!(declared, total, "{name}: header must declare the total");
+
+            let emitted: usize =
+                head.len() - HEADER_SIZE + segments.iter().map(Bytes::len).sum::<usize>();
+            assert_eq!(
+                emitted, total,
+                "{name}: emitted payload bytes must match the declared length"
+            );
+
+            let mut reassembled = BytesMut::from(&head[..]);
+            for segment in &segments {
+                assert!(!segment.is_empty(), "{name}: no empty segments");
+                reassembled.put_slice(segment);
+            }
+            assert_eq!(
+                reassembled.freeze(),
+                expected,
+                "{name}: must reassemble to the contiguous envelope"
+            );
+        }
     }
 
     #[test]

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -343,7 +343,11 @@ impl UnaryResponse {
     /// Build a `UnaryResponse` from an encoded handler response.
     pub fn from_encoded(resp: EncodedResponse, format: CodecFormat) -> Self {
         Response {
-            body: Payload::new(resp.body, format),
+            // Interceptors inspect and replace whole message bodies, so the
+            // payload has to be contiguous here. Flattening is a no-op unless
+            // the encoder segmented, and an interceptor is the one consumer
+            // that cannot work with segments.
+            body: Payload::new(resp.body.into_contiguous(), format),
             headers: resp.headers,
             trailers: resp.trailers,
             compress: resp.compress,
@@ -358,7 +362,7 @@ impl UnaryResponse {
     /// [`Payload::set_message`] fails to re-encode.
     pub fn into_encoded(self) -> Result<EncodedResponse, ConnectError> {
         Ok(Response {
-            body: self.body.encoded()?,
+            body: self.body.encoded()?.into(),
             headers: self.headers,
             trailers: self.trailers,
             compress: self.compress,
@@ -721,7 +725,7 @@ pub(crate) async fn call_client_streaming_intercepted<D: crate::Dispatcher>(
         }
     };
     Ok(Response {
-        body,
+        body: body.into(),
         headers,
         trailers,
         compress,
@@ -814,9 +818,9 @@ impl<D: crate::Dispatcher> StreamTerminal for ClientStreamingTerminal<'_, D> {
         // Wrap the single response in a 1-item outbound stream so the
         // chain has a uniform type. `call_client_streaming_intercepted`
         // pulls it back out for the dispatch path.
-        Ok(resp.map_body(move |bytes| -> PayloadStream {
+        Ok(resp.map_body(move |body| -> PayloadStream {
             Box::pin(futures::stream::once(async move {
-                Ok(Payload::new(bytes, format))
+                Ok(Payload::new(body.into_contiguous(), format))
             }))
         }))
     }
@@ -858,7 +862,7 @@ impl<D: crate::Dispatcher> StreamTerminal for BidiStreamingTerminal<'_, D> {
 /// let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(MyInterceptor)];
 /// let resp = connectrpc::interceptor::run_chain(&chain, my_req, |req| async move {
 ///     // assert what the handler would see
-///     Ok(UnaryResponse::from_encoded(EncodedResponse::new(Bytes::new()), CodecFormat::Proto))
+///     Ok(UnaryResponse::from_encoded(EncodedResponse::new(Bytes::new().into()), CodecFormat::Proto))
 /// })
 /// .await?;
 /// ```
@@ -968,7 +972,7 @@ mod tests {
                 value: self.respond_with.into(),
                 ..Default::default()
             })?;
-            let mut resp = EncodedResponse::new(body);
+            let mut resp = EncodedResponse::new(body.into());
             resp.headers.insert("x-in-len", in_len.parse().unwrap());
             Ok(UnaryResponse::from_encoded(resp, CodecFormat::Proto))
         }
@@ -1201,7 +1205,7 @@ mod tests {
         // Exercise the public test helper that downstream crates use.
         let resp = run_chain(&chain, req(), |_| async {
             Ok(UnaryResponse::from_encoded(
-                EncodedResponse::new(Bytes::new()),
+                EncodedResponse::new(Bytes::new().into()),
                 CodecFormat::Proto,
             ))
         })
@@ -1220,7 +1224,7 @@ mod tests {
         impl Interceptor for Passthrough {}
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
         let resp = run_chain(&chain, req(), |_| async {
-            let mut r = EncodedResponse::new(Bytes::from_static(b"x"));
+            let mut r = EncodedResponse::new(Bytes::from_static(b"x").into());
             r.headers.insert("x-h", "1".parse().unwrap());
             r.trailers.insert("x-t", "2".parse().unwrap());
             r.compress = Some(true);
@@ -1232,7 +1236,7 @@ mod tests {
         assert_eq!(encoded.headers.get("x-h").unwrap(), "1");
         assert_eq!(encoded.trailers.get("x-t").unwrap(), "2");
         assert_eq!(encoded.compress, Some(true));
-        assert_eq!(&*encoded.body, b"x");
+        assert_eq!(&*encoded.body.into_contiguous(), b"x");
     }
 
     #[tokio::test]
@@ -1256,7 +1260,7 @@ mod tests {
                 request: Payload,
                 _: CodecFormat,
             ) -> crate::dispatcher::UnaryResult {
-                Box::pin(async move { Ok(EncodedResponse::new(request.encoded()?)) })
+                Box::pin(async move { Ok(EncodedResponse::new(request.encoded()?.into())) })
             }
             fn call_server_streaming(
                 &self,
@@ -1298,7 +1302,10 @@ mod tests {
         .await
         .unwrap();
         // Same backing storage — no copy through Payload.
-        assert!(std::ptr::eq(resp.body.as_ptr(), body.as_ptr()));
+        assert!(std::ptr::eq(
+            resp.body.into_contiguous().as_ptr(),
+            body.as_ptr()
+        ));
     }
 
     /// `DispatchTerminal` hands the `Payload` — not raw bytes — to the
@@ -1333,7 +1340,7 @@ mod tests {
                 Box::pin(async move {
                     let m: StringValue = request.take_message()?;
                     *captured.lock().unwrap() = Some(m.value);
-                    Ok(EncodedResponse::new(Bytes::new()))
+                    Ok(EncodedResponse::new(Bytes::new().into()))
                 })
             }
             fn call_server_streaming(
@@ -1761,7 +1768,7 @@ mod tests {
                 while let Some(item) = requests.next().await {
                     total += item?.len();
                 }
-                Ok(EncodedResponse::new(Bytes::from(total.to_string())))
+                Ok(EncodedResponse::new(Bytes::from(total.to_string()).into()))
             })
         }
         fn call_bidi_streaming(
@@ -1822,7 +1829,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(&*resp.body, b"4");
+        assert_eq!(&*resp.body.into_contiguous(), b"4");
 
         // Bidi-streaming.
         let body = Bytes::from_static(b"z");
@@ -1998,7 +2005,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(&*resp.body, b"5");
+        assert_eq!(&*resp.body.into_contiguous(), b"5");
 
         // Bidi: 2-item inbound → echo dispatcher returns it as outbound.
         let inbound: RequestStream = Box::pin(futures::stream::iter(vec![

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -288,6 +288,7 @@ pub use stream_message::StreamMessage;
 pub mod __codegen {
     pub use crate::response::encode_view_body;
     pub use crate::response::encode_view_body_segments;
+    pub use crate::response::encode_view_body_with_min_segment;
 }
 
 // Error types

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -271,6 +271,7 @@ pub use handler::view_streaming_handler_fn;
 pub use request::HasMessageView;
 pub use request::ServiceRequest;
 pub use response::Encodable;
+pub use response::EncodedBody;
 pub use response::EncodedResponse;
 pub use response::InboundStream;
 pub use response::MaybeBorrowed;

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -286,6 +286,7 @@ pub use stream_message::StreamMessage;
 #[doc(hidden)]
 pub mod __codegen {
     pub use crate::response::encode_view_body;
+    pub use crate::response::encode_view_body_segments;
 }
 
 // Error types

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -1079,7 +1079,7 @@ impl<M: Message + JsonSerialize> Encodable<M> for PreEncoded<M> {
 /// This is what the [`Dispatcher`](crate::Dispatcher) returns to the
 /// protocol layer — encoding happens inside the dispatcher so the body
 /// type stays generic across the trait boundary.
-pub type EncodedResponse = Response<Bytes>;
+pub type EncodedResponse = Response<EncodedBody>;
 
 impl<B> Response<B> {
     /// Encode the body to bytes via [`Encodable<M>`], preserving
@@ -1089,9 +1089,14 @@ impl<B> Response<B> {
     where
         B: Encodable<M>,
     {
-        let bytes = self.body.encode(codec)?;
+        // Bodies that can hand a large payload over by reference count say so
+        // here; everything else takes the default and returns the same single
+        // buffer it always did.
+        let body = self
+            .body
+            .encode_segments(codec, crate::envelope::MIN_CHAIN_SIZE)?;
         Ok(Response {
-            body: bytes,
+            body,
             headers: self.headers,
             trailers: self.trailers,
             compress: self.compress,
@@ -1317,7 +1322,9 @@ mod tests {
         let enc = r.encode::<StringValue>(CodecFormat::Proto).unwrap();
         assert_eq!(enc.headers.get("x-a").unwrap(), "1");
         assert_eq!(
-            StringValue::decode_from_slice(&enc.body).unwrap().value,
+            StringValue::decode_from_slice(&enc.body.into_contiguous())
+                .unwrap()
+                .value,
             "hi"
         );
     }

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -709,7 +709,7 @@ pub fn encode_view_body<'a, V: ViewEncode<'a>>(
 /// keeping the whole allocation alive until the response finishes flushing —
 /// a handler that answers a 64 MiB upload with a 32 KiB summary would hold
 /// 64 MiB per in-flight response where it used to hold 32 KiB. Copying is
-/// cheaper than that. When the response is most of the buffer it borrows from,
+/// cheaper than that. When the response is at least half the buffer it borrows from,
 /// the buffer was going to stay alive anyway and the capture is free.
 fn worth_segmenting(size: usize, backing_len: usize, min_segment: usize) -> bool {
     size >= min_segment && size.saturating_mul(2) >= backing_len
@@ -761,7 +761,7 @@ fn checked_response_size(size: u32) -> Result<usize, ConnectError> {
 /// This is where buffa 0.9's rope pays. A view's fields are slices into the
 /// buffer it was decoded from, so a rope told about that buffer can take a
 /// large field by reference, and the encode then costs the same whatever the
-/// payload weighs. The `view_encode` benchmark in `benches/rpc` measures the
+/// payload weighs. The `view_rope_encode` benchmark in `benches/rpc` measures the
 /// curve; above the threshold the encode goes flat, because only the framing
 /// is still being written.
 ///
@@ -1350,6 +1350,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "json")]
     fn json_encoding_stays_contiguous() {
         // JSON is serialized whole, so there is nothing to hand over by
         // reference and the segmented call must not pretend otherwise.

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 use buffa::Message;
 use buffa::view::{MessageView, ViewEncode};
 use bytes::Bytes;
+use bytes::BytesMut;
 use futures::Stream;
 use http::HeaderMap;
 use http::header::{HeaderName, HeaderValue};
@@ -504,6 +505,86 @@ pub type ServiceStream<T> = Pin<Box<dyn Stream<Item = Result<T, ConnectError>> +
 /// parameters with this alias so signatures stay readable.
 pub type InboundStream<M> = ServiceStream<crate::StreamMessage<M>>;
 
+/// Encoded message bytes, either contiguous or split into reference-counted
+/// segments.
+///
+/// Concatenating [`segments`](Self::segments) always yields the message's wire
+/// bytes; how they are divided is an artifact of how the body was encoded and
+/// carries no protocol meaning. Envelope framing has never depended on HTTP
+/// frame boundaries, so a segmented body reaches the peer as the same message.
+///
+/// The single-buffer case is kept unboxed: a small message that was never
+/// worth segmenting costs no allocation to carry.
+#[derive(Debug, Clone)]
+pub enum EncodedBody {
+    /// One contiguous buffer — what a non-segmenting encode produces.
+    Contiguous(Bytes),
+    /// Several buffers, concatenating to the message's wire bytes.
+    Segmented(Vec<Bytes>),
+}
+
+impl EncodedBody {
+    /// Build from a rope's segments, collapsing the trivial cases so callers
+    /// never see a needless `Vec` for zero or one segment.
+    #[must_use]
+    pub fn from_segments(mut segments: Vec<Bytes>) -> Self {
+        match segments.len() {
+            0 => Self::Contiguous(Bytes::new()),
+            1 => Self::Contiguous(segments.pop().unwrap_or_default()),
+            _ => Self::Segmented(segments),
+        }
+    }
+
+    /// Total encoded length across all segments.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Contiguous(b) => b.len(),
+            Self::Segmented(v) => v.iter().map(Bytes::len).sum(),
+        }
+    }
+
+    /// Whether the encoded message is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The segments in wire order.
+    #[must_use]
+    pub fn segments(&self) -> &[Bytes] {
+        match self {
+            Self::Contiguous(b) => std::slice::from_ref(b),
+            Self::Segmented(v) => v,
+        }
+    }
+
+    /// Flatten to a single contiguous buffer, copying only when segmented.
+    ///
+    /// This is the escape hatch for paths that genuinely need one buffer
+    /// (compression, JSON, base64) — it gives back exactly what a
+    /// non-segmenting encode would have produced.
+    #[must_use]
+    pub fn into_contiguous(self) -> Bytes {
+        match self {
+            Self::Contiguous(b) => b,
+            Self::Segmented(v) => {
+                let mut out = BytesMut::with_capacity(v.iter().map(Bytes::len).sum());
+                for segment in &v {
+                    out.extend_from_slice(segment);
+                }
+                out.freeze()
+            }
+        }
+    }
+}
+
+impl From<Bytes> for EncodedBody {
+    fn from(bytes: Bytes) -> Self {
+        Self::Contiguous(bytes)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Encodable<M>
 // ---------------------------------------------------------------------------
@@ -536,6 +617,32 @@ pub type InboundStream<M> = ServiceStream<crate::StreamMessage<M>>;
 pub trait Encodable<M> {
     /// Encode `self` as wire bytes for `M` in the requested format.
     fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError>;
+
+    /// Encode `self` as wire bytes that may arrive in several reference-counted
+    /// segments rather than one contiguous buffer.
+    ///
+    /// Concatenating the segments yields exactly what [`encode`](Self::encode)
+    /// would have returned, so this is an optimization and never a wire-format
+    /// difference. A payload of at least `min_segment` bytes that the encoder
+    /// can hand over by reference count — a large `bytes::Bytes` field, or a
+    /// view field borrowed from the buffer the view was decoded from — becomes
+    /// its own segment instead of being copied into the output.
+    ///
+    /// The default implementation returns [`encode`](Self::encode)'s single
+    /// buffer, which is always correct; overriding it is worthwhile only for
+    /// bodies that can carry a large payload by reference.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`encode`](Self::encode).
+    fn encode_segments(
+        &self,
+        codec: CodecFormat,
+        min_segment: usize,
+    ) -> Result<EncodedBody, ConnectError> {
+        let _ = min_segment;
+        self.encode(codec).map(EncodedBody::from)
+    }
 }
 
 impl<M: Message + JsonSerialize> Encodable<M> for M {
@@ -543,6 +650,23 @@ impl<M: Message + JsonSerialize> Encodable<M> for M {
         match codec {
             CodecFormat::Proto => Ok(self.encode_to_bytes()),
             CodecFormat::Json => encode_json(self),
+        }
+    }
+
+    fn encode_segments(
+        &self,
+        codec: CodecFormat,
+        min_segment: usize,
+    ) -> Result<EncodedBody, ConnectError> {
+        match codec {
+            // JSON is serialized whole; there is nothing to hand over by
+            // reference, so it takes the contiguous path.
+            CodecFormat::Json => encode_json(self).map(EncodedBody::from),
+            CodecFormat::Proto => {
+                let mut rope = buffa::Rope::with_min_segment(min_segment);
+                buffa::Message::encode(self, &mut rope);
+                Ok(EncodedBody::from_segments(rope.into_segments()))
+            }
         }
     }
 }
@@ -928,6 +1052,63 @@ impl<B> Response<B> {
 mod tests {
     use super::*;
     use buffa_types::google::protobuf::StringValue;
+
+    /// The invariant the whole segmented path rests on: however the encoder
+    /// chose to divide the output, concatenating it must reproduce exactly
+    /// what the contiguous encode produced. A divergence here is a wire-format
+    /// bug, not a performance one.
+    #[test]
+    fn segments_concatenate_to_the_contiguous_encoding() {
+        let msg = StringValue::from("a message that round-trips");
+
+        for min_segment in [1usize, 8, 1024, usize::MAX] {
+            let segmented =
+                Encodable::<StringValue>::encode_segments(&msg, CodecFormat::Proto, min_segment)
+                    .expect("proto encode");
+            let contiguous =
+                Encodable::<StringValue>::encode(&msg, CodecFormat::Proto).expect("proto encode");
+
+            assert_eq!(
+                segmented.len(),
+                contiguous.len(),
+                "min_segment={min_segment}: length must match"
+            );
+            assert_eq!(
+                segmented.into_contiguous(),
+                contiguous,
+                "min_segment={min_segment}: bytes must match"
+            );
+        }
+    }
+
+    #[test]
+    fn json_encoding_stays_contiguous() {
+        // JSON is serialized whole, so there is nothing to hand over by
+        // reference and the segmented call must not pretend otherwise.
+        let msg = StringValue::from("json");
+        let body =
+            Encodable::<StringValue>::encode_segments(&msg, CodecFormat::Json, 1).expect("json");
+        assert!(matches!(body, EncodedBody::Contiguous(_)));
+    }
+
+    #[test]
+    fn encoded_body_collapses_trivial_segment_counts() {
+        assert!(matches!(
+            EncodedBody::from_segments(vec![]),
+            EncodedBody::Contiguous(b) if b.is_empty()
+        ));
+        assert!(matches!(
+            EncodedBody::from_segments(vec![Bytes::from_static(b"one")]),
+            EncodedBody::Contiguous(_)
+        ));
+        assert!(matches!(
+            EncodedBody::from_segments(vec![
+                Bytes::from_static(b"one"),
+                Bytes::from_static(b"two")
+            ]),
+            EncodedBody::Segmented(_)
+        ));
+    }
 
     #[tokio::test]
     async fn response_stream_ok_shorthand() {

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -653,22 +653,14 @@ impl<M: Message + JsonSerialize> Encodable<M> for M {
         }
     }
 
-    fn encode_segments(
-        &self,
-        codec: CodecFormat,
-        min_segment: usize,
-    ) -> Result<EncodedBody, ConnectError> {
-        match codec {
-            // JSON is serialized whole; there is nothing to hand over by
-            // reference, so it takes the contiguous path.
-            CodecFormat::Json => encode_json(self).map(EncodedBody::from),
-            CodecFormat::Proto => {
-                let mut rope = buffa::Rope::with_min_segment(min_segment);
-                buffa::Message::encode(self, &mut rope);
-                Ok(EncodedBody::from_segments(rope.into_segments()))
-            }
-        }
-    }
+    // Deliberately does not override `encode_segments`. An owned message
+    // holds its `string` and `bytes` fields as `String` / `Vec<u8>` under the
+    // default codegen mapping, and neither can be handed over by reference
+    // count — so a rope here captures nothing and only adds its own cost.
+    // Measured on a four-field message (benches/rpc `view_encode`), routing
+    // owned messages through a rope cost 30.6µs -> 43.5µs at 256 KiB and
+    // 136ns -> 317ns at 1 KiB. The win lives on the view path, which borrows
+    // its fields out of a buffer a rope can capture from.
 }
 
 /// Encode a view body via [`ViewEncode`] for [`CodecFormat::Proto`], or
@@ -691,6 +683,65 @@ pub fn encode_view_body<'a, V: ViewEncode<'a>>(
         CodecFormat::Json => Err(ConnectError::unimplemented(
             "view-body responses do not support the JSON codec; return the owned message type for JSON-serving handlers",
         )),
+    }
+}
+
+/// Encode a view body, capturing its large borrowed fields by reference count
+/// instead of copying them.
+///
+/// This is where buffa 0.9's rope actually pays. A view's fields are slices
+/// into the buffer it was decoded from, so a rope told about that buffer can
+/// take a large field by reference — the encode then costs the same whatever
+/// the payload weighs. Measured on a four-string message
+/// (benches/rpc `view_encode`): 1.49µs -> 421ns at 16 KiB per field, and
+/// 252µs -> 421ns at 1 MiB, flat because only the framing is being written.
+///
+/// The same measurement is why `backing` is not optional in spirit: a rope
+/// with no buffer to capture from captures nothing and runs *slower* than a
+/// contiguous encode, so callers that cannot supply the view's own buffer
+/// should stay on [`encode_view_body`].
+///
+/// Pass `envelope::MIN_CHAIN_SIZE` as `min_segment` unless there is a reason
+/// not to. A segment below that is copied into the framing buffer anyway, so
+/// producing one spends the rope's overhead without saving a copy — and at
+/// 4 KiB the pathology is measurable: a four-field message clears the gate
+/// while no individual field does, so nothing is captured and the encode goes
+/// 141ns -> 365ns. Matching the framing threshold also makes every segment
+/// the encoder emits map to exactly one frame the body writes.
+///
+/// # Errors
+///
+/// [`ErrorCode::Unimplemented`](crate::ErrorCode::Unimplemented) for
+/// [`CodecFormat::Json`], as [`encode_view_body`].
+#[doc(hidden)]
+pub fn encode_view_body_segments<'a, V: ViewEncode<'a>>(
+    view: &V,
+    backing: &Bytes,
+    codec: CodecFormat,
+    min_segment: usize,
+) -> Result<EncodedBody, ConnectError> {
+    match codec {
+        CodecFormat::Json => Err(ConnectError::unimplemented(
+            "view-body responses do not support the JSON codec; return the owned message type for JSON-serving handlers",
+        )),
+        CodecFormat::Proto => {
+            let mut cache = buffa::SizeCache::new();
+            let size = buffa::checked_encode_size(view.compute_size(&mut cache)).map_err(|_| {
+                ConnectError::internal("response message exceeds the 2 GiB protobuf size limit")
+            })?;
+
+            // Below one segment nothing can be captured, so the rope would be
+            // pure overhead — see the note above.
+            if (size as usize) < min_segment {
+                let mut buf = BytesMut::with_capacity(size as usize);
+                view.write_to(&mut cache, &mut buf);
+                return Ok(EncodedBody::Contiguous(buf.freeze()));
+            }
+
+            let mut rope = buffa::Rope::with_min_segment(min_segment).with_backing(backing.clone());
+            view.write_to(&mut cache, &mut rope);
+            Ok(EncodedBody::from_segments(rope.into_segments()))
+        }
     }
 }
 
@@ -1051,22 +1102,27 @@ impl<B> Response<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use buffa_types::google::protobuf::__buffa::view::StringValueView;
     use buffa_types::google::protobuf::StringValue;
 
     /// The invariant the whole segmented path rests on: however the encoder
     /// chose to divide the output, concatenating it must reproduce exactly
     /// what the contiguous encode produced. A divergence here is a wire-format
     /// bug, not a performance one.
+    ///
+    /// Swept across thresholds because each one divides the output
+    /// differently — 1 makes almost every write its own segment, `usize::MAX`
+    /// never segments at all, and the interesting cases sit between.
     #[test]
-    fn segments_concatenate_to_the_contiguous_encoding() {
-        let msg = StringValue::from("a message that round-trips");
+    fn view_segments_concatenate_to_the_contiguous_encoding() {
+        let buffer = encoded_string_value(&"m".repeat(64 * 1024));
+        let view = StringValueView::decode_view(&buffer).expect("decode view");
+        let contiguous = encode_view_body(&view, CodecFormat::Proto).expect("proto encode");
 
-        for min_segment in [1usize, 8, 1024, usize::MAX] {
+        for min_segment in [1usize, 8, 4096, 64 * 1024, usize::MAX] {
             let segmented =
-                Encodable::<StringValue>::encode_segments(&msg, CodecFormat::Proto, min_segment)
+                encode_view_body_segments(&view, &buffer, CodecFormat::Proto, min_segment)
                     .expect("proto encode");
-            let contiguous =
-                Encodable::<StringValue>::encode(&msg, CodecFormat::Proto).expect("proto encode");
 
             assert_eq!(
                 segmented.len(),
@@ -1079,6 +1135,81 @@ mod tests {
                 "min_segment={min_segment}: bytes must match"
             );
         }
+    }
+
+    /// Wire bytes for a `StringValue`, to decode a borrowing view from.
+    fn encoded_string_value(value: &str) -> Bytes {
+        Bytes::from(buffa::Message::encode_to_vec(&StringValue::from(value)))
+    }
+
+    #[test]
+    fn small_views_skip_the_rope() {
+        // A rope costs more than it saves on a message too small to contain a
+        // capturable field, so the gate must send those down the contiguous
+        // path. Pinning it because the regression would be invisible: the
+        // bytes stay correct and only the encode gets slower.
+        let buffer = encoded_string_value("small");
+        let view = StringValueView::decode_view(&buffer).expect("decode view");
+
+        let body = encode_view_body_segments(
+            &view,
+            &buffer,
+            CodecFormat::Proto,
+            crate::envelope::MIN_CHAIN_SIZE,
+        )
+        .expect("proto encode");
+        assert!(
+            matches!(body, EncodedBody::Contiguous(_)),
+            "a message under one segment must not pay for a rope"
+        );
+    }
+
+    #[test]
+    fn large_view_fields_are_captured_as_segments() {
+        // The whole point of the exercise: a field larger than one segment,
+        // borrowed from the buffer the rope is backed by, is handed over by
+        // reference instead of copied. If this stops splitting, the encode has
+        // silently gone back to copying the payload.
+        let buffer = encoded_string_value(&"x".repeat(64 * 1024));
+        let view = StringValueView::decode_view(&buffer).expect("decode view");
+
+        let body = encode_view_body_segments(
+            &view,
+            &buffer,
+            CodecFormat::Proto,
+            crate::envelope::MIN_CHAIN_SIZE,
+        )
+        .expect("proto encode");
+        assert!(
+            matches!(body, EncodedBody::Segmented(_)),
+            "a 64 KiB borrowed field must be captured, not copied"
+        );
+        assert_eq!(
+            body.into_contiguous(),
+            encode_view_body(&view, CodecFormat::Proto).expect("proto encode"),
+            "segmented output must equal what the contiguous encoder produced"
+        );
+    }
+
+    #[test]
+    fn view_segments_without_backing_are_still_correct() {
+        // A rope pointed at the wrong buffer captures nothing, which costs
+        // speed but must never cost correctness.
+        let buffer = encoded_string_value(&"y".repeat(64 * 1024));
+        let view = StringValueView::decode_view(&buffer).expect("decode view");
+        let unrelated = Bytes::from_static(b"not the buffer this view came from");
+
+        let body = encode_view_body_segments(
+            &view,
+            &unrelated,
+            CodecFormat::Proto,
+            crate::envelope::MIN_CHAIN_SIZE,
+        )
+        .expect("proto encode");
+        assert_eq!(
+            body.into_contiguous(),
+            encode_view_body(&view, CodecFormat::Proto).expect("proto encode")
+        );
     }
 
     #[test]

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -623,24 +623,29 @@ pub trait Encodable<M> {
     ///
     /// Concatenating the segments yields exactly what [`encode`](Self::encode)
     /// would have returned, so this is an optimization and never a wire-format
-    /// difference. A payload of at least `min_segment` bytes that the encoder
-    /// can hand over by reference count — a large `bytes::Bytes` field, or a
-    /// view field borrowed from the buffer the view was decoded from — becomes
-    /// its own segment instead of being copied into the output.
+    /// difference. A payload the encoder can hand over by reference count — a
+    /// large `bytes::Bytes` field, or a view field borrowed from the buffer the
+    /// view was decoded from — becomes its own segment instead of being copied
+    /// into the output.
     ///
     /// The default implementation returns [`encode`](Self::encode)'s single
-    /// buffer, which is always correct; overriding it is worthwhile only for
-    /// bodies that can carry a large payload by reference.
+    /// buffer, which is always correct. Overriding it is worthwhile only for a
+    /// body that can carry a large payload by reference; a body whose fields
+    /// are `String` or `Vec<u8>` has nothing to hand over, and segmenting it
+    /// would add the rope's cost for no saving.
+    ///
+    /// How large a payload has to be before it earns its own segment is the
+    /// framing layer's decision, not the implementation's — anything smaller
+    /// is copied into the framing buffer downstream regardless, so a smaller
+    /// threshold spends effort without saving a copy. Implementations that
+    /// need to encode a view should call
+    /// [`__codegen::encode_view_body_segments`](crate::__codegen::encode_view_body_segments),
+    /// which applies that threshold for them.
     ///
     /// # Errors
     ///
     /// Same conditions as [`encode`](Self::encode).
-    fn encode_segments(
-        &self,
-        codec: CodecFormat,
-        min_segment: usize,
-    ) -> Result<EncodedBody, ConnectError> {
-        let _ = min_segment;
+    fn encode_segments(&self, codec: CodecFormat) -> Result<EncodedBody, ConnectError> {
         self.encode(codec).map(EncodedBody::from)
     }
 }
@@ -656,11 +661,9 @@ impl<M: Message + JsonSerialize> Encodable<M> for M {
     // Deliberately does not override `encode_segments`. An owned message
     // holds its `string` and `bytes` fields as `String` / `Vec<u8>` under the
     // default codegen mapping, and neither can be handed over by reference
-    // count — so a rope here captures nothing and only adds its own cost.
-    // Measured on a four-field message (benches/rpc `view_encode`), routing
-    // owned messages through a rope cost 30.6µs -> 43.5µs at 256 KiB and
-    // 136ns -> 317ns at 1 KiB. The win lives on the view path, which borrows
-    // its fields out of a buffer a rope can capture from.
+    // count, so a rope here would capture nothing and only add its own cost.
+    // The win lives on the view path, which borrows its fields out of a
+    // buffer a rope can capture from.
 }
 
 /// Encode a view body via [`ViewEncode`] for [`CodecFormat::Proto`], or
@@ -679,35 +682,100 @@ pub fn encode_view_body<'a, V: ViewEncode<'a>>(
     codec: CodecFormat,
 ) -> Result<Bytes, ConnectError> {
     match codec {
-        CodecFormat::Proto => Ok(view.encode_to_bytes()),
+        // Not `encode_to_bytes`, which panics past the 2 GiB protobuf limit:
+        // an oversized response is a request-shaped input reaching a server,
+        // and the segmented sibling already reports it as an error. The work
+        // is the same either way — `encode_to_bytes` runs these two passes
+        // internally.
+        CodecFormat::Proto => {
+            let mut cache = buffa::SizeCache::new();
+            let size = checked_response_size(view.compute_size(&mut cache))?;
+            let mut buf = BytesMut::with_capacity(size);
+            view.write_to(&mut cache, &mut buf);
+            Ok(buf.freeze())
+        }
         CodecFormat::Json => Err(ConnectError::unimplemented(
             "view-body responses do not support the JSON codec; return the owned message type for JSON-serving handlers",
         )),
     }
 }
 
+/// Whether a response of `size` bytes should be encoded through a rope, given
+/// that its captures would alias a `backing` buffer of `backing_len` bytes.
+///
+/// Two ways a rope loses. A response below one segment has nothing large
+/// enough to capture, so the rope is pure overhead. And a small response
+/// derived from a large request would capture slices of that request's buffer,
+/// keeping the whole allocation alive until the response finishes flushing —
+/// a handler that answers a 64 MiB upload with a 32 KiB summary would hold
+/// 64 MiB per in-flight response where it used to hold 32 KiB. Copying is
+/// cheaper than that. When the response is most of the buffer it borrows from,
+/// the buffer was going to stay alive anyway and the capture is free.
+fn worth_segmenting(size: usize, backing_len: usize, min_segment: usize) -> bool {
+    size >= min_segment && size.saturating_mul(2) >= backing_len
+}
+
+/// Merge segments below `min_segment` into their neighbour.
+///
+/// A rope flushes its pending tail before each capture, so a view with several
+/// large fields yields alternating tag/length fragments and captured payloads.
+/// Emitted as-is those fragments become their own HTTP data frames, each a
+/// handful of bytes behind a 9-byte HTTP/2 frame header. Merging them costs a
+/// copy proportional to the fragment, not the payload.
+fn coalesce_small(segments: Vec<Bytes>, min_segment: usize) -> Vec<Bytes> {
+    if segments.len() < 2 {
+        return segments;
+    }
+    let mut out: Vec<Bytes> = Vec::with_capacity(segments.len());
+    let mut pending = BytesMut::new();
+    for segment in segments {
+        if segment.len() >= min_segment {
+            if !pending.is_empty() {
+                out.push(std::mem::take(&mut pending).freeze());
+            }
+            out.push(segment);
+        } else {
+            pending.extend_from_slice(&segment);
+        }
+    }
+    if !pending.is_empty() {
+        out.push(pending.freeze());
+    }
+    out
+}
+
+/// Reject a response larger than protobuf can encode, as an error rather than
+/// a panic — this runs on a server, where the size is a function of what a
+/// caller asked for.
+fn checked_response_size(size: u32) -> Result<usize, ConnectError> {
+    buffa::checked_encode_size(size)
+        .map(|size| size as usize)
+        .map_err(|_| {
+            ConnectError::internal("response message exceeds the 2 GiB protobuf size limit")
+        })
+}
+
 /// Encode a view body, capturing its large borrowed fields by reference count
 /// instead of copying them.
 ///
-/// This is where buffa 0.9's rope actually pays. A view's fields are slices
-/// into the buffer it was decoded from, so a rope told about that buffer can
-/// take a large field by reference — the encode then costs the same whatever
-/// the payload weighs. Measured on a four-string message
-/// (benches/rpc `view_encode`): 1.49µs -> 421ns at 16 KiB per field, and
-/// 252µs -> 421ns at 1 MiB, flat because only the framing is being written.
+/// This is where buffa 0.9's rope pays. A view's fields are slices into the
+/// buffer it was decoded from, so a rope told about that buffer can take a
+/// large field by reference, and the encode then costs the same whatever the
+/// payload weighs. The `view_encode` benchmark in `benches/rpc` measures the
+/// curve; above the threshold the encode goes flat, because only the framing
+/// is still being written.
 ///
-/// The same measurement is why `backing` is not optional in spirit: a rope
-/// with no buffer to capture from captures nothing and runs *slower* than a
-/// contiguous encode, so callers that cannot supply the view's own buffer
-/// should stay on [`encode_view_body`].
+/// `backing` must be the buffer this view was decoded from. A rope pointed
+/// anywhere else captures nothing and is slower than a contiguous encode — it
+/// still produces correct bytes, so the cost of getting this wrong is silent.
+/// A caller with no buffer to give should use [`encode_view_body`].
 ///
-/// Pass `envelope::MIN_CHAIN_SIZE` as `min_segment` unless there is a reason
-/// not to. A segment below that is copied into the framing buffer anyway, so
-/// producing one spends the rope's overhead without saving a copy — and at
-/// 4 KiB the pathology is measurable: a four-field message clears the gate
-/// while no individual field does, so nothing is captured and the encode goes
-/// 141ns -> 365ns. Matching the framing threshold also makes every segment
-/// the encoder emits map to exactly one frame the body writes.
+/// The threshold below which a payload is not worth its own segment is the
+/// framing layer's, applied here so callers cannot pick a worse one: anything
+/// smaller is copied into the framing buffer downstream regardless, and a
+/// message can clear a smaller gate while none of its individual fields do,
+/// which spends the rope's cost and captures nothing. Matching the framing
+/// threshold also makes every segment map to exactly one body frame.
 ///
 /// # Errors
 ///
@@ -715,6 +783,22 @@ pub fn encode_view_body<'a, V: ViewEncode<'a>>(
 /// [`CodecFormat::Json`], as [`encode_view_body`].
 #[doc(hidden)]
 pub fn encode_view_body_segments<'a, V: ViewEncode<'a>>(
+    view: &V,
+    backing: &Bytes,
+    codec: CodecFormat,
+) -> Result<EncodedBody, ConnectError> {
+    encode_view_body_with_min_segment(view, backing, codec, crate::envelope::MIN_CHAIN_SIZE)
+}
+
+/// [`encode_view_body_segments`] with the segment threshold spelled out, so
+/// tests and benchmarks can sweep it. Production callers take the framing
+/// layer's threshold via [`encode_view_body_segments`].
+///
+/// # Errors
+///
+/// As [`encode_view_body_segments`].
+#[doc(hidden)]
+pub fn encode_view_body_with_min_segment<'a, V: ViewEncode<'a>>(
     view: &V,
     backing: &Bytes,
     codec: CodecFormat,
@@ -726,21 +810,26 @@ pub fn encode_view_body_segments<'a, V: ViewEncode<'a>>(
         )),
         CodecFormat::Proto => {
             let mut cache = buffa::SizeCache::new();
-            let size = buffa::checked_encode_size(view.compute_size(&mut cache)).map_err(|_| {
-                ConnectError::internal("response message exceeds the 2 GiB protobuf size limit")
-            })?;
+            let size = checked_response_size(view.compute_size(&mut cache))?;
 
-            // Below one segment nothing can be captured, so the rope would be
-            // pure overhead — see the note above.
-            if (size as usize) < min_segment {
-                let mut buf = BytesMut::with_capacity(size as usize);
+            if !worth_segmenting(size, backing.len(), min_segment) {
+                let mut buf = BytesMut::with_capacity(size);
                 view.write_to(&mut cache, &mut buf);
                 return Ok(EncodedBody::Contiguous(buf.freeze()));
             }
 
+            // Known cost: a rope's tail starts empty and grows by doubling,
+            // and every field too small to capture lands in it. A message that
+            // clears the gate while none of its fields do therefore copies
+            // itself roughly twice over instead of once into a sized buffer.
+            // buffa 0.9 exposes no way to pre-size the tail; until it does,
+            // that shape pays for a rope that captures nothing.
             let mut rope = buffa::Rope::with_min_segment(min_segment).with_backing(backing.clone());
             view.write_to(&mut cache, &mut rope);
-            Ok(EncodedBody::from_segments(rope.into_segments()))
+            Ok(EncodedBody::from_segments(coalesce_small(
+                rope.into_segments(),
+                min_segment,
+            )))
         }
     }
 }
@@ -801,6 +890,18 @@ where
         match self {
             Self::Owned(m) => m.encode(codec),
             Self::Borrowed(v) => v.encode(codec),
+        }
+    }
+
+    /// Forwards to the wrapped body rather than taking the contiguous
+    /// default. `Borrowed` is the arm handlers reach for to avoid copying, so
+    /// it is exactly the arm that must not lose the segmented encode by being
+    /// wrapped — the wrapper would otherwise quietly undo the reason it was
+    /// chosen.
+    fn encode_segments(&self, codec: CodecFormat) -> Result<EncodedBody, ConnectError> {
+        match self {
+            Self::Owned(m) => m.encode_segments(codec),
+            Self::Borrowed(v) => v.encode_segments(codec),
         }
     }
 }
@@ -1092,9 +1193,7 @@ impl<B> Response<B> {
         // Bodies that can hand a large payload over by reference count say so
         // here; everything else takes the default and returns the same single
         // buffer it always did.
-        let body = self
-            .body
-            .encode_segments(codec, crate::envelope::MIN_CHAIN_SIZE)?;
+        let body = self.body.encode_segments(codec)?;
         Ok(Response {
             body,
             headers: self.headers,
@@ -1126,7 +1225,7 @@ mod tests {
 
         for min_segment in [1usize, 8, 4096, 64 * 1024, usize::MAX] {
             let segmented =
-                encode_view_body_segments(&view, &buffer, CodecFormat::Proto, min_segment)
+                encode_view_body_with_min_segment(&view, &buffer, CodecFormat::Proto, min_segment)
                     .expect("proto encode");
 
             assert_eq!(
@@ -1156,13 +1255,8 @@ mod tests {
         let buffer = encoded_string_value("small");
         let view = StringValueView::decode_view(&buffer).expect("decode view");
 
-        let body = encode_view_body_segments(
-            &view,
-            &buffer,
-            CodecFormat::Proto,
-            crate::envelope::MIN_CHAIN_SIZE,
-        )
-        .expect("proto encode");
+        let body =
+            encode_view_body_segments(&view, &buffer, CodecFormat::Proto).expect("proto encode");
         assert!(
             matches!(body, EncodedBody::Contiguous(_)),
             "a message under one segment must not pay for a rope"
@@ -1178,13 +1272,8 @@ mod tests {
         let buffer = encoded_string_value(&"x".repeat(64 * 1024));
         let view = StringValueView::decode_view(&buffer).expect("decode view");
 
-        let body = encode_view_body_segments(
-            &view,
-            &buffer,
-            CodecFormat::Proto,
-            crate::envelope::MIN_CHAIN_SIZE,
-        )
-        .expect("proto encode");
+        let body =
+            encode_view_body_segments(&view, &buffer, CodecFormat::Proto).expect("proto encode");
         assert!(
             matches!(body, EncodedBody::Segmented(_)),
             "a 64 KiB borrowed field must be captured, not copied"
@@ -1197,6 +1286,54 @@ mod tests {
     }
 
     #[test]
+    fn a_small_response_does_not_pin_a_large_request_buffer() {
+        // Capturing means the response's segments alias the request's buffer,
+        // which keeps the whole allocation alive until the response finishes
+        // flushing. For a summary of a large upload that trades a copy for
+        // holding orders of magnitude more memory per in-flight response, so
+        // the encoder copies instead.
+        let big_request = 4 * 1024 * 1024;
+        let small_response = 64 * 1024;
+        assert!(
+            !worth_segmenting(small_response, big_request, 16 * 1024),
+            "a response this much smaller than its request must not capture"
+        );
+
+        // Returning most of what arrived is the case capture is for: the
+        // buffer stays alive regardless, so aliasing it costs nothing.
+        assert!(worth_segmenting(64 * 1024, 66 * 1024, 16 * 1024));
+
+        // Still gated on the segment threshold.
+        assert!(!worth_segmenting(1024, 1024, 16 * 1024));
+    }
+
+    #[test]
+    fn tiny_segments_are_merged_into_their_neighbours() {
+        // A rope flushes its tail before each capture, so a multi-field view
+        // yields alternating small tag/length fragments and large payloads.
+        // Left alone each fragment becomes its own HTTP frame, a few bytes
+        // behind a 9-byte frame header.
+        let big = Bytes::from(vec![1u8; 32 * 1024]);
+        let segments = vec![
+            Bytes::from_static(b"ab"),
+            big.clone(),
+            Bytes::from_static(b"cd"),
+            big.clone(),
+            Bytes::from_static(b"ef"),
+        ];
+        let merged = coalesce_small(segments, 16 * 1024);
+
+        assert_eq!(merged.len(), 5, "large payloads stay their own segments");
+        let total: usize = merged.iter().map(Bytes::len).sum();
+        assert_eq!(total, 2 + 32 * 1024 + 2 + 32 * 1024 + 2);
+
+        // The large payloads must still be the original allocations, not
+        // copies — merging the fragments must not gather the payloads too.
+        assert!(std::ptr::eq(merged[1].as_ptr(), big.as_ptr()));
+        assert!(std::ptr::eq(merged[3].as_ptr(), big.as_ptr()));
+    }
+
+    #[test]
     fn view_segments_without_backing_are_still_correct() {
         // A rope pointed at the wrong buffer captures nothing, which costs
         // speed but must never cost correctness.
@@ -1204,13 +1341,8 @@ mod tests {
         let view = StringValueView::decode_view(&buffer).expect("decode view");
         let unrelated = Bytes::from_static(b"not the buffer this view came from");
 
-        let body = encode_view_body_segments(
-            &view,
-            &unrelated,
-            CodecFormat::Proto,
-            crate::envelope::MIN_CHAIN_SIZE,
-        )
-        .expect("proto encode");
+        let body =
+            encode_view_body_segments(&view, &unrelated, CodecFormat::Proto).expect("proto encode");
         assert_eq!(
             body.into_contiguous(),
             encode_view_body(&view, CodecFormat::Proto).expect("proto encode")
@@ -1223,7 +1355,7 @@ mod tests {
         // reference and the segmented call must not pretend otherwise.
         let msg = StringValue::from("json");
         let body =
-            Encodable::<StringValue>::encode_segments(&msg, CodecFormat::Json, 1).expect("json");
+            Encodable::<StringValue>::encode_segments(&msg, CodecFormat::Json).expect("json");
         assert!(matches!(body, EncodedBody::Contiguous(_)));
     }
 

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -1323,10 +1323,14 @@ impl<D: Dispatcher> ConnectRpcService<D> {
 pub struct GrpcUnaryBody {
     data: Option<Bytes>,
     /// Large message payload (post-compression, when negotiated) emitted as
-    /// its own data frame
-    /// after `data` (which then carries only the 5-byte envelope header),
-    /// so the payload is passed through by refcount instead of copied.
-    payload: Option<Bytes>,
+    /// its own data frame after `data` (which then carries only the 5-byte
+    /// envelope header), so the payload is passed through by refcount
+    /// instead of copied.
+    ///
+    /// More than one when the encoder handed back several segments — a view
+    /// re-encode captures each large borrowed field separately rather than
+    /// gathering them, so they stay separate all the way to the socket.
+    payload: std::collections::VecDeque<Bytes>,
     trailers: Option<GrpcUnaryTrailers>,
 }
 
@@ -1349,7 +1353,7 @@ impl Body for GrpcUnaryBody {
         let me = self.get_mut();
         if let Some(data) = me.data.take() {
             Poll::Ready(Some(Ok(Frame::data(data))))
-        } else if let Some(payload) = me.payload.take() {
+        } else if let Some(payload) = me.payload.pop_front() {
             Poll::Ready(Some(Ok(Frame::data(payload))))
         } else if let Some(trailers) = me.trailers.take() {
             match trailers {
@@ -1890,17 +1894,23 @@ where
 
     // Compress response body if negotiated, respecting the compression policy
     let effective_policy = compression_policy.with_override(resp.compress);
+    // Connect unary puts the message straight in the HTTP body with no
+    // envelope, so there is no frame boundary to hang a segment on — and
+    // compression needs one contiguous input regardless. Flattening is a
+    // no-op unless the encoder segmented.
+    let body_len = resp.body.len();
+    let resp_body = resp.body.into_contiguous();
     let (final_body, content_encoding) = if let Some(encoding) = response_encoding {
-        if !effective_policy.should_compress(resp.body.len()) {
-            (resp.body, None)
-        } else {
-            match compression.compress(encoding, &resp.body) {
+        if effective_policy.should_compress(body_len) {
+            match compression.compress(encoding, &resp_body) {
                 Ok(compressed) => (compressed, Some(encoding)),
-                Err(_) => (resp.body, None), // Fall back to uncompressed
+                Err(_) => (resp_body, None), // Fall back to uncompressed
             }
+        } else {
+            (resp_body, None)
         }
     } else {
-        (resp.body, None)
+        (resp_body, None)
     };
 
     // Build response with the same content type as the request
@@ -1990,13 +2000,13 @@ where
         }
         let body = GrpcUnaryBody {
             data: None,
-            payload: None,
+            payload: std::collections::VecDeque::new(),
             trailers: Some(trailers),
         };
         response.body(body).unwrap_or_else(|_| {
             Response::new(GrpcUnaryBody {
                 data: None,
-                payload: None,
+                payload: std::collections::VecDeque::new(),
                 trailers: None,
             })
         })
@@ -2133,12 +2143,21 @@ where
     let (encoded_data, chained_payload) = if let Some(encoding) = response_encoding
         && effective_policy.should_compress(resp.body.len())
     {
-        match compression.compress(encoding, &resp.body) {
-            Ok(compressed) => Envelope::compressed(compressed).encode_parts(min_chain),
-            Err(_) => Envelope::data(resp.body).encode_parts(min_chain),
+        // Compression needs one contiguous input and produces one contiguous
+        // output, so any segmentation the encoder managed ends here. That is
+        // the right trade: the compressor was going to read every byte anyway.
+        let flat = resp.body.into_contiguous();
+        match compression.compress(encoding, &flat) {
+            Ok(compressed) => {
+                let (head, payload) = Envelope::compressed(compressed).encode_parts(min_chain);
+                (head, payload.into_iter().collect())
+            }
+            Err(_) => {
+                Envelope::encode_body_parts(crate::envelope::flags::DATA, flat.into(), min_chain)
+            }
         }
     } else {
-        Envelope::data(resp.body).encode_parts(min_chain)
+        Envelope::encode_body_parts(crate::envelope::flags::DATA, resp.body, min_chain)
     };
 
     // Build gRPC trailers
@@ -2173,7 +2192,7 @@ where
 
     let body = GrpcUnaryBody {
         data: Some(encoded_data),
-        payload: chained_payload,
+        payload: chained_payload.into(),
         trailers: Some(trailers),
     };
 
@@ -2434,8 +2453,13 @@ where
             );
             match with_request_deadline(deadline, fut).await {
                 // Wrap single response in a one-item stream
-                Ok(r) => r.map_body(|bytes| -> BoxStream<Result<Bytes, ConnectError>> {
-                    Box::pin(futures::stream::once(async move { Ok(bytes) }))
+                // The streaming machinery carries contiguous message bytes,
+                // and re-enveloping happens per item downstream, so a
+                // client-streaming response flattens here.
+                Ok(r) => r.map_body(|body| -> BoxStream<Result<Bytes, ConnectError>> {
+                    Box::pin(futures::stream::once(
+                        async move { Ok(body.into_contiguous()) },
+                    ))
                 }),
                 Err(e) => return streaming_error_response(&e, protocol, codec_format),
             }
@@ -2617,7 +2641,9 @@ where
 
     let stream_compression = response_encoding.map(|encoding| (compression, encoding));
     let response_stream: BoxStream<Result<Bytes, ConnectError>> =
-        Box::pin(futures::stream::once(async { Ok(resp.body) }));
+        Box::pin(futures::stream::once(async {
+            Ok(resp.body.into_contiguous())
+        }));
     let effective_policy = compression_policy.with_override(resp.compress);
     let body = StreamingResponseBody::new(
         response_stream,
@@ -3456,7 +3482,7 @@ mod tests {
             Envelope::data(payload.clone()).encode_parts(crate::envelope::MIN_CHAIN_SIZE);
         let mut body = GrpcUnaryBody {
             data: Some(head.clone()),
-            payload: chained,
+            payload: chained.into_iter().collect(),
             trailers: Some(GrpcUnaryTrailers::Http2(http::HeaderMap::new())),
         };
 

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -1314,10 +1314,10 @@ impl<D: Dispatcher> ConnectRpcService<D> {
 
 /// A lightweight body for gRPC unary responses.
 ///
-/// Yields two or three frames: one data frame carrying the gRPC envelope
-/// (or, for large chained responses, just its 5-byte header followed by a
-/// second data frame with the payload by refcount), then one trailers frame
-/// (for gRPC) or a final data frame (for gRPC-Web trailer encoding).
+/// Yields one data frame carrying the gRPC envelope — or, for a large
+/// response, just its 5-byte header followed by one data frame per payload
+/// segment, each passed through by refcount — then one trailers frame (for
+/// gRPC) or a final data frame (for gRPC-Web trailer encoding).
 /// This avoids the overhead of `Pin<Box<dyn Stream>>` + `stream::unfold` +
 /// `EnvelopeEncoder` for the common unary case.
 pub struct GrpcUnaryBody {
@@ -1894,10 +1894,14 @@ where
 
     // Compress response body if negotiated, respecting the compression policy
     let effective_policy = compression_policy.with_override(resp.compress);
-    // Connect unary puts the message straight in the HTTP body with no
-    // envelope, so there is no frame boundary to hang a segment on — and
-    // compression needs one contiguous input regardless. Flattening is a
-    // no-op unless the encoder segmented.
+    // Connect unary flattens. Compression needs one contiguous input, and the
+    // uncompressed case would need `Full<Bytes>` replaced with a multi-frame
+    // body to carry segments — Connect puts the message straight in the HTTP
+    // body, so nothing here splits it for us the way an envelope does. That is
+    // a body-type change rather than an impossibility, and it is worth doing:
+    // Connect is the primary protocol, so the segmented encode currently
+    // reaches only gRPC and gRPC-Web unary. Flattening is a no-op unless the
+    // encoder segmented.
     let body_len = resp.body.len();
     let resp_body = resp.body.into_contiguous();
     let (final_body, content_encoding) = if let Some(encoding) = response_encoding {
@@ -2148,10 +2152,11 @@ where
         // the right trade: the compressor was going to read every byte anyway.
         let flat = resp.body.into_contiguous();
         match compression.compress(encoding, &flat) {
-            Ok(compressed) => {
-                let (head, payload) = Envelope::compressed(compressed).encode_parts(min_chain);
-                (head, payload.into_iter().collect())
-            }
+            Ok(compressed) => Envelope::encode_body_parts(
+                crate::envelope::flags::COMPRESSED,
+                compressed.into(),
+                min_chain,
+            ),
             Err(_) => {
                 Envelope::encode_body_parts(crate::envelope::flags::DATA, flat.into(), min_chain)
             }
@@ -3478,11 +3483,14 @@ mod tests {
 
         let payload = Bytes::from(vec![0x33u8; crate::envelope::MIN_CHAIN_SIZE]);
         let ptr = payload.as_ptr();
-        let (head, chained) =
-            Envelope::data(payload.clone()).encode_parts(crate::envelope::MIN_CHAIN_SIZE);
+        let (head, chained) = Envelope::encode_body_parts(
+            crate::envelope::flags::DATA,
+            payload.clone().into(),
+            crate::envelope::MIN_CHAIN_SIZE,
+        );
         let mut body = GrpcUnaryBody {
             data: Some(head.clone()),
-            payload: chained.into_iter().collect(),
+            payload: chained.into(),
             trailers: Some(GrpcUnaryTrailers::Http2(http::HeaderMap::new())),
         };
 

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -1897,11 +1897,9 @@ where
     // Connect unary flattens. Compression needs one contiguous input, and the
     // uncompressed case would need `Full<Bytes>` replaced with a multi-frame
     // body to carry segments — Connect puts the message straight in the HTTP
-    // body, so nothing here splits it for us the way an envelope does. That is
-    // a body-type change rather than an impossibility, and it is worth doing:
-    // Connect is the primary protocol, so the segmented encode currently
-    // reaches only gRPC and gRPC-Web unary. Flattening is a no-op unless the
-    // encoder segmented.
+    // body, so nothing here splits it for us the way an envelope does. The
+    // segmented encode therefore reaches only gRPC and gRPC-Web unary.
+    // Flattening is a no-op unless the encoder segmented.
     let body_len = resp.body.len();
     let resp_body = resp.body.into_contiguous();
     let (final_body, content_encoding) = if let Some(encoding) = response_encoding {

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -48,13 +48,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -84,13 +82,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -120,13 +116,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -41,6 +41,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<crate::proto::connectrpc::eliza::v1::ConverseResponse>
 for crate::proto::connectrpc::eliza::v1::__buffa::view::ConverseResponseView<'_> {
@@ -61,6 +77,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<crate::proto::connectrpc::eliza::v1::IntroduceResponse>
 for crate::proto::connectrpc::eliza::v1::__buffa::view::IntroduceResponseView<'_> {
@@ -80,6 +112,22 @@ for ::buffa::view::OwnedView<
         codec: ::connectrpc::CodecFormat,
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
+    }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
     }
 }
 /// Full service name for this service.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -44,13 +44,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -37,6 +37,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const GREET_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.greet.v1.GreetService";

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -36,13 +36,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -29,6 +29,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 /// Full service name for this service.
 pub const MATH_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.math.v1.MathService";

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -69,6 +69,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<
     crate::proto::anthropic::connectrpc::wkt::v1::CalculateDurationResponse,
@@ -97,6 +113,22 @@ for ::buffa::view::OwnedView<
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
     }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
+    }
 }
 impl ::connectrpc::Encodable<
     crate::proto::anthropic::connectrpc::wkt::v1::ProcessMetadataResponse,
@@ -124,6 +156,22 @@ for ::buffa::view::OwnedView<
         codec: ::connectrpc::CodecFormat,
     ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body(self.reborrow(), codec)
+    }
+    /// An `OwnedView` still holds the buffer it was decoded from, so
+    /// its large fields can be handed to the response body by
+    /// reference count instead of copied. The bare view impl above
+    /// cannot do this: it has borrows but no buffer to name.
+    fn encode_segments(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+        min_segment: usize,
+    ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body_segments(
+            self.reborrow(),
+            self.bytes(),
+            codec,
+            min_segment,
+        )
     }
 }
 /// Full service name for this service.

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -76,13 +76,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -120,13 +118,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }
@@ -164,13 +160,11 @@ for ::buffa::view::OwnedView<
     fn encode_segments(
         &self,
         codec: ::connectrpc::CodecFormat,
-        min_segment: usize,
     ) -> ::std::result::Result<::connectrpc::EncodedBody, ::connectrpc::ConnectError> {
         ::connectrpc::__codegen::encode_view_body_segments(
             self.reborrow(),
             self.bytes(),
             codec,
-            min_segment,
         )
     }
 }


### PR DESCRIPTION
## Summary

Carries buffa 0.9's reference-counted encode segments from the encoder all the way to the HTTP body, so a gRPC or gRPC-Web unary response whose body is an `OwnedView` never copies its large fields.

A view's fields are slices into the buffer the view was decoded from. A rope told about that buffer takes a large field by reference instead of copying it into the encode buffer, and the segments then become their own HTTP data frames. Past the framing threshold the encode stops growing with the payload, because only the framing is still being written.

Measured on a dedicated bare-metal instance (`benches/rpc/view_rope_encode`, four-string message, contiguous vs segmented):

| bytes per field | contiguous | segmented |
|---|---|---|
| 256 B | 171 ns | 184 ns |
| 1 KiB | 210 ns | 204 ns |
| 16 KiB | 2.29 µs | 682 ns |
| 256 KiB | 48.6 µs | 709 ns |
| 1 MiB | 363 µs | 643 ns |

The control is the part worth reading: an *unbacked* rope at 1 MiB costs 363 µs, identical to the contiguous encode. The rope machinery is free; the reference-count capture is the entire effect.

## Where this deliberately does nothing

Segmenting is skipped wherever it would not pay, each guarded in code rather than left to chance:

- **Owned-message bodies.** Their `string` and `bytes` fields are `String` and `Vec<u8>`, which cannot be handed over by reference. Routing them through a rope only adds cost.
- **Responses below the framing threshold.** Anything smaller is copied into the framing buffer downstream regardless.
- **A response much smaller than the request it borrows from.** Capturing would keep the whole request buffer alive until the response finishes flushing — answering a 64 MiB upload with a 32 KiB summary would hold 64 MiB per in-flight response. Copying is cheaper than that.
- **Connect unary, streaming, and any call through an interceptor.** See below.

## Reach, stated plainly

This lands on gRPC and gRPC-Web unary responses. Connect unary still flattens because its body type hardcodes `Full<Bytes>`; multiple HTTP/2 DATA frames concatenate to the same Connect body, so that path *could* carry segments and is worth doing — Connect being the primary protocol. Streaming re-envelopes per item and is the next piece of work. A call with an interceptor configured takes the contiguous path, because an interceptor may replace the whole body.

## Breaking change, confined to custom dispatch

`EncodedResponse` is now `Response<EncodedBody>` rather than `Response<Bytes>`. This is reachable through the public `Dispatcher` trait, so anyone implementing custom dispatch is affected: construct with `Bytes::into()`, and recover a single buffer with `EncodedBody::into_contiguous()`.

Interceptor authors need no change — `UnaryResponse` still carries a contiguous `Payload`. That seam is what keeps the blast radius to dispatch rather than every extension point.

## Builds on

Both prerequisites are now merged, and this branch is rebased onto `main`: #233 (the buffa 0.9 adoption, which supplies the rope and `EncodeSink`) and #219, whose framing emission path this reuses rather than reimplementing.

## Testing

Server conformance 3600 passed / 0 failed, 56 test suites, lint, docs, and `task generate:all` (no drift) all green — re-run after rebasing onto `main`, not carried over from the stacked base. `Envelope::encode_body_parts` has a table test sweeping empty, sub-threshold contiguous, sub-threshold segmented, over-threshold contiguous, two-segment and many-segment bodies, asserting in each that the envelope header declares exactly the byte count that follows it and that reassembly equals the contiguous envelope.

A high-effort review pass found four defects that produced correct bytes and so would never have failed a test — buffer pinning, a gate that compared whole-message size against a per-field threshold, tiny rope fragments becoming their own frames, and `MaybeBorrowed` silently not forwarding the segmented encode. All four are fixed in the final commit, "response: only segment where it pays, and merge the fragments", whose message carries the reasoning.

One known limitation left in place: a message that clears the gate while none of its individual fields do lands everything in a rope tail that grows by doubling rather than one sized allocation. buffa 0.9 exposes no way to pre-size the tail, so it is documented where it bites rather than worked around.

