### PR TITLE
error: preserve the source chain of client transport failures

### DIFF
--- a/.changes/unreleased/Added-20260723-023643.yaml
+++ b/.changes/unreleased/Added-20260723-023643.yaml
@@ -1,0 +1,16 @@
+kind: Added
+body: |-
+  **`ConnectError` now preserves the underlying cause of transport
+  failures.** A new `ConnectError::with_source` builder attaches an
+  underlying error, surfaced through `Error::source()`; `ConnectError` stays
+  `Clone` since the source is held in an `Arc`. Every place a transport
+  error was previously stringified into `message` and discarded now
+  retains it: the HTTP and HTTPS `HttpClient` transports, `Http2Connection`
+  (unix-socket connect, eager/lazy connect, TLS handshake, h2 send), and
+  `From<std::io::Error>` / `From<http::Error>` for `ConnectError`. The wire
+  format and `Display` output are unchanged; the derived `Debug` output now
+  additionally includes the source when one is attached. This is purely
+  additive ([#237]).
+
+  [#237]: https://github.com/connectrpc/connect-rust/issues/237
+time: 2026-07-23T02:36:43.000000000Z

--- a/.changes/unreleased/Added-20260723-023643.yaml
+++ b/.changes/unreleased/Added-20260723-023643.yaml
@@ -2,15 +2,21 @@ kind: Added
 body: |-
   **`ConnectError` now preserves the underlying cause of transport
   failures.** A new `ConnectError::with_source` builder attaches an
-  underlying error, surfaced through `Error::source()`; `ConnectError` stays
-  `Clone` since the source is held in an `Arc`. Every place a transport
-  error was previously stringified into `message` and discarded now
-  retains it: the HTTP and HTTPS `HttpClient` transports, `Http2Connection`
-  (unix-socket connect, eager/lazy connect, TLS handshake, h2 send), and
-  `From<std::io::Error>` / `From<http::Error>` for `ConnectError`. The wire
-  format and `Display` output are unchanged; the derived `Debug` output now
-  additionally includes the source when one is attached. This is purely
-  additive ([#237]).
+  underlying error, surfaced through `Error::source()` and, as a
+  `SharedSource` handle that can be moved into another error type, through
+  `ConnectError::source_arc()` (with `with_shared_source` to re-attach one);
+  `ConnectError` stays `Clone` since the source is held in an `Arc`. The
+  built-in client transports now retain the cause wherever a failure they
+  classify was previously stringified into `message` and discarded: the HTTP
+  and HTTPS `HttpClient` transports, `Http2Connection` (unix-socket connect,
+  eager/lazy connect and its establishment timeout, TLS handshake, h2 send),
+  and `From<std::io::Error>` / `From<http::Error>` for `ConnectError`.
+  `ConnectError::unavailable_from_transport` exposes the same convention to
+  custom `ClientTransport` implementations. Errors the call path synthesises
+  itself (the call deadline, request build/encode, response decode, a
+  body-read reset) do not carry one. The wire format and `Display` output are
+  unchanged; the derived `Debug` output now additionally includes the source
+  when one is attached. This is purely additive ([#237]).
 
   [#237]: https://github.com/connectrpc/connect-rust/issues/237
 time: 2026-07-23T02:36:43.000000000Z

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -41,7 +41,7 @@ use http::Request;
 use http::Response;
 use http::Uri;
 
-use super::{BoxFuture, ClientBody, ClientTransport, unavailable_from_transport_error};
+use super::{BoxFuture, ClientBody, ClientTransport};
 use crate::error::ConnectError;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -106,7 +106,7 @@ fn unix_connector(
         let path = path.clone();
         async move {
             let stream = tokio::net::UnixStream::connect(&path).await.map_err(|e| {
-                unavailable_from_transport_error(
+                ConnectError::unavailable_from_transport(
                     format_args!("unix socket connect to {} failed", path.display()),
                     e,
                 )
@@ -948,7 +948,7 @@ impl Http2ConnectionBuilder {
 async fn drive_connect(conn: &mut Http2Connection, ctx: &str) -> Result<(), ConnectError> {
     std::future::poll_fn(|cx| conn.inner.poll_ready(cx))
         .await
-        .map_err(|e| unavailable_from_transport_error(ctx, e))
+        .map_err(|e| ConnectError::unavailable_from_transport(ctx, e))
 }
 
 impl tower::Service<Request<ClientBody>> for Http2Connection {
@@ -1041,7 +1041,7 @@ impl ClientTransport for SharedHttp2Connection {
         Box::pin(async move {
             svc.oneshot(request)
                 .await
-                .map_err(|e| unavailable_from_transport_error("h2 send failed", e))
+                .map_err(|e| ConnectError::unavailable_from_transport("h2 send failed", e))
         })
     }
 }
@@ -1188,7 +1188,10 @@ impl tower::Service<Uri> for MakeSendRequest {
                     let tcp = io.into_inner();
                     let connector = tokio_rustls::TlsConnector::from(tls);
                     let tls_stream = connector.connect(server_name, tcp).await.map_err(|e| {
-                        BoxError::from(unavailable_from_transport_error("TLS handshake failed", e))
+                        BoxError::from(ConnectError::unavailable_from_transport(
+                            "TLS handshake failed",
+                            e,
+                        ))
                     })?;
 
                     // Verify ALPN negotiated h2. A server that doesn't speak h2
@@ -1244,10 +1247,10 @@ where
     match timeout {
         Some(dur) => match tokio::time::timeout(dur, fut).await {
             Ok(res) => res.map_err(Into::into),
-            Err(elapsed) => Err(unavailable_from_transport_error(
-                format_args!("connection establishment did not complete within {dur:?}"),
-                elapsed,
-            )
+            Err(elapsed) => Err(ConnectError::unavailable(format!(
+                "connection establishment did not complete within {dur:?}"
+            ))
+            .with_source(elapsed)
             .into()),
         },
         None => fut.await.map_err(Into::into),

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -1188,10 +1188,7 @@ impl tower::Service<Uri> for MakeSendRequest {
                     let tcp = io.into_inner();
                     let connector = tokio_rustls::TlsConnector::from(tls);
                     let tls_stream = connector.connect(server_name, tcp).await.map_err(|e| {
-                        BoxError::from(unavailable_from_transport_error(
-                            "TLS handshake failed",
-                            e,
-                        ))
+                        BoxError::from(unavailable_from_transport_error("TLS handshake failed", e))
                     })?;
 
                     // Verify ALPN negotiated h2. A server that doesn't speak h2

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -41,7 +41,7 @@ use http::Request;
 use http::Response;
 use http::Uri;
 
-use super::{BoxFuture, ClientBody, ClientTransport};
+use super::{BoxFuture, ClientBody, ClientTransport, unavailable_from_transport_error};
 use crate::error::ConnectError;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -106,10 +106,10 @@ fn unix_connector(
         let path = path.clone();
         async move {
             let stream = tokio::net::UnixStream::connect(&path).await.map_err(|e| {
-                ConnectError::unavailable(format!(
-                    "unix socket connect to {} failed: {e}",
-                    path.display()
-                ))
+                unavailable_from_transport_error(
+                    format_args!("unix socket connect to {} failed", path.display()),
+                    e,
+                )
             })?;
             Ok(hyper_util::rt::TokioIo::new(stream))
         }
@@ -948,7 +948,7 @@ impl Http2ConnectionBuilder {
 async fn drive_connect(conn: &mut Http2Connection, ctx: &str) -> Result<(), ConnectError> {
     std::future::poll_fn(|cx| conn.inner.poll_ready(cx))
         .await
-        .map_err(|e| ConnectError::unavailable(format!("{ctx}: {e}")))
+        .map_err(|e| unavailable_from_transport_error(ctx, e))
 }
 
 impl tower::Service<Request<ClientBody>> for Http2Connection {
@@ -1041,7 +1041,7 @@ impl ClientTransport for SharedHttp2Connection {
         Box::pin(async move {
             svc.oneshot(request)
                 .await
-                .map_err(|e| ConnectError::unavailable(format!("h2 send failed: {e}")))
+                .map_err(|e| unavailable_from_transport_error("h2 send failed", e))
         })
     }
 }
@@ -1188,9 +1188,10 @@ impl tower::Service<Uri> for MakeSendRequest {
                     let tcp = io.into_inner();
                     let connector = tokio_rustls::TlsConnector::from(tls);
                     let tls_stream = connector.connect(server_name, tcp).await.map_err(|e| {
-                        BoxError::from(ConnectError::unavailable(format!(
-                            "TLS handshake failed: {e}"
-                        )))
+                        BoxError::from(unavailable_from_transport_error(
+                            "TLS handshake failed",
+                            e,
+                        ))
                     })?;
 
                     // Verify ALPN negotiated h2. A server that doesn't speak h2
@@ -1246,9 +1247,10 @@ where
     match timeout {
         Some(dur) => match tokio::time::timeout(dur, fut).await {
             Ok(res) => res.map_err(Into::into),
-            Err(_) => Err(ConnectError::unavailable(format!(
-                "connection establishment did not complete within {dur:?}"
-            ))
+            Err(elapsed) => Err(unavailable_from_transport_error(
+                format_args!("connection establishment did not complete within {dur:?}"),
+                elapsed,
+            )
             .into()),
         },
         None => fut.await.map_err(Into::into),
@@ -1408,8 +1410,13 @@ mod tests {
     #[tokio::test]
     async fn connect_plaintext_to_nonexistent_fails() {
         // Port 1 should not have a listener.
-        let err = Http2Connection::connect_plaintext("http://127.0.0.1:1".parse().unwrap()).await;
-        assert!(err.is_err(), "expected connect to port 1 to fail");
+        let err = Http2Connection::connect_plaintext("http://127.0.0.1:1".parse().unwrap())
+            .await
+            .expect_err("expected connect to port 1 to fail");
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "eager-connect failure must retain its cause as source(): {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -1506,6 +1513,74 @@ mod tests {
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
+    #[cfg(feature = "client-tls")]
+    #[tokio::test]
+    async fn connect_tls_handshake_failure_preserves_source() {
+        // A listener that accepts the TCP connection and immediately closes
+        // it, before any TLS bytes are exchanged — the client's handshake
+        // fails fast on the resulting EOF, without needing a timeout.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
+            }
+        });
+
+        let tls_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let uri: Uri = format!("https://{addr}").parse().unwrap();
+        let err = Http2Connection::connect_tls(uri, tls_config)
+            .await
+            .expect_err("handshake against a closed connection must fail");
+
+        assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
+        assert!(
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("TLS handshake failed"),
+            "expected a TLS-handshake-failure message, got: {err:?}"
+        );
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "TLS handshake failure must retain its cause as source(): {err:?}"
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn shared_send_after_deferred_connect_failure_preserves_source() {
+        // A lazy connection defers its first connect failure to call() (see
+        // Reconnect::poll_ready) — that deferred-error path is exactly what
+        // SharedHttp2Connection::send goes through for a shared connection
+        // that never manages to connect.
+        let conn = Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap());
+        let shared = conn.shared(1);
+
+        let request = Request::builder()
+            .method(http::Method::POST)
+            .uri("http://127.0.0.1:1/")
+            .body(crate::client::full_body(bytes::Bytes::new()))
+            .unwrap();
+
+        let err = ClientTransport::send(&shared, request)
+            .await
+            .expect_err("send over a connection that can never connect must fail");
+        assert!(
+            err.message.as_deref().unwrap().contains("h2 send failed"),
+            "unexpected message: {err:?}"
+        );
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "h2-send failure must retain its cause as source(): {err:?}"
+        );
+    }
+
     #[test]
     fn lazy_with_connector_starts_idle() {
         let conn = Http2Connection::lazy_with_connector(
@@ -1559,6 +1634,10 @@ mod tests {
         assert!(
             err.message.as_deref().unwrap().contains(path),
             "error should include socket path, got: {err:?}"
+        );
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "unix-connect failure must retain its cause as source(): {err:?}"
         );
     }
 
@@ -1733,6 +1812,10 @@ mod tests {
             "expected a handshake-timeout message, got: {err:?}"
         );
         assert!(
+            std::error::Error::source(&err).is_some(),
+            "establishment-timeout failure must retain its cause as source(): {err:?}"
+        );
+        assert!(
             elapsed < Duration::from_secs(2),
             "establishment_timeout(150ms) should fire within ~2s, took {elapsed:?}"
         );
@@ -1785,6 +1868,10 @@ mod tests {
             "expected a handshake-timeout message, got: {err:?}"
         );
         assert!(
+            std::error::Error::source(&err).is_some(),
+            "establishment-timeout failure must retain its cause as source(): {err:?}"
+        );
+        assert!(
             elapsed < Duration::from_secs(2),
             "establishment_timeout(150ms) should fire within ~2s, took {elapsed:?}"
         );
@@ -1818,6 +1905,10 @@ mod tests {
                 .unwrap()
                 .contains("establishment did not complete"),
             "expected a handshake-timeout message, got: {err:?}"
+        );
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "establishment-timeout failure must retain its cause as source(): {err:?}"
         );
         assert!(
             elapsed < Duration::from_secs(2),

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -5133,9 +5133,15 @@ mod tests {
             .body(full_body(Bytes::new()))
             .unwrap();
 
-        let err = http.send(req).await.expect_err("connect to port 1 must fail");
+        let err = http
+            .send(req)
+            .await
+            .expect_err("connect to port 1 must fail");
         assert!(
-            err.message.as_deref().unwrap().contains("HTTP request failed"),
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("HTTP request failed"),
             "unexpected message: {err:?}"
         );
         assert!(
@@ -5161,9 +5167,15 @@ mod tests {
             .body(full_body(Bytes::new()))
             .unwrap();
 
-        let err = http.send(req).await.expect_err("connect to port 1 must fail");
+        let err = http
+            .send(req)
+            .await
+            .expect_err("connect to port 1 must fail");
         assert!(
-            err.message.as_deref().unwrap().contains("HTTPS request failed"),
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("HTTPS request failed"),
             "unexpected message: {err:?}"
         );
         assert!(

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -214,6 +214,23 @@ fn find_connect_error_in_chain(
     }
 }
 
+/// Build an `unavailable` [`ConnectError`] for a transport failure: the
+/// message is `"{context}: {err}"` (unchanged from before `source()` was
+/// tracked) and `err` is retained as the returned error's `source()`, so
+/// its cause (DNS failure, connection reset, TLS failure, timeout, ...)
+/// isn't lost even though only the `Display` text reaches the wire.
+///
+/// `err` is boxed once up front and reused for both the message and the
+/// source, rather than boxing again inside `with_source`.
+fn unavailable_from_transport_error(
+    context: impl std::fmt::Display,
+    err: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+) -> ConnectError {
+    let err = err.into();
+    let message = format!("{context}: {err}");
+    ConnectError::unavailable(message).with_source(err)
+}
+
 /// Map a [`ClientTransport::send`] failure into the error surfaced to the
 /// caller.
 ///
@@ -223,13 +240,15 @@ fn find_connect_error_in_chain(
 /// Both built-in transports already produce classified `ConnectError`s
 /// directly, so for them `context` never appears in the surfaced error.
 /// Errors with no `ConnectError` in their chain are wrapped as `unavailable`
-/// with the `context` prefix.
+/// with the `context` prefix; the original error is retained as the
+/// returned `ConnectError`'s `source()` so its cause (DNS failure,
+/// connection reset, timeout, ...) isn't lost.
 fn map_transport_send_error<E>(err: E, context: &str) -> ConnectError
 where
     E: std::error::Error + Send + Sync + 'static,
 {
     find_connect_error_in_chain(&err)
-        .unwrap_or_else(|| ConnectError::unavailable(format!("{context}: {err}")))
+        .unwrap_or_else(|| unavailable_from_transport_error(context, err))
 }
 
 /// Extra slack added to client-side response buffer caps beyond the message
@@ -798,7 +817,7 @@ impl ClientTransport for HttpClient {
                     client
                         .request(request)
                         .await
-                        .map_err(|e| ConnectError::unavailable(format!("HTTP request failed: {e}")))
+                        .map_err(|e| unavailable_from_transport_error("HTTP request failed", e))
                 })
             }
             #[cfg(feature = "client-tls")]
@@ -815,9 +834,10 @@ impl ClientTransport for HttpClient {
                 }
                 let client = client.clone();
                 Box::pin(async move {
-                    client.request(request).await.map_err(|e| {
-                        ConnectError::unavailable(format!("HTTPS request failed: {e}"))
-                    })
+                    client
+                        .request(request)
+                        .await
+                        .map_err(|e| unavailable_from_transport_error("HTTPS request failed", e))
                 })
             }
         }
@@ -5102,6 +5122,56 @@ mod tests {
         server.abort();
     }
 
+    #[cfg(feature = "client")]
+    #[tokio::test]
+    async fn http_client_plaintext_send_failure_preserves_source() {
+        let http = HttpClient::plaintext();
+        // Port 1 should not have a listener — the OS refuses immediately.
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("http://127.0.0.1:1/")
+            .body(full_body(Bytes::new()))
+            .unwrap();
+
+        let err = http.send(req).await.expect_err("connect to port 1 must fail");
+        assert!(
+            err.message.as_deref().unwrap().contains("HTTP request failed"),
+            "unexpected message: {err:?}"
+        );
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "connection-refused failure must retain its cause as source(): {err:?}"
+        );
+    }
+
+    #[cfg(feature = "client-tls")]
+    #[tokio::test]
+    async fn http_client_tls_send_failure_preserves_source() {
+        let tls_config = std::sync::Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let http = HttpClient::with_tls(tls_config);
+        // Port 1 should not have a listener — the OS refuses before any TLS
+        // handshake starts.
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("https://127.0.0.1:1/")
+            .body(full_body(Bytes::new()))
+            .unwrap();
+
+        let err = http.send(req).await.expect_err("connect to port 1 must fail");
+        assert!(
+            err.message.as_deref().unwrap().contains("HTTPS request failed"),
+            "unexpected message: {err:?}"
+        );
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "connection-refused failure must retain its cause as source(): {err:?}"
+        );
+    }
+
     #[test]
     fn client_config_builders_round_trip_through_accessors() {
         // Each `with_*` builder must be readable back through the bare-name
@@ -6518,6 +6588,25 @@ mod tests {
         );
         assert_eq!(mapped.code, ErrorCode::InvalidArgument);
         assert_eq!(mapped.message.as_deref(), Some("bad client config"));
+    }
+
+    #[test]
+    fn transport_send_error_mapper_preserves_source_when_no_connect_error_in_chain() {
+        #[derive(Debug)]
+        struct PlainTransportError;
+
+        impl std::fmt::Display for PlainTransportError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "connection reset by peer")
+            }
+        }
+
+        impl std::error::Error for PlainTransportError {}
+
+        let mapped = map_transport_send_error(PlainTransportError, "request failed");
+        assert_eq!(mapped.code, ErrorCode::Unavailable);
+        let source = std::error::Error::source(&mapped).expect("source must be preserved");
+        assert_eq!(source.to_string(), "connection reset by peer");
     }
 
     #[cfg(feature = "client")]

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -199,10 +199,12 @@ pub fn full_body(b: Bytes) -> ClientBody {
 
 /// Walk an error's `source()` chain looking for a [`ConnectError`].
 ///
-/// Boxed trait objects cannot appear as links in the chain: `Box<dyn Error>`
-/// does not itself implement `Error` (the blanket impl requires a sized
-/// type), so every link is a concrete error type and a plain `downcast_ref`
-/// at each link is exhaustive.
+/// A plain `downcast_ref` at each link is exhaustive as long as no link is a
+/// sized smart-pointer wrapper: `Box<dyn Error>` does not itself implement
+/// `Error` (the blanket impl requires a sized type), so a boxed cause is
+/// stored and walked as the concrete type behind it. `ConnectError`'s own
+/// `Arc`'d source is surfaced by dereferencing (`&**arc`), so that link too
+/// carries the wrapped type's vtable rather than `Arc`'s.
 fn find_connect_error_in_chain(
     mut err: &(dyn std::error::Error + 'static),
 ) -> Option<ConnectError> {
@@ -212,23 +214,6 @@ fn find_connect_error_in_chain(
         }
         err = err.source()?;
     }
-}
-
-/// Build an `unavailable` [`ConnectError`] for a transport failure: the
-/// message is `"{context}: {err}"` (unchanged from before `source()` was
-/// tracked) and `err` is retained as the returned error's `source()`, so
-/// its cause (DNS failure, connection reset, TLS failure, timeout, ...)
-/// isn't lost even though only the `Display` text reaches the wire.
-///
-/// `err` is boxed once up front and reused for both the message and the
-/// source, rather than boxing again inside `with_source`.
-fn unavailable_from_transport_error(
-    context: impl std::fmt::Display,
-    err: impl Into<Box<dyn std::error::Error + Send + Sync>>,
-) -> ConnectError {
-    let err = err.into();
-    let message = format!("{context}: {err}");
-    ConnectError::unavailable(message).with_source(err)
 }
 
 /// Map a [`ClientTransport::send`] failure into the error surfaced to the
@@ -248,7 +233,7 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     find_connect_error_in_chain(&err)
-        .unwrap_or_else(|| unavailable_from_transport_error(context, err))
+        .unwrap_or_else(|| ConnectError::unavailable_from_transport(context, err))
 }
 
 /// Extra slack added to client-side response buffer caps beyond the message
@@ -299,7 +284,10 @@ pub trait ClientTransport: Clone + Send + Sync + 'static {
     /// discarding any outer wrappers' `Display` context. A transport can use
     /// this to control the surfaced error classification, for example
     /// returning `deadline_exceeded` from a timeout middleware. Errors with
-    /// no `ConnectError` in their chain are wrapped as `unavailable`.
+    /// no `ConnectError` in their chain are wrapped as `unavailable` with the
+    /// original retained as the [source](ConnectError::with_source); a
+    /// transport that builds its own `ConnectError` for such a failure can
+    /// use [`ConnectError::unavailable_from_transport`] to match.
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Send an HTTP request and receive a response.
@@ -814,10 +802,9 @@ impl ClientTransport for HttpClient {
                 }
                 let client = client.clone();
                 Box::pin(async move {
-                    client
-                        .request(request)
-                        .await
-                        .map_err(|e| unavailable_from_transport_error("HTTP request failed", e))
+                    client.request(request).await.map_err(|e| {
+                        ConnectError::unavailable_from_transport("HTTP request failed", e)
+                    })
                 })
             }
             #[cfg(feature = "client-tls")]
@@ -834,10 +821,9 @@ impl ClientTransport for HttpClient {
                 }
                 let client = client.clone();
                 Box::pin(async move {
-                    client
-                        .request(request)
-                        .await
-                        .map_err(|e| unavailable_from_transport_error("HTTPS request failed", e))
+                    client.request(request).await.map_err(|e| {
+                        ConnectError::unavailable_from_transport("HTTPS request failed", e)
+                    })
                 })
             }
         }

--- a/connectrpc/src/error.rs
+++ b/connectrpc/src/error.rs
@@ -270,12 +270,24 @@ pub struct ConnectError {
     /// The underlying cause, if this error was converted from another error
     /// (not serialized — never sent over the wire).
     ///
-    /// Surfaced through [`Error::source`](std::error::Error::source).
-    /// `Arc` (rather than `Box`) so `ConnectError` stays `Clone` without
-    /// requiring the wrapped error to be.
+    /// Surfaced through [`Error::source`](std::error::Error::source) and
+    /// [`ConnectError::source_arc`]. `Arc` (rather than `Box`) so
+    /// `ConnectError` stays `Clone` without requiring the wrapped error to be.
     #[serde(skip)]
-    source: Option<Arc<dyn std::error::Error + Send + Sync>>,
+    source: Option<SharedSource>,
 }
+
+/// The type of a [`ConnectError`]'s retained cause, as returned by
+/// [`ConnectError::source_arc`] and accepted by
+/// [`ConnectError::with_shared_source`]. Shared so `ConnectError` can stay
+/// `Clone`.
+///
+/// Downcast the handle itself to inspect the concrete error
+/// (`cause.downcast_ref::<std::io::Error>()`). If it is stored as another
+/// error type's `#[source]` field, that type's `source()` chain shows an
+/// opaque `Arc` link rather than the wrapped error, because std implements
+/// `Error` for `Arc<T>` but not for `Box<T>`.
+pub type SharedSource = Arc<dyn std::error::Error + Send + Sync>;
 
 /// Shared empty `HeaderMap` for the `None` arm of the read accessors, so
 /// callers can iterate / `.get()` unconditionally.
@@ -489,7 +501,14 @@ impl ConnectError {
     /// on an error a client parsed from a server response is always `None`.
     /// Accepts either a concrete error or an already-boxed one, so it
     /// composes with transport errors that are type-erased before reaching
-    /// this call. Replaces any source attached by a previous call.
+    /// this call. (The same conversion also accepts a bare `String` or
+    /// `&str`, which becomes a source with no type to downcast to — pass a
+    /// real error type.) Replaces any source attached by a previous call.
+    ///
+    /// This does not touch `message`. The crate's own transport errors put
+    /// the cause's `Display` text in `message` *and* attach it here, so plain
+    /// `{}` formatting stays informative; a renderer that also walks the
+    /// source chain will show that text twice.
     #[must_use]
     pub fn with_source(
         mut self,
@@ -497,6 +516,73 @@ impl ConnectError {
     ) -> Self {
         self.source = Some(Arc::from(source.into()));
         self
+    }
+
+    /// Attach a cause already held as a [`SharedSource`] — typically one taken
+    /// from another `ConnectError` with [`source_arc`](Self::source_arc) when
+    /// rebuilding an error under a different code. Passing such a handle to
+    /// [`with_source`](Self::with_source) instead would compile but wrap it in
+    /// a second `Arc` link that hides the concrete type from `downcast_ref`.
+    #[must_use]
+    pub fn with_shared_source(mut self, source: SharedSource) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    /// The underlying cause as a shared handle, for carrying it into another
+    /// error type. [`Error::source`](std::error::Error::source) returns the
+    /// same error by reference when it only needs inspecting.
+    ///
+    /// ```rust
+    /// use connectrpc::{ConnectError, SharedSource};
+    ///
+    /// #[derive(Debug, thiserror::Error)]
+    /// enum FetchError {
+    ///     #[error("profile service unreachable")]
+    ///     Unreachable(#[source] SharedSource),
+    ///     #[error(transparent)]
+    ///     Rpc(ConnectError),
+    /// }
+    ///
+    /// fn classify(err: ConnectError) -> FetchError {
+    ///     match err.source_arc() {
+    ///         Some(cause) => FetchError::Unreachable(cause),
+    ///         None => FetchError::Rpc(err),
+    ///     }
+    /// }
+    ///
+    /// let refused = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
+    /// let e = classify(ConnectError::unavailable("connect failed").with_source(refused));
+    /// let FetchError::Unreachable(cause) = &e else { panic!() };
+    /// // Downcast the handle itself; see `SharedSource` for why the outer
+    /// // error's `source()` chain shows an `Arc` link here instead.
+    /// let io = cause.downcast_ref::<std::io::Error>().unwrap();
+    /// assert_eq!(io.kind(), std::io::ErrorKind::ConnectionRefused);
+    /// ```
+    #[must_use]
+    pub fn source_arc(&self) -> Option<SharedSource> {
+        self.source.clone()
+    }
+
+    /// Build an `unavailable` error from a raw client transport failure,
+    /// keeping the failure both in `message` (as `"{context}: {err}"`) and as
+    /// the [source](Self::with_source).
+    ///
+    /// This is the convention the built-in transports follow for the
+    /// failures they classify themselves; a custom
+    /// [`ClientTransport`](crate::client::ClientTransport) can use it to
+    /// match them. Pass the underlying transport error, not a `ConnectError`:
+    /// the result is always `unavailable`, so wrapping an already-classified
+    /// error here would bury its code — return that error directly instead.
+    /// (Contrast the `From<std::io::Error>` impl, which is for handler-side
+    /// I/O and yields `internal`.)
+    #[must_use]
+    pub fn unavailable_from_transport(
+        context: impl std::fmt::Display,
+        err: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+    ) -> Self {
+        let err = err.into();
+        Self::unavailable(format!("{context}: {err}")).with_source(err)
     }
 
     /// Get the HTTP status code for this error.
@@ -610,6 +696,59 @@ mod tests {
         assert!(std::error::Error::source(&e).is_some());
     }
 
+    /// The whole safety argument for `source` is one `#[serde(skip)]`; pin
+    /// that a local-only cause never reaches the wire in either direction.
+    #[test]
+    fn source_is_neither_serialized_nor_deserialized() {
+        let e =
+            ConnectError::unavailable("boom").with_source(std::io::Error::other("secret cause"));
+        let json = String::from_utf8(e.to_json().to_vec()).unwrap();
+        assert!(
+            !json.contains("source") && !json.contains("secret cause"),
+            "{json}"
+        );
+        let with_key = json.replacen('{', r#"{"source":"injected","#, 1);
+        let round: ConnectError = serde_json::from_str(&with_key).unwrap();
+        assert!(std::error::Error::source(&round).is_none());
+    }
+
+    #[test]
+    fn source_arc_can_be_carried_and_downcast() {
+        let e = ConnectError::unavailable("wrapped").with_source(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "refused",
+        ));
+        let carried: SharedSource = e.source_arc().expect("source must be set");
+        drop(e);
+        let io = carried
+            .downcast_ref::<std::io::Error>()
+            .expect("concrete type survives the Arc");
+        assert_eq!(io.kind(), std::io::ErrorKind::ConnectionRefused);
+    }
+
+    #[test]
+    fn with_shared_source_keeps_the_link_transparent() {
+        let first = ConnectError::unavailable("a").with_source(std::io::Error::other("io"));
+        let second = ConnectError::internal("b")
+            .with_shared_source(first.source_arc().expect("first has a source"));
+        let link = std::error::Error::source(&second).expect("second has a source");
+        assert!(link.downcast_ref::<std::io::Error>().is_some());
+    }
+
+    #[test]
+    fn unavailable_from_transport_keeps_cause_in_message_and_source() {
+        let e = ConnectError::unavailable_from_transport(
+            "connect failed",
+            std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused"),
+        );
+        assert_eq!(e.code, ErrorCode::Unavailable);
+        assert_eq!(e.message.as_deref(), Some("connect failed: refused"));
+        let io = std::error::Error::source(&e)
+            .and_then(|s| s.downcast_ref::<std::io::Error>())
+            .expect("source is the io::Error");
+        assert_eq!(io.kind(), std::io::ErrorKind::ConnectionRefused);
+    }
+
     #[test]
     fn test_grpc_code_round_trip() {
         let codes = [
@@ -663,8 +802,10 @@ mod tests {
 
     #[test]
     fn connect_error_stays_under_result_large_err_threshold() {
-        // clippy::result_large_err fires at 128 bytes. Keep some headroom so
-        // adding a small field doesn't immediately re-trip the lint.
+        // clippy::result_large_err fires at 128 bytes. This test is set to
+        // trip well before that (88 of 96 with the `source` Arc), so growth
+        // prompts boxing a field here rather than a lint in a downstream
+        // crate.
         const THRESHOLD: usize = 96;
         let size = std::mem::size_of::<ConnectError>();
         assert!(

--- a/connectrpc/src/error.rs
+++ b/connectrpc/src/error.rs
@@ -3,6 +3,8 @@
 //! This module provides error types that conform to the ConnectRPC protocol
 //! specification, including proper error code mappings to HTTP status codes.
 
+use std::sync::Arc;
+
 use bytes::Bytes;
 use http::StatusCode;
 use serde::Deserialize;
@@ -265,6 +267,14 @@ pub struct ConnectError {
     /// extra trailers.
     #[serde(skip)]
     pub(crate) trailers: Option<Box<http::HeaderMap>>,
+    /// The underlying cause, if this error was converted from another error
+    /// (not serialized — never sent over the wire).
+    ///
+    /// Surfaced through [`Error::source`](std::error::Error::source).
+    /// `Arc` (rather than `Box`) so `ConnectError` stays `Clone` without
+    /// requiring the wrapped error to be.
+    #[serde(skip)]
+    source: Option<Arc<dyn std::error::Error + Send + Sync>>,
 }
 
 /// Shared empty `HeaderMap` for the `None` arm of the read accessors, so
@@ -290,6 +300,7 @@ impl ConnectError {
             http_status_override: None,
             response_headers: None,
             trailers: None,
+            source: None,
         }
     }
 
@@ -467,6 +478,27 @@ impl ConnectError {
         self
     }
 
+    /// Attach the underlying cause, surfaced through
+    /// [`Error::source`](std::error::Error::source).
+    ///
+    /// Unlike `message` (which is sent over the wire and shown to callers),
+    /// the source is local-only — useful for logging/observability without
+    /// leaking internal detail to the client. It is never populated by
+    /// decoding a `ConnectError` received over the wire (there is nothing to
+    /// attach), only by local code that calls this method — so `source()`
+    /// on an error a client parsed from a server response is always `None`.
+    /// Accepts either a concrete error or an already-boxed one, so it
+    /// composes with transport errors that are type-erased before reaching
+    /// this call. Replaces any source attached by a previous call.
+    #[must_use]
+    pub fn with_source(
+        mut self,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+    ) -> Self {
+        self.source = Some(Arc::from(source.into()));
+        self
+    }
+
     /// Get the HTTP status code for this error.
     ///
     /// Returns the HTTP status override if set, otherwise derives it from the error code.
@@ -494,11 +526,17 @@ impl std::fmt::Display for ConnectError {
     }
 }
 
-impl std::error::Error for ConnectError {}
+impl std::error::Error for ConnectError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|e| &**e as &(dyn std::error::Error + 'static))
+    }
+}
 
 impl From<std::io::Error> for ConnectError {
     fn from(err: std::io::Error) -> Self {
-        Self::internal(err.to_string())
+        Self::internal(err.to_string()).with_source(err)
     }
 }
 
@@ -506,7 +544,7 @@ impl From<std::io::Error> for ConnectError {
 /// handler.
 impl From<http::Error> for ConnectError {
     fn from(err: http::Error) -> Self {
-        Self::internal(err.to_string())
+        Self::internal(err.to_string()).with_source(err)
     }
 }
 
@@ -521,6 +559,55 @@ mod tests {
             .into();
         let e: ConnectError = http_err.into();
         assert_eq!(e.code, ErrorCode::Internal);
+    }
+
+    #[test]
+    fn from_io_error_preserves_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+        let e: ConnectError = io_err.into();
+        let source = std::error::Error::source(&e).expect("source must be preserved");
+        assert_eq!(source.to_string(), "refused");
+    }
+
+    #[test]
+    fn from_http_error_preserves_source() {
+        let http_err: http::Error = http::HeaderValue::from_bytes(b"bad\nval")
+            .unwrap_err()
+            .into();
+        let e: ConnectError = http_err.into();
+        assert!(std::error::Error::source(&e).is_some());
+    }
+
+    #[test]
+    fn with_source_is_returned_by_error_source() {
+        let cause = std::io::Error::other("boom");
+        let e = ConnectError::unavailable("wrapped").with_source(cause);
+        let source = std::error::Error::source(&e).expect("source must be set");
+        assert_eq!(source.to_string(), "boom");
+    }
+
+    #[test]
+    fn with_source_accepts_already_boxed_error() {
+        let boxed: Box<dyn std::error::Error + Send + Sync> =
+            Box::new(std::io::Error::other("boxed boom"));
+        let e = ConnectError::unavailable("wrapped").with_source(boxed);
+        let source = std::error::Error::source(&e).expect("source must be set");
+        assert_eq!(source.to_string(), "boxed boom");
+    }
+
+    #[test]
+    fn no_source_by_default() {
+        let e = ConnectError::internal("plain");
+        assert!(std::error::Error::source(&e).is_none());
+    }
+
+    #[test]
+    fn with_source_survives_clone() {
+        let cause = std::io::Error::other("boom");
+        let e = ConnectError::unavailable("wrapped")
+            .with_source(cause)
+            .clone();
+        assert!(std::error::Error::source(&e).is_some());
     }
 
     #[test]

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -297,6 +297,7 @@ pub mod __codegen {
 pub use error::ConnectError;
 pub use error::ErrorCode;
 pub use error::ErrorDetail;
+pub use error::SharedSource;
 
 /// Re-export of the `http-body` crate whose [`Body`](http_body::Body) trait
 /// appears in generated client bounds — so consumers don't need their own

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1725,6 +1725,19 @@ For more structured errors, attach `ErrorDetail` entries (which carry
 typed protobuf messages) before returning. These flow through to
 clients in the standard Connect error-detail wire format.
 
+To keep an underlying error's cause available for logging without
+sending it to the client, attach it with `.with_source(err)`; it's
+surfaced through `Error::source()` but never serialized. Transport
+failures on the client (DNS, connection refused/reset, TLS handshake,
+timeout) populate this automatically, so `err.source()` reveals the
+original transport error even though `err.to_string()` only shows the
+Connect-level message. `source()` is local-only: it's set only by code
+that calls `.with_source(..)` in this process, so a `ConnectError`
+decoded from a server's response — including one an interceptor
+constructs from RPC status metadata — always has `source() == None`,
+even when its `message` is populated. Only locally-originated errors
+(client transport failures, `From<std::io::Error>`) carry a source.
+
 ## Compression
 
 The runtime ships with gzip, zstd, and identity by default. Servers

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1697,6 +1697,8 @@ pub struct ConnectError {
     pub details: Vec<ErrorDetail>,
     // response headers and trailers: private, exposed via the
     // response_headers()/trailers() accessors and their _mut variants
+    // source: private, exposed via std::error::Error::source() and
+    // source_arc(); never serialized
 }
 ```
 
@@ -1726,17 +1728,34 @@ typed protobuf messages) before returning. These flow through to
 clients in the standard Connect error-detail wire format.
 
 To keep an underlying error's cause available for logging without
-sending it to the client, attach it with `.with_source(err)`; it's
-surfaced through `Error::source()` but never serialized. Transport
-failures on the client (DNS, connection refused/reset, TLS handshake,
-timeout) populate this automatically, so `err.source()` reveals the
-original transport error even though `err.to_string()` only shows the
-Connect-level message. `source()` is local-only: it's set only by code
-that calls `.with_source(..)` in this process, so a `ConnectError`
-decoded from a server's response — including one an interceptor
-constructs from RPC status metadata — always has `source() == None`,
-even when its `message` is populated. Only locally-originated errors
-(client transport failures, `From<std::io::Error>`) carry a source.
+sending it to the client, attach it with `.with_source(err)`. It is
+surfaced through `std::error::Error::source()` (bring the trait into
+scope, or call `std::error::Error::source(&err)`) and, as a
+`SharedSource` handle that can be moved into another error type,
+through `err.source_arc()`; it is never serialized. A `ConnectError`
+decoded from a server's response therefore always has
+`.source().is_none()`, even when its `message` is populated; only an
+error that code in this process attached a cause to carries one.
+
+On the client, a source is present when the *transport* classified the
+failure and absent when the call path did. The built-in transports
+attach the underlying `hyper` / `rustls` / `std::io` error for DNS
+resolution, connection refused, TLS handshake, HTTP/2 connection
+establishment (including its timeout) and request send, so
+`err.source()` yields the original typed error, which can be downcast
+to inspect an `io::ErrorKind`, for example. Only that error's `Display`
+text reaches `message`, and it is repeated there deliberately so that
+plain `{}` formatting stays informative; a renderer that also walks
+the source chain, such as `anyhow`'s `{:#}`, will print it twice.
+Errors the call path synthesises itself do not carry a source: the
+call deadline (`with_timeout` / `with_default_timeout`) whenever it
+fires, request construction and encoding failures, response decoding,
+and a reset while reading the response body (whose error type the
+public call functions bound only by `Display`). A custom
+`ClientTransport` that returns its own `ConnectError` should call
+`.with_source(..)` itself, or build the error with
+`ConnectError::unavailable_from_transport`, to follow the same
+convention.
 
 ## Compression
 


### PR DESCRIPTION
## Summary

`ConnectError`'s `Error` impl never overrode `source()`, so any client-side transport failure — a DNS failure, a refused/reset connection, a TLS handshake failure, a timeout — was reduced to a single `Display`-formatted string before any caller code ran. Fixes #237.

- Adds a non-serialized `source: Option<Arc<dyn std::error::Error + Send + Sync>>` field to `ConnectError`, a `ConnectError::with_source(..)` builder, and an `Error::source()` override that returns it.
- `Arc` rather than the `Box` suggested in #237, specifically so `ConnectError` keeps its existing `#[derive(Clone)]` without requiring the wrapped error to be `Clone`.
- `message`/`Display` output — and therefore wire format — is unchanged; this is purely additive.
- Populates `source` at every place a transport error becomes a `ConnectError`, named in the issue:
  - `HttpClient::send`'s plaintext and TLS paths
  - `map_transport_send_error`'s fallback branch
  - `Http2Connection`: unix-socket connect, TLS handshake, eager/lazy connect (`drive_connect`), h2 send, and (bonus) the establishment-timeout branch
  - `From<std::io::Error>` and `From<http::Error>` for `ConnectError`
- A shared `unavailable_from_transport_error` helper collapses the repeated `format!` + `.with_source(..)` idiom across `client/mod.rs` and `client/http2.rs`, boxing the error once and reusing it for both the message and the source.

## Docs

`docs/guide.md` gets a short paragraph on `.with_source(..)`/`Error::source()`, including that it's local-only — a `ConnectError` decoded from a server's response never has one.

## Test plan

- [x] Added/extended unit tests covering every named conversion site (`HttpClient` HTTP/HTTPS, unix-socket connect, TLS handshake, eager connect, h2 send, establishment timeout, `map_transport_send_error` fallback, both `From` impls) — all assert `Error::source()` is populated.
- [x] `cargo build -p connectrpc --all-features`
- [x] `cargo clippy -p connectrpc --all-features --all-targets` with `-D warnings`
- [x] `cargo test -p connectrpc --all-features` — 584/584 lib tests pass, 6/6 doctests pass (13 pre-existing tests in the unrelated `max_connection_age`/`max_connection_idle` graceful-shutdown family were excluded — confirmed flaky/hanging on a clean `main` checkout as well, unrelated to this change)
- [x] Changelog fragment added under `.changes/unreleased/`

Co-authored with Claude via research on idiomatic Rust 1.95+ error-source patterns.