### PR TITLE
client: make the response element-memory budget configurable

### DIFF
--- a/.changes/unreleased/Added-20260720-134339.yaml
+++ b/.changes/unreleased/Added-20260720-134339.yaml
@@ -27,8 +27,23 @@ body: |-
   interceptor is held to the same budget as the handler behind it. JSON bodies
   are decoded without it, on the interceptor and handler paths alike. A
   rejection now names the limit to raise, since it is the one decode failure an
-  operator can fix without the peer changing anything. Clients still decode
-  *responses* under buffa's defaults; that knob is a follow-up.
+  operator can fix without the peer changing anything.
+
+  **Clients get the same control over responses.** A client decoding a
+  response of very many small elements hit the same 32 MiB wall with no
+  override. `ClientConfig::with_default_element_memory_limit` sets a default
+  and `CallOptions::with_element_memory_limit` overrides it per call, the same
+  config-default/per-call pair `max_message_size` already uses, and it covers
+  unary, server-streaming, client-streaming and bidi responses. It is set on
+  both codecs, but defends less on JSON: `serde_json` materializes the owned
+  message before the budget is consulted, so there the budget bounds the
+  view decode rather than the parse.
+
+  An over-budget response is `resource_exhausted`, matching the neighbouring
+  `max_message_size` overflow rather than reporting a limit as an internal
+  error, and it names the setter that raises it. Neither knob is a breaking
+  change: both types are already `#[non_exhaustive]`, and leaving them unset
+  keeps buffa's default.
 
   **Breaking, for generated code only.** `decode_borrowed_request_view` and
   `decode_message_request_stream` now take the decode limits, and `Limits` is

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -852,6 +852,7 @@ pub struct ClientConfig {
     pub(crate) compression_policy: CompressionPolicy,
     pub(crate) default_timeout: Option<Duration>,
     pub(crate) default_max_message_size: Option<usize>,
+    pub(crate) default_element_memory_limit: Option<usize>,
     pub(crate) default_headers: http::HeaderMap,
 }
 
@@ -869,6 +870,7 @@ impl ClientConfig {
             compression_policy: CompressionPolicy::default(),
             default_timeout: None,
             default_max_message_size: None,
+            default_element_memory_limit: None,
             default_headers: http::HeaderMap::new(),
         }
     }
