### PR TITLE
conformance: remove the local debug proxy scaffolding

### DIFF
--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -49,8 +49,6 @@ use connectrpc_conformance::{
 use futures::StreamExt;
 use http::HeaderName;
 use http::HeaderValue;
-use std::process::Command;
-use std::process::Stdio;
 use tracing_subscriber::EnvFilter;
 
 /// Parse a gRPC timeout header value to milliseconds.
@@ -943,108 +941,6 @@ impl ConformanceService for ConformanceServiceImpl {
     }
 }
 
-/// Start Caddy as a reverse proxy for debugging HTTP traffic.
-/// Returns the proxy port if successful.
-fn start_caddy_proxy(server_port: u16) -> Result<(u16, std::process::Child)> {
-    // Find an available port for the proxy
-    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-    let proxy_port = listener.local_addr()?.port();
-    drop(listener);
-
-    let caddy_bin = std::env::var("CADDY_BIN").unwrap_or_else(|_| "/tmp/caddy".to_string());
-
-    // Create Caddy config - simpler version without custom keep_alive settings
-    let config = format!(
-        r#"{{
-  "logging": {{
-    "logs": {{
-      "default": {{
-        "level": "DEBUG",
-        "encoder": {{ "format": "console" }}
-      }}
-    }}
-  }},
-  "apps": {{
-    "http": {{
-      "servers": {{
-        "proxy": {{
-          "listen": [":{proxy_port}"],
-          "logs": {{ "default_logger_name": "default" }},
-          "routes": [{{
-            "handle": [{{
-              "handler": "reverse_proxy",
-              "upstreams": [{{ "dial": "127.0.0.1:{server_port}" }}]
-            }}]
-          }}]
-        }}
-      }}
-    }}
-  }}
-}}"#
-    );
-
-    let config_path = format!("/tmp/caddy-proxy-{server_port}.json");
-    std::fs::write(&config_path, &config)?;
-
-    // Start Caddy
-    let log_path = format!("/tmp/caddy-proxy-{server_port}.log");
-    let log_file = std::fs::File::create(&log_path)?;
-
-    let child = Command::new(&caddy_bin)
-        .args(["run", "--config", &config_path])
-        .stdout(Stdio::from(log_file.try_clone()?))
-        .stderr(Stdio::from(log_file))
-        .spawn()?;
-
-    // Give Caddy time to start
-    std::thread::sleep(std::time::Duration::from_millis(500));
-
-    tracing::info!(
-        "Caddy proxy started: :{} -> :{}, logs at {}",
-        proxy_port,
-        server_port,
-        log_path
-    );
-
-    Ok((proxy_port, child))
-}
-
-/// Start tcplog as a TCP logging proxy for diagnosing connection lifecycle issues.
-/// Only useful for non-TLS connections (raw TCP proxying would break TLS handshakes).
-/// Returns the proxy port and child process.
-fn start_tcplog_proxy(server_port: u16) -> Result<(u16, std::process::Child)> {
-    // Find an available port for the proxy
-    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-    let proxy_port = listener.local_addr()?.port();
-    drop(listener);
-
-    let tcplog_bin = std::env::var("TCPLOG_BIN")
-        .unwrap_or_else(|_| "/tmp/tcplog/target/release/tcplog".to_string());
-    let log_path = format!("/tmp/tcplog-{server_port}.log");
-
-    let child = Command::new(&tcplog_bin)
-        .args([
-            &proxy_port.to_string(),
-            &format!("127.0.0.1:{server_port}"),
-            &log_path,
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()?;
-
-    // Give tcplog time to bind
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    tracing::info!(
-        "tcplog proxy started: :{} -> :{}, logging to {}",
-        proxy_port,
-        server_port,
-        log_path
-    );
-
-    Ok((proxy_port, child))
-}
-
 fn code_to_connect_error(code: connectrpc_conformance::Code) -> connectrpc::error::ErrorCode {
     use connectrpc::error::ErrorCode;
     use connectrpc_conformance::Code;
@@ -1174,19 +1070,6 @@ async fn main() -> Result<()> {
     let server_addr = bound.local_addr()?;
     tracing::info!("Server listening on {}", server_addr);
 
-    // Optionally start a debugging proxy (Caddy for HTTP-level, tcplog for TCP-level).
-    // tcplog only works for non-TLS (raw TCP proxy would break TLS handshakes).
-    let (report_port, _proxy_child) = if std::env::var("ENABLE_CADDY_PROXY").is_ok() {
-        let (proxy_port, child) = start_caddy_proxy(server_addr.port())?;
-        (proxy_port, Some(child))
-    } else if std::env::var("ENABLE_TCPLOG").is_ok() && !request.use_tls {
-        let (proxy_port, child) = start_tcplog_proxy(server_addr.port())?;
-        (proxy_port, Some(child))
-    } else {
-        (server_addr.port(), None)
-    };
-
-    // Send the response with the port to connect to (proxy or direct)
     // Include the PEM cert if TLS is enabled so the runner can trust our server
     let pem_cert = if request.server_creds.is_set() {
         request.server_creds.cert.clone()
@@ -1196,7 +1079,7 @@ async fn main() -> Result<()> {
 
     let response = ServerCompatResponse {
         host: "127.0.0.1".to_string(),
-        port: report_port as u32,
+        port: server_addr.port() as u32,
         pem_cert,
         ..Default::default()
     };
@@ -1204,7 +1087,7 @@ async fn main() -> Result<()> {
 
     tracing::info!(
         "Sent ServerCompatResponse (port {}, tls={}), starting to serve requests",
-        report_port,
+        server_addr.port(),
         tls_config.is_some()
     );
 


### PR DESCRIPTION
Fixes #248

Removes the local debugging scaffolding from the conformance server: `start_caddy_proxy`, `start_tcplog_proxy`, and the `ENABLE_CADDY_PROXY` / `ENABLE_TCPLOG` dispatch in `main`. Net 114 lines deleted.

Both helpers spawned binaries that are not part of this repository, are not built by the Taskfile, and are documented nowhere — `tcplog` defaulted to `/tmp/tcplog/target/release/tcplog`, a cargo target directory that exists on one machine. Grepping the tree for `tcplog`, `caddy`, `TCPLOG_BIN`, `CADDY_BIN`, `ENABLE_TCPLOG` and `ENABLE_CADDY_PROXY` turns up nothing outside the deleted code, so nothing else in the repo, the Taskfile or CI referenced them.

They cost nothing at runtime, since both were off unless the environment variable was set. The cost was that a contributor reading the conformance harness met a hundred lines of dead-end setup pointing at paths they do not have.

`main` now reports the real listener port unconditionally. The `_proxy_child` half of the old tuple was `None` on every path the deleted branches did not take, so dropping the binding changes nothing about what is kept alive. `std::process::Command` and `Stdio` became unused and are removed.

No changelog fragment. `conformance` is `publish = false` and has no surface a library user consumes, and the repo's own practice matches: of the 33 commits touching only harness, CI, docs, examples or benches — including all four since changie was adopted in #195 — none carries a fragment.

Verified beyond the build: feeding a `ServerCompatRequest` on stdin, the server logs its listener address and writes a `ServerCompatResponse` whose port field decodes to that same port, and a live Connect JSON unary call against it returns a well-formed `ConformancePayload`. Serving is intact end to end.

One note on CI: two `handler::tests` element-budget tests fail on `main` right now, independently of this change — fixture rot from buffa 0.9.1, fixed by #239. This diff touches one file under `conformance/` and does not link that crate's test binary.
