### PR TITLE
server: make the element-memory decode budget configurable

### DIFF
--- a/.changes/unreleased/Added-20260720-134339.yaml
+++ b/.changes/unreleased/Added-20260720-134339.yaml
@@ -1,0 +1,35 @@
+kind: Added
+body: |-
+  **The decode-time element-memory budget is now configurable.** buffa 0.9
+  introduced a 32 MiB budget on the memory a single decode may commit to
+  repeated, map, string and bytes *elements* — an amplification defence,
+  charged on element footprint rather than on contents, so a few bytes on the
+  wire cannot ask the decoder to materialize a very large number of small
+  elements. A single large payload is unaffected however big it grows.
+
+  Until now that budget applied to every received message with no way to
+  change it, so a legitimate message carrying very many small elements that
+  0.8 accepted would be rejected with no recourse. Servers set it through the
+  existing `Limits`:
+
+  ```rust
+  ConnectRpcService::new(dispatcher)
+      .with_limits(Limits::default().element_memory_limit(128 * 1024 * 1024))
+  ```
+
+  `Limits::unlimited()` lifts it along with the other limits.
+
+  It applies to every server receive path — unary, server-streaming,
+  client-streaming and bidi, on both the generated dispatch and hand-registered
+  handlers, view-based and owned-message alike. A rejection now names the limit
+  to raise, since it is the one decode failure an operator can fix without the
+  peer changing anything. Clients still decode *responses* under buffa's
+  defaults; that knob is a follow-up.
+
+  **Breaking, for generated code only.** `decode_borrowed_request_view` and
+  `decode_message_request_stream` now take the decode limits, and `Limits` is
+  `#[non_exhaustive]` so further limits can be added without another break.
+  Both functions are `#[doc(hidden)]` and called only from generated dispatch,
+  so regenerating with the matching `protoc-gen-connect-rust` is the whole
+  migration — which 0.9.0 already requires for buffa 0.9.
+time: 2026-07-20T13:43:39.897161068-07:00

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,9 @@ jobs:
             conformance/src/generated \
             examples/eliza/src/generated \
             examples/multiservice/src/generated \
-            benches/rpc/src/generated; then
+            benches/rpc/src/generated \
+            connectrpc-health/src/generated \
+            connectrpc-reflection/src/generated; then
             echo "::error::Checked-in generated code is stale. Run 'task generate:all' and commit the diff."
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ and the three client suites.
 
 ## Checked-In Generated Code
 
-Five directories contain checked-in `buf generate` output and **must be
+Six directories contain checked-in `buf generate` output and **must be
 regenerated** whenever `connectrpc-codegen` output changes (or the buffa
 dependency is bumped):
 
@@ -140,6 +140,7 @@ dependency is bumped):
 - `examples/multiservice/src/generated/`
 - `benches/rpc/src/generated/`
 - `connectrpc-health/src/generated/`
