### PR TITLE
codegen: fail when a type is absent from the descriptor set

### DIFF
--- a/.changes/unreleased/Fixed-20260723-222229.yaml
+++ b/.changes/unreleased/Fixed-20260723-222229.yaml
@@ -1,0 +1,18 @@
+kind: Fixed
+body: |-
+  **A method type missing from the descriptor set is now an error on the
+  build-script path instead of a silent bare-name reference** ([#244]).
+  `connectrpc-build` used to accept a `Config::descriptor_set` input whose
+  service referenced a type absent from the set — for example a set built
+  without `protoc --include_imports` — and report success while emitting code
+  that named a type existing nowhere, so the first signal was rustc complaining
+  about a file in `$OUT_DIR` the user never wrote. The
+  `protoc-gen-connect-rust` plugin already rejected the same input; both paths
+  now fail with the same message, naming the unresolved type and pointing at
+  `--include_imports`. Sets produced by connectrpc-build's own protoc and buf
+  sources always carry the import closure, so only `Config::descriptor_set`
+  users are affected. A corrupt precompiled set also now names the file that
+  failed to decode.
+
+  [#244]: https://github.com/connectrpc/connect-rust/issues/244
+time: 2026-07-23T22:22:29.709734822-07:00

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -287,7 +287,9 @@ impl Config {
     /// or `buf build --as-file-descriptor-set -o ...`, then ship it with
     /// your source. Add `--include_source_info` to the `protoc` invocation
     /// if you want proto comments carried into the generated Rust docs
-    /// (buf includes source info by default).
+    /// (buf includes source info by default). `--include_imports` is not
+    /// optional: a set built without it omits imported message types, and
+    /// generation fails naming the first type it cannot resolve.
     ///
     /// [`Config::files`] selects which files in the set to generate code for.
     /// **These must be the proto-relative names as they appear in the
@@ -361,7 +363,8 @@ impl Config {
     /// - `protoc` or `buf` is not on `PATH` (when using those sources)
     /// - the compiler exits non-zero (syntax error, missing import, ...)
     /// - a precompiled descriptor set cannot be read or decoded
-    /// - codegen fails (unsupported proto feature)
+    /// - codegen fails (unsupported proto feature, or a method type absent
+    ///   from the descriptor set — see [`Config::descriptor_set`])
     /// - the output directory cannot be created or written to
     /// - [`Config::emit_descriptor_set`] was given a name containing path
     ///   separators, or the descriptor set cannot be written
@@ -419,7 +422,13 @@ impl Config {
         let decode_options = buffa_codegen::tooling_decode_options().map_err(|e| anyhow!("{e}"))?;
         let mut fds = decode_options
             .decode_from_slice::<FileDescriptorSet>(&descriptor_bytes)
-            .map_err(|e| descriptor_decode_error(&e, decode_options.element_memory_limit()))?;
+            .map_err(|e| {
+                descriptor_decode_error(
+                    &e,
+                    decode_options.element_memory_limit(),
+                    &self.descriptor_source,
+                )
+            })?;
 
         // 3. Generate.
         let generated = codegen::generate_files(&fds.file, &files_to_generate, &self.options)?;
@@ -533,8 +542,18 @@ impl Default for Config {
 /// an over-budget set it also names two remedies, and only one of them is
 /// reachable from here — a build script has no plugin parameter string — so
 /// this says which, and points at the connectrpc guide rather than buffa's.
-fn descriptor_decode_error(e: &buffa::DecodeError, limit: usize) -> anyhow::Error {
-    let base = buffa_codegen::decode_failure("FileDescriptorSet", e, limit);
+fn descriptor_decode_error(
+    e: &buffa::DecodeError,
+    limit: usize,
+    source: &DescriptorSource,
+) -> anyhow::Error {
+    // A precompiled set is the one source whose bytes the user can point a
+    // tool at, so name the file instead of the message type.
+    let subject = match source {
+        DescriptorSource::Precompiled(p) => format!("descriptor set '{}'", p.display()),
+        DescriptorSource::Protoc | DescriptorSource::Buf => "FileDescriptorSet".to_owned(),
+    };
+    let base = buffa_codegen::decode_failure(&subject, e, limit);
     if matches!(e, buffa::DecodeError::ElementMemoryLimitExceeded) {
         anyhow!(
             "{base}\nOf those two, only the {env} environment variable applies to a \
@@ -1488,6 +1507,7 @@ service NoteService {
         let rendered = descriptor_decode_error(
             &buffa::DecodeError::ElementMemoryLimitExceeded,
             buffa::DEFAULT_ELEMENT_MEMORY_LIMIT,
+            &DescriptorSource::Protoc,
         )
         .to_string();
 
@@ -1512,12 +1532,34 @@ service NoteService {
         let rendered = descriptor_decode_error(
             &buffa::DecodeError::UnexpectedEof,
             buffa::DEFAULT_ELEMENT_MEMORY_LIMIT,
+            &DescriptorSource::Protoc,
         )
         .to_string();
 
         assert!(
             !rendered.contains(buffa_codegen::ELEMENT_MEMORY_LIMIT_ENV),
             "a truncated set must not point at the budget: {rendered}"
+        );
+    }
+
+    /// A precompiled set is the one source whose bytes the caller can open,
+    /// so the failure names the file rather than the message type.
+    #[test]
+    fn a_corrupt_precompiled_set_names_the_file() {
+        let rendered = descriptor_decode_error(
+            &buffa::DecodeError::UnexpectedEof,
+            buffa::DEFAULT_ELEMENT_MEMORY_LIMIT,
+            &DescriptorSource::Precompiled(PathBuf::from("/tmp/schema.binpb")),
+        )
+        .to_string();
+
+        assert!(
+            rendered.contains("/tmp/schema.binpb"),
+            "must name the file to open: {rendered}"
+        );
+        assert!(
+            !rendered.contains("FileDescriptorSet"),
+            "naming the file beats naming the message type: {rendered}"
         );
     }
 }

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -267,8 +267,10 @@ fn emit_service_files(
 /// # Errors
 ///
 /// Returns an error if buffa-codegen fails (e.g. unsupported proto
-/// feature) or if the generated service binding Rust does not parse
-/// under `syn` (indicates a bug in this crate).
+/// feature), if a method input/output type is absent from `proto_file`
+/// (an import missing from the descriptor set), or if the generated
+/// service binding Rust does not parse under `syn` (indicates a bug in
+/// this crate).
 pub fn generate_files(
     proto_file: &[FileDescriptorProto],
     file_to_generate: &[String],
@@ -800,16 +802,15 @@ impl<'a> TypeResolver<'a> {
     /// Resolve a proto FQN (e.g. `.google.protobuf.Empty`) to a Rust type-path
     /// string relative to `current_package`.
     ///
-    /// In `require_extern` mode, errors if the path is not absolute or the
-    /// type is absent from the descriptor set. Otherwise falls back to the
-    /// bare type name for unknown types (rustc will point at the use site).
+    /// Errors if the type is absent from the descriptor set, and — in
+    /// `require_extern` mode — if the resolved path is not absolute.
     fn resolve_path(&self, proto_fqn: &str, current_package: &str) -> Result<String> {
         match self.ctx.rust_type_relative(proto_fqn, current_package, 0) {
             Some(path) => {
                 self.check_extern_coverage(proto_fqn, &path)?;
                 Ok(path)
             }
-            None => self.fallback_unresolved(proto_fqn).map(str::to_string),
+            None => Err(self.unresolved_type_error(proto_fqn)),
         }
     }
 
@@ -830,14 +831,21 @@ impl<'a> TypeResolver<'a> {
         Ok(())
     }
 
-    /// Fallback when a FQN is absent from the descriptor set: error in
-    /// `require_extern` mode, otherwise return the bare type name (rustc
-    /// will point at the use site if it's wrong).
-    fn fallback_unresolved<'f>(&self, proto_fqn: &'f str) -> Result<&'f str> {
-        if self.require_extern {
-            anyhow::bail!("type {proto_fqn} not found in descriptor set (missing proto import?)");
-        }
-        Ok(bare_type_name(proto_fqn))
+    /// Error for a proto FQN absent from the descriptor set. Shared by the
+    /// type and view resolution paths so both report the same fix.
+    ///
+    /// The precompiled-set hint is for [`generate_files`] only: protoc
+    /// hands the plugin path a complete import closure, so a plugin user
+    /// has no descriptor set of their own to rebuild.
+    fn unresolved_type_error(&self, proto_fqn: &str) -> anyhow::Error {
+        let hint = if self.require_extern {
+            ""
+        } else {
+            " for a precompiled descriptor set, rebuild it with --include_imports"
+        };
+        anyhow::anyhow!(
+            "type {proto_fqn} not found in descriptor set (missing proto import?{hint})"
+        )
     }
 
     /// Resolve a proto FQN to Rust type-path tokens.
@@ -863,10 +871,7 @@ impl<'a> TypeResolver<'a> {
                     self.check_extern_coverage(proto_fqn, &s.to_package)?;
                     (s.to_package, s.within_package)
                 }
-                None => (
-                    String::new(),
-                    self.fallback_unresolved(proto_fqn)?.to_string(),
-                ),
+                None => return Err(self.unresolved_type_error(proto_fqn)),
             };
         let prefix = if to_package.is_empty() {
             format!("{SENTINEL_MOD}::view")
@@ -878,7 +883,6 @@ impl<'a> TypeResolver<'a> {
 }
 
 /// Last segment of a proto FQN, e.g. `.google.protobuf.Empty` → `"Empty"`.
-/// Fallback for types absent from the resolver context.
 fn bare_type_name(proto_fqn: &str) -> &str {
     proto_fqn
         .strip_prefix('.')
@@ -3532,6 +3536,90 @@ mod tests {
         assert!(
             msg.contains("extern_path"),
             "error message lacks hint: {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_descriptor_type_errors_on_build_script_path() {
+        // A descriptor set built without `--include_imports` carries the
+        // service but not the imported request type. The build-script path
+        // must fail here rather than emit a reference to a type that exists
+        // nowhere (issue #244).
+        let file = minimal_file(
+            Some("example.v1"),
+            ".dep.v1.Dep",
+            ".example.v1.PingResp",
+            &["PingResp"],
+        );
+        let err = generate_files(
+            std::slice::from_ref(&file),
+            &["ping.proto".into()],
+            &Options::default(),
+        )
+        .expect_err("a dangling method type must not generate successfully");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(".dep.v1.Dep") && msg.contains("descriptor set"),
+            "error message should name the missing type: {msg}"
+        );
+        assert!(
+            msg.contains("--include_imports"),
+            "error message should point at the precompiled-set fix: {msg}"
+        );
+    }
+
+    #[test]
+    fn imported_type_outside_file_to_generate_still_resolves() {
+        // The strictness above keys on presence in the descriptor set, not
+        // on membership in `file_to_generate`: an imported proto carried by
+        // the set resolves even though no code is generated for it here.
+        // This is how every WKT reference works, so it must keep working.
+        let wkt = FileDescriptorProto {
+            name: Some("google/protobuf/empty.proto".into()),
+            package: Some("google.protobuf".into()),
+            message_type: vec![DescriptorProto {
+                name: Some("Empty".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let svc = minimal_file(
+            Some("example.v1"),
+            ".google.protobuf.Empty",
+            ".example.v1.PingResp",
+            &["PingResp"],
+        );
+        let generated = generate_files(&[wkt, svc], &["ping.proto".into()], &Options::default())
+            .expect("an imported type present in the set resolves");
+        let all: String = generated.iter().map(|f| f.content.as_str()).collect();
+        assert!(
+            all.contains("buffa_types :: google :: protobuf :: Empty")
+                || all.contains("buffa_types::google::protobuf::Empty"),
+            "imported WKT should resolve through its extern mapping: {all}"
+        );
+    }
+
+    #[test]
+    fn missing_descriptor_type_on_plugin_path_omits_precompiled_hint() {
+        // protoc hands the plugin a complete import closure, so a plugin
+        // user has no descriptor set of their own to rebuild — only the
+        // missing-import half of the message applies.
+        let file = minimal_file(
+            Some("example.v1"),
+            ".dep.v1.Dep",
+            ".example.v1.PingResp",
+            &["PingResp"],
+        );
+        let extern_paths = [(".".into(), "crate::proto".into())];
+        let err = gen_service(std::slice::from_ref(&file), 0, &extern_paths, true).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains(".dep.v1.Dep") && msg.contains("missing proto import"),
+            "error message should name the missing type: {msg}"
+        );
+        assert!(
+            !msg.contains("--include_imports"),
+            "precompiled-set hint does not apply to the plugin path: {msg}"
         );
     }
 


### PR DESCRIPTION
Fixes #244

`connectrpc-build` generated code referencing types that do not exist, and reported success.

`TypeResolver`'s `require_extern` flag gated two unrelated conditions: "the resolved path must come from an `extern_path` mapping", which is meaningful only on the plugin path, and "the type must exist in the descriptor set", which is meaningful on both. Because the build-script path constructs the resolver with `require_extern = false`, a type absent from the descriptor set silently degraded to its bare name — so generation emitted `impl Encodable<Dep>` and `__buffa::view::DepView` for a `Dep` that appears nowhere in the output, and the first thing the user saw was rustc complaining about a type in a `$OUT_DIR` file they never wrote. The plugin, given a byte-identical descriptor set, failed cleanly.

The two conditions are now separate: `check_extern_coverage` stays gated as before, and the missing-type case fails on both paths. The remedy is selected by the path that hit it, since a plugin user has no precompiled descriptor set to rebuild — the build-script message names `--include_imports`, the plugin message does not.

This lands on users of `Config::descriptor_set()`, the escape hatch for Bazel and BSR builds that cannot run protoc. Protoc mode was never affected because `connectrpc-build` always passes `--include_imports` there, and the buf source carries the import closure too. The docs for `descriptor_set` warn about `--include_imports` three times; they had to, because the error did not.

While in the same statement, the descriptor decode error now names the file it failed on. It reads `self.descriptor_source` and enumerates the variants rather than taking a wildcard arm, so a new source cannot silently inherit the wrong message.

One scenario was worth ruling out before tightening this: for a same-package type the unified path emits a bare ident anyway, so the old fallback could in principle have produced a correct path. It cannot in practice — the emitted stubs also reference a *view* type rooted in this run's own sentinel module, which a type absent from the set was never generated into, and the check keys on presence in the descriptor set rather than membership in `file_to_generate`, so "generate services here, messages elsewhere" keeps working as long as the import stays in the set. A test pins that boundary.

Nothing else in the workspace depended on the leniency: all 94 existing `connectrpc-codegen` tests pass unchanged, and every in-repo generation consumer still compiles. The new test drives `generate_files` with a service whose request type is absent from the set and asserts the error names both the type and the remedy; it was confirmed to pass (that is, generation succeeded) before the fix.

One note on CI: two `handler::tests` element-budget tests fail on `main` right now, independently of this change — fixture rot from buffa 0.9.1, fixed by #239. The `connectrpc` crate does not depend on either codegen crate, so this change cannot reach them.