@@ -958,11 +960,45 @@ impl ClientConfig {
 
     /// Set a default maximum decompressed response message size.
     ///
+    /// This bounds decompressed bytes, not element footprint. A response of
+    /// very many small elements can sit inside this limit and still exhaust
+    /// memory; that is what
+    /// [`Self::with_default_element_memory_limit`] defends against, and
+    /// raising this one will not help with it.
+    ///
     /// Read via [`Self::default_max_message_size`]. Per-call
     /// [`CallOptions::with_max_message_size`] overrides this.
     #[must_use]
     pub fn with_default_max_message_size(mut self, size: usize) -> Self {
         self.default_max_message_size = Some(size);
+        self
+    }
+
+    /// Set a default budget for the memory a response decode may commit to
+    /// repeated, map, string and bytes elements.
+    ///
+    /// Distinct from [`Self::with_default_max_message_size`], which bounds
+    /// decompressed bytes: this bounds the in-memory footprint those bytes
+    /// ask for. A response of very many small elements can be well inside
+    /// the size limit and still expand by orders of magnitude, which is the
+    /// amplification this defends against. Unset means buffa's 32 MiB
+    /// default; raise it for a server that legitimately returns such
+    /// responses.
+    ///
+    ///
+    /// Set on both codecs, but it defends less on JSON. A JSON response is
+    /// parsed by `serde_json` into an owned message first, and that parse is
+    /// bounded only by `max_message_size` — the amplification has already
+    /// happened by the time the budget is checked on the view decode. On
+    /// JSON the budget therefore bounds the second materialization and makes
+    /// the knob behave the same way it does on proto; it is not an
+    /// equivalent defence.
+    ///
+    /// Read via [`Self::default_element_memory_limit`]. Per-call
+    /// [`CallOptions::with_element_memory_limit`] overrides this.
+    #[must_use]
+    pub fn with_default_element_memory_limit(mut self, bytes: usize) -> Self {
+        self.default_element_memory_limit = Some(bytes);
         self
     }
 
@@ -1055,6 +1091,14 @@ impl ClientConfig {
         self.default_max_message_size
     }
 
+    /// The default response element-memory budget, if set.
+    ///
+    /// Set via [`Self::with_default_element_memory_limit`]. Per-call
+    /// [`CallOptions::with_element_memory_limit`] overrides this when set.
+    pub fn default_element_memory_limit(&self) -> Option<usize> {
+        self.default_element_memory_limit
+    }
+
     /// The headers applied to every request through this config.
     ///
     /// Useful for auth tokens, user-agent, tracing context.
@@ -1094,6 +1138,7 @@ pub struct CallOptions {
     pub(crate) headers: http::HeaderMap,
     pub(crate) timeout: Option<Duration>,
     pub(crate) max_message_size: Option<usize>,
+    pub(crate) element_memory_limit: Option<usize>,
     pub(crate) compress: Option<bool>,
 }
 
@@ -1167,10 +1212,37 @@ impl CallOptions {
 
     /// Set the maximum decompressed message size in bytes.
     ///
+    /// This bounds decompressed bytes, not element footprint. A response of
+    /// very many small elements can sit inside this limit and still exhaust
+    /// memory; that is what
+    /// [`Self::with_element_memory_limit`] defends against, and raising this
+    /// one will not help with it.
+    ///
     /// Read via [`Self::max_message_size`].
     #[must_use]
     pub fn with_max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = Some(size);
+        self
+    }
+
+    /// Set the budget for the memory this call's response decode may commit
+    /// to repeated, map, string and bytes elements.
+    ///
+    /// Overrides [`ClientConfig::with_default_element_memory_limit`]; see
+    /// there for how this differs from the message-size limit.
+    ///
+    /// Set on both codecs, but it defends less on JSON. A JSON response is
+    /// parsed by `serde_json` into an owned message first, and that parse is
+    /// bounded only by `max_message_size` — the amplification has already
+    /// happened by the time the budget is checked on the view decode. On
+    /// JSON the budget therefore bounds the second materialization and makes
+    /// the knob behave the same way it does on proto; it is not an
+    /// equivalent defence.
+    ///
+    /// Read via [`Self::element_memory_limit`].
+    #[must_use]
+    pub fn with_element_memory_limit(mut self, bytes: usize) -> Self {
+        self.element_memory_limit = Some(bytes);
         self
     }
 
@@ -1214,6 +1286,25 @@ impl CallOptions {
         self.max_message_size
     }
 
+    /// The response element-memory budget for this call.
+    ///
+    /// When unset the decode uses buffa's 32 MiB default. Exceeding it fails
+    /// the call rather than truncating.
+    ///
+    /// Set via [`Self::with_element_memory_limit`].
+    pub fn element_memory_limit(&self) -> Option<usize> {
+        self.element_memory_limit
+    }
+
+    /// The buffa decode options this call's response decode uses.
+    pub(crate) fn decode_options(&self) -> buffa::DecodeOptions {
+        let options = buffa::DecodeOptions::new();
+        match self.element_memory_limit {
+            Some(bytes) => options.with_element_memory_limit(bytes),
+            None => options,
+        }
+    }
+
     /// The per-call compression override. `Some(true)` forces compression,
     /// `Some(false)` disables it, `None` defers to the policy.
     ///
@@ -1236,6 +1327,9 @@ fn effective_options(config: &ClientConfig, options: CallOptions) -> CallOptions
     CallOptions {
         timeout: options.timeout.or(config.default_timeout),
         max_message_size: options.max_message_size.or(config.default_max_message_size),
+        element_memory_limit: options
+            .element_memory_limit
+            .or(config.default_element_memory_limit),
         compress: options.compress,
         headers: merge_headers(&config.default_headers, options.headers),
     }
@@ -1490,6 +1584,32 @@ where
     }
 }
 
