### PR TITLE
compression: remove the unused streaming-compression surface

### DIFF
--- a/.changes/unreleased/Removed-20260723-222641.yaml
+++ b/.changes/unreleased/Removed-20260723-222641.yaml
@@ -1,0 +1,20 @@
+kind: Removed
+body: |-
+    **Removed the `streaming` feature and the `StreamingCompressionProvider`
+    API** ([#246]). **Streaming RPCs are unaffected** — the feature name invites
+    the opposite conclusion, but what it gated was an incremental-compression API
+    that no wire path could reach, not streaming RPC support.
+
+    **Breaking.** Gone: the `streaming` feature (previously on by default), the
+    `StreamingCompressionProvider` trait, the `BoxedAsyncRead` and
+    `BoxedAsyncBufRead` aliases, and `CompressionRegistry`'s `register_streaming`,
+    `get_streaming`, `supports_streaming`, `compress_stream` and
+    `decompress_stream`. A custom provider registered through `register_streaming`
+    moves to `register` and keeps working on every path that ever used it. Removed
+    API surfaces as a rustc error; a stale `streaming` entry in a
+    `features = [...]` array fails earlier still, as a Cargo resolution error —
+    drop it there too. The removal also drops the `async-compression` dependency,
+    which was compiled into every default build.
+
+    [#246]: https://github.com/connectrpc/connect-rust/issues/246
+time: 2026-07-23T22:26:41.865238285-07:00

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ GitHub Actions CI (`.github/workflows/ci.yml`) runs on every push to
 - **Examples** — builds and runs the example crates
 - **Minimal features** — `cargo check` *and* `cargo test`, both
   `-p connectrpc --no-default-features`. Because the tests run, a test that
-  needs `json`, `gzip`, `zstd` or `streaming` must be
+  needs `json`, `gzip` or `zstd` must be
   `#[cfg(feature = "...")]`-gated or it fails here while passing the
   default-feature suite
 - **Wasm** — `wasm32-unknown-unknown` build of the client example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ serde_json = "1"
 # Compression
 flate2 = { version = "1.0", default-features = false, features = ["zlib-rs"] }
 zstd = "0.13"
-async-compression = { version = "0.4", features = ["tokio"] }
 
 # Error handling
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -323,7 +323,6 @@ The Quick Start above shows the unary path. For everything else, see the user gu
 | `json`       | Yes     | JSON codec for protobuf messages. Disable (with codegen `no_json`) for proto-only builds — see [Proto-only builds](#proto-only-no-json-builds) |
 | `gzip`       | Yes     | Gzip compression via flate2                      |
 | `zstd`       | Yes     | Zstandard compression via zstd                   |
-| `streaming`  | Yes     | Streaming compression via async-compression      |
 | `client`     | No      | HTTP client transports (plaintext)               |
 | `client-tls` | No      | TLS for client transports (`HttpClient::with_tls`, `Http2Connection::connect_tls`) |
 | `server`     | No      | Standalone hyper-based server                    |
@@ -359,7 +358,7 @@ feature:
 [dependencies]
 # Note: `default-features = false` is the only way to drop `json`, so it also
 # drops the default compression features — re-list any you still want.
-connectrpc = { version = "0.8", default-features = false, features = ["server", "gzip", "zstd", "streaming"] }
+connectrpc = { version = "0.8", default-features = false, features = ["server", "gzip", "zstd"] }
 ```
 
 With `json` off, message-type bounds relax from `Message + Serialize` to just

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -61,9 +61,8 @@ serde_json = { workspace = true }
 flate2 = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 
-# Streaming compression (optional)
-async-compression = { workspace = true, optional = true }
-tokio-util = { workspace = true, features = ["codec", "io"] }
+# Envelope framing (`Encoder`/`Decoder` for the 5-byte message header)
+tokio-util = { workspace = true, features = ["codec"] }
 
 # Error handling
 thiserror = { workspace = true }
@@ -100,7 +99,7 @@ buffa-types = { workspace = true }
 h2 = { workspace = true }
 
 [features]
-default = ["gzip", "zstd", "streaming", "json"]
+default = ["gzip", "zstd", "json"]
 
 # JSON codec for protobuf message types. On by default. Disabling it drops the
 # `serde::Serialize`/`DeserializeOwned` requirement on message types (see
@@ -111,9 +110,8 @@ default = ["gzip", "zstd", "streaming", "json"]
 json = ["buffa/json"]
 
 # Compression algorithms
-gzip = ["dep:flate2", "async-compression?/gzip"]
-zstd = ["dep:zstd", "async-compression?/zstd"]
-streaming = ["dep:async-compression"]
+gzip = ["dep:flate2"]
+zstd = ["dep:zstd"]
 
 # Standalone hyper-based server (convenience feature)
 server = [

--- a/connectrpc/src/compression.rs
+++ b/connectrpc/src/compression.rs
@@ -7,11 +7,14 @@
 //! - `gzip` - Gzip compression via flate2 (enabled by default)
 //! - `zstd` - Zstandard compression via zstd (enabled by default)
 //!
-//! # Streaming Compression
-//!
-//! When the `streaming` feature is enabled (default), providers can also
-//! support streaming compression/decompression for handling large payloads
-//! without buffering the entire message in memory.
+//! Compression is always applied a whole message at a time, on every wire
+//! shape. The enveloped framings — Connect streaming, gRPC, and gRPC-Web —
+//! are length-prefixed: the 5-byte header carries the *compressed* length, so
+//! a message must be fully compressed before its own header can be written.
+//! Connect unary has no envelope, just a `content-encoding` body, but that
+//! body is collected in full and size-checked before it is decompressed. So
+//! neither direction ever holds a partial message, and there is no point in
+//! the pipeline at which an incremental compressor could attach.
 //!
 //! # Example
 //!
@@ -53,15 +56,9 @@
 //! ```
 
 use std::collections::HashMap;
-#[cfg(feature = "streaming")]
-use std::pin::Pin;
 use std::sync::Arc;
 
 use bytes::Bytes;
-#[cfg(feature = "streaming")]
-use tokio::io::AsyncBufRead;
-#[cfg(feature = "streaming")]
-use tokio::io::AsyncRead;
 
 use crate::error::ConnectError;
 
@@ -69,20 +66,6 @@ use crate::error::ConnectError;
 fn malformed_compressed_payload(message: impl Into<String>) -> ConnectError {
     ConnectError::invalid_argument(message)
 }
-
-// ============================================================================
-// Streaming Types
-// ============================================================================
-
-/// A boxed async reader for streaming compression/decompression.
-#[cfg(feature = "streaming")]
-#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-pub type BoxedAsyncRead = Pin<Box<dyn AsyncRead + Send>>;
-
-/// A boxed async buffered reader for streaming input.
-#[cfg(feature = "streaming")]
-#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-pub type BoxedAsyncBufRead = Pin<Box<dyn AsyncBufRead + Send>>;
 
 /// Trait for compression algorithm implementations.
 ///
@@ -155,26 +138,6 @@ pub trait CompressionProvider: Send + Sync + 'static {
     }
 }
 
-/// Trait for streaming compression support.
-///
-/// This trait extends [`CompressionProvider`] with streaming methods that
-/// process data incrementally without buffering the entire payload in memory.
-///
-/// Available when the `streaming` feature is enabled (default).
-#[cfg(feature = "streaming")]
-#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-pub trait StreamingCompressionProvider: CompressionProvider {
-    /// Create a streaming decompressor.
-    ///
-    /// Returns an `AsyncRead` that decompresses data from the input reader.
-    fn decompress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead;
-
-    /// Create a streaming compressor.
-    ///
-    /// Returns an `AsyncRead` that compresses data from the input reader.
-    fn compress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead;
-}
-
 /// Registry of compression providers.
 ///
 /// The registry maps encoding names to their provider implementations.
@@ -183,8 +146,6 @@ pub trait StreamingCompressionProvider: CompressionProvider {
 #[derive(Clone)]
 pub struct CompressionRegistry {
     providers: Arc<HashMap<&'static str, Arc<dyn CompressionProvider>>>,
-    #[cfg(feature = "streaming")]
-    streaming_providers: Arc<HashMap<&'static str, Arc<dyn StreamingCompressionProvider>>>,
     /// Cached, sorted, comma-joined list of supported encodings for
     /// Accept-Encoding headers. Recomputed when providers are registered
     /// (rather than on every request).
@@ -207,8 +168,6 @@ impl CompressionRegistry {
     pub fn new() -> Self {
         Self {
             providers: Arc::new(HashMap::new()),
-            #[cfg(feature = "streaming")]
-            streaming_providers: Arc::new(HashMap::new()),
             accept_encoding: Arc::from(""),
         }
     }
@@ -367,96 +326,6 @@ impl CompressionRegistry {
 
         provider.compress(data)
     }
-
-    /// Register a streaming compression provider.
-    ///
-    /// This also registers the provider for buffered compression.
-    /// Returns self for method chaining.
-    ///
-    /// Available when the `streaming` feature is enabled.
-    #[cfg(feature = "streaming")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-    #[must_use]
-    pub fn register_streaming<P: StreamingCompressionProvider>(mut self, provider: P) -> Self {
-        let name = provider.name();
-        let provider = Arc::new(provider);
-
-        // Register for both buffered and streaming
-        let providers = Arc::make_mut(&mut self.providers);
-        providers.insert(name, provider.clone());
-
-        let streaming_providers = Arc::make_mut(&mut self.streaming_providers);
-        streaming_providers.insert(name, provider);
-
-        self.rebuild_accept_encoding();
-        self
-    }
-
-    /// Get a streaming provider by encoding name.
-    ///
-    /// Returns `None` if no streaming provider is registered for the given name.
-    #[cfg(feature = "streaming")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-    pub fn get_streaming(&self, name: &str) -> Option<Arc<dyn StreamingCompressionProvider>> {
-        self.streaming_providers.get(name).cloned()
-    }
-
-    /// Check if streaming compression is supported for the given encoding name.
-    #[cfg(feature = "streaming")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-    pub fn supports_streaming(&self, name: &str) -> bool {
-        self.streaming_providers.contains_key(name)
-    }
-
-    /// Create a streaming decompressor for the specified encoding.
-    ///
-    /// Returns an `AsyncRead` that decompresses data from the input reader.
-    /// Returns an error if the encoding is not supported for streaming.
-    #[cfg(feature = "streaming")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-    pub fn decompress_stream(
-        &self,
-        encoding: &str,
-        reader: BoxedAsyncBufRead,
-    ) -> Result<BoxedAsyncRead, ConnectError> {
-        // "identity" means no compression - just return the reader as-is
-        if encoding == "identity" {
-            return Ok(reader);
-        }
-
-        let provider = self.get_streaming(encoding).ok_or_else(|| {
-            ConnectError::unimplemented(format!(
-                "streaming decompression not supported for encoding: {encoding}"
-            ))
-        })?;
-
-        Ok(provider.decompress_stream(reader))
-    }
-
-    /// Create a streaming compressor for the specified encoding.
-    ///
-    /// Returns an `AsyncRead` that compresses data from the input reader.
-    /// Returns an error if the encoding is not supported for streaming.
-    #[cfg(feature = "streaming")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-    pub fn compress_stream(
-        &self,
-        encoding: &str,
-        reader: BoxedAsyncBufRead,
-    ) -> Result<BoxedAsyncRead, ConnectError> {
-        // "identity" means no compression - just return the reader as-is
-        if encoding == "identity" {
-            return Ok(reader);
-        }
-
-        let provider = self.get_streaming(encoding).ok_or_else(|| {
-            ConnectError::unimplemented(format!(
-                "streaming compression not supported for encoding: {encoding}"
-            ))
-        })?;
-
-        Ok(provider.compress_stream(reader))
-    }
 }
 
 /// Policy controlling when compression is applied.
