### PR TITLE
server: apply the configured element budget to interceptor payloads

### DIFF
--- a/.changes/unreleased/Added-20260720-134339.yaml
+++ b/.changes/unreleased/Added-20260720-134339.yaml
@@ -21,10 +21,14 @@ body: |-
 
   It applies to every server receive path — unary, server-streaming,
   client-streaming and bidi, on both the generated dispatch and hand-registered
-  handlers, view-based and owned-message alike. A rejection now names the limit
-  to raise, since it is the one decode failure an operator can fix without the
-  peer changing anything. Clients still decode *responses* under buffa's
-  defaults; that knob is a follow-up.
+  handlers, view-based and owned-message alike. On a proto wire it also governs
+  an interceptor's own decode of the inbound request body, through both
+  `Payload::message` and `Payload::view`, on all four of those shapes — so an
+  interceptor is held to the same budget as the handler behind it. JSON bodies
+  are decoded without it, on the interceptor and handler paths alike. A
+  rejection now names the limit to raise, since it is the one decode failure an
+  operator can fix without the peer changing anything. Clients still decode
+  *responses* under buffa's defaults; that knob is a follow-up.
 
   **Breaking, for generated code only.** `decode_borrowed_request_view` and
   `decode_message_request_stream` now take the decode limits, and `Limits` is

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -637,8 +637,17 @@ fn payload_stream_to_request_stream(stream: PayloadStream) -> RequestStream {
 
 /// Wrap a dispatcher inbound `RequestStream` (raw `Bytes`) as a
 /// [`PayloadStream`] for the interceptor chain.
-fn request_stream_to_payload_stream(stream: RequestStream, format: CodecFormat) -> PayloadStream {
-    Box::pin(stream.map(move |item| item.map(|bytes| Payload::new(bytes, format))))
+///
+/// `decode_options` comes from the request context, so an interceptor that
+/// decodes a message itself is held to the same budget as the handler.
+fn request_stream_to_payload_stream(
+    stream: RequestStream,
+    format: CodecFormat,
+    decode_options: buffa::DecodeOptions,
+) -> PayloadStream {
+    Box::pin(stream.map(move |item| {
+        item.map(|bytes| Payload::new(bytes, format).with_decode_options(decode_options.clone()))
+    }))
 }
 
 /// Run a server-streaming call through the interceptor chain, or skip
@@ -665,9 +674,10 @@ pub(crate) async fn call_server_streaming_intercepted<D: crate::Dispatcher>(
         path,
         format,
     };
+    let decode_options = ctx.decode_options().clone();
     let req = StreamRequest::new(ctx);
     let inbound: PayloadStream = Box::pin(futures::stream::once(async move {
-        Ok(Payload::new(body, format))
+        Ok(Payload::new(body, format).with_decode_options(decode_options))
     }));
     let resp = NextStream::new(interceptors, &terminal)
         .run(req, inbound)
@@ -698,8 +708,9 @@ pub(crate) async fn call_client_streaming_intercepted<D: crate::Dispatcher>(
         path,
         format,
     };
+    let decode_options = ctx.decode_options().clone();
     let req = StreamRequest::new(ctx);
-    let inbound = request_stream_to_payload_stream(requests, format);
+    let inbound = request_stream_to_payload_stream(requests, format, decode_options);
     let resp = NextStream::new(interceptors, &terminal)
         .run(req, inbound)
         .await?;
@@ -749,8 +760,9 @@ pub(crate) async fn call_bidi_streaming_intercepted<D: crate::Dispatcher>(
         path,
         format,
     };
+    let decode_options = ctx.decode_options().clone();
     let req = StreamRequest::new(ctx);
-    let inbound = request_stream_to_payload_stream(requests, format);
+    let inbound = request_stream_to_payload_stream(requests, format, decode_options);
     let resp = NextStream::new(interceptors, &terminal)
         .run(req, inbound)
         .await?;
@@ -2023,5 +2035,213 @@ mod tests {
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].as_ref().unwrap(), &Bytes::from_static(b"1"));
         assert_eq!(out[1].as_ref().unwrap(), &Bytes::from_static(b"2"));
+    }
+
+    // ========================================================================
+    // Configured decode limits reach streaming interceptors
+    // ========================================================================
+
+    /// An interceptor that decodes each inbound message itself and records
+    /// the outcome, then forwards the stream untouched.
+    struct DecodeInbound(Arc<Mutex<Vec<Result<usize, ConnectError>>>>);
+
+    #[async_trait::async_trait]
+    impl Interceptor for DecodeInbound {
+        async fn intercept_streaming(
+            &self,
+            req: StreamRequest,
+            inbound: PayloadStream,
+            next: NextStream<'_>,
+        ) -> Result<StreamResponse, ConnectError> {
+            use buffa_types::google::protobuf::ListValue;
+            let seen = Arc::clone(&self.0);
+            let wrapped: PayloadStream = Box::pin(inbound.map(move |item| {
+                if let Ok(payload) = &item {
+                    seen.lock()
+                        .unwrap()
+                        .push(payload.message::<ListValue>().map(|m| m.values.len()));
+                }
+                item
+            }));
+            next.run(req, wrapped).await
+        }
+    }
+
+    /// The `view()` counterpart of `DecodeInbound`. The budget has to reach
+    /// both accessors: `view()` is the idiomatic one, so a bypass there is
+    /// the one an interceptor is most likely to hit.
+    struct ViewInbound(Arc<Mutex<Vec<Result<usize, ConnectError>>>>);
+
+    #[async_trait::async_trait]
+    impl Interceptor for ViewInbound {
+        async fn intercept_streaming(
+            &self,
+            req: StreamRequest,
+            inbound: PayloadStream,
+            next: NextStream<'_>,
+        ) -> Result<StreamResponse, ConnectError> {
+            use buffa_types::google::protobuf::__buffa::view::ListValueView;
+            let seen = Arc::clone(&self.0);
+            let wrapped: PayloadStream = Box::pin(inbound.map(move |item| {
+                if let Ok(payload) = &item {
+                    let len = payload
+                        .view::<ListValueView<'_>>()
+                        .map(|v| v.reborrow().values.len());
+                    seen.lock().unwrap().push(len);
+                }
+                item
+            }));
+            next.run(req, wrapped).await
+        }
+    }
+
+    /// A `ListValue` that is small on the wire but has more than one
+    /// element, so a one-byte element budget rejects it while the default
+    /// budget admits it.
+    fn element_heavy_body() -> Bytes {
+        use buffa_types::google::protobuf::{ListValue, Value};
+        let list = ListValue {
+            values: (0..64).map(|_| Value::default()).collect(),
+            ..Default::default()
+        };
+        Bytes::from(buffa::Message::encode_to_vec(&list))
+    }
+
+    /// A context whose element budget is one byte — small enough that any
+    /// element allocation exceeds it. An explicit tiny limit keeps the
+    /// fixture message small and independent of how large the decoded
+    /// element type happens to be.
+    fn tight_budget_ctx() -> RequestContext {
+        RequestContext::default().with_decode_options(
+            crate::Limits::default()
+                .with_element_memory_limit(1)
+                .decode_options(),
+        )
+    }
+
+    /// Assert the interceptor decoded exactly once and was rejected for
+    /// exceeding the budget, rather than for some unrelated decode failure.
+    fn assert_rejected_over_budget(seen: &[Result<usize, ConnectError>]) {
+        assert_eq!(seen.len(), 1);
+        let err = seen[0]
+            .as_ref()
+            .expect_err("a lowered element budget must reach the interceptor's own decode");
+        assert_eq!(err.code, crate::ErrorCode::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn client_streaming_interceptor_sees_the_configured_element_budget() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(DecodeInbound(Arc::clone(&seen)))];
+        let inbound: RequestStream =
+            Box::pin(futures::stream::once(async { Ok(element_heavy_body()) }));
+        call_client_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            tight_budget_ctx(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        assert_rejected_over_budget(&seen.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn server_streaming_interceptor_sees_the_configured_element_budget() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(DecodeInbound(Arc::clone(&seen)))];
+        call_server_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            tight_budget_ctx(),
+            element_heavy_body(),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        assert_rejected_over_budget(&seen.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn bidi_streaming_interceptor_sees_the_configured_element_budget() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(DecodeInbound(Arc::clone(&seen)))];
+        let inbound: RequestStream =
+            Box::pin(futures::stream::once(async { Ok(element_heavy_body()) }));
+        let resp = call_bidi_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            tight_budget_ctx(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        let _: Vec<_> = resp.body.collect().await;
+        assert_rejected_over_budget(&seen.lock().unwrap());
+    }
+
+    /// `Payload::view` must honour the budget too, not just
+    /// `Payload::message`. Both halves are here because a `view()` that
+    /// ignored the options entirely would still fail the first half if the
+    /// fixture were simply undecodable.
+    #[tokio::test]
+    async fn interceptor_view_decode_sees_the_configured_element_budget() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(ViewInbound(Arc::clone(&seen)))];
+        let inbound: RequestStream =
+            Box::pin(futures::stream::once(async { Ok(element_heavy_body()) }));
+        call_client_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            tight_budget_ctx(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        assert_rejected_over_budget(&seen.lock().unwrap());
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(ViewInbound(Arc::clone(&seen)))];
+        let inbound: RequestStream =
+            Box::pin(futures::stream::once(async { Ok(element_heavy_body()) }));
+        call_client_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            RequestContext::default(),
+            inbound,
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        assert_eq!(*seen.lock().unwrap()[0].as_ref().unwrap(), 64);
+    }
+
+    /// The control: the same bytes decode cleanly when the context carries
+    /// the default budget, so the rejections above come from the configured
+    /// limit rather than from the fixture being undecodable.
+    #[tokio::test]
+    async fn default_element_budget_admits_the_same_payload() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(DecodeInbound(Arc::clone(&seen)))];
+        call_server_streaming_intercepted(
+            &StreamEcho,
+            &chain,
+            "p",
+            RequestContext::default(),
+            element_heavy_body(),
+            CodecFormat::Proto,
+        )
+        .await
+        .unwrap();
+        let seen = seen.lock().unwrap();
+        assert_eq!(*seen.first().unwrap().as_ref().unwrap(), 64);
     }
 }

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -321,17 +321,25 @@ impl Payload {
     ///   branch on [`format()`](Payload::format) and call
     ///   [`message()`](Payload::message) for JSON wires instead.
     /// - [`invalid_argument`](ConnectError::invalid_argument) if the wire
-    ///   bytes fail to decode as `V` — peer-supplied data, not a server
-    ///   bug.
+    ///   bytes exceed one of the payload's
+    ///   [decode options](Payload::with_decode_options)' limits, or fail to
+    ///   decode as `V` — peer-supplied data, not a server bug.
     /// - [`internal`](ConnectError::internal) if a replacement set with
     ///   [`set_message`](Payload::set_message) fails to re-encode or
     ///   decode as `V` — server-supplied data, so the asymmetry with the
-    ///   wire-bytes case is intentional.
+    ///   wire-bytes case is intentional. A replacement is decoded without
+    ///   the limits for the same reason.
     pub fn view<V>(&self) -> Result<OwnedView<V>, ConnectError>
     where
         V: MessageView<'static>,
     {
         if let Some(replaced) = &self.replaced {
+            // A replacement was just encoded from a message this process
+            // already holds, so the wire-facing decode limits do not apply:
+            // the element-memory budget is an amplification defence against a
+            // small peer payload materializing a huge one, and a server-built
+            // message can legitimately exceed it. `StreamMessage::from_message`
+            // lifts the same limits for the same reason.
             let bytes = replaced.encode(CodecFormat::Proto)?;
             return OwnedView::decode(bytes).map_err(|e| {
                 ConnectError::internal(format!("failed to decode replacement as view: {e}"))
@@ -342,7 +350,7 @@ impl Payload {
                 "Payload::view requires a proto-encoded wire; use Payload::message for JSON",
             ));
         }
-        OwnedView::decode(self.bytes.clone()).map_err(|e| {
+        OwnedView::decode_with_options(self.bytes.clone(), &self.decode_options).map_err(|e| {
             ConnectError::invalid_argument(format!("failed to decode payload as view: {e}"))
         })
     }


### PR DESCRIPTION
Fixes #243

`Limits::element_memory_limit` reached the `Payload` an interceptor sees on unary requests but on none of the three streaming kinds, so an interceptor that decoded the request itself was held to buffa's defaults rather than to whatever the server was configured with.

`UnaryRequest::new` already attached `ctx.decode_options()`; the three streaming construction sites called `Payload::new` bare, and that defaults to `buffa::DecodeOptions::new()`. All four kinds now thread the context's options through.

**The larger half turned out to be `Payload::view`,** which ignored the options entirely — so even unary was only half covered, and the accessor that bypassed the budget was the one this codebase steers users toward. Driving it live confirmed the shape: before the change, `view()` decoded 50,000 elements under a 1 KiB budget on *all four* RPC kinds including unary, while `message()` was correctly rejected on unary only. After, all six combinations of {unary, client-stream, bidi} × {`message`, `view`} agree.

A replacement set by an interceptor is still decoded unbudgeted. Those are bytes this process just encoded from a message it already holds, so the amplification defence has nothing to defend against — the same reasoning `StreamMessage` already records for lifting the wire limits on locally-encoded bytes. Applying the budget there would let an interceptor set a legitimate replacement and then fail to read it back.

Handler-side decode was never affected, so the blast radius is interceptors that decode. That is narrow, but the limit is a DoS control and the gap was wrong in both directions: lowering it did not apply where an interceptor decoded, and raising it made an interceptor fail on a message the handler would have accepted.

Response-side payloads are deliberately untouched — `UnaryResponse::from_encoded`, `StreamResponse::from_encoded` and `ClientStreamingTerminal` carry handler output, not a peer-controlled decode.

JSON bodies remain un-budgeted on the interceptor and handler paths alike; that is pre-existing and out of scope here, but the changelog now says so rather than implying otherwise.

No new changelog fragment. The configurable budget is itself unreleased, so the coverage sentence in its existing `Added` entry is corrected in place — a release note that announced a feature and then apologised for a bug in it would be a PR description, not release notes.

Five unit tests, each confirmed to fail without the change, plus a live drive over a real socket through generated dispatch with a matched base-tree control.

One note on CI: two `handler::tests` element-budget tests fail on `main` right now, independently of this change — fixture rot from buffa 0.9.1, fixed by #239.