+/// Report a failed response decode.
+///
+/// Exceeding the element-memory budget is the one decode failure the caller
+/// can act on — the response is well-formed, just larger than this client
+/// agreed to materialize — so it says which knob to raise. Every other
+/// variant keeps the bare message, because naming a limit there would send
+/// someone chasing a setting that cannot help. `DecodeError` is
+/// `#[non_exhaustive]`, hence the catch-all arm.
+fn decode_response_error(e: buffa::DecodeError) -> ConnectError {
+    match e {
+        // `ResourceExhausted`, not `internal`, and deliberately: this is the
+        // same class as the `max_message_size` overflow above it, which
+        // already uses that code. `internal` reads as "the client broke" and
+        // would route a raise-and-retry caller into an on-call page.
+        buffa::DecodeError::ElementMemoryLimitExceeded => ConnectError::new(
+            ErrorCode::ResourceExhausted,
+            format!(
+                "failed to decode response: {e}; if this server is trusted, raise \
+                 CallOptions::with_element_memory_limit or \
+                 ClientConfig::with_default_element_memory_limit"
+            ),
+        ),
+        _ => ConnectError::internal(format!("failed to decode response: {e}")),
+    }
+}
+
 /// Decode a response message as an `OwnedView` from bytes.
 ///
 /// For proto-encoded responses, this is a true zero-copy decode — the view borrows
@@ -1497,24 +1617,42 @@ where
 /// deserialized to an owned message, then re-encoded to proto bytes and decoded as
 /// a view. This JSON round-trip adds overhead relative to owned-type decoding, but
 /// is negligible compared to JSON parsing itself.
+///
+/// `options` carries the caller's decode limits, and bounds the protobuf
+/// decode on both paths — the JSON arm re-encodes and decodes under the same
+/// limits rather than taking buffa's defaults. The `serde_json` parse that
+/// precedes it is bounded by `max_message_size` alone.
 fn decode_response_view<RespView>(
     data: Bytes,
     format: CodecFormat,
+    options: &buffa::DecodeOptions,
 ) -> Result<OwnedView<RespView>, ConnectError>
 where
     RespView: MessageView<'static> + Send,
     RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
     match format {
-        CodecFormat::Proto => OwnedView::<RespView>::decode(data)
-            .map_err(|e| ConnectError::internal(format!("failed to decode response: {e}"))),
+        CodecFormat::Proto => {
+            OwnedView::<RespView>::decode_with_options(data, options).map_err(decode_response_error)
+        }
         #[cfg(feature = "json")]
         CodecFormat::Json => {
             let owned: RespView::Owned = serde_json::from_slice(&data).map_err(|e| {
                 ConnectError::internal(format!("failed to decode JSON response: {e}"))
             })?;
-            OwnedView::<RespView>::from_owned(&owned)
-                .map_err(|e| ConnectError::internal(format!("failed to re-encode for view: {e}")))
+            // This is `OwnedView::from_owned` inlined so the decode half can
+            // take the caller's limits — `from_owned` uses buffa's defaults,
+            // which made the knob a silent no-op for JSON clients. The
+            // round-trip itself is not new: a view has to borrow from proto
+            // bytes, and serde hands us an owned message.
+            //
+            // `try_encode_to_vec`, not `encode_to_vec`: the latter panics
+            // past 2 GiB, and this size is chosen by the peer.
+            let bytes = Bytes::from(buffa::Message::try_encode_to_vec(&owned).map_err(|e| {
+                ConnectError::internal(format!("failed to re-encode for view: {e}"))
+            })?);
+            OwnedView::<RespView>::decode_with_options(bytes, options)
+                .map_err(decode_response_error)
         }
         #[cfg(not(feature = "json"))]
         CodecFormat::Json => Err(ConnectError::unimplemented(
@@ -2026,7 +2164,9 @@ where
         )));
     }
 