@@ -558,23 +427,12 @@ impl Default for CompressionRegistry {
     fn default() -> Self {
         let mut registry = Self::new();
 
-        // When streaming is enabled, use register_streaming to get both capabilities
-        #[cfg(all(feature = "gzip", feature = "streaming"))]
-        {
-            registry = registry.register_streaming(GzipProvider::default());
-        }
-
-        #[cfg(all(feature = "gzip", not(feature = "streaming")))]
+        #[cfg(feature = "gzip")]
         {
             registry = registry.register(GzipProvider::default());
         }
 
-        #[cfg(all(feature = "zstd", feature = "streaming"))]
-        {
-            registry = registry.register_streaming(ZstdProvider::default());
-        }
-
-        #[cfg(all(feature = "zstd", not(feature = "streaming")))]
+        #[cfg(feature = "zstd")]
         {
             registry = registry.register(ZstdProvider::default());
         }
@@ -937,23 +795,6 @@ impl CompressionProvider for GzipProvider {
     }
 }
 
-#[cfg(all(feature = "gzip", feature = "streaming"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "gzip", feature = "streaming"))))]
-impl StreamingCompressionProvider for GzipProvider {
-    fn decompress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead {
-        Box::pin(async_compression::tokio::bufread::GzipDecoder::new(reader))
-    }
-
-    fn compress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead {
-        Box::pin(
-            async_compression::tokio::bufread::GzipEncoder::with_quality(
-                reader,
-                async_compression::Level::Precise(self.level as i32),
-            ),
-        )
-    }
-}
-
 /// Zstandard compression provider with internal compressor pooling.
 ///
 /// Pools `zstd::bulk::Compressor` objects to avoid repeated allocation of
@@ -1115,23 +956,6 @@ impl CompressionProvider for ZstdProvider {
     }
 }
 
