### PR TITLE
codegen: decode descriptor sets under buffa 0.9.1's tooling budget

### DIFF
--- a/.changes/unreleased/Fixed-20260721-130128.yaml
+++ b/.changes/unreleased/Fixed-20260721-130128.yaml
@@ -1,0 +1,22 @@
+kind: Fixed
+body: |-
+  **Code generation handles large schemas.** buffa 0.9's element-memory budget
+  is charged per element on struct size rather than on encoded bytes, and
+  descriptor structs are wide, so the 32 MiB default rejected descriptor sets
+  that are entirely legitimate — ordinary schemas of a few hundred `.proto`
+  files, not pathological ones.
+
+  `protoc-gen-connect-rust` and `connectrpc-build` decode the compiler's own
+  output, which is not the untrusted input that budget defends against, so both
+  now decode under buffa 0.9.1's 1 GiB tooling budget. Both honour the same
+  overrides buffa's own plugins do — the `element_memory_limit=` plugin option
+  and the `BUFFA_ELEMENT_MEMORY_LIMIT` environment variable — so one setting
+  raises every plugin in a `buf generate` run rather than needing a
+  connect-specific twin. See "Very large schemas" in the guide.
+
+  Descriptor sets supplied at *runtime* stay bounded, because a reflection
+  service may be fed descriptors by a peer rather than by its own build. An
+  over-budget set there now reports the new `ReflectionError::ElementBudget`,
+  which says the bytes are well-formed and the schema is simply large, rather
+  than a decode failure that reads like corruption.
+time: 2026-07-21T13:01:28.404442539-07:00

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,21 +30,23 @@ pin-project = "1"
 sync_wrapper = "1"
 async-trait = "0.1"
 
-# Protobuf. The 0.9 floor matches the regen baseline for the checked-in
-# generated code, and is a hard floor rather than a preference: 0.9.0 widens
-# `types::put_len_delimited_header` and the `map_codec::field_len`
-# accumulator to `u64`, so code emitted by a 0.8.x codegen does not compile
-# against a 0.9 runtime. Regenerate whenever this moves.
+# Protobuf. 0.9.1 is a hard floor rather than a preference, for two reasons.
+# 0.9.0 widens `types::put_len_delimited_header` and the
+# `map_codec::field_len` accumulator to `u64`, so code emitted by a 0.8.x
+# codegen does not compile against a 0.9 runtime; and the codegen paths call
+# `buffa_codegen::decode_request` and `tooling_decode_options`, which arrived
+# in 0.9.1. The floor also matches the regen baseline for the checked-in
+# generated code — regenerate whenever it moves.
 # (connectrpc-build also sources the generated `mod.rs` `#[allow(...)]` list
 # from `buffa_codegen::ALLOW_LINTS`.)
 # NOTE: the `connectrpc` crate pins `buffa` directly (not `workspace = true`)
 # so its `json` cargo feature can gate `buffa/json` for proto-only builds —
 # keep that floor aligned with this one when bumping.
-buffa = { version = "0.9", features = ["json"] }
-buffa-types = { version = "0.9", features = ["json"] }
-buffa-codegen = { version = "0.9" }
+buffa = { version = "0.9.1", features = ["json"] }
+buffa-types = { version = "0.9.1", features = ["json"] }
+buffa-codegen = { version = "0.9.1" }
 # `reflect` is needed for `DescriptorPool`, which backs connectrpc-reflection.