-    let message = decode_response_view::<RespView>(body, config.codec_format).map_err(&attach)?;
+    let message =
+        decode_response_view::<RespView>(body, config.codec_format, &options.decode_options())
+            .map_err(&attach)?;
     drop(attach);
 
     Ok(UnaryResponse {
@@ -2318,7 +2458,8 @@ where
         ));
     }
 
-    let message = decode_response_view::<RespView>(data, config.codec_format)?;
+    let message =
+        decode_response_view::<RespView>(data, config.codec_format, &options.decode_options())?;
 
     Ok(UnaryResponse {
         headers: resp_headers,
@@ -2478,6 +2619,7 @@ pub struct ServerStream<B, RespView> {
     codec_format: CodecFormat,
     protocol: Protocol,
     max_message_size: Option<usize>,
+    element_memory_limit: Option<usize>,
     deadline: Option<std::time::Instant>,
     /// The terminal record; `Some` once the stream has ended, by any cause.
     end: Option<StreamEnd>,
@@ -2486,6 +2628,17 @@ pub struct ServerStream<B, RespView> {
     /// from a stream that produced data and was then cut off.
     saw_body_data: bool,
     _phantom: PhantomData<RespView>,
+}
+
+impl<B, RespView> ServerStream<B, RespView> {
+    /// The buffa decode options this stream's per-message decode uses.
+    fn decode_options(&self) -> buffa::DecodeOptions {
+        let options = buffa::DecodeOptions::new();
+        match self.element_memory_limit {
+            Some(bytes) => options.with_element_memory_limit(bytes),
+            None => options,
+        }
+    }
 }
 
 // Manual impl: the body type `B` (typically `hyper::body::Incoming`) isn't
@@ -2668,7 +2821,11 @@ where
                         .into());
                     }
 
-                    let msg = decode_response_view::<RespView>(data, self.codec_format)?;
+                    let msg = decode_response_view::<RespView>(
+                        data,
+                        self.codec_format,
+                        &self.decode_options(),
+                    )?;
                     return Ok(msg);
                 }
                 None => match self.poll_body().await? {
@@ -3000,6 +3157,7 @@ where
             &config.compression,
             config.codec_format,
             options.max_message_size,
+            options.element_memory_limit,
             deadline,
         )
         .await
@@ -3023,6 +3181,7 @@ async fn make_server_stream<B, RespView>(
     compression: &CompressionRegistry,
     codec_format: CodecFormat,
     max_message_size: Option<usize>,
+    element_memory_limit: Option<usize>,
     deadline: Option<std::time::Instant>,
 ) -> Result<ServerStream<B, RespView>, ConnectError>
 where
@@ -3100,6 +3259,7 @@ where
         .map(|s| s.to_owned());
 
     Ok(ServerStream {
+        element_memory_limit,
         headers: response_headers,
         body: response.into_body(),
         buf: BytesMut::new(),
@@ -3403,6 +3563,7 @@ struct StreamConfig {
     codec_format: CodecFormat,
     compression: CompressionRegistry,
     max_message_size: Option<usize>,
+    element_memory_limit: Option<usize>,
     deadline: Option<std::time::Instant>,
 }
 
@@ -3529,6 +3690,7 @@ where
                     let codec_format = self.stream_config.codec_format;
                     let compression = self.stream_config.compression.clone();
                     let max_message_size = self.stream_config.max_message_size;
+                    let element_memory_limit = self.stream_config.element_memory_limit;
                     let deadline = self.stream_config.deadline;
 
                     let construct_task = tokio::spawn(async move {
@@ -3543,6 +3705,7 @@ where
                                 &compression,
                                 codec_format,
                                 max_message_size,
+                                element_memory_limit,
                                 deadline,
                             ),
                         )
@@ -3831,6 +3994,7 @@ where
                 codec_format: config.codec_format,
                 compression: config.compression.clone(),
                 max_message_size: options.max_message_size,
+                element_memory_limit: options.element_memory_limit,
                 deadline,
             },
         },