-#[cfg(all(feature = "zstd", feature = "streaming"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "zstd", feature = "streaming"))))]
-impl StreamingCompressionProvider for ZstdProvider {
-    fn decompress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead {
-        Box::pin(async_compression::tokio::bufread::ZstdDecoder::new(reader))
-    }
-
-    fn compress_stream(&self, reader: BoxedAsyncBufRead) -> BoxedAsyncRead {
-        Box::pin(
-            async_compression::tokio::bufread::ZstdEncoder::with_quality(
-                reader,
-                async_compression::Level::Precise(self.level),
-            ),
-        )
-    }
-}
-
 // ============================================================================
 // Tests
 // ============================================================================
@@ -1270,29 +1094,21 @@ mod tests {
         }
     }
 
-    #[cfg(all(feature = "gzip", feature = "streaming"))]
-    #[tokio::test]
-    async fn test_gzip_streaming_honors_level() {
-        use tokio::io::AsyncReadExt;
-        async fn stream_compress(p: &GzipProvider, data: &[u8]) -> Vec<u8> {
-            let reader: BoxedAsyncBufRead = Box::pin(std::io::Cursor::new(data.to_vec()));
-            let mut enc = p.compress_stream(reader);
-            let mut out = Vec::new();
-            enc.read_to_end(&mut out).await.unwrap();
-            out
-        }
-        let data = b"hello world, streaming gzip at the configured level".repeat(200);
-        let fast = stream_compress(&GzipProvider::with_level(1), &data).await;
-        let best = stream_compress(&GzipProvider::with_level(9), &data).await;
-        // Both must round-trip via the buffered decoder.
+    #[cfg(feature = "gzip")]
+    #[test]
+    fn test_gzip_honors_level() {
+        let data = b"hello world, gzip at the configured level".repeat(200);
+        let fast = GzipProvider::with_level(1).compress(&data).unwrap();
+        let best = GzipProvider::with_level(9).compress(&data).unwrap();
+        // Both must round-trip.
         for c in [&fast, &best] {
             let out = GzipProvider::default()
                 .decompress_with_limit(c, usize::MAX)
                 .unwrap();
             assert_eq!(&out[..], &data[..]);
         }
-        // Level must actually affect output (previously ignored): level 9 on
-        // highly repetitive input compresses strictly smaller than level 1.
+        // Level must actually affect output: level 9 on highly repetitive
+        // input compresses strictly smaller than level 1.
         assert!(
             best.len() < fast.len(),
             "level 9 ({}) should be smaller than level 1 ({})",
@@ -1777,7 +1593,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "zstd")]
+    #[cfg(all(feature = "gzip", feature = "zstd"))]
     fn test_decompress_empty_body_with_encoding_header() {
         // Connect spec: "Servers must not attempt to decompress zero-length
         // HTTP request content." Clients may set Content-Encoding but skip
@@ -1916,81 +1732,6 @@ mod tests {
         let decompressed = registry
             .decompress_with_limit("mock", compressed, usize::MAX)
             .unwrap();
-        assert_eq!(&decompressed[..], data);
-    }
-
-    #[cfg(all(feature = "gzip", feature = "streaming"))]
-    #[tokio::test]
-    async fn test_gzip_streaming() {
-        use tokio::io::AsyncReadExt;
-
-        let registry = CompressionRegistry::default();
-        assert!(registry.supports_streaming("gzip"));
-
-        // Create test data
-        let data = b"hello world, this is a test of streaming gzip compression";
-
-        // Compress using buffered method
-        let compressed = registry.compress("gzip", data).unwrap();
-
-        // Decompress using streaming
-        let reader: BoxedAsyncBufRead = Box::pin(std::io::Cursor::new(compressed.to_vec()));
-        let mut decompressor = registry.decompress_stream("gzip", reader).unwrap();
-
-        let mut decompressed = Vec::new();
-        decompressor.read_to_end(&mut decompressed).await.unwrap();
-
-        assert_eq!(&decompressed[..], data);
-    }
-
-    #[cfg(all(feature = "zstd", feature = "streaming"))]
-    #[tokio::test]
-    async fn test_zstd_streaming() {
-        use tokio::io::AsyncReadExt;
-
-        let registry = CompressionRegistry::default();
-        assert!(registry.supports_streaming("zstd"));
-
-        // Create test data
-        let data = b"hello world, this is a test of streaming zstd compression";
-
-        // Compress using buffered method
-        let compressed = registry.compress("zstd", data).unwrap();
-
-        // Decompress using streaming
-        let reader: BoxedAsyncBufRead = Box::pin(std::io::Cursor::new(compressed.to_vec()));
-        let mut decompressor = registry.decompress_stream("zstd", reader).unwrap();
-
-        let mut decompressed = Vec::new();
-        decompressor.read_to_end(&mut decompressed).await.unwrap();
-
-        assert_eq!(&decompressed[..], data);
-    }
-
-    #[cfg(all(feature = "gzip", feature = "streaming"))]
-    #[tokio::test]
-    async fn test_streaming_compress_decompress_roundtrip() {
-        use tokio::io::AsyncReadExt;
-
-        let registry = CompressionRegistry::default();
-
-        // Create test data
-        let data = b"hello world, this is a roundtrip test of streaming compression";
-
-        // Compress using streaming
-        let input: BoxedAsyncBufRead = Box::pin(std::io::Cursor::new(data.to_vec()));
-        let mut compressor = registry.compress_stream("gzip", input).unwrap();
-
-        let mut compressed = Vec::new();
-        compressor.read_to_end(&mut compressed).await.unwrap();
-
-        // Decompress using streaming
-        let reader: BoxedAsyncBufRead = Box::pin(std::io::Cursor::new(compressed));
-        let mut decompressor = registry.decompress_stream("gzip", reader).unwrap();
-
-        let mut decompressed = Vec::new();
-        decompressor.read_to_end(&mut decompressed).await.unwrap();
-
         assert_eq!(&decompressed[..], data);
     }
 

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -61,7 +61,7 @@
 //! # Modules
 //!
 //! - [`codec`] - Message encoding/decoding (protobuf and JSON)
-//! - [`compression`] - Pluggable compression (gzip, zstd) with streaming support
+//! - [`compression`] - Pluggable compression (gzip, zstd)
 //! - [`envelope`] - Streaming message framing (5-byte header + payload)
 //! - [`error`] - ConnectRPC error types and HTTP status mapping
 //! - [`handler`] - Async handler traits for implementing RPC methods
@@ -88,7 +88,7 @@
 //!   (full-duplex bidi requires HTTP/2; browsers additionally cannot
 //!   stream request bodies, regardless of protocol)
 //! - Proto and JSON message encoding
-//! - Compression negotiation (gzip, zstd) with streaming support
+//! - Compression negotiation (gzip, zstd)
 //! - Error handling with proper HTTP status mapping
 //! - Trailers via `trailer-` prefixed headers
 //! - Envelope framing for streaming messages
@@ -154,7 +154,6 @@
 //! | `json` | ✓ | JSON codec for protobuf messages; disable for proto-only builds |
 //! | `gzip` | ✓ | Gzip compression |
 //! | `zstd` | ✓ | Zstandard compression |
-//! | `streaming` | ✓ | Streaming compression support |
 //! | `client` | ✗ | HTTP client transports (plaintext) |
 //! | `client-tls` | ✗ | TLS for client transports |
 //! | `server` | ✗ | Standalone hyper-based server |
@@ -375,18 +374,6 @@ pub use compression::GzipProvider;
 #[cfg(feature = "zstd")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 pub use compression::ZstdProvider;
-
-#[cfg(feature = "streaming")]
-#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-pub use compression::BoxedAsyncBufRead;
-
-#[cfg(feature = "streaming")]
-#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-pub use compression::BoxedAsyncRead;
-
-#[cfg(feature = "streaming")]
-#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
-pub use compression::StreamingCompressionProvider;
 
 // ============================================================================
 // Optional: Standalone server

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -73,7 +73,6 @@ The runtime is feature-gated so you only pay for what you use:
 | `json` | yes | JSON codec for protobuf messages (the proto3-JSON wire format). Disabling it drops the `serde` requirement on message types — see [Proto-only builds](#proto-only-no-json-builds) |
 | `gzip` | yes | Gzip compression via `flate2` |
 | `zstd` | yes | Zstandard compression via `zstd` |
-| `streaming` | yes | Streaming compression via `async-compression` |
 | `client` | no | HTTP client transports (cleartext) |
 | `client-tls` | no | TLS for client transports |
 | `server` | no | Built-in hyper server (`Server`) |
@@ -118,9 +117,9 @@ It takes two coordinated settings:
    ```toml
    # Proto-only server: no JSON codec, no serde on message types.
    # `default-features = false` is the only way to drop `json`, so it also drops
-   # the default compression features (`gzip`/`zstd`/`streaming`) — re-list the
-   # ones you still want.
-   connectrpc = { version = "0.8", default-features = false, features = ["server", "gzip", "zstd", "streaming"] }
+   # the default compression features (`gzip`/`zstd`) — re-list the ones you
+   # still want.
+   connectrpc = { version = "0.8", default-features = false, features = ["server", "gzip", "zstd"] }
    ```
 
 With `json` off, the `Message + serde` requirement is replaced by the


### PR DESCRIPTION
Fixes #246

Removes `StreamingCompressionProvider`, the second provider map on `CompressionRegistry`, the five registry methods built on it (`register_streaming`, `get_streaming`, `supports_streaming`, `decompress_stream`, `compress_stream`), the two boxed-reader aliases, the impls on both built-in providers, the three `pub use` re-exports, the `streaming` Cargo feature and the `async-compression` dependency.

**Breaking**, so it wants the 0.9.0 window. But nothing a user can reach is lost: grepping every one of those symbols across the workspace finds hits only inside `compression.rs`, its own test module and the re-exports. No RPC path calls any of it, and none could — the enveloped framings carry the compressed length in the 5-byte header, so a message must be fully compressed before its header can be written, and Connect unary collects the whole body before decompressing. Neither direction ever holds a partial message for an incremental codec to work on.

The feature name is the part most likely to mislead. `streaming` was in `default`, and a user reading that list would reasonably conclude that dropping it disables streaming RPCs. It never did — it gated an unused compression API. The guide even told proto-only builds to re-list it. Feature tables in `README.md`, `docs/guide.md`, `CONTRIBUTING.md` and the crate rustdoc are updated to match, and `async-compression` is gone from both the crate and workspace manifests; `cargo tree -p connectrpc -i async-compression` now reports no match.

Two things found while doing it, both kept:

The `register` / `register_streaming` split meant a custom provider registered the normal way was invisible to `get_streaming`. With one map and `register` as the only way in, that trap is gone by construction rather than by discipline.

`test_decompress_empty_body_with_encoding_header` was gated `#[cfg(feature = "zstd")]` but calls `decompress_with_limit("gzip", ..)` and unwraps. `decompress_with_limit` resolves the provider before the empty-body short-circuit, so a zstd-only build would have panicked on the `None`. CI never saw it because its configurations are both-or-neither. Gate corrected to `all(gzip, zstd)`, and both single-codec builds now pass.

Test coverage is unchanged in substance: the three removed tests covered removed API, and `test_gzip_streaming_honors_level` was converted rather than dropped so the compression-level assertion survives on the buffered path.

One note on CI: two `handler::tests` element-budget tests fail on `main` right now, independently of this change — fixture rot from buffa 0.9.1, fixed by #239.
