### PR TITLE
client: resolve the gRPC unary response status before the HTTP status

### DIFF
--- a/.changes/unreleased/Fixed-20260723-222329.yaml
+++ b/.changes/unreleased/Fixed-20260723-222329.yaml
@@ -1,0 +1,42 @@
+kind: Fixed
+body: |-
+  **A gRPC or gRPC-Web unary call now reports a trailers-only error instead of
+  the bare HTTP status** ([#241]). When a proxy answers with a non-200 status
+  and a gRPC status in the response headers — an Envoy local reply sends `503`
+  alongside `grpc-status: 14` and `grpc-message: upstream connect error` — the
+  call surfaces the server's code, message, and metadata rather than
+  `HTTP error 503`. This matches grpc-go, which decides that a reply is gRPC
+  from its content-type and reads the status from it; connect-go instead
+  reports the HTTP status and discards the server's code, message and metadata
+  entirely. The header status applies only to a genuine trailers-only
+  response: a response carrying body data or HTTP/2 trailers takes its status
+  from those, never from the headers, and a success delivered on a non-200 is
+  still refused. The error code can change as a result, not just the message:
+  a proxy pairing HTTP 500 with `grpc-status: 3` now yields `InvalidArgument`
+  where it previously yielded `Unknown`, so a caller matching on `ErrorCode`
+  may observe the server's code rather than the one derived from the HTTP
+  status.
+
+  A non-2xx reply that is not a usable gRPC response reports its HTTP status,
+  so an nginx or load-balancer error page still arrives as `Unavailable` on a
+  `502` and stays recognizable as retryable. What went wrong is appended to
+  the message rather than replacing the code, and this now holds however the
+  error page fails: `HTTP error 502: unexpected content-type: text/html` when
+  the proxy labels it as HTML, and `HTTP error 502: envelope decode failed:
+  ...` when the proxy keeps the gRPC content-type and the page fails framing
+  instead. A reply with no `content-type` at all is still parsed for a
+  `grpc-status`, since an absent content-type is not evidence the peer is not
+  speaking gRPC.
+
+  **A plain gRPC unary response whose body sets the `0x80` envelope flag is
+  now a framing error** ([#242]). That flag marks a gRPC-Web trailer frame
+  and is not defined for gRPC, so a server or intermediary that set it could
+  replace the trailers received in the HTTP/2 trailer section with trailers
+  of its own choosing, including the `grpc-status`. gRPC-Web is unaffected:
+  its trailer frames are parsed as before. The flag now has a name,
+  `envelope::flags::GRPC_WEB_TRAILER`, public alongside the existing `DATA`,
+  `COMPRESSED` and `END_STREAM` flags.
+
+  [#241]: https://github.com/connectrpc/connect-rust/issues/241
+  [#242]: https://github.com/connectrpc/connect-rust/issues/242
+time: 2026-07-23T22:23:29.547732463-07:00

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -255,7 +255,7 @@ fn grpc_web_trailer_frame_end(data: &[u8]) -> Option<usize> {
         if frame_end > data.len() {
             return None;
         }
-        if data[offset] & 0x80 != 0 {
+        if data[offset] & crate::envelope::flags::GRPC_WEB_TRAILER != 0 {
             return Some(frame_end);
         }
         offset = frame_end;
@@ -2027,15 +2027,42 @@ where
     let status = response.status();
     let resp_headers = response.headers().clone();
 
-    // Non-200 HTTP status (connection-level error)
-    if !status.is_success() {
-        let code = http_status_to_error_code(status);
-        let mut err = ConnectError::new(code, format!("HTTP error {}", status.as_u16()));
-        err.set_response_headers(resp_headers);
-        return Err(err);
+    // grpc-go decides gRPC-ness from the content-type and then discards the
+    // HTTP status entirely; connect-go decides from the HTTP status and never
+    // reads the gRPC one. This sits between them: a non-2xx reply that is not
+    // speaking gRPC reports its HTTP status, because that is the code telling
+    // the caller whether to retry, and a `text/html` rejection would flatten
+    // every proxy failure to `unknown`.
+    //
+    // A wrong content-type is positive evidence the peer is not speaking gRPC.
+    // An absent one is not: a proxy that drops `content-type` from its local
+    // reply may still send `grpc-status`, so that reply is parsed and its
+    // trailers-only status honoured below.
+    let content_type = validate_grpc_response_content_type(&resp_headers, config);
+    let speaks_grpc = content_type.is_ok()
+        && (resp_headers.contains_key(http::header::CONTENT_TYPE)
+            || resp_headers.contains_key("grpc-status"));
+    if !status.is_success() && !speaks_grpc {
+        return Err(match content_type {
+            // Reuse the rejection: it already carries the response headers, and
+            // its message becomes the detail on the HTTP status.
+            Err(mut err) => {
+                let detail = err.message.take().unwrap_or_default();
+                err.code = http_status_to_error_code(status);
+                err.message = Some(format!("HTTP error {}: {detail}", status.as_u16()));
+                err
+            }
+            Ok(()) => {
+                let mut err = ConnectError::new(
+                    http_status_to_error_code(status),
+                    format!("HTTP error {}", status.as_u16()),
+                );
+                err.set_response_headers(resp_headers);
+                err
+            }
+        });
     }
-
-    validate_grpc_response_content_type(&resp_headers, config)?;
+    content_type?;
 
     // Check for unsupported compression before reading the body
     let response_encoding = resp_headers
@@ -2096,9 +2123,17 @@ where
                 }
             }
             Some(Err(e)) => {
-                return Err(ConnectError::internal(format!(
-                    "failed to read response body: {e}"
-                )));
+                // The body of a non-200 response is read only to find a gRPC
+                // status, and the HTTP status is reported below when there is
+                // none, so a read that dies part-way through (a proxy that
+                // resets the stream after its error headers) still reports the
+                // status rather than the read failure.
+                if status.is_success() {
+                    return Err(ConnectError::internal(format!(
+                        "failed to read response body: {e}"
+                    )));
+                }
+                break;
             }
             None => break,
         }
@@ -2113,8 +2148,22 @@ where
     let mut message_count = 0u32;
 
     while !buf.is_empty() {
-        // Check for gRPC-Web trailer frame (flag 0x80)
-        if buf[0] & 0x80 != 0 {
+        // A set high bit marks a gRPC-Web trailer frame.
+        if buf[0] & crate::envelope::flags::GRPC_WEB_TRAILER != 0 {
+            if !matches!(config.protocol, Protocol::GrpcWeb) {
+                // Plain gRPC defines no flag in the high bit, and envelope
+                // decoding ignores unknown bits, so accepting the frame here
+                // would let a data envelope overwrite the HTTP/2 trailers.
+                return Err(body_parse_error(
+                    status,
+                    resp_headers,
+                    format!(
+                        "invalid gRPC response framing: envelope flag {:#04x} \
+                         (gRPC-Web trailer marker) is not valid on a plain gRPC response",
+                        buf[0]
+                    ),
+                ));
+            }
             let decompression = response_encoding
                 .as_deref()
                 .map(|enc| (&config.compression, enc));
@@ -2134,9 +2183,11 @@ where
             Ok(Some(env)) => env,
             Ok(None) => break,
             Err(e) => {
-                return Err(ConnectError::internal(format!(
-                    "envelope decode failed: {e}"
-                )));
+                return Err(body_parse_error(
+                    status,
+                    resp_headers,
+                    format!("envelope decode failed: {e}"),
+                ));
             }
         };
 
@@ -2172,16 +2223,35 @@ where
     // Check for errors in trailers (HTTP/2 trailers or gRPC-Web trailer frame).
     // If we have trailers from HTTP/2 or gRPC-Web, those take precedence.
     // Only fall back to initial headers if no body data was received (trailers-only).
-    let effective_trailers = if !grpc_trailers.is_empty() {
-        &grpc_trailers
-    } else if !has_body_data {
+    let status_from_headers = grpc_trailers.is_empty() && !has_body_data;
+    let effective_trailers = if status_from_headers {
         // Trailers-only response: initial headers contain the status
         &resp_headers
     } else {
-        &grpc_trailers // empty — no trailers found
+        &grpc_trailers // empty when no trailers were found
     };
 
     if let Some(mut err) = parse_grpc_error_from_trailers(effective_trailers) {
+        if status_from_headers {
+            // The status came from the initial headers, so the entries copied
+            // alongside it are response metadata, not trailing metadata:
+            // `content-type` and friends must not surface from
+            // `ConnectError::trailers()`. They stay reachable through
+            // `response_headers()`, set below.
+            err.trailers_mut().clear();
+        }
+        err.set_response_headers(resp_headers);
+        return Err(err);
+    }
+
+    // A non-200 response is an error even when the gRPC status says otherwise
+    // or is missing entirely; an error status found above is the more specific
+    // report, so this is only reached when there was none. Refusing a success
+    // delivered on a non-200 is the one place this is stricter than grpc-go,
+    // which having decided the reply is gRPC accepts it.
+    if !status.is_success() {
+        let code = http_status_to_error_code(status);
+        let mut err = ConnectError::new(code, format!("HTTP error {}", status.as_u16()));
         err.set_response_headers(resp_headers);
         return Err(err);
     }
@@ -2482,7 +2552,7 @@ where
             // a data envelope flag rather than the gRPC-Web trailer sentinel).
             if matches!(self.protocol, Protocol::GrpcWeb)
                 && self.buf.len() >= 5
-                && self.buf[0] & 0x80 != 0
+                && self.buf[0] & crate::envelope::flags::GRPC_WEB_TRAILER != 0
             {
                 let trailer_len =
                     u32::from_be_bytes([self.buf[1], self.buf[2], self.buf[3], self.buf[4]])
@@ -2512,7 +2582,7 @@ where
             // flag) to avoid misinterpreting the trailer frame as a data message.
             let envelope_result = if matches!(self.protocol, Protocol::GrpcWeb)
                 && !self.buf.is_empty()
-                && self.buf[0] & 0x80 != 0
+                && self.buf[0] & crate::envelope::flags::GRPC_WEB_TRAILER != 0
             {
                 // We know the trailer frame is incomplete (checked above),
                 // so signal that more data is needed.
@@ -2576,7 +2646,7 @@ where
                         // "no usable termination metadata".
                         let parsed = if matches!(self.protocol, Protocol::GrpcWeb)
                             && !self.buf.is_empty()
-                            && self.buf[0] & 0x80 != 0
+                            && self.buf[0] & crate::envelope::flags::GRPC_WEB_TRAILER != 0
                         {
                             let decompression =
                                 self.encoding.as_deref().map(|enc| (&self.compression, enc));
@@ -4164,6 +4234,33 @@ struct ConnectErrorResponse {
 ///
 /// Only specific HTTP status codes have defined mappings. All other codes map to
 /// `Unknown` per the specification.
+/// Build the error for a gRPC response body that could not be parsed.
+///
+/// On a non-2xx the HTTP status is the more useful report — it is the code that
+/// says whether the request may be retried — so the parse failure is appended
+/// to it as detail rather than replacing it, matching how a content-type
+/// rejection is reported. A proxy serves its error page under whatever
+/// content-type suits the request, so an HTML 502 can arrive under
+/// `application/grpc` and fail framing rather than the content-type check;
+/// reporting that as `internal` would make two spellings of one 502 give
+/// opposite retry answers.
+fn body_parse_error(
+    status: http::StatusCode,
+    resp_headers: http::HeaderMap,
+    detail: String,
+) -> ConnectError {
+    let mut err = if status.is_success() {
+        ConnectError::internal(detail)
+    } else {
+        ConnectError::new(
+            http_status_to_error_code(status),
+            format!("HTTP error {}: {detail}", status.as_u16()),
+        )
+    };
+    err.set_response_headers(resp_headers);
+    err
+}
+
 fn http_status_to_error_code(status: http::StatusCode) -> ErrorCode {
     match status.as_u16() {
         400 => ErrorCode::Internal,
@@ -4413,10 +4510,10 @@ fn parse_grpc_web_trailer_frame_with_compression(
     data: &[u8],
     decompression: Option<(&CompressionRegistry, &str)>,
 ) -> Option<http::HeaderMap> {
-    if data.len() < 5 || data[0] & 0x80 == 0 {
+    if data.len() < 5 || data[0] & crate::envelope::flags::GRPC_WEB_TRAILER == 0 {
         return None;
     }
-    let is_compressed = data[0] & 0x01 != 0;
+    let is_compressed = data[0] & crate::envelope::flags::COMPRESSED != 0;
     let len = u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize;
     // Cap trailer frame size to prevent a malicious server from forcing
     // unbounded memory allocation. 1 MB is generous for trailer metadata.
@@ -6744,6 +6841,524 @@ mod tests {
             response.trailers().get("grpc-status").unwrap(),
             http::HeaderValue::from_static("0")
         );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_trailers_only_status_wins_over_http_status() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // A proxy pairs a non-200 status with a trailers-only gRPC error in the
+        // initial headers. The gRPC code is the one reported, which for this
+        // pairing is not the code the HTTP status maps to (500 is `unknown`).
+        let response = Response::builder()
+            .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+            .header(http::header::CONTENT_TYPE, "application/grpc")
+            .header("grpc-status", "3")
+            .header("grpc-message", "malformed request")
+            .header("x-request-id", "abc123")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a trailers-only gRPC error must surface as an error");
+        assert_eq!(err.code, ErrorCode::InvalidArgument);
+        assert_eq!(err.message.as_deref(), Some("malformed request"));
+        assert_eq!(
+            err.response_headers().get("x-request-id").unwrap(),
+            "abc123"
+        );
+        // Response headers are not trailing metadata, so nothing from the
+        // header block may surface through `trailers()`.
+        assert!(
+            err.trailers().is_empty(),
+            "initial headers must not be reported as trailers: {:?}",
+            err.trailers()
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_html_error_page_reports_http_status_with_detail() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // The commonest real failure: an nginx or load-balancer error page. The
+        // HTTP status is what says the request may be retried, so it is the
+        // code reported, with the content-type rejection kept as detail.
+        let response = Response::builder()
+            .status(http::StatusCode::BAD_GATEWAY)
+            .header(http::header::CONTENT_TYPE, "text/html")
+            .header("x-request-id", "abc123")
+            .body(Full::new(Bytes::from_static(
+                b"<html><body>502 Bad Gateway</body></html>",
+            )))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("an HTML error page is an error");
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(
+            err.message.as_deref(),
+            Some(
+                "HTTP error 502: unexpected content-type: text/html (expected application/grpc+proto)"
+            )
+        );
+        assert_eq!(
+            err.response_headers().get("x-request-id").unwrap(),
+            "abc123"
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_error_page_without_content_type_reports_http_status() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // No content-type at all is equally not a gRPC reply, and the body must
+        // not be parsed for a status it cannot contain.
+        let response = Response::builder()
+            .status(http::StatusCode::BAD_GATEWAY)
+            .body(Full::new(Bytes::from_static(
+                b"<html><body>502 Bad Gateway</body></html>",
+            )))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("an error page without a content-type is an error");
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.message.as_deref(), Some("HTTP error 502"));
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_undecodable_body_keeps_response_headers() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // An error page served under a gRPC content-type: the first bytes read
+        // as an oversized length prefix, so the framing error is what surfaces.
+        // The proxy's headers have to survive it.
+        let response = Response::builder()
+            .status(http::StatusCode::BAD_GATEWAY)
+            .header(http::header::CONTENT_TYPE, "application/grpc")
+            .header("x-request-id", "abc123")
+            .body(Full::new(Bytes::from_static(
+                b"<html><body>502 Bad Gateway</body></html>",
+            )))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("an undecodable body is an error");
+        // The same 502 as the `text/html` case, differing only in the
+        // content-type the proxy kept, so it has to reach the same verdict.
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert!(
+            err.message
+                .as_deref()
+                .is_some_and(|m| m.starts_with("HTTP error 502: envelope decode failed")),
+            "unexpected message: {:?}",
+            err.message
+        );
+        assert_eq!(
+            err.response_headers().get("x-request-id").unwrap(),
+            "abc123"
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_trailers_only_without_content_type_keeps_grpc_status() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // A proxy that omits `content-type` from its local reply but still
+        // sends a gRPC status is speaking gRPC well enough for that status to
+        // be the answer; an absent content-type is not evidence otherwise.
+        let response = Response::builder()
+            .status(http::StatusCode::SERVICE_UNAVAILABLE)
+            .header("grpc-status", "14")
+            .header("grpc-message", "upstream connect error")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a trailers-only gRPC error must surface as an error");
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.message.as_deref(), Some("upstream connect error"));
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_ignores_header_status_when_body_present() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        // Conformance `trailers-only/ignore-header-if-body-present`: a status
+        // in the initial headers is only the status of a trailers-only
+        // response. With a message in the body and no trailers, the status is
+        // missing, not `9`.
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc")
+            .header("grpc-status", "9")
+            .body(Full::new(
+                Envelope::data(StringValue::from("hi").encode_to_bytes()).encode(),
+            ))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a response with body data and no trailers has no status");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("gRPC response missing grpc-status trailer")
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_ignores_header_status_when_trailer_present() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        // Conformance `trailers-only/ignore-header-if-trailer-present`: the
+        // HTTP/2 trailer wins over the header.
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "9".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> = vec![
+            Ok(Frame::data(
+                Envelope::data(StringValue::from("hi").encode_to_bytes()).encode(),
+            )),
+            Ok(Frame::trailers(trailers)),
+        ];
+
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc")
+            .header("grpc-status", "8")
+            .body(StreamBody::new(futures::stream::iter(frames)))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("the trailer status must be reported");
+        assert_eq!(err.code, ErrorCode::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn grpc_web_unary_ignores_header_status_when_body_present() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        // Conformance `trailers-only/ignore-header-if-body-present` for
+        // gRPC-Web: the trailer frame in the body wins over the header.
+        let mut body = BytesMut::new();
+        body.extend_from_slice(&Envelope::data(StringValue::from("hi").encode_to_bytes()).encode());
+        let trailer_payload = b"grpc-status: 9\r\n";
+        body.extend_from_slice(&[0x80]);
+        body.extend_from_slice(&(trailer_payload.len() as u32).to_be_bytes());
+        body.extend_from_slice(trailer_payload);
+
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc-web")
+            .header("grpc-status", "8")
+            .body(Full::new(body.freeze()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("the trailer-frame status must be reported");
+        assert_eq!(err.code, ErrorCode::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_non_200_with_body_reports_http_status() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        // A body means the header status does not apply, and a non-200 is an
+        // error however successful the trailers claim the call was.
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "0".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> = vec![
+            Ok(Frame::data(
+                Envelope::data(StringValue::from("hi").encode_to_bytes()).encode(),
+            )),
+            Ok(Frame::trailers(trailers)),
+        ];
+
+        let response = Response::builder()
+            .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+            .header(http::header::CONTENT_TYPE, "application/grpc")
+            .header("grpc-status", "3")
+            .body(StreamBody::new(futures::stream::iter(frames)))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a non-200 response is an error");
+        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(err.message.as_deref(), Some("HTTP error 500"));
+    }
+
+    #[tokio::test]
+    async fn grpc_web_unary_trailers_only_status_wins_over_http_status() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // The header check is protocol-agnostic, so gRPC-Web reads a
+        // trailers-only error the same way plain gRPC does.
+        let response = Response::builder()
+            .status(http::StatusCode::BAD_GATEWAY)
+            .header(http::header::CONTENT_TYPE, "application/grpc-web")
+            .header("grpc-status", "14")
+            .header("grpc-message", "upstream connect error")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a trailers-only gRPC-Web error must surface as an error");
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.message.as_deref(), Some("upstream connect error"));
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_malformed_grpc_status_on_non_200_is_unknown() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // A present-but-unparseable status must not read as the HTTP status
+        // either: it is a protocol error in its own right.
+        let response = Response::builder()
+            .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+            .header(http::header::CONTENT_TYPE, "application/grpc")
+            .header("grpc-status", "banana")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a malformed gRPC status must not read as success");
+        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("protocol error: malformed grpc-status: \"banana\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_non_200_without_grpc_status_uses_http_status() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let response = Response::builder()
+            .status(http::StatusCode::SERVICE_UNAVAILABLE)
+            .header(http::header::CONTENT_TYPE, "application/grpc")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a non-200 response without a gRPC status is an error");
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert_eq!(err.message.as_deref(), Some("HTTP error 503"));
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_rejects_trailer_flag_in_body() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        // 0x80 is the gRPC-Web trailer marker and is not a gRPC envelope flag.
+        // Honouring it here would replace the HTTP/2 trailers with whatever the
+        // body claims.
+        let trailer_payload = b"grpc-status: 5\r\n";
+        let mut body = BytesMut::new();
+        body.extend_from_slice(&[0x80]);
+        body.extend_from_slice(&(trailer_payload.len() as u32).to_be_bytes());
+        body.extend_from_slice(trailer_payload);
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "0".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> = vec![
+            Ok(Frame::data(body.freeze())),
+            Ok(Frame::trailers(trailers)),
+        ];
+
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc+proto")
+            .body(StreamBody::new(futures::stream::iter(frames)))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("the trailer flag must be rejected on plain gRPC");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert_eq!(
+            err.message.as_deref(),
+            Some(
+                "invalid gRPC response framing: envelope flag 0x80 (gRPC-Web trailer marker) is not valid on a plain gRPC response"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_unary_framing_error_names_the_offending_flag_byte() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // Any byte with the high bit set takes the trailer branch, so the
+        // error has to report the byte received rather than a bare 0x80.
+        let mut body = BytesMut::new();
+        body.extend_from_slice(&[0xC1]);
+        body.extend_from_slice(&0u32.to_be_bytes());
+
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc+proto")
+            .body(Full::new(body.freeze()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect_err("a high-bit flag byte must be rejected on plain gRPC");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert_eq!(
+            err.message.as_deref(),
+            Some(
+                "invalid gRPC response framing: envelope flag 0xc1 (gRPC-Web trailer marker) is not valid on a plain gRPC response"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn grpc_web_unary_parses_trailer_frame_after_message() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut body = BytesMut::new();
+        body.extend_from_slice(&Envelope::data(StringValue::from("hi").encode_to_bytes()).encode());
+        let trailer_payload = b"grpc-status: 0\r\nx-trailer: v\r\n";
+        body.extend_from_slice(&[0x80]);
+        body.extend_from_slice(&(trailer_payload.len() as u32).to_be_bytes());
+        body.extend_from_slice(trailer_payload);
+
+        let response = Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/grpc-web+proto")
+            .body(Full::new(body.freeze()))
+            .unwrap();
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
+
+        let response = parse_grpc_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+            None,
+        )
+        .await
+        .expect("gRPC-Web trailer frames must still be parsed");
+        assert_eq!(response.view().value, "hi");
+        assert_eq!(response.trailers().get("x-trailer").unwrap(), "v");
     }
 
     #[tokio::test]

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -23,6 +23,10 @@ pub mod flags {
     pub const COMPRESSED: u8 = 0x01;
     /// End of stream (trailers follow).
     pub const END_STREAM: u8 = 0x02;
+    /// gRPC-Web trailer frame. The payload is an HTTP/1-style trailer block
+    /// rather than a message, and the flag is defined only for gRPC-Web: on
+    /// plain gRPC a set high bit is a framing error.
+    pub const GRPC_WEB_TRAILER: u8 = 0x80;
 }
 
 /// Size of the envelope header in bytes.

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -798,10 +798,10 @@ fn encode_grpc_web_trailers(trailers: &http::HeaderMap) -> Bytes {
         trailer_payload.extend_from_slice(b"\r\n");
     }
 
-    // Envelope: flag=0x80 (trailer), 4-byte big-endian length, payload
+    // Envelope: trailer flag, 4-byte big-endian length, payload
     let len = trailer_payload.len() as u32;
     let mut frame = Vec::with_capacity(5 + trailer_payload.len());
-    frame.push(0x80); // trailer flag
+    frame.push(crate::envelope::flags::GRPC_WEB_TRAILER);
     frame.extend_from_slice(&len.to_be_bytes());
     frame.extend_from_slice(&trailer_payload);
     Bytes::from(frame)


### PR DESCRIPTION
Fixes #241
Fixes #242

Two divergences between the unary gRPC response parser and its streaming sibling.

**#241 — a proxy's trailers-only error lost its message and metadata on unary calls.** The unary path checked the HTTP status first and returned immediately, so `grpc-status` was never consulted. Given an Envoy local reply carrying `503` alongside `grpc-status: 14` and `grpc-message: upstream connect error`, a server-streaming call reported `Unavailable("upstream connect error")` with the server's metadata and a unary call reported `Unavailable("HTTP error 503")` with both discarded.

The unary path now resolves the gRPC status whenever the reply plausibly speaks gRPC, and keeps the HTTP-derived code otherwise. The header status is honoured only for a genuine trailers-only response, tested as `!has_body_data`.

**#242 — on plain gRPC, a high bit in the first body byte could overwrite the real trailers.** The gRPC-Web trailer-frame check appears twice in this function and only the first was gated on the protocol. `0x80` is the gRPC-Web trailer sentinel and is not a defined flag in plain gRPC, but `Envelope::decode_with_limit` does not validate unknown flag bits, so the frame was parsed and `grpc_trailers` was replaced — including over trailers already captured from the HTTP/2 trailer section. Both sites are gated now, and the sentinel gets a name.

## Verified against real Go implementations

Both changes are wire-visible interpretation, and neither case is reachable through conformance — the suite has no non-200 raw-response case and no conformant server emits `0x80`. So I built a raw-h2c harness emitting each shape exactly and drove **connect-go v1.19.1**, **grpc-go v1.81.1**, this branch and its base against identical bytes.

**The premise in #241 was half wrong, in our favour.** connect-go does check the HTTP status first — `grpcValidateResponse` returns `httpToCode(status)` before touching content-type or any gRPC status. **grpc-go does not**: a valid gRPC content-type sets `isGRPC` and the HTTP-status branch is never entered. Measured on the Envoy shape, grpc-go returns `Unavailable("upstream connect error")` and so does this branch, byte for byte; on `500` + `grpc-status: 3` both return `InvalidArgument("bad argument")`. It is the *base* tree that matched connect-go. So this matches grpc-go and diverges from connect-go, on a case where connect-go discards the server's code, message and metadata entirely.

**On `0x80`, both Go clients already reject the frame** — connect-go with "invalid envelope flags 128", grpc-go with "received unexpected payload format 128". The base tree was the outlier: it parsed the attacker's frame as gRPC-Web trailers and reported `NotFound`, *overriding real HTTP/2 trailers that said `grpc-status: 0`*. This removes a divergence rather than creating one.

**No incompatibility is introduced.** Across fourteen scenarios there is no case where a Go client completes a call and this branch fails it. Every difference is a different error for a call that fails in all four clients.

The interop run also caught a regression in an earlier revision of this PR: a 502 carrying an HTML page reported `Unknown` where base, connect-go and grpc-go all report `Unavailable`, losing the retryability signal. Fixed, and the rule is now applied wherever a body fails to parse, so the two spellings of the same proxy failure cannot produce different retry decisions.

One pre-existing divergence found and deliberately not adopted: grpc-go accepts a *successful* response delivered on HTTP 503. We and connect-go reject it, which seems right.

## Conformance

The trailers-only gate is load-bearing and an earlier revision got it wrong — hoisting the header check above the body read fails four cases named `trailers-only/ignore-header-if-body-present`, measured at 12 passed / 4 failed versus 16/16 for this one. Full suites: gRPC-Web client 2838/0, gRPC client 1452/1454 with both failures in the load-induced `Timeouts` flake that is equally present on base, and the `gRPC Unexpected Responses` subset 22/0.

One note on CI: two `handler::tests` element-budget tests fail on `main` right now, independently of this change — fixture rot from buffa 0.9.1, fixed by #239.