@@ -4105,8 +4269,9 @@ where
         &resp_headers,
     )?;
     // The trailers are parsed by now, so a decode failure reports them too.
-    let message = decode_response_view::<RespView>(data, config.codec_format)
-        .map_err(with_response_metadata(&resp_headers, &trailers))?;
+    let message =
+        decode_response_view::<RespView>(data, config.codec_format, &options.decode_options())
+            .map_err(with_response_metadata(&resp_headers, &trailers))?;
 
     Ok(UnaryResponse {
         headers: resp_headers,
@@ -4701,8 +4866,12 @@ mod tests {
         // the deleted fallible `into_owned` used, so the wire-visible
         // behavior for an over-limit response is pinned here.
         let body = crate::request::tests::unknown_field_overflow_body();
-        let err =
-            decode_response_view::<StringValueView<'static>>(body, CodecFormat::Proto).unwrap_err();
+        let err = decode_response_view::<StringValueView<'static>>(
+            body,
+            CodecFormat::Proto,
+            &buffa::DecodeOptions::new(),
+        )
+        .unwrap_err();
         assert_eq!(err.code, ErrorCode::Internal);
     }
 
@@ -5032,6 +5201,7 @@ mod tests {
             recv: BidiRecvHalf {
                 recv: RecvState::AwaitingHeaders(response_task),
                 stream_config: StreamConfig {
+                    element_memory_limit: None,
                     protocol: Protocol::Connect,
                     codec_format: CodecFormat::Proto,
                     compression: CompressionRegistry::new(),
@@ -5381,6 +5551,55 @@ mod tests {
             .expect_err("guard sender should be dropped by the abort");
     }
 
+    /// The streaming path carries its own copy of the budget, so a
+    /// construction site that forgot to populate it would leave streamed
+    /// messages decoding under buffa's default while the unary tests stayed
+    /// green. Drive a real over-budget envelope through `ServerStream` to
+    /// pin that the field is actually consulted.
+    #[tokio::test]
+    async fn server_stream_per_message_decode_honours_the_element_budget() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::{ListValueView, ValueView};
+        use buffa_types::google::protobuf::{ListValue, Value};
+
+        // Sized from the view type, since that is what `message()` decodes.
+        let n = crate::test_budget::elements_over_default_budget::<ValueView<'_>>();
+        let list = ListValue {
+            values: (0..n).map(|_| Value::default()).collect(),
+            ..Default::default()
+        };
+        let envelope = Envelope::data(list.encode_to_bytes()).encode();
+
+        let make = |element_memory_limit| ServerStream::<_, ListValueView<'static>> {
+            element_memory_limit,
+            headers: http::HeaderMap::new(),
+            body: Full::new(envelope.clone()),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Connect,
+            max_message_size: Some(64 * 1024 * 1024),
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let err = make(None)
+            .message()
+            .await
+            .expect_err("a streamed message must be rejected at buffa's default budget");
+        assert_eq!(err.code, ErrorCode::ResourceExhausted);
+
+        let msg = make(Some(usize::MAX))
+            .message()
+            .await
+            .expect("raising the stream's budget must admit the same envelope")
+            .expect("the envelope carries a data frame");
+        assert_eq!(msg.view().values.len(), n);
+    }
+
     #[tokio::test]
     async fn connect_server_stream_truncated_after_data_errors() {
         use buffa::Message;
@@ -5389,6 +5608,7 @@ mod tests {
 
         let body = Full::new(Envelope::data(StringValue::from("hello").encode_to_bytes()).encode());
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
             buf: BytesMut::new(),
@@ -5439,6 +5659,7 @@ mod tests {
 
         let body = Full::new(Bytes::new());
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
             buf: BytesMut::new(),
@@ -5492,6 +5713,7 @@ mod tests {
             .encode(),
         );
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body: Full::new(body.freeze()),
             buf: BytesMut::new(),
@@ -5559,6 +5781,7 @@ mod tests {
         headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers,
             body: Full::new(body.freeze()),
             buf: BytesMut::new(),
@@ -5624,6 +5847,7 @@ mod tests {
         headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers,
             body: Full::new(body.freeze()),
             buf: BytesMut::new(),
@@ -5691,6 +5915,7 @@ mod tests {
         headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers,
             body: StreamBody::new(futures::stream::iter(frames)),
             buf: BytesMut::new(),
@@ -5750,6 +5975,7 @@ mod tests {
         headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers,
             body: StreamBody::new(futures::stream::iter(frames)),
             buf: BytesMut::new(),
@@ -5838,6 +6064,7 @@ mod tests {
         let body = StreamBody::new(futures::stream::iter(frames));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
             buf: BytesMut::new(),
@@ -5895,6 +6122,7 @@ mod tests {
         let body = StreamBody::new(futures::stream::iter(frames));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
             buf: BytesMut::new(),
@@ -5922,6 +6150,7 @@ mod tests {
         use buffa_types::google::protobuf::__buffa::view::StringValueView;
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body: Full::new(Bytes::new()),
             buf: BytesMut::new(),
@@ -5967,6 +6196,7 @@ mod tests {
         headers.insert("grpc-status", "0".parse().unwrap());
         let body = Full::new(Envelope::data(StringValue::from("hello").encode_to_bytes()).encode());
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers,
             body,
             buf: BytesMut::new(),
@@ -6006,6 +6236,7 @@ mod tests {
         let mut headers = http::HeaderMap::new();
         headers.insert("grpc-status", "0".parse().unwrap());
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers,
             body: Full::new(Bytes::new()),
             buf: BytesMut::new(),
@@ -6042,6 +6273,7 @@ mod tests {
         let body = StreamBody::new(futures::stream::iter(frames));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
             buf: BytesMut::new(),
@@ -6106,6 +6338,7 @@ mod tests {
         let body = StreamBody::new(frames);
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
             buf: BytesMut::new(),
@@ -6160,6 +6393,7 @@ mod tests {
         let body = StreamBody::new(futures::stream::iter(frames));
 
         let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
             buf: BytesMut::new(),
@@ -7854,6 +8088,97 @@ mod tests {
         assert_eq!(unary_request_content_type(&config), "application/json");
     }
 
+    /// The knob has to be load-bearing in both directions: the same bytes
+    /// rejected under the default budget and accepted once it is raised.
+    /// A one-sided assertion would pass even if the limit were never read.
+    #[test]
+    fn response_element_memory_limit_is_load_bearing() {
+        use buffa_types::google::protobuf::__buffa::view::{ListValueView, ValueView};
+        use buffa_types::google::protobuf::{ListValue, Value};
+
+        // Element footprint is charged, not contents, so this is small on
+        // the wire and large decoded. Sized from the view type, since that
+        // is what `decode_response_view` materialises.
+        let n = crate::test_budget::elements_over_default_budget::<ValueView<'_>>();
+        let list = ListValue {
+            values: (0..n).map(|_| Value::default()).collect(),
+            ..Default::default()
+        };
+        let encoded = Bytes::from(buffa::Message::encode_to_vec(&list));
+
+        let defaults = CallOptions::default();
+        let err = decode_response_view::<ListValueView<'static>>(
+            encoded.clone(),
+            CodecFormat::Proto,
+            &defaults.decode_options(),
+        )
+        .unwrap_err();
+        // Assert the SETTER names: an earlier version of this hint cited the
+        // getters, which do not raise anything.
+        let message = err.message.as_deref().unwrap_or_default();
+        assert!(
+            message.contains("CallOptions::with_element_memory_limit")
+                && message.contains("ClientConfig::with_default_element_memory_limit"),
+            "an over-budget response must name the setters that fix it, got {message:?}"
+        );
+
+        let raised = CallOptions::default().with_element_memory_limit(usize::MAX);
+        let view = decode_response_view::<ListValueView<'static>>(
+            encoded,
+            CodecFormat::Proto,
+            &raised.decode_options(),
+        )
+        .expect("raising the budget must admit the same bytes");
+        assert_eq!(view.reborrow().values.len(), n);
+    }
+
+    /// A response that is merely malformed must not point at a limit — that
+    /// would send someone chasing a setting that cannot help.
+    #[test]
+    fn a_malformed_response_does_not_name_a_limit() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let err = decode_response_view::<StringValueView<'static>>(
+            Bytes::from_static(&[0xFF, 0xFF, 0xFF]),
+            CodecFormat::Proto,
+            &CallOptions::default().decode_options(),
+        )
+        .unwrap_err();
+        assert!(
+            !err.message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("element_memory_limit"),
+            "got {:?}",
+            err.message
+        );
+    }
+
+    /// Per-call wins over the config default, and the config default applies
+    /// when the call says nothing — the same precedence `max_message_size`
+    /// already has.
+    #[test]
+    fn element_memory_limit_precedence_matches_max_message_size() {
+        let config = ClientConfig::new("http://example.com".parse().unwrap())
+            .with_default_element_memory_limit(1024);
+
+        let inherited = effective_options(&config, CallOptions::default());
+        assert_eq!(inherited.element_memory_limit(), Some(1024));
+
+        let overridden = effective_options(
+            &config,
+            CallOptions::default().with_element_memory_limit(4096),
+        );
+        assert_eq!(overridden.element_memory_limit(), Some(4096));
+
+        let unset = ClientConfig::new("http://example.com".parse().unwrap());
+        assert_eq!(
+            effective_options(&unset, CallOptions::default()).element_memory_limit(),
+            None,
+            "unset must stay unset so the decode uses buffa's default"
+        );
+    }
+
     #[cfg(not(feature = "json"))]
     #[test]
     fn decode_response_view_json_is_unimplemented_without_feature() {
@@ -7867,13 +8192,21 @@ mod tests {
         let err = decode_response_view::<StringValueView>(
             Bytes::from_static(b"\"x\""),
             CodecFormat::Json,
+            &buffa::DecodeOptions::new(),
         )
         .unwrap_err();
         assert_eq!(err.code, ErrorCode::Unimplemented);
 
         // Proto decoding still works.
         let bytes = StringValue::from("ok").encode_to_bytes();
-        assert!(decode_response_view::<StringValueView>(bytes, CodecFormat::Proto).is_ok());
+        assert!(
+            decode_response_view::<StringValueView>(
+                bytes,
+                CodecFormat::Proto,
+                &buffa::DecodeOptions::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -465,9 +465,10 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 /// `max_message_size` can still expand by orders of magnitude. Raising one
 /// does not raise the other.
 ///
-/// These are **server** limits, applied to received requests. A client
-/// decoding responses currently uses buffa's defaults, with no equivalent
-/// override.
+/// These are **server** limits, applied to received requests. The client
+/// side has its own equivalents for received *responses*:
+/// [`ClientConfig::with_default_element_memory_limit`](crate::client::ClientConfig::with_default_element_memory_limit)
+/// and [`CallOptions::with_element_memory_limit`](crate::client::CallOptions::with_element_memory_limit).
 ///
 /// # Construction
 ///


### PR DESCRIPTION
## Summary

#235, now merged, gave server operators control over the element-memory budget buffa 0.9 applies to received *requests*. Clients had the same wall on *responses* with no way through it: a server that legitimately returns very many small elements fails the call at 32 MiB, and the caller can do nothing about it.

```rust
// default for every call through this client
ClientConfig::new(uri).with_default_element_memory_limit(128 * 1024 * 1024)

// or per call
client.ingest_with_options(req, CallOptions::default().with_element_memory_limit(usize::MAX))
```

Same config-default plus per-call-override pair `max_message_size` already uses, merged with the same precedence. Not a breaking change — both types are already `#[non_exhaustive]`, and leaving the limit unset keeps buffa's default.

## Every response path, both codecs

The value reaches Connect unary, gRPC unary, client-streaming, and per-message server-streaming through `ServerStream`, which the bidi receive half also goes through.

The JSON arm inlines `OwnedView::from_owned` so the decode half can take the caller's limits. `from_owned` uses buffa's defaults, which made the knob a silent no-op for JSON-codec clients.

**This adds no work.** `from_owned` is `try_encode_to_vec` followed by `decode`; the inlined version is the same two steps with `decode_with_options` in place of `decode`. The encode/decode round-trip on the JSON path predates this change and is inherent to the view design — a view borrows from proto bytes, and serde hands back an owned message.

**It is a weaker defence on JSON, and the docs now say so** rather than claiming parity. `serde_json` has already materialized the owned message by the time the budget is consulted, so on JSON the budget bounds the second materialization and makes the knob behave consistently; it does not bound the parse. What it fixes is the knob being inert: before, a JSON client hit the same 32 MiB wall and could not raise it.

The inlined encode uses `try_encode_to_vec`, not `encode_to_vec` — the latter panics past 2 GiB, and on a client that size is chosen by the peer.

The underlying gap — buffa's JSON path consulting none of the `DecodeOptions` limits — is tracked upstream as anthropics/buffa#330.

No codegen change and no regeneration: `decode_response_view` is private, and generated clients only touch `ClientConfig`, `CallOptions` and `UnaryResponse`.

## `resource_exhausted`, not `internal`

An over-budget response is the same class of failure as the `max_message_size` overflow a few lines above it, which already uses `resource_exhausted`. Reporting a limit the caller set as an internal error says "the library broke" and would route a caller who branches on the code — raise and retry versus page someone — into the wrong branch. The message names the setter that raises it:

```
failed to decode response: element memory limit exceeded; if this server is trusted,
raise CallOptions::with_element_memory_limit or ClientConfig::with_default_element_memory_limit
```

Only that one `DecodeError` variant gets the hint. A malformed response keeps the bare message, because pointing at a limit would send someone chasing a setting that cannot help; a test pins both directions.

## Docs

The `max_message_size` setters now point at the element budget. That cross-reference is the one that matters: someone debugging an element-budget error starts from the size knob they already know, and without it they raise `max_message_size` and are confused when nothing changes.

## Follows #235

#235 merged while this was in progress, so this is rebased onto `main` and stands alone. The full gate was re-run on the new base rather than inherited from the stacked one.

## Testing

Clippy on the pinned 1.95 toolchain, `cargo test -p connectrpc --no-default-features` (423), 56 suites, lint, fmt, docs. Client conformance: Connect 2580/0 and gRPC-Web 2838/0 clean.

The gRPC client suite shows flaky `Timeouts/...` failures — between 1 and 5 across runs. These are **pre-existing and reproduce on clean `main`** (verified), and are #210: post-deadline transport errors map to `internal` instead of `deadline_exceeded`.

Driven live: one server returning 800,000 small elements, two clients differing only in this budget. The default client fails and names the knob; a per-call `with_element_memory_limit(usize::MAX)` receives all 800,000 items. The unit tests assert both directions too, including one that drives an over-budget envelope through `ServerStream` — the streaming path carries its own copy of the budget, so a construction site that forgot to populate it would otherwise leave streamed messages on buffa's default while every unary test stayed green.