+- `connectrpc-reflection/src/generated/`
 
 Regenerate all of them with:
 

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -683,6 +683,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::v1::BenchRequest,
@@ -702,6 +703,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::v1::LogRequest,
@@ -721,6 +723,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::v1::LogRequest,
@@ -755,6 +758,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::v1::BenchRequest,
@@ -790,7 +794,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                 Box::pin(async move {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_message_request_stream::<
                         crate::proto::bench::v1::BenchRequest,
-                    >(requests, format);
+                    >(requests, format, ctx.decode_options().clone());
                     svc.client_stream(ctx, req_stream)
                         .await?
                         .encode::<crate::proto::bench::v1::BenchResponse>(format)
@@ -816,7 +820,7 @@ impl<T: BenchService> ::connectrpc::Dispatcher for BenchServiceServer<T> {
                 Box::pin(async move {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_message_request_stream::<
                         crate::proto::bench::v1::BenchRequest,
-                    >(requests, format);
+                    >(requests, format, ctx.decode_options().clone());
                     let resp = svc.bidi_stream(ctx, req_stream).await?;
                     Ok(
                         resp
@@ -1404,6 +1408,7 @@ impl<T: EchoService> ::connectrpc::Dispatcher for EchoServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::v1::EchoRequest,
@@ -1808,6 +1813,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::v1::LogRequest,

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -271,6 +271,7 @@ impl<T: LogIngestService> ::connectrpc::Dispatcher for LogIngestServiceServer<T>
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::noutf8::v1::LogRequest,

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -266,6 +266,7 @@ impl<T: BloatEchoService> ::connectrpc::Dispatcher for BloatEchoServiceServer<T>
                     >(request.encoded()?, format)?;
                     let req: crate::proto::bench::v1::__buffa::view::BloatEchoView<'_> = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::bench::v1::BloatEcho,

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -270,6 +270,7 @@ impl<T: FilterService> ::connectrpc::Dispatcher for FilterServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::anthropic::connectrpc::filter::v1::Record,

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -271,6 +271,7 @@ impl<T: FortuneService> ::connectrpc::Dispatcher for FortuneServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::fortune::v1::GetFortunesRequest,

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -960,6 +960,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::connectrpc::conformance::v1::UnaryRequest,
@@ -981,6 +982,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::connectrpc::conformance::v1::UnimplementedRequest,
@@ -1002,6 +1004,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::connectrpc::conformance::v1::IdempotentUnaryRequest,
@@ -1039,6 +1042,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::connectrpc::conformance::v1::ServerStreamRequest,
@@ -1075,7 +1079,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                 Box::pin(async move {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_message_request_stream::<
                         crate::proto::connectrpc::conformance::v1::ClientStreamRequest,
-                    >(requests, format);
+                    >(requests, format, ctx.decode_options().clone());
                     svc.client_stream(ctx, req_stream)
                         .await?
                         .encode::<
@@ -1104,7 +1108,7 @@ impl<T: ConformanceService> ::connectrpc::Dispatcher for ConformanceServiceServe
                 Box::pin(async move {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_message_request_stream::<
                         crate::proto::connectrpc::conformance::v1::BidiStreamRequest,
-                    >(requests, format);
+                    >(requests, format, ctx.decode_options().clone());
                     let resp = svc.bidi_stream(ctx, req_stream).await?;
                     Ok(
                         resp

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1886,7 +1886,7 @@ fn generate_service_server(
         let stream_decode = {
             let input_fqn = m.input_type.as_deref().unwrap_or("");
             let input_owned = resolver.rust_type(input_fqn, package)?;
-            quote! { ::connectrpc::dispatcher::codegen::decode_message_request_stream::<#input_owned>(requests, format) }
+            quote! { ::connectrpc::dispatcher::codegen::decode_message_request_stream::<#input_owned>(requests, format, ctx.decode_options().clone()) }
         };
 
         if cs && ss {
@@ -1927,7 +1927,7 @@ fn generate_service_server(
                         // The normalized body is owned by this future; the handler
                         // borrows from it until it returns the response stream.
                         let body = ::connectrpc::dispatcher::codegen::request_proto_bytes::<#input_owned>(request, format)?;
-                        let req: #input_view<'_> = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(&body)?;
+                        let req: #input_view<'_> = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(&body, ctx.decode_options())?;
                         #call_handler
                         Ok(resp.map_body(|s| ::connectrpc::dispatcher::codegen::encode_response_stream::<#output_type, _, _>(s, format)))
                     })
@@ -1952,7 +1952,7 @@ fn generate_service_server(
                         // The normalized body is owned by this future; the handler
                         // borrows from it for the duration of the call.
                         let body = ::connectrpc::dispatcher::codegen::request_proto_bytes::<#input_owned>(request.encoded()?, format)?;
-                        let req: #input_view<'_> = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(&body)?;
+                        let req: #input_view<'_> = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(&body, ctx.decode_options())?;
                         #call_handler
                     })
                 }

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -352,6 +352,7 @@ impl<T: Health> ::connectrpc::Dispatcher for HealthServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::grpc::health::v1::HealthCheckRequest,
@@ -388,6 +389,7 @@ impl<T: Health> ::connectrpc::Dispatcher for HealthServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::grpc::health::v1::HealthCheckRequest,

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -316,7 +316,7 @@ impl<T: ServerReflection> ::connectrpc::Dispatcher for ServerReflectionServer<T>
                 Box::pin(async move {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_message_request_stream::<
                         crate::proto::grpc::reflection::v1::ServerReflectionRequest,
-                    >(requests, format);
+                    >(requests, format, ctx.decode_options().clone());
                     let resp = svc.server_reflection_info(ctx, req_stream).await?;
                     Ok(
                         resp

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -318,7 +318,7 @@ impl<T: ServerReflection> ::connectrpc::Dispatcher for ServerReflectionServer<T>
                 Box::pin(async move {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_message_request_stream::<
                         crate::proto::grpc::reflection::v1alpha::ServerReflectionRequest,
-                    >(requests, format);
+                    >(requests, format, ctx.decode_options().clone());
                     let resp = svc.server_reflection_info(ctx, req_stream).await?;
                     Ok(
                         resp

--- a/connectrpc/src/codec.rs
+++ b/connectrpc/src/codec.rs
@@ -96,9 +96,22 @@ pub fn encode_proto<M: Message>(message: &M) -> Result<Bytes, ConnectError> {
     Ok(message.encode_to_bytes())
 }
 
-/// Decode bytes into a protobuf message.
+/// Decode bytes into a protobuf message under buffa's default limits.
 pub fn decode_proto<M: Message>(data: &[u8]) -> Result<M, ConnectError> {
-    M::decode_from_slice(data)
+    decode_proto_with_options(data, &buffa::DecodeOptions::new())
+}
+
+/// Decode bytes into a protobuf message under explicit decode limits.
+///
+/// The server passes the limits from its [`Limits`](crate::Limits); see
+/// [`Payload::decode_options`](crate::Payload::decode_options) for how they
+/// reach an owned-message handler.
+pub fn decode_proto_with_options<M: Message>(
+    data: &[u8],
+    options: &buffa::DecodeOptions,
+) -> Result<M, ConnectError> {
+    options
+        .decode_from_slice(data)
         .map_err(|e| ConnectError::invalid_argument(format!("failed to decode proto: {e}")))
 }
 

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -416,17 +416,24 @@ pub mod codegen {
     /// Used by generated `call_client_streaming` and `call_bidi_streaming`
     /// arms; the per-item decode is the same normalize-then-decode used on
     /// the unary paths.
+    ///
+    /// Takes the limits by value because the returned stream outlives the
+    /// caller's frame; generated arms pass `ctx.decode_options().clone()`
+    /// before `ctx` is moved into the handler call.
     pub fn decode_message_request_stream<M>(
         requests: BoxStream<Result<Bytes, ConnectError>>,
         format: CodecFormat,
+        options: buffa::DecodeOptions,
     ) -> crate::ServiceStream<crate::StreamMessage<M>>
     where
         M: crate::HasMessageView + JsonDeserialize + 'static,
         M::View<'static>: 'static,
     {
         Box::pin(requests.map(move |r| {
-            r.and_then(|raw| crate::handler::decode_request_view::<M::View<'static>>(raw, format))
-                .map(crate::StreamMessage::from_owned_view)
+            r.and_then(|raw| {
+                crate::handler::decode_request_view::<M::View<'static>>(raw, format, &options)
+            })
+            .map(crate::StreamMessage::from_owned_view)
         }))
     }
 }

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -39,15 +39,36 @@ use crate::response::{
     Encodable, EncodedResponse, RequestContext, Response, ServiceResult, ServiceStream,
 };
 
+/// Report a failed request decode as `invalid_argument`.
+///
+/// Exceeding the element-memory budget is the one decode failure a server
+/// operator can fix without the peer changing anything, so it says which
+/// limit to raise. Every other variant is a malformed request, where naming
+/// a limit would misdirect. `DecodeError` is `#[non_exhaustive]`, hence the
+/// catch-all arm.
+fn decode_request_error(e: &buffa::DecodeError) -> ConnectError {
+    match e {
+        buffa::DecodeError::ElementMemoryLimitExceeded => ConnectError::invalid_argument(format!(
+            "failed to decode proto request: {e}; if this peer is trusted, \
+             raise Limits::element_memory_limit"
+        )),
+        _ => ConnectError::invalid_argument(format!("failed to decode proto request: {e}")),
+    }
+}
+
 /// Decode a request message from bytes using the specified codec format.
-pub(crate) fn decode_request<Req>(request: &Bytes, format: CodecFormat) -> Result<Req, ConnectError>
+pub(crate) fn decode_request<Req>(
+    request: &Bytes,
+    format: CodecFormat,
+    options: &buffa::DecodeOptions,
+) -> Result<Req, ConnectError>
 where
     Req: Message + JsonDeserialize,
 {
     match format {
-        CodecFormat::Proto => Req::decode_from_slice(&request[..]).map_err(|e| {
-            ConnectError::invalid_argument(format!("failed to decode proto request: {e}"))
-        }),
+        CodecFormat::Proto => options
+            .decode_from_slice(&request[..])
+            .map_err(|e| decode_request_error(&e)),
         CodecFormat::Json => decode_json(&request[..]),
     }
 }
@@ -398,7 +419,7 @@ where
     ) -> StreamingHandlerResult {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let req: Req = decode_request(&request, format)?;
+            let req: Req = decode_request(&request, format, ctx.decode_options())?;
             let resp = handler.call(ctx, req).await?;
             Ok(resp.map_body(|s| encode_body_stream(s, format)))
         })
@@ -511,9 +532,13 @@ where
         use futures::StreamExt as _;
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let request_stream: ServiceStream<Req> = Box::pin(
-                requests.map(move |result| result.and_then(|raw| decode_request(&raw, format))),
-            );
+            // The stream outlives this frame, so it owns its limits rather
+            // than borrowing them from `ctx`, which is moved into the call.
+            let options = ctx.decode_options().clone();
+            let request_stream: ServiceStream<Req> =
+                Box::pin(requests.map(move |result| {
+                    result.and_then(|raw| decode_request(&raw, format, &options))
+                }));
             handler
                 .call(ctx, request_stream)
                 .await?
@@ -636,9 +661,13 @@ where
         use futures::StreamExt as _;
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let request_stream: ServiceStream<Req> = Box::pin(
-                requests.map(move |result| result.and_then(|raw| decode_request(&raw, format))),
-            );
+            // The stream outlives this frame, so it owns its limits rather
+            // than borrowing them from `ctx`, which is moved into the call.
+            let options = ctx.decode_options().clone();
+            let request_stream: ServiceStream<Req> =
+                Box::pin(requests.map(move |result| {
+                    result.and_then(|raw| decode_request(&raw, format, &options))
+                }));
             let resp = handler.call(ctx, request_stream).await?;
             Ok(resp.map_body(|s| encode_body_stream(s, format)))
         })
@@ -658,14 +687,14 @@ where
 pub(crate) fn decode_request_view<ReqView>(
     request: Bytes,
     format: CodecFormat,
+    options: &buffa::DecodeOptions,
 ) -> Result<OwnedView<ReqView>, ConnectError>
 where
     ReqView: MessageView<'static> + Send,
     ReqView::Owned: Message + JsonDeserialize,
 {
     let body = request_proto_bytes::<ReqView::Owned>(request, format)?;
-    OwnedView::<ReqView>::decode(body)
-        .map_err(|e| ConnectError::invalid_argument(format!("failed to decode proto request: {e}")))
+    OwnedView::<ReqView>::decode_with_options(body, options).map_err(|e| decode_request_error(&e))
 }
 
 /// Normalize a request body to protobuf wire bytes.
@@ -703,17 +732,25 @@ where
 /// so the view's borrows are tied to the call frame rather than promoted to
 /// a synthetic `'static`.
 ///
+/// `options` carries the service's configured decode limits; see
+/// [`Limits`](crate::Limits).
+///
 /// # Errors
 ///
-/// Returns `ConnectError::invalid_argument` if the bytes are not a valid
+/// Returns `ConnectError::invalid_argument` if the bytes exceed one of
+/// `options`' limits, or if the bytes are not a valid
 /// encoding of the request message.
 #[doc(hidden)] // exposed only for dispatcher::codegen (generated code)
-pub fn decode_borrowed_request_view<'a, ReqView>(body: &'a [u8]) -> Result<ReqView, ConnectError>
+pub fn decode_borrowed_request_view<'a, ReqView>(
+    body: &'a [u8],
+    options: &buffa::DecodeOptions,
+) -> Result<ReqView, ConnectError>
 where
     ReqView: MessageView<'a>,
 {
-    ReqView::decode_view(body)
-        .map_err(|e| ConnectError::invalid_argument(format!("failed to decode proto request: {e}")))
+    options
+        .decode_view(body)
+        .map_err(|e| decode_request_error(&e))
 }
 
 /// Trait for unary RPC handlers using zero-copy request views.
@@ -822,7 +859,8 @@ where
             // here. `encoded()` is the wire bytes — a cheap `Bytes` clone
             // unless an interceptor replaced the body, in which case it
             // re-encodes the replacement.
-            let req = decode_request_view::<ReqView>(request.encoded()?, format)?;
+            let req =
+                decode_request_view::<ReqView>(request.encoded()?, format, ctx.decode_options())?;
             handler.call(ctx, req, format).await
         })
     }
@@ -938,7 +976,7 @@ where
     ) -> StreamingHandlerResult {
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
-            let req = decode_request_view::<ReqView>(request, format)?;
+            let req = decode_request_view::<ReqView>(request, format, ctx.decode_options())?;
             let resp = handler.call(ctx, req).await?;
             Ok(resp.map_body(|s| encode_body_stream(s, format)))
         })
@@ -1047,9 +1085,12 @@ where
         use futures::StreamExt as _;
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
+            // The stream outlives this frame, so it owns its limits rather
+            // than borrowing them from `ctx`, which is moved into the call.
+            let options = ctx.decode_options().clone();
             let request_stream: ServiceStream<OwnedView<ReqView>> =
                 Box::pin(requests.map(move |result| {
-                    result.and_then(|raw| decode_request_view::<ReqView>(raw, format))
+                    result.and_then(|raw| decode_request_view::<ReqView>(raw, format, &options))
                 }));
             handler.call(ctx, request_stream, format).await
         })
@@ -1167,9 +1208,12 @@ where
         use futures::StreamExt as _;
         let handler = Arc::clone(&self.handler);
         Box::pin(async move {
+            // The stream outlives this frame, so it owns its limits rather
+            // than borrowing them from `ctx`, which is moved into the call.
+            let options = ctx.decode_options().clone();
             let request_stream: ServiceStream<OwnedView<ReqView>> =
                 Box::pin(requests.map(move |result| {
-                    result.and_then(|raw| decode_request_view::<ReqView>(raw, format))
+                    result.and_then(|raw| decode_request_view::<ReqView>(raw, format, &options))
                 }));
             let resp = handler.call(ctx, request_stream).await?;
             Ok(resp.map_body(|s| encode_body_stream(s, format)))
@@ -1187,7 +1231,8 @@ mod tests {
     fn test_decode_request_proto() {
         let msg = StringValue::from("hello");
         let encoded = Bytes::from(msg.encode_to_vec());
-        let decoded: StringValue = decode_request(&encoded, CodecFormat::Proto).unwrap();
+        let decoded: StringValue =
+            decode_request(&encoded, CodecFormat::Proto, &buffa::DecodeOptions::new()).unwrap();
         assert_eq!(decoded.value, "hello");
     }
 
@@ -1195,14 +1240,20 @@ mod tests {
     #[test]
     fn test_decode_request_json() {
         let encoded = Bytes::from_static(b"\"world\"");
-        let decoded: StringValue = decode_request(&encoded, CodecFormat::Json).unwrap();
+        let decoded: StringValue =
+            decode_request(&encoded, CodecFormat::Json, &buffa::DecodeOptions::new()).unwrap();
         assert_eq!(decoded.value, "world");
     }
 
     #[test]
     fn test_decode_request_proto_invalid() {
         let garbage = Bytes::from_static(&[0xFF, 0xFF, 0xFF]);
-        let err = decode_request::<StringValue>(&garbage, CodecFormat::Proto).unwrap_err();
+        let err = decode_request::<StringValue>(
+            &garbage,
+            CodecFormat::Proto,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
@@ -1210,7 +1261,12 @@ mod tests {
     #[test]
     fn test_decode_request_json_invalid() {
         let garbage = Bytes::from_static(b"not json");
-        let err = decode_request::<StringValue>(&garbage, CodecFormat::Json).unwrap_err();
+        let err = decode_request::<StringValue>(
+            &garbage,
+            CodecFormat::Json,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
@@ -1221,8 +1277,12 @@ mod tests {
         // classified like any other malformed request, before any handler
         // (and its owned conversion) runs.
         let body = crate::request::tests::unknown_field_overflow_body();
-        let err =
-            decode_request_view::<StringValueView<'static>>(body, CodecFormat::Proto).unwrap_err();
+        let err = decode_request_view::<StringValueView<'static>>(
+            body,
+            CodecFormat::Proto,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
@@ -1230,7 +1290,12 @@ mod tests {
     fn test_decode_request_view_proto() {
         let msg = StringValue::from("view-test");
         let encoded = Bytes::from(msg.encode_to_vec());
-        let view = decode_request_view::<StringValueView>(encoded, CodecFormat::Proto).unwrap();
+        let view = decode_request_view::<StringValueView>(
+            encoded,
+            CodecFormat::Proto,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap();
         assert_eq!(view.reborrow().value, "view-test");
     }
 
@@ -1238,7 +1303,12 @@ mod tests {
     #[test]
     fn test_decode_request_view_json() {
         let encoded = Bytes::from_static(b"\"json-view\"");
-        let view = decode_request_view::<StringValueView>(encoded, CodecFormat::Json).unwrap();
+        let view = decode_request_view::<StringValueView>(
+            encoded,
+            CodecFormat::Json,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap();
         assert_eq!(view.reborrow().value, "json-view");
     }
 
@@ -1251,7 +1321,9 @@ mod tests {
     #[test]
     fn decode_request_json_is_unimplemented_without_feature() {
         let body = Bytes::from_static(b"\"world\"");
-        let err = decode_request::<StringValue>(&body, CodecFormat::Json).unwrap_err();
+        let err =
+            decode_request::<StringValue>(&body, CodecFormat::Json, &buffa::DecodeOptions::new())
+                .unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::Unimplemented);
     }
 
@@ -1259,14 +1331,24 @@ mod tests {
     #[test]
     fn decode_request_view_json_is_unimplemented_without_feature() {
         let body = Bytes::from_static(b"\"world\"");
-        let err = decode_request_view::<StringValueView>(body, CodecFormat::Json).unwrap_err();
+        let err = decode_request_view::<StringValueView>(
+            body,
+            CodecFormat::Json,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::Unimplemented);
     }
 
     #[test]
     fn test_decode_request_view_proto_invalid() {
         let garbage = Bytes::from_static(&[0xFF, 0xFF, 0xFF]);
-        let err = decode_request_view::<StringValueView>(garbage, CodecFormat::Proto).unwrap_err();
+        let err = decode_request_view::<StringValueView>(
+            garbage,
+            CodecFormat::Proto,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
@@ -1378,5 +1460,138 @@ mod tests {
             )]))
         });
         assert_handler::<_, StringValue, StringValue, PreEncoded<StringValue>>(&pre);
+    }
+
+    /// Owned-message handlers decode through `Payload`/`decode_request`
+    /// rather than the view helpers, and that path silently used buffa's
+    /// defaults until the limits were threaded onto `Payload` too. Both
+    /// owned entry points are pinned here.
+    #[test]
+    fn owned_message_decoding_honours_the_configured_limit() {
+        use buffa_types::google::protobuf::{ListValue, Value};
+
+        let list = ListValue {
+            values: (0..800_000).map(|_| Value::default()).collect(),
+            ..Default::default()
+        };
+        let encoded = Bytes::from(buffa::Message::encode_to_vec(&list));
+        let raised = crate::Limits::default().element_memory_limit(usize::MAX);
+
+        // `decode_request`, used by the owned-message streaming wrappers.
+        assert!(
+            decode_request::<ListValue>(
+                &encoded,
+                CodecFormat::Proto,
+                &crate::Limits::default().decode_options()
+            )
+            .is_err(),
+            "the default budget must still reject"
+        );
+        let decoded: ListValue =
+            decode_request(&encoded, CodecFormat::Proto, &raised.decode_options())
+                .expect("raised budget must admit");
+        assert_eq!(decoded.values.len(), 800_000);
+
+        // `Payload::take_message`, used by the owned-message unary wrapper.
+        let payload = crate::Payload::new(encoded.clone(), CodecFormat::Proto);
+        assert!(
+            payload.take_message::<ListValue>().is_err(),
+            "a payload with no limits attached decodes under buffa defaults"
+        );
+        let payload = crate::Payload::new(encoded, CodecFormat::Proto)
+            .with_decode_options(raised.decode_options());
+        let decoded: ListValue = payload
+            .take_message()
+            .expect("a payload carrying raised limits must admit");
+        assert_eq!(decoded.values.len(), 800_000);
+    }
+
+    /// The budget rejection names the limit to raise, since it is the one
+    /// decode failure an operator can fix without the peer changing.
+    #[test]
+    fn an_over_budget_decode_says_which_limit_to_raise() {
+        use buffa_types::google::protobuf::__buffa::view::ListValueView;
+        use buffa_types::google::protobuf::{ListValue, Value};
+
+        let list = ListValue {
+            values: (0..800_000).map(|_| Value::default()).collect(),
+            ..Default::default()
+        };
+        let encoded = Bytes::from(buffa::Message::encode_to_vec(&list));
+        let err = decode_borrowed_request_view::<ListValueView<'_>>(
+            &encoded,
+            &crate::Limits::default().decode_options(),
+        )
+        .expect_err("over budget");
+        let message = err.message.unwrap_or_default();
+        assert!(
+            message.contains("element_memory_limit"),
+            "the budget rejection must name the knob, got {message:?}"
+        );
+
+        // A malformed request must NOT suggest raising a limit — that would
+        // send an operator chasing a setting that cannot help.
+        let garbage = Bytes::from_static(&[0xFF, 0xFF, 0xFF]);
+        let err = decode_borrowed_request_view::<ListValueView<'_>>(
+            &garbage,
+            &crate::Limits::default().decode_options(),
+        )
+        .expect_err("malformed");
+        let message = err.message.unwrap_or_default();
+        assert!(
+            !message.contains("element_memory_limit"),
+            "a malformed request must not point at a limit, got {message:?}"
+        );
+    }
+
+    /// The element-memory budget is a *configured* limit, not a constant:
+    /// the same bytes must be rejected at the default and accepted once the
+    /// service raises it. Without the second half, wiring the knob to
+    /// nothing would still pass.
+    #[test]
+    fn element_memory_limit_is_taken_from_the_configured_limits() {
+        use buffa_types::google::protobuf::__buffa::view::ListValueView;
+        use buffa_types::google::protobuf::{ListValue, Value};
+
+        // Element footprint is what the budget charges, not element
+        // contents, so this stays small on the wire.
+        let n = 800_000;
+        let list = ListValue {
+            values: (0..n).map(|_| Value::default()).collect(),
+            ..Default::default()
+        };
+        let encoded = Bytes::from(buffa::Message::encode_to_vec(&list));
+
+        let defaults = crate::Limits::default();
+        let err =
+            decode_borrowed_request_view::<ListValueView<'_>>(&encoded, &defaults.decode_options())
+                .expect_err("800k elements must exceed the 32 MiB default");
+        assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
+
+        let raised = crate::Limits::default().element_memory_limit(usize::MAX);
+        let view =
+            decode_borrowed_request_view::<ListValueView<'_>>(&encoded, &raised.decode_options())
+                .expect("raising the limit must admit the same bytes");
+        assert_eq!(view.values.len(), n);
+    }
+
+    /// `unlimited()` must lift the decode budget too — a caller who asks for
+    /// no restrictions and still gets a 32 MiB element ceiling has been
+    /// silently ignored.
+    #[test]
+    fn unlimited_limits_lift_the_element_budget() {
+        assert_eq!(crate::Limits::unlimited().element_memory_limit, usize::MAX);
+    }
+
+    /// A context built outside the service carries buffa's defaults rather
+    /// than no limits at all.
+    #[test]
+    fn a_bare_request_context_decodes_under_buffa_defaults() {
+        let ctx = RequestContext::new(http::HeaderMap::new());
+        let listing = format!("{:?}", ctx.decode_options());
+        assert!(
+            listing.contains(&buffa::DEFAULT_ELEMENT_MEMORY_LIMIT.to_string()),
+            "expected buffa's default element-memory budget, got {listing}"
+        );
     }
 }

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -324,10 +324,8 @@ impl UnaryRequest {
     /// Build a `UnaryRequest` from a dispatch context and wire-encoded
     /// body. Used by the dispatch path and by test fixtures.
     pub fn new(ctx: RequestContext, body: Bytes, format: CodecFormat) -> Self {
-        Self {
-            ctx,
-            payload: Payload::new(body, format),
-        }
+        let payload = Payload::new(body, format).with_decode_options(ctx.decode_options().clone());
+        Self { ctx, payload }
     }
 }
 
@@ -913,9 +911,8 @@ pub(crate) async fn call_unary_intercepted<D: crate::Dispatcher>(
     format: CodecFormat,
 ) -> Result<EncodedResponse, ConnectError> {
     if interceptors.is_empty() {
-        return dispatcher
-            .call_unary(path, ctx, Payload::new(body, format), format)
-            .await;
+        let payload = Payload::new(body, format).with_decode_options(ctx.decode_options().clone());
+        return dispatcher.call_unary(path, ctx, payload, format).await;
     }
     let terminal = DispatchTerminal {
         dispatcher,

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -28,8 +28,8 @@ use buffa::view::{MessageView, OwnedView};
 use bytes::Bytes;
 
 use crate::codec::{
-    CodecFormat, JsonDeserialize, JsonSerialize, decode_json, decode_proto, encode_json,
-    encode_proto,
+    CodecFormat, JsonDeserialize, JsonSerialize, decode_json, decode_proto_with_options,
+    encode_json, encode_proto,
 };
 use crate::error::ConnectError;
 
@@ -131,6 +131,7 @@ pub struct Payload {
     format: CodecFormat,
     decoded: OnceLock<Box<dyn AnyMessage>>,
     replaced: Option<Box<dyn AnyMessage>>,
+    decode_options: buffa::DecodeOptions,
 }
 
 impl Payload {
@@ -142,7 +143,26 @@ impl Payload {
             format,
             decoded: OnceLock::new(),
             replaced: None,
+            decode_options: buffa::DecodeOptions::new(),
         }
+    }
+
+    /// Attach the decode limits a typed accessor should honour.
+    ///
+    /// The server sets this from its [`Limits`](crate::Limits); a payload
+    /// built anywhere else decodes under buffa's defaults.
+    #[doc(hidden)] // set by the service from its configured `Limits`
+    #[must_use]
+    pub fn with_decode_options(mut self, options: buffa::DecodeOptions) -> Self {
+        self.decode_options = options;
+        self
+    }
+
+    /// The decode limits this payload's typed accessors honour.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn decode_options(&self) -> &buffa::DecodeOptions {
+        &self.decode_options
     }
 
     /// The original wire bytes the peer sent, **ignoring** any
@@ -196,7 +216,7 @@ impl Payload {
         // the other caller gets the wrong-type error below.
         if self.decoded.get().is_none() {
             let m: M = match self.format {
-                CodecFormat::Proto => decode_proto(&self.bytes)?,
+                CodecFormat::Proto => decode_proto_with_options(&self.bytes, &self.decode_options)?,
                 CodecFormat::Json => decode_json(&self.bytes)?,
             };
             let _ = self.decoded.set(Box::new(m));
@@ -278,7 +298,7 @@ impl Payload {
             });
         }
         match self.format {
-            CodecFormat::Proto => decode_proto(&self.bytes),
+            CodecFormat::Proto => decode_proto_with_options(&self.bytes, &self.decode_options),
             CodecFormat::Json => decode_json(&self.bytes),
         }
     }
@@ -461,10 +481,10 @@ mod tests {
         assert_eq!(v.reborrow().value, "after");
         // encoded() re-encodes for the original format.
         let encoded = p.encoded().unwrap();
-        let rt: StringValue = decode_proto(&encoded).unwrap();
+        let rt: StringValue = crate::codec::decode_proto(&encoded).unwrap();
         assert_eq!(rt.value, "after");
         // bytes() is unchanged.
-        let orig: StringValue = decode_proto(p.bytes()).unwrap();
+        let orig: StringValue = crate::codec::decode_proto(p.bytes()).unwrap();
         assert_eq!(orig.value, "before");
     }
 

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -62,6 +62,11 @@ pub struct RequestContext {
     pub(crate) protocol: Option<crate::Protocol>,
     /// The procedure path the client requested, with a leading slash.
     pub(crate) path: Option<String>,
+    /// Decode limits for this request's message, from the service's
+    /// [`Limits`](crate::Limits). Default when the context was built outside
+    /// the service (a hand-rolled test, a tower layer), which is why this is
+    /// the service's value rather than a global.
+    pub(crate) decode_options: buffa::DecodeOptions,
 }
 
 impl RequestContext {
@@ -74,7 +79,23 @@ impl RequestContext {
             spec: None,
             protocol: None,
             path: None,
+            decode_options: buffa::DecodeOptions::new(),
         }
+    }
+
+    /// Set the decode limits applied to this request's message.
+    #[doc(hidden)] // set by the service from its configured `Limits`
+    #[must_use]
+    pub fn with_decode_options(mut self, options: buffa::DecodeOptions) -> Self {
+        self.decode_options = options;
+        self
+    }
+
+    /// The decode limits applied to this request's message.
+    #[doc(hidden)] // read by generated dispatch
+    #[must_use]
+    pub fn decode_options(&self) -> &buffa::DecodeOptions {
+        &self.decode_options
     }
 
     /// Set the request deadline (absolute `Instant`).

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -2176,10 +2176,9 @@ mod tests {
         use crate::service::Limits;
         use crate::{CompressionPolicy, CompressionRegistry};
 
-        let limits = Limits {
-            max_request_body_size: 1024,
-            max_message_size: 512,
-        };
+        let limits = Limits::default()
+            .max_request_body_size(1024)
+            .max_message_size(512);
         let server = Server::new(Router::new())
             .with_limits(limits.clone())
             .with_compression(CompressionRegistry::default())

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -455,7 +455,21 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 /// incrementally from the body stream — the full body is never buffered.
 /// In that case `max_request_body_size` does not apply, and
 /// `max_message_size` is the primary per-message protection.
+///
+/// `element_memory_limit` is the odd one out, and the distinction from
+/// `max_message_size` is the one worth getting right: `max_message_size`
+/// bounds *decompressed bytes on the wire*, while `element_memory_limit`
+/// bounds the *in-memory footprint of the element count* those bytes ask
+/// for. A repeated field of empty messages costs two bytes each encoded and
+/// a whole struct each decoded, so a body comfortably inside
+/// `max_message_size` can still expand by orders of magnitude. Raising one
+/// does not raise the other.
+///
+/// These are **server** limits, applied to received requests. A client
+/// decoding responses currently uses buffa's defaults, with no equivalent
+/// override.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Limits {
     /// Maximum size of the request body on the wire (before decompression).
     ///
@@ -476,6 +490,22 @@ pub struct Limits {
     ///
     /// Default: 4 MB.
     pub max_message_size: usize,
+
+    /// Maximum memory a single decode may commit to repeated, map, string
+    /// and bytes *elements*.
+    ///
+    /// This is an amplification defence, and it is charged on element
+    /// footprint rather than on contents: a few bytes on the wire can ask
+    /// the decoder to materialize a very large number of small elements,
+    /// each with its own allocation overhead, while staying well under
+    /// `max_message_size`. A single large payload is unaffected however big
+    /// it grows, because its contents are not charged.
+    ///
+    /// Raise it for a trusted peer that legitimately sends messages with
+    /// very many small elements; lower it to tighten the defence.
+    ///
+    /// Default: 32 MiB (buffa's `DEFAULT_ELEMENT_MEMORY_LIMIT`).
+    pub element_memory_limit: usize,
 }
 
 impl Default for Limits {
@@ -483,6 +513,7 @@ impl Default for Limits {
         Self {
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
+            element_memory_limit: buffa::DEFAULT_ELEMENT_MEMORY_LIMIT,
         }
     }
 }
@@ -495,6 +526,7 @@ impl Limits {
         Self {
             max_request_body_size: usize::MAX,
             max_message_size: usize::MAX,
+            element_memory_limit: usize::MAX,
         }
     }
 
@@ -517,6 +549,24 @@ impl Limits {
     pub fn max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = size;
         self
+    }
+
+    /// Set the maximum memory a single decode may commit to repeated, map,
+    /// string and bytes elements.
+    ///
+    /// See [`Limits`] for what this charges and why it is separate from
+    /// `max_message_size`.
+    #[must_use]
+    pub fn element_memory_limit(mut self, bytes: usize) -> Self {
+        self.element_memory_limit = bytes;
+        self
+    }
+
+    /// The buffa decode options these limits imply.
+    #[doc(hidden)] // read by generated dispatch via `RequestContext`
+    #[must_use]
+    pub fn decode_options(&self) -> buffa::DecodeOptions {
+        buffa::DecodeOptions::new().with_element_memory_limit(self.element_memory_limit)
     }
 }
 
@@ -1151,6 +1201,9 @@ fn create_grpc_web_envelope_stream(
 /// By default, the service applies security limits to prevent DoS attacks:
 /// - Request body: 4 MB (on-wire, before decompression)
 /// - Message size: 4 MB (after decompression, applied uniformly)
+/// - Element memory: 32 MiB per decode (the footprint of repeated, map,
+///   string and bytes elements, which a small body can inflate — see
+///   [`Limits`])
 ///
 /// These can be configured using [`with_limits`](Self::with_limits):
 ///
@@ -1877,7 +1930,8 @@ where
         // The leading slash was stripped for the Dispatcher::lookup key;
         // restore it so RequestContext::path() matches http::Uri::path()
         // and Spec::procedure.
-        .with_path(format!("/{path}"));
+        .with_path(format!("/{path}"))
+        .with_decode_options(limits.decode_options());
 
     // Call the handler with the appropriate codec format.
     let resp: EncodedResponse = with_request_deadline(
@@ -2111,7 +2165,8 @@ where
         .with_extensions(extensions)
         .with_spec(spec)
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"));
+        .with_path(format!("/{path}"))
+        .with_decode_options(limits.decode_options());
 
     // Call the handler with the same deadline used while receiving the body.
     let resp = match with_request_deadline(
@@ -2426,7 +2481,8 @@ where
         .with_extensions(extensions)
         .with_spec(method_desc.and_then(|d| d.spec))
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"));
+        .with_path(format!("/{path}"))
+        .with_decode_options(limits.decode_options());
 
     // Call the handler with the appropriate codec format.
     // For gRPC unary handlers, we wrap the single response in a one-item stream.
@@ -2569,7 +2625,8 @@ where
         .with_extensions(extensions)
         .with_spec(spec)
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"));
+        .with_path(format!("/{path}"))
+        .with_decode_options(limits.decode_options());
 
     // Call the handler. On error paths, the reader task is left running
     // (detached) so it can finish draining the request body — aborting it
@@ -2975,7 +3032,8 @@ where
         .with_extensions(extensions)
         .with_spec(spec)
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"));
+        .with_path(format!("/{path}"))
+        .with_decode_options(limits.decode_options());
 
     // Call the handler with timeout if configured
     let handler_result = if let Some(timeout) = metadata.timeout {

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -486,6 +486,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::connectrpc::eliza::v1::SayRequest,
@@ -522,6 +523,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::connectrpc::eliza::v1::IntroduceRequest,
@@ -572,7 +574,7 @@ impl<T: ElizaService> ::connectrpc::Dispatcher for ElizaServiceServer<T> {
                 Box::pin(async move {
                     let req_stream = ::connectrpc::dispatcher::codegen::decode_message_request_stream::<
                         crate::proto::connectrpc::eliza::v1::ConverseRequest,
-                    >(requests, format);
+                    >(requests, format, ctx.decode_options().clone());
                     let resp = svc.converse(ctx, req_stream).await?;
                     Ok(
                         resp

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -285,6 +285,7 @@ impl<T: GreetService> ::connectrpc::Dispatcher for GreetServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::anthropic::connectrpc::greet::v1::GreetRequest,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -276,6 +276,7 @@ impl<T: MathService> ::connectrpc::Dispatcher for MathServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::anthropic::connectrpc::math::v1::AddRequest,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -603,6 +603,7 @@ for WellKnownTypesServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::anthropic::connectrpc::wkt::v1::CreateEventRequest,
@@ -624,6 +625,7 @@ for WellKnownTypesServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::anthropic::connectrpc::wkt::v1::CalculateDurationRequest,
@@ -645,6 +647,7 @@ for WellKnownTypesServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         crate::proto::anthropic::connectrpc::wkt::v1::ProcessMetadataRequest,
@@ -666,6 +669,7 @@ for WellKnownTypesServiceServer<T> {
                         '_,
                     > = ::connectrpc::dispatcher::codegen::decode_borrowed_request_view(
                         &body,
+                        ctx.decode_options(),
                     )?;
                     let req = ::connectrpc::ServiceRequest::<
                         ::buffa_types::google::protobuf::Empty,


### PR DESCRIPTION
## Summary

buffa 0.9 bounds the memory a single decode may commit to repeated, map, string and bytes elements, defaulting to 32 MiB. It is charged on element *footprint* rather than contents, which is what makes it catch the amplification a size limit cannot: a few bytes on the wire can ask the decoder to materialize a very large number of small elements, each with its own allocation. A single large payload is unaffected however big it grows.

Since #233 that budget has reached every received request as a constant. A peer that legitimately sends many small elements — and that 0.8 accepted — is rejected, and there is nothing an operator can do about it. This makes it configuration.

```rust
ConnectRpcService::new(router)
    .with_limits(Limits::default().element_memory_limit(128 * 1024 * 1024))
```

`Limits::unlimited()` lifts it along with the other two.

## Both decode paths, not just the obvious one

The value travels to the decoder on `RequestContext` for the view paths and on `Payload` for the owned-message ones.

The second half is the part worth reviewing. Generated dispatch is view-based throughout, so threading only `decode_borrowed_request_view` and `decode_message_request_stream` looks complete and passes every test. But `Router::route_unary` and the `*_handler_fn` registrations decode through `Payload::take_message` and `decode_request`, and those would have kept buffa's default silently — on exactly the handlers where a fully materialized owned message costs most. `Payload` carries the limits so its public `take_message` signature is unchanged.

## The rejection says what to do about it

`invalid_argument: failed to decode proto request: element memory limit exceeded; if this peer is trusted, raise Limits::element_memory_limit`

Exceeding the budget is the one decode failure a server operator can fix without the peer changing anything, so it names the limit. Every other `DecodeError` keeps the bare message — pointing at a limit there would send someone chasing a setting that cannot help. A test pins both directions.

## Breaking, for generated code only

`decode_borrowed_request_view` and `decode_message_request_stream` take the decode limits. Both are `#[doc(hidden)]` and called only from generated dispatch, so regenerating is the whole migration — which 0.9.0 already requires for buffa 0.9. Doing it now costs nothing; doing it later costs a second forced regeneration.

`Limits` also becomes `#[non_exhaustive]`, so the next limit is not another break. Struct-literal construction becomes `Limits::default().max_request_body_size(a).max_message_size(b)`; fields stay public for reads.

## Incidental: the generated-code check was missing two directories

CI diffed four generated directories, `CONTRIBUTING` listed five, and there are six. `connectrpc-health/src/generated` and `connectrpc-reflection/src/generated` were unverified — and this change regenerates both, so the gap was live rather than theoretical. The check now covers all six and the doc is corrected.

## Not in scope

Clients still decode *responses* under buffa's defaults, with no override. The server is where the budget bites first, so this ships server-only; the `Limits` docs now say so rather than leaving the asymmetry to be discovered.

## Testing

Clippy on the pinned 1.95 toolchain, `cargo test -p connectrpc --no-default-features` (419), 56 test suites, lint, docs, server conformance 3600/0, and `task generate:all` regenerated with the CI-pinned protoc 33.5 / buf 1.69.0 and verified idempotent by hashing every generated file across two runs.

Driven live over a socket against a generated service with a repeated field, two servers differing only in this limit: default returns HTTP 400 naming the knob, `element_memory_limit(usize::MAX)` returns HTTP 200. The unit tests assert both halves too — rejected at the default, accepted when raised — so wiring the limit to nothing cannot pass.