-buffa-descriptor = { version = "0.9", features = ["reflect"] }
+buffa-descriptor = { version = "0.9.1", features = ["reflect"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -411,8 +411,15 @@ impl Config {
                 (bytes, proto_relative_names(&self.files))
             }
         };
-        let mut fds = FileDescriptorSet::decode_from_slice(&descriptor_bytes)
-            .map_err(|e| anyhow!("failed to decode FileDescriptorSet: {e}"))?;
+        // 2. Decode the descriptor set.
+        //
+        // The compiler's own output — protoc or buf that this build script just
+        // ran, or a descriptor set the build points at — so buffa's tooling
+        // bound applies rather than its untrusted-input default.
+        let decode_options = buffa_codegen::tooling_decode_options().map_err(|e| anyhow!("{e}"))?;
+        let mut fds = decode_options
+            .decode_from_slice::<FileDescriptorSet>(&descriptor_bytes)
+            .map_err(|e| descriptor_decode_error(&e, decode_options.element_memory_limit()))?;
 
         // 3. Generate.
         let generated = codegen::generate_files(&fds.file, &files_to_generate, &self.options)?;
@@ -484,6 +491,16 @@ impl Config {
         if !self.emit_rerun_directives {
             return Ok(());
         }
+        // The decode above reads this, so it is a build input like any source
+        // file. Emitting any `rerun-if` directive narrows cargo to exactly the
+        // triggers listed, so without this a build that succeeded with the
+        // variable set is not re-run when it changes or is unset — the stale
+        // output is reused and the setting looks inert. Only the failing
+        // direction self-heals, because a failed build script always re-runs.
+        println!(
+            "cargo:rerun-if-env-changed={}",
+            buffa_codegen::ELEMENT_MEMORY_LIMIT_ENV
+        );
         match &self.descriptor_source {
             DescriptorSource::Precompiled(p) => {
                 println!("cargo:rerun-if-changed={}", p.display());
@@ -507,6 +524,27 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Describe a descriptor-set decode failure for a build script.
+///
+/// buffa composes the base text, including the budget actually in force. For
+/// an over-budget set it also names two remedies, and only one of them is
+/// reachable from here — a build script has no plugin parameter string — so
+/// this says which, and points at the connectrpc guide rather than buffa's.
+fn descriptor_decode_error(e: &buffa::DecodeError, limit: usize) -> anyhow::Error {
+    let base = buffa_codegen::decode_failure("FileDescriptorSet", e, limit);
+    if matches!(e, buffa::DecodeError::ElementMemoryLimitExceeded) {
+        anyhow!(
+            "{base}\nOf those two, only the {env} environment variable applies to a \
+             build script, which has no plugin parameter string. See \"Very large \
+             schemas\" in the connectrpc guide: \
+             https://github.com/connectrpc/connect-rust/blob/main/docs/guide.md",
+            env = buffa_codegen::ELEMENT_MEMORY_LIMIT_ENV,
+        )
+    } else {
+        anyhow!(base)
     }
 }
 
@@ -1391,5 +1429,95 @@ service NoteService {
 
         write_if_changed(&path, b"new").unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"new");
+    }
+
+    /// Build a descriptor set that overruns buffa's default element-memory
+    /// budget. The budget charges `size_of::<FileDescriptorProto>()` per
+    /// element rather than encoded bytes, so many tiny files trip it while
+    /// staying small on the wire — which is exactly why descriptor sets hit it
+    /// at a few megabytes. Derived from the live size, because a literal count
+    /// stops overrunning the budget the moment that struct shrinks — see
+    /// `connectrpc::test_budget` for the full rationale and the buffa 0.9.1
+    /// change that proved it.
+    fn over_default_budget_set() -> Vec<u8> {
+        use buffa_codegen::generated::descriptor::FileDescriptorProto;
+
+        let per_element = std::mem::size_of::<FileDescriptorProto>();
+        let n = (buffa::DEFAULT_ELEMENT_MEMORY_LIMIT / per_element) * 5 / 4;
+        let set = FileDescriptorSet {
+            file: (0..n)
+                .map(|i| FileDescriptorProto {
+                    name: Some(format!("f{i}.proto")),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        buffa::Message::encode_to_vec(&set)
+    }
+
+    /// The regression this crate's decode path exists to prevent: a build's
+    /// own descriptors must decode even when they exceed the bound sized for
+    /// untrusted wire input.
+    ///
+    /// The first assertion is the control. Without it the second would pass
+    /// whether or not the tooling options do anything at all.
+    #[test]
+    fn the_tooling_options_decode_a_set_the_untrusted_default_rejects() {
+        let bytes = over_default_budget_set();
+
+        assert!(
+            matches!(
+                FileDescriptorSet::decode_from_slice(&bytes),
+                Err(buffa::DecodeError::ElementMemoryLimitExceeded)
+            ),
+            "fixture no longer exceeds the default budget ({} encoded bytes); \
+             it must, or the assertion below proves nothing",
+            bytes.len()
+        );
+
+        let opts = buffa_codegen::tooling_decode_options().expect("no override set");
+        opts.decode_from_slice::<FileDescriptorSet>(&bytes)
+            .expect("a build's own descriptors must decode under the tooling budget");
+    }
+
+    /// An over-budget failure has to correct buffa's hint, which offers a
+    /// plugin option that cannot be set from a build script.
+    #[test]
+    fn an_over_budget_decode_names_only_the_remedy_a_build_script_has() {
+        let rendered = descriptor_decode_error(
+            &buffa::DecodeError::ElementMemoryLimitExceeded,
+            buffa::DEFAULT_ELEMENT_MEMORY_LIMIT,
+        )
+        .to_string();
+
+        assert!(
+            rendered.contains(buffa_codegen::ELEMENT_MEMORY_LIMIT_ENV),
+            "must name the variable that works here: {rendered}"
+        );
+        assert!(
+            rendered.contains("build script"),
+            "must say why the plugin option does not apply: {rendered}"
+        );
+        assert!(
+            rendered.contains("connectrpc/connect-rust"),
+            "must point at our guide, not buffa's: {rendered}"
+        );
+    }
+
+    /// A malformed set must not be dressed up as a budget problem — that
+    /// would send someone raising a limit that cannot help.
+    #[test]
+    fn a_malformed_set_is_not_reported_as_a_budget_problem() {
+        let rendered = descriptor_decode_error(
+            &buffa::DecodeError::UnexpectedEof,
+            buffa::DEFAULT_ELEMENT_MEMORY_LIMIT,
+        )
+        .to_string();
+
+        assert!(
+            !rendered.contains(buffa_codegen::ELEMENT_MEMORY_LIMIT_ENV),
+            "a truncated set must not point at the budget: {rendered}"
+        );
     }
 }

--- a/connectrpc-codegen/src/bin/protoc-gen-connect-rust.rs
+++ b/connectrpc-codegen/src/bin/protoc-gen-connect-rust.rs
@@ -54,8 +54,16 @@ fn main() -> Result<()> {
         .read_to_end(&mut input)
         .context("failed to read from stdin")?;
 
-    let request = CodeGeneratorRequest::decode_from_slice(&input)
-        .context("failed to decode CodeGeneratorRequest")?;
+    // buffa's plugins decode the identical request in the same `buf generate`
+    // run, so the bound, the overrides that raise it and the message naming
+    // them all come from there rather than from a connect-specific twin.
+    //
+    // The two overrides differ in reach, which the guide spells out: the
+    // environment variable covers every plugin in the run, while `opt:` is
+    // per-plugin, so setting the option on one plugin does nothing for this
+    // one.
+    let request: CodeGeneratorRequest =
+        buffa_codegen::decode_request(&input).map_err(|e| anyhow::anyhow!(e))?;
 
     // Process the request
     let response = codegen::generate(&request)?;

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -586,6 +586,14 @@ pub fn generate_services(
 ///   foreign crate via `extern_path` are still skipped.
 ///   `encodable_impls=outputs` is the explicit default. See
 ///   [`Options::encodable_impls`].
+/// - `element_memory_limit=<bytes|unlimited>` — raises the element-memory
+///   budget used to decode the request, for schemas too large for the
+///   default (see "Very large schemas" in the guide). Accepted and ignored
+///   here: it governs the decode that produced the `CodeGeneratorRequest`,
+///   so `buffa_codegen::decode_request` has already read and applied it by
+///   scanning the wire. A caller who decodes the request itself and then
+///   calls this function must apply the option on that decode; passing it
+///   here alone does nothing.
 ///
 /// # Client-side cfg gate
 ///
@@ -661,6 +669,14 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
                          `all_messages` or `outputs`"
                     ),
                 }
+            } else if opt
+                .split_once('=')
+                .is_some_and(|(key, _)| key.trim() == buffa_codegen::ELEMENT_MEMORY_LIMIT_OPT)
+            {
+                // Consumed before this point, by the scan `decode_request` runs
+                // to size the decode that produced `request`. Reaching the
+                // unknown-option arm would reject it from the one caller who
+                // needs it: whoever's schema was too large to decode.
             } else {
                 match opt {
                     "file_per_package" => options.buffa.file_per_package = true,
@@ -673,9 +689,11 @@ pub fn generate(request: &CodeGeneratorRequest) -> Result<CodeGeneratorResponse>
                             "unknown plugin option: {opt:?}. Supported: \
                              buffa_module=<rust_path>, extern_path=<proto>=<rust>, \
                              encodable_impls=<all_messages|outputs>, \
+                             {mem}=<bytes|unlimited>, \
                              file_per_package, strict_utf8_mapping, no_json, \
                              no_register_fn, gate_client_feature, \
-                             gate_client_feature=<name>"
+                             gate_client_feature=<name>",
+                            mem = buffa_codegen::ELEMENT_MEMORY_LIMIT_OPT
                         ));
                     }
                 }
@@ -4638,6 +4656,28 @@ mod tests {
             msg.contains("unknown plugin option"),
             "error should say the option is unknown: {msg}"
         );
+    }
+
+    /// `element_memory_limit` is read off the wire before the request is
+    /// decoded, so by the time options are parsed it is a leftover. Rejecting
+    /// it would fail the build of the only person who ever sets it — someone
+    /// whose schema was too large to decode without it.
+    #[test]
+    fn plugin_accepts_the_element_memory_limit_option_it_consumed_pre_decode() {
+        for value in ["unlimited", "max", "2147483648"] {
+            let request = CodeGeneratorRequest {
+                parameter: Some(format!(
+                    "buffa_module=crate::proto,{}={value}",
+                    buffa_codegen::ELEMENT_MEMORY_LIMIT_OPT
+                )),
+                file_to_generate: vec![],
+                proto_file: vec![],
+                ..Default::default()
+            };
+            generate(&request).unwrap_or_else(|e| {
+                panic!("element_memory_limit={value} must not reach the unknown-option arm: {e}")
+            });
+        }
     }
 
     #[test]

--- a/connectrpc-reflection/src/reflector.rs
+++ b/connectrpc-reflection/src/reflector.rs
@@ -33,8 +33,26 @@ use buffa_descriptor::{DescriptorPool, PoolError};
 #[non_exhaustive]
 pub enum ReflectionError {
     /// The bytes did not decode as a `FileDescriptorSet`.
+    ///
+    /// Exceeding the element-memory budget is reported separately as
+    /// [`ElementBudget`](Self::ElementBudget), because there the bytes are
+    /// fine; this variant is every other wire-level failure.
     #[error("failed to decode FileDescriptorSet: {0}")]
-    Decode(#[from] buffa::DecodeError),
+    Decode(buffa::DecodeError),
+    /// The descriptor set was well-formed but exceeded the decode's
+    /// element-memory budget.
+    ///
+    /// Split apart from [`Decode`](Self::Decode) because the remedy is
+    /// different: the bytes are fine, and a reflection service is normally
+    /// handed its own server's descriptors, which are trusted. The remedy is
+    /// a smaller set — strip `source_code_info`, or narrow it to the files
+    /// this server reflects.
+    #[error(
+        "FileDescriptorSet exceeds the decode element-memory budget; the bytes \
+         are well-formed, the schema is simply large. Strip source_code_info \
+         or reduce the set to the files this server reflects."
+    )]
+    ElementBudget,
     /// The decoded descriptors did not link into a valid pool (dangling
     /// type reference, duplicate symbol, malformed map entry, ...).
     #[error("invalid descriptor set: {0}")]
@@ -71,6 +89,21 @@ pub enum ReflectionError {
     /// the reflector from bytes.
     #[error("cannot add to a descriptor pool with outstanding references")]
     SharedPool,
+}
+
+/// Written out rather than derived with `#[from]`, so that the budget/corrupt
+/// split cannot be bypassed. A derived conversion sends every
+/// [`buffa::DecodeError`] to [`Decode`](ReflectionError::Decode), so the next
+/// decode path added here — reached with `?`, which compiles fine — would
+/// report an over-budget set as corruption again, silently undoing the reason
+/// [`ElementBudget`](ReflectionError::ElementBudget) exists.
+impl From<buffa::DecodeError> for ReflectionError {
+    fn from(e: buffa::DecodeError) -> Self {
+        match e {
+            buffa::DecodeError::ElementMemoryLimitExceeded => Self::ElementBudget,
+            other => Self::Decode(other),
+        }
+    }
 }
 
 /// The answer to a single reflection query, protocol-version agnostic.
@@ -147,7 +180,9 @@ impl Reflector {
     ///
     /// Returns [`ReflectionError`] when the bytes do not decode as a
     /// `FileDescriptorSet`, the descriptors do not link, or a contained
-    /// file has no name.
+    /// file has no name. A set too large for the decode's element-memory
+    /// budget reports [`ElementBudget`](ReflectionError::ElementBudget)
+    /// rather than a decode failure.
     pub fn from_descriptor_set_bytes(bytes: &[u8]) -> Result<Self, ReflectionError> {
         let mut reflector = Self {
             pool: Arc::new(DescriptorPool::default()),
@@ -211,9 +246,11 @@ impl Reflector {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectionError`] when the bytes do not decode or link,
-    /// a contained file has no name, or any other reference to the
-    /// backing pool exists ([`ReflectionError::SharedPool`]) — which is
+    /// Returns [`ReflectionError`] when the bytes do not decode or link
+    /// (including [`ElementBudget`](ReflectionError::ElementBudget) for a set
+    /// over the decode's element-memory budget), a contained file has no
+    /// name, or any other reference to the backing pool exists
+    /// ([`ReflectionError::SharedPool`]) — which is
     /// always the case for reflectors built with
     /// [`from_descriptor_pool`](Self::from_descriptor_pool) from a
     /// long-lived pool. On error the reflector should be discarded: the
@@ -446,8 +483,10 @@ fn self_descriptors() -> &'static SelfDescriptors {
         // crate's tests, so a failure here is a build defect, not input.
         let bytes = crate::FILE_DESCRIPTOR_SET;
         let raw_files = split_descriptor_set(bytes).expect("embedded descriptor set is framed");
-        let set =
-            FileDescriptorSet::decode_from_slice(bytes).expect("embedded descriptor set decodes");
+        // This crate's own descriptors, nothing user-controlled, and far
+        // below any budget — so the default limits stay.
+        let set = FileDescriptorSet::decode_from_slice(bytes)
+            .expect("this crate's embedded descriptor set decodes");
         let response_bytes = set
             .file
             .iter()
@@ -817,6 +856,48 @@ mod tests {
             .add_descriptor_set_bytes(&FileDescriptorSet::default().encode_to_vec())
             .unwrap_err();
         assert!(matches!(err, ReflectionError::SharedPool));
+    }
+
+    /// The runtime path deliberately stays bounded, so an oversized set must
+    /// reach the caller as `ElementBudget` — the variant that says the bytes
+    /// are fine — and not as a decode failure that reads like corruption.
+    #[test]
+    fn an_oversized_set_reports_the_element_budget_not_a_decode_failure() {
+        // Charged per element on struct size, so many small files exceed the
+        // budget while staying small on the wire. The count is derived rather
+        // than written as a literal: the charge tracks
+        // `size_of::<FileDescriptorProto>()`, so a literal silently stops
+        // exceeding the budget whenever that struct shrinks, and the test
+        // would then assert a rejection that no longer happens. Same
+        // derivation as `connectrpc::test_budget` and connectrpc-build's
+        // `over_default_budget_set`, repeated because a `#[cfg(test)]` helper
+        // cannot cross a crate boundary; that module carries the full
+        // rationale.
+        let per_element = std::mem::size_of::<FileDescriptorProto>();
+        let n = (buffa::DEFAULT_ELEMENT_MEMORY_LIMIT / per_element) * 5 / 4;
+        let set = FileDescriptorSet {
+            file: (0..n)
+                .map(|i| FileDescriptorProto {
+                    name: Some(format!("f{i}.proto")),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let bytes = buffa::Message::encode_to_vec(&set);
+
+        let err = Reflector::from_descriptor_set_bytes(&bytes).unwrap_err();
+        assert!(
+            matches!(err, ReflectionError::ElementBudget),
+            "expected ElementBudget, got {err:?}"
+        );
+        // The message has to say the schema is large, not that the bytes are
+        // bad — that distinction is the whole reason the variant exists.
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("well-formed"),
+            "message should absolve the bytes, got {rendered:?}"
+        );
     }
 
     #[test]

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = { workspace = true }
 # silently drop it. Keep the version in sync with the
 # `[workspace.dependencies]` `buffa` entry, which documents why the floor is
 # where it is.
-buffa = { version = "0.9", default-features = false, features = ["std", "fast-utf8"] }
+buffa = { version = "0.9.1", default-features = false, features = ["std", "fast-utf8"] }
 
 # Serialization. Non-optional even in proto-only builds: the Connect error and
 # streaming end-of-stream wire frames are always JSON regardless of the message

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -1224,6 +1224,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_budget::elements_over_default_budget;
     use buffa_types::google::protobuf::__buffa::view::StringValueView;
     use buffa_types::google::protobuf::StringValue;
 
@@ -1463,15 +1464,18 @@ mod tests {
     }
 
     /// Owned-message handlers decode through `Payload`/`decode_request`
-    /// rather than the view helpers, and that path silently used buffa's
-    /// defaults until the limits were threaded onto `Payload` too. Both
+    /// rather than the view helpers, so they read their budget from the
+    /// `DecodeOptions` carried on `Payload`. That is easy to leave
+    /// unattached, which silently falls back to buffa's defaults, so both
     /// owned entry points are pinned here.
     #[test]
     fn owned_message_decoding_honours_the_configured_limit() {
         use buffa_types::google::protobuf::{ListValue, Value};
 
+        // Decoded as owned `Value`s, so the owned footprint sets the count.
+        let n = elements_over_default_budget::<Value>();
         let list = ListValue {
-            values: (0..800_000).map(|_| Value::default()).collect(),
+            values: (0..n).map(|_| Value::default()).collect(),
             ..Default::default()
         };
         let encoded = Bytes::from(buffa::Message::encode_to_vec(&list));
@@ -1490,7 +1494,7 @@ mod tests {
         let decoded: ListValue =
             decode_request(&encoded, CodecFormat::Proto, &raised.decode_options())
                 .expect("raised budget must admit");
-        assert_eq!(decoded.values.len(), 800_000);
+        assert_eq!(decoded.values.len(), n);
 
         // `Payload::take_message`, used by the owned-message unary wrapper.
         let payload = crate::Payload::new(encoded.clone(), CodecFormat::Proto);
@@ -1503,18 +1507,22 @@ mod tests {
         let decoded: ListValue = payload
             .take_message()
             .expect("a payload carrying raised limits must admit");
-        assert_eq!(decoded.values.len(), 800_000);
+        assert_eq!(decoded.values.len(), n);
     }
 
     /// The budget rejection names the limit to raise, since it is the one
     /// decode failure an operator can fix without the peer changing.
     #[test]
     fn an_over_budget_decode_says_which_limit_to_raise() {
-        use buffa_types::google::protobuf::__buffa::view::ListValueView;
+        use buffa_types::google::protobuf::__buffa::view::{ListValueView, ValueView};
         use buffa_types::google::protobuf::{ListValue, Value};
 
+        // Decoded as borrowed `ValueView`s, so the view footprint — the
+        // smaller of the two — sets the count.
         let list = ListValue {
-            values: (0..800_000).map(|_| Value::default()).collect(),
+            values: (0..elements_over_default_budget::<ValueView<'_>>())
+                .map(|_| Value::default())
+                .collect(),
             ..Default::default()
         };
         let encoded = Bytes::from(buffa::Message::encode_to_vec(&list));
@@ -1550,12 +1558,12 @@ mod tests {
     /// nothing would still pass.
     #[test]
     fn element_memory_limit_is_taken_from_the_configured_limits() {
-        use buffa_types::google::protobuf::__buffa::view::ListValueView;
+        use buffa_types::google::protobuf::__buffa::view::{ListValueView, ValueView};
         use buffa_types::google::protobuf::{ListValue, Value};
 
         // Element footprint is what the budget charges, not element
         // contents, so this stays small on the wire.
-        let n = 800_000;
+        let n = elements_over_default_budget::<ValueView<'_>>();
         let list = ListValue {
             values: (0..n).map(|_| Value::default()).collect(),
             ..Default::default()
@@ -1565,7 +1573,7 @@ mod tests {
         let defaults = crate::Limits::default();
         let err =
             decode_borrowed_request_view::<ListValueView<'_>>(&encoded, &defaults.decode_options())
-                .expect_err("800k elements must exceed the 32 MiB default");
+                .expect_err("the fixture must exceed the default element-memory budget");
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
 
         let raised = crate::Limits::default().element_memory_limit(usize::MAX);

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -212,6 +212,9 @@ pub mod service;
 pub mod spec;
 pub mod stream_message;
 
+#[cfg(test)]
+pub(crate) mod test_budget;
+
 // Optional: HTTP client
 pub mod client;
 

--- a/connectrpc/src/stream_message.rs
+++ b/connectrpc/src/stream_message.rs
@@ -214,13 +214,21 @@ mod tests {
 
     #[test]
     fn from_message_accepts_more_elements_than_the_wire_budget_allows() {
+        use buffa_types::google::protobuf::__buffa::view::ValueView;
         use buffa_types::google::protobuf::{ListValue, Value};
 
         // Enough elements to exceed buffa's 32 MiB element-memory default.
         // Element footprint is what that budget charges, not element
         // contents, so this stays small on the wire — a single large payload
         // would not trip it however big it got.
-        let n = 800_000;
+        //
+        // Two decodes must both be over budget here: the control below, which
+        // materialises owned `Value` (48 bytes), and `from_message` itself,
+        // which materialises `ValueView` (32 bytes). Sizing by the *smaller*
+        // is what clears both. Sizing by `Value` puts the view decode at 0.83x
+        // the budget, and the test then passes with `from_message`'s
+        // element-memory lift deleted outright — proving nothing.
+        let n = crate::test_budget::elements_over_default_budget::<ValueView<'_>>();
         let list = ListValue {
             values: (0..n).map(|_| Value::default()).collect(),
             ..Default::default()

--- a/connectrpc/src/test_budget.rs
+++ b/connectrpc/src/test_budget.rs
@@ -1,0 +1,28 @@
+//! Sizing helper for tests that need to overrun buffa's element-memory budget.
+
+/// Repeated-element count that overruns buffa's default element-memory
+/// budget when decoded as `T`.
+///
+/// The budget charges `size_of::<T>()` per element, so a fixture written as a
+/// literal count silently stops overrunning it the moment `T` shrinks. buffa
+/// 0.9.1 did exactly that — moving view unknown-field state behind a pointer
+/// took `ValueView` from 48 bytes to 32, and a hardcoded 800_000 fell from
+/// 1.14x the budget to 0.76x, so tests asserting a rejection began decoding
+/// successfully. Deriving the count from the live size cannot go stale that
+/// way.
+///
+/// The charge is a deterministic `n * size_of::<T>()`, so strictly the count
+/// only has to clear the division remainder. The quarter of headroom is margin
+/// against buffa retuning the default or the per-element charge; the exact
+/// multiple does not matter, only that it is safely over.
+///
+/// Pass the **smallest** type any decode in the test materialises. Where a
+/// test has both a control and a subject they often differ — an owned `Value`
+/// is 48 bytes against `ValueView`'s 32 — and only the smaller clears the
+/// budget for both. Sizing by the larger leaves the view decode at 0.83x, and
+/// a test written that way passes with the behaviour it checks deleted
+/// outright.
+pub(crate) fn elements_over_default_budget<T>() -> usize {
+    let per_element = std::mem::size_of::<T>().max(1);
+    (buffa::DEFAULT_ELEMENT_MEMORY_LIMIT / per_element) * 5 / 4
+}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -333,6 +333,70 @@ pub mod proto;
 The underlying difference (`OUT_DIR` vs a known source path) is honest
 and visible, but the call-site shape is parallel.
 
+### Very large schemas
+
+Generation reads a descriptor set, and buffa bounds how much memory a
+decode may commit to repeated elements. That bound is an amplification
+defence sized for untrusted wire input, and it is charged on each
+element's struct size rather than on its encoded bytes — so descriptor
+sets, whose structs are wide, reach it while still looking small on the
+wire. The tooling paths — this plugin and `connectrpc-build` — therefore
+decode under buffa's much higher tooling bound of 1 GiB. It stays finite,
+so a truncated or corrupt set still fails with an error instead of
+exhausting memory.
+
+If you do exceed it, generation stops with a message naming the budget in
+force and both ways to raise it. Both accept a byte count or `unlimited`,
+and they differ in reach.
+
+**The environment variable covers the whole run**, which is normally what
+you want:
+
+```sh
+BUFFA_ELEMENT_MEMORY_LIMIT=4294967296 buf generate
+BUFFA_ELEMENT_MEMORY_LIMIT=4294967296 cargo build
+```
+
+`buf generate` hands the identical request to every plugin in the run, so
+a schema big enough to need raising needs it for `protoc-gen-buffa` and
+`protoc-gen-connect-rust` alike. The variable is buffa's rather than a
+connect-specific twin precisely so that one setting serves both. It is
+also the only override that reaches `connectrpc-build`, since a build
+script has no plugin parameter string.
+
+**The plugin option is per-plugin.** `buf` gives each plugin its own `opt`
+list, so this raises the bound for `protoc-gen-connect-rust` and nothing
+else — every other plugin in the run needs its own entry:
+
+```yaml
+plugins:
+  - local: protoc-gen-buffa
+    out: src/generated
+    opt:
+      - element_memory_limit=4294967296
+  - local: protoc-gen-connect-rust
+    out: src/generated
+    opt:
+      - element_memory_limit=4294967296
+```
+
+Prefer a byte count to `unlimited`. `unlimited` removes the ceiling
+entirely, so a truncated or corrupt descriptor set stops failing with an
+error and starts exhausting memory instead — on CI that reads as a flaky
+runner rather than a bad input. A generous number keeps the diagnostic.
+
+This bound governs *generation* only, and nothing here reaches a running
+server. A descriptor set handed to a `Reflector` decodes on buffa's
+untrusted-input default with no override: reflection descriptors can come
+from a peer rather than your own build, so the defence stays on. A set
+over that budget reports `ReflectionError::ElementBudget`, and the remedy
+is a smaller set — strip `source_code_info`, or narrow it to the files
+that server reflects.
+
+Request decoding is a different budget again, configured per service
+through `Limits::element_memory_limit`. None of the three read each
+other, so raising the build-time bound has no effect on either.
+
 ## Implementing servers
 
 A service is a Rust trait generated from your `.proto` file. The

--- a/examples/multiservice/src/generated/buffa/anthropic.connectrpc.greet.v1.mod.rs
+++ b/examples/multiservice/src/generated/buffa/anthropic.connectrpc.greet.v1.mod.rs
@@ -351,6 +351,14 @@ pub mod __buffa {
         /// `Reflectable` impls. Built from
         /// [`FILE_DESCRIPTOR_SET_BYTES`] on first access.
         ///
+        /// The element-memory bound is derived from the embedded length
+        /// rather than the untrusted-input default, which is sized for
+        /// wire input and which a schema of a few hundred `.proto` files
+        /// exceeds — descriptor types being wide structs. Scaling with the
+        /// input keeps the bound correct at any schema size while staying
+        /// finite, so corrupt embedded bytes still fail rather than
+        /// exhausting memory.
+        ///
         /// # Panics
         ///
         /// Panics on first access if the embedded bytes are malformed —
@@ -364,9 +372,16 @@ pub mod __buffa {
                 ::buffa::alloc::sync::Arc<::buffa_descriptor::DescriptorPool>,
             > = ::std::sync::OnceLock::new();
             POOL.get_or_init(|| {
+                let options = ::buffa::DecodeOptions::new()
+                    .with_element_memory_limit(
+                        FILE_DESCRIPTOR_SET_BYTES.len().saturating_mul(64),
+                    );
                 ::buffa::alloc::sync::Arc::new(
-                    ::buffa_descriptor::DescriptorPool::decode(FILE_DESCRIPTOR_SET_BYTES)
-                        .expect("embedded FileDescriptorSet is well-formed"),
+                    ::buffa_descriptor::DescriptorPool::decode_with_options(
+                            FILE_DESCRIPTOR_SET_BYTES,
+                            &options,
+                        )
+                        .expect("buffa-codegen emitted a decodable FileDescriptorSet"),
                 )
             })
         }

--- a/examples/multiservice/src/generated/buffa/anthropic.connectrpc.math.v1.mod.rs
+++ b/examples/multiservice/src/generated/buffa/anthropic.connectrpc.math.v1.mod.rs
@@ -351,6 +351,14 @@ pub mod __buffa {
         /// `Reflectable` impls. Built from
         /// [`FILE_DESCRIPTOR_SET_BYTES`] on first access.
         ///
+        /// The element-memory bound is derived from the embedded length
+        /// rather than the untrusted-input default, which is sized for
+        /// wire input and which a schema of a few hundred `.proto` files
+        /// exceeds — descriptor types being wide structs. Scaling with the
+        /// input keeps the bound correct at any schema size while staying
+        /// finite, so corrupt embedded bytes still fail rather than
+        /// exhausting memory.
+        ///
         /// # Panics
         ///
         /// Panics on first access if the embedded bytes are malformed —
@@ -364,9 +372,16 @@ pub mod __buffa {
                 ::buffa::alloc::sync::Arc<::buffa_descriptor::DescriptorPool>,
             > = ::std::sync::OnceLock::new();
             POOL.get_or_init(|| {
+                let options = ::buffa::DecodeOptions::new()
+                    .with_element_memory_limit(
+                        FILE_DESCRIPTOR_SET_BYTES.len().saturating_mul(64),
+                    );
                 ::buffa::alloc::sync::Arc::new(
-                    ::buffa_descriptor::DescriptorPool::decode(FILE_DESCRIPTOR_SET_BYTES)
-                        .expect("embedded FileDescriptorSet is well-formed"),
+                    ::buffa_descriptor::DescriptorPool::decode_with_options(
+                            FILE_DESCRIPTOR_SET_BYTES,
+                            &options,
+                        )
+                        .expect("buffa-codegen emitted a decodable FileDescriptorSet"),
                 )
             })
         }

--- a/examples/multiservice/src/generated/buffa/anthropic.connectrpc.wkt.v1.mod.rs
+++ b/examples/multiservice/src/generated/buffa/anthropic.connectrpc.wkt.v1.mod.rs
@@ -356,6 +356,14 @@ pub mod __buffa {
         /// `Reflectable` impls. Built from
         /// [`FILE_DESCRIPTOR_SET_BYTES`] on first access.
         ///
+        /// The element-memory bound is derived from the embedded length
+        /// rather than the untrusted-input default, which is sized for
+        /// wire input and which a schema of a few hundred `.proto` files
+        /// exceeds — descriptor types being wide structs. Scaling with the
+        /// input keeps the bound correct at any schema size while staying
+        /// finite, so corrupt embedded bytes still fail rather than
+        /// exhausting memory.
+        ///
         /// # Panics
         ///
         /// Panics on first access if the embedded bytes are malformed —
@@ -369,9 +377,16 @@ pub mod __buffa {
                 ::buffa::alloc::sync::Arc<::buffa_descriptor::DescriptorPool>,
             > = ::std::sync::OnceLock::new();
             POOL.get_or_init(|| {
+                let options = ::buffa::DecodeOptions::new()
+                    .with_element_memory_limit(
+                        FILE_DESCRIPTOR_SET_BYTES.len().saturating_mul(64),
+                    );
                 ::buffa::alloc::sync::Arc::new(
-                    ::buffa_descriptor::DescriptorPool::decode(FILE_DESCRIPTOR_SET_BYTES)
-                        .expect("embedded FileDescriptorSet is well-formed"),
+                    ::buffa_descriptor::DescriptorPool::decode_with_options(
+                            FILE_DESCRIPTOR_SET_BYTES,
+                            &options,
+                        )
+                        .expect("buffa-codegen emitted a decodable FileDescriptorSet"),
                 )
             })
         }


### PR DESCRIPTION
The connect-rust half of anthropics/buffa#331, now that buffa 0.9.1 has shipped.

## What changed since the first version of this PR

buffa 0.9.1 did not just raise its own bound — it **exported the whole mechanism**. So this no longer keeps a connect-side implementation at all. The `descriptor_limits` module and its 16 GiB constant are gone, replaced by delegation to `buffa_codegen::{decode_request, tooling_decode_options, decode_failure}`.

That matters beyond tidiness: `buf generate` hands the identical `CodeGeneratorRequest` to every plugin in a run, so a schema large enough to need raising needs it for `protoc-gen-buffa` and `protoc-gen-connect-rust` alike. One mechanism means one setting, rather than a connect-specific twin the user has to discover and set separately.

## The problem

buffa 0.9 charges its element-memory budget per element on **struct size**, not on encoded bytes. Descriptor structs are wide, so the 32 MiB default rejected descriptor sets from ordinary schemas of a few hundred `.proto` files.

Measured here, one 400-file schema producing a 19,749,990-byte descriptor set through `connectrpc_build::Config`:

| element-memory budget | result |
|---|---|
| 32 MiB (buffa 0.9.0's default) | `failed to decode FileDescriptorSet: element memory limit exceeded` |
| 1 GiB (buffa 0.9.1's tooling budget) | `OK — 1600 files generated` |

## What this does

`protoc-gen-connect-rust` decodes through `buffa_codegen::decode_request`; `connectrpc-build`, which has no plugin parameter string, through `tooling_decode_options`. Both get the 1 GiB tooling bound, and both overrides:

- `element_memory_limit=<bytes|unlimited>` as a plugin option, read by scanning the wire for the parameter *before* the decode it governs, and
- `BUFFA_ELEMENT_MEMORY_LIMIT`, which covers every plugin in the run and is the only route into a build script.

The bound stays finite rather than lifting entirely, so a truncated or corrupt set still fails with an error instead of exhausting memory. The guide recommends a byte count over `unlimited` for that reason.

## Two traps this exposed, both of which would have shipped

**Our own option parser would have rejected the option.** Plugin options are parsed *after* the decode that consumed this one, so `element_memory_limit=` reached the `unknown plugin option` arm and failed the build — for precisely the one user who ever sets it, whose schema was too large to decode without it. Proven by disabling the new arm and watching `unknown plugin option: "element_memory_limit=unlimited"` come back.

**Test fixtures sized by element count had silently stopped testing.** buffa 0.9.1 took `ValueView` from 48 bytes to 32, so a hardcoded `800_000` fell from 1.14x the budget to 0.76x. Two tests merged in #235 flipped from proving a rejection to decoding successfully. Such fixtures now derive their count from the live `size_of`, sized by the **smallest** type any decode in the test materialises — sizing by the larger leaves a view decode under budget, which I did at first, and the `stream_message` test then passed with the behaviour it checks deleted outright.

## Also in here

- `connectrpc-build` declares `rerun-if-env-changed` for the variable it now reads. Without it, cargo does not re-run the build script when the variable changes, and the setting looks inert.
- The over-budget failure from a build script corrects buffa's hint, which offers a plugin option unreachable there, and points at this repo's guide rather than buffa's.
- `ReflectionError::ElementBudget` reports an over-budget set at runtime as a large schema rather than as corruption. The `From<DecodeError>` conversion is written out instead of derived, so a future `?` on a new decode path cannot silently route around the split. Runtime reflection stays on the untrusted default deliberately — a reflection service may be fed descriptors by a peer.
- The generated `descriptor_pool()` picks up buffa's self-scaling bound, which is why the multiservice example regenerates. That closes the last carry-forward item from #331 with no code of ours.

## Testing

Both overrides exercised in **both directions**. Raising proves little on its own — the path could be ignoring the setting and succeeding anyway. *Lowering* via the plugin option brings the failure back, which is the only thing that proves the option is read pre-decode.

Four suites: server conformance 3600/0, client Connect 2580/0, client gRPC-Web 2838/0. The client gRPC `Timeouts` cases fail 3–4 here, and reproduce identically on `main` (1, 3 and 5 failures across three runs) — that is #210, fixed by #238, not this change.

Reflection driven over a real socket against both descriptor sources. 56 test suites, clippy on the pinned 1.95 toolchain, `cargo test -p connectrpc --no-default-features` (420), fmt on the pinned nightly, rustdoc, and `task generate:all` idempotent.

## Note for the merge

`buffa = "0.9.1"` is a hard floor — `decode_request` and `tooling_decode_options` do not exist in 0.9.0. This homespace's registry mirror was still serving a stale index while I worked, so local verification ran against a path override; CI resolves against real crates.io, where buffa 0.9.1 published cleanly, so its dependency job is the real check on that floor.
