### PR TITLE
config: prefix the remaining setters with with_ and hide Limits' fields

### DIFF
--- a/.changes/unreleased/Added-20260720-134339.yaml
+++ b/.changes/unreleased/Added-20260720-134339.yaml
@@ -14,7 +14,7 @@ body: |-
 
   ```rust
   ConnectRpcService::new(dispatcher)
-      .with_limits(Limits::default().element_memory_limit(128 * 1024 * 1024))
+      .with_limits(Limits::default().with_element_memory_limit(128 * 1024 * 1024))
   ```
 
   `Limits::unlimited()` lifts it along with the other limits.

--- a/.changes/unreleased/Changed-20260723-223805.yaml
+++ b/.changes/unreleased/Changed-20260723-223805.yaml
@@ -1,0 +1,35 @@
+kind: Changed
+body: |-
+    **Breaking: the `Limits` and `CompressionPolicy` setters are renamed with a
+    `with_` prefix, and the `Limits` fields behind them are now private**
+    ([#247]), to match the `with_` convention used by the other configuration
+    setters. The `Limits` fields were also `pub` and shared their names with the
+    setters, giving each value two ways to be written.
+
+    The rename is a lookup table:
+
+    | Old | New |
+    |---|---|
+    | `Limits::max_request_body_size(n)` | `Limits::with_max_request_body_size(n)` |
+    | `Limits::max_message_size(n)` | `Limits::with_max_message_size(n)` |
+    | `CompressionPolicy::min_size(n)` | `CompressionPolicy::with_min_size(n)` |
+
+    Each old setter name is now a plain accessor, so `limits.max_message_size()`
+    reads back what `with_max_message_size` set and `policy.min_size()` reads the
+    compression threshold, which had no read path before. Code that read a
+    `Limits` field directly (`limits.max_message_size`) just adds the
+    parentheses.
+
+    Writing a `Limits` field directly is what goes away. `Limits` also becomes
+    `#[non_exhaustive]` in 0.9.0, so both remaining forms stop compiling:
+    assignment to a public field, and struct-literal or functional-update
+    construction such as `Limits { max_message_size: 512, ..Default::default() }`.
+    Start from `Limits::default()` or `Limits::unlimited()` and chain the setters
+    instead. `CompressionPolicy`'s fields were already private, so it is a rename
+    plus the new accessor.
+
+    The element-memory budget setter added in this same release arrives already
+    prefixed, as `Limits::with_element_memory_limit`.
+
+    [#247]: https://github.com/connectrpc/connect-rust/issues/247
+time: 2026-07-23T22:38:05.068294686-07:00

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -1579,13 +1579,13 @@ fn compression_encoding_name(compression: Compression) -> Option<&'static str> {
 }
 
 /// Apply request compression config if the test specified an encoding.
-/// `min_size(0)` forces compression even for tiny/empty bodies so the
+/// `with_min_size(0)` forces compression even for tiny/empty bodies so the
 /// conformance runner sees the advertised encoding applied.
 fn apply_compression(config: ClientConfig, compression: Compression) -> ClientConfig {
     match compression_encoding_name(compression) {
         Some(enc) => config
             .compress_requests(enc)
-            .with_compression_policy(connectrpc::CompressionPolicy::default().min_size(0)),
+            .with_compression_policy(connectrpc::CompressionPolicy::default().with_min_size(0)),
         None => config,
     }
 }

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -1210,7 +1210,7 @@ async fn main() -> Result<()> {
 
     // Configure message size limits if requested by the conformance runner
     let limits = if request.message_receive_limit > 0 {
-        Limits::default().max_message_size(request.message_receive_limit as usize)
+        Limits::default().with_max_message_size(request.message_receive_limit as usize)
     } else {
         Limits::default()
     };

--- a/connectrpc/src/compression.rs
+++ b/connectrpc/src/compression.rs
@@ -472,7 +472,7 @@ impl CompressionRegistry {
 /// use connectrpc::CompressionPolicy;
 ///
 /// // Only compress messages >= 4 KiB
-/// let policy = CompressionPolicy::default().min_size(4096);
+/// let policy = CompressionPolicy::default().with_min_size(4096);
 /// assert!(!policy.should_compress(1024));
 /// assert!(policy.should_compress(8192));
 ///
@@ -518,10 +518,22 @@ impl CompressionPolicy {
     ///
     /// Messages smaller than this (in bytes, before compression) will
     /// be sent uncompressed even if compression is negotiated.
+    ///
+    /// Default: 1 KiB ([`DEFAULT_COMPRESSION_MIN_SIZE`]).
     #[must_use]
-    pub fn min_size(mut self, size: usize) -> Self {
+    pub fn with_min_size(mut self, size: usize) -> Self {
         self.min_size = size;
         self
+    }
+
+    /// The minimum message size, in bytes, before compression is applied.
+    ///
+    /// Set via [`Self::with_min_size`]. This is the threshold alone, so it
+    /// says nothing about whether compression is enabled at all — ask
+    /// [`Self::should_compress`] for the decision about a given message.
+    #[must_use]
+    pub fn min_size(&self) -> usize {
+        self.min_size
     }
 
     /// Check whether compression should be applied for a message of the given size.
@@ -2093,11 +2105,26 @@ mod tests {
 
     #[test]
     fn test_compression_policy_custom_min_size() {
-        let policy = CompressionPolicy::default().min_size(4096);
+        let policy = CompressionPolicy::default().with_min_size(4096);
         assert!(!policy.should_compress(1024));
         assert!(!policy.should_compress(4095));
         assert!(policy.should_compress(4096));
         assert!(policy.should_compress(8192));
+    }
+
+    /// The threshold must be readable back, not just observable by probing
+    /// `should_compress` either side of it.
+    #[test]
+    fn compression_policy_min_size_reads_back_through_the_accessor() {
+        assert_eq!(
+            CompressionPolicy::default().min_size(),
+            DEFAULT_COMPRESSION_MIN_SIZE
+        );
+        assert_eq!(
+            CompressionPolicy::default().with_min_size(4096).min_size(),
+            4096
+        );
+        assert_eq!(CompressionPolicy::disabled().min_size(), 0);
     }
 
     #[test]
@@ -2109,7 +2136,7 @@ mod tests {
         // min_size=0 compresses even empty bodies — the Connect spec permits
         // this (receivers skip decompression for zero-length content), and
         // conformance runners check that advertised encodings are applied.
-        let zero_min = CompressionPolicy::default().min_size(0);
+        let zero_min = CompressionPolicy::default().with_min_size(0);
         assert!(zero_min.should_compress(0));
 
         let disabled = CompressionPolicy::disabled();

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -470,7 +470,7 @@ mod tests {
         let registry = Arc::new(CompressionRegistry::default());
         let mut enc = EnvelopeEncoder::new(
             Some((Arc::clone(&registry), "gzip")),
-            CompressionPolicy::default().min_size(0),
+            CompressionPolicy::default().with_min_size(0),
         );
         // Incompressible-ish random-ish payload so the compressed form stays
         // above the chain threshold.
@@ -791,7 +791,7 @@ mod tests {
         let registry = Arc::new(CompressionRegistry::default());
         let mut enc = EnvelopeEncoder::new(
             Some((registry, "gzip")),
-            CompressionPolicy::default().min_size(0),
+            CompressionPolicy::default().with_min_size(0),
         );
         let mut buf = BytesMut::new();
         enc.encode(Bytes::from_static(b"compress me"), &mut buf)

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -50,7 +50,7 @@ fn decode_request_error(e: &buffa::DecodeError) -> ConnectError {
     match e {
         buffa::DecodeError::ElementMemoryLimitExceeded => ConnectError::invalid_argument(format!(
             "failed to decode proto request: {e}; if this peer is trusted, \
-             raise Limits::element_memory_limit"
+             raise the limit with Limits::with_element_memory_limit"
         )),
         _ => ConnectError::invalid_argument(format!("failed to decode proto request: {e}")),
     }
@@ -1479,7 +1479,7 @@ mod tests {
             ..Default::default()
         };
         let encoded = Bytes::from(buffa::Message::encode_to_vec(&list));
-        let raised = crate::Limits::default().element_memory_limit(usize::MAX);
+        let raised = crate::Limits::default().with_element_memory_limit(usize::MAX);
 
         // `decode_request`, used by the owned-message streaming wrappers.
         assert!(
@@ -1576,7 +1576,7 @@ mod tests {
                 .expect_err("the fixture must exceed the default element-memory budget");
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
 
-        let raised = crate::Limits::default().element_memory_limit(usize::MAX);
+        let raised = crate::Limits::default().with_element_memory_limit(usize::MAX);
         let view =
             decode_borrowed_request_view::<ListValueView<'_>>(&encoded, &raised.decode_options())
                 .expect("raising the limit must admit the same bytes");
@@ -1588,7 +1588,10 @@ mod tests {
     /// silently ignored.
     #[test]
     fn unlimited_limits_lift_the_element_budget() {
-        assert_eq!(crate::Limits::unlimited().element_memory_limit, usize::MAX);
+        assert_eq!(
+            crate::Limits::unlimited().element_memory_limit(),
+            usize::MAX
+        );
     }
 
     /// A context built outside the service carries buffa's defaults rather

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -2177,16 +2177,16 @@ mod tests {
         use crate::{CompressionPolicy, CompressionRegistry};
 
         let limits = Limits::default()
-            .max_request_body_size(1024)
-            .max_message_size(512);
+            .with_max_request_body_size(1024)
+            .with_max_message_size(512);
         let server = Server::new(Router::new())
             .with_limits(limits.clone())
             .with_compression(CompressionRegistry::default())
-            .with_compression_policy(CompressionPolicy::default().min_size(8192))
+            .with_compression_policy(CompressionPolicy::default().with_min_size(8192))
             .with_http1_keep_alive(false);
 
-        assert_eq!(server.service.limits().max_request_body_size, 1024);
-        assert_eq!(server.service.limits().max_message_size, 512);
+        assert_eq!(server.service.limits().max_request_body_size(), 1024);
+        assert_eq!(server.service.limits().max_message_size(), 512);
         assert!(!server.http1_keep_alive);
     }
 

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -443,7 +443,7 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 /// after decompression.
 ///
 /// For **unary RPCs**, the request body contains a single message (possibly
-/// compressed). Set `max_request_body_size >= max_message_size` to allow
+/// compressed). Keep `max_request_body_size >= max_message_size` to allow
 /// uncompressed messages up to the message limit. Compressed messages may
 /// have a smaller on-wire body that expands up to `max_message_size`.
 ///
@@ -468,44 +468,29 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 /// These are **server** limits, applied to received requests. A client
 /// decoding responses currently uses buffa's defaults, with no equivalent
 /// override.
+///
+/// # Construction
+///
+/// Start from [`Limits::default`] or [`Limits::unlimited`] and apply the
+/// `with_*` builder methods, then read settings back through the accessor
+/// methods of the same name without the prefix:
+///
+/// ```rust
+/// use connectrpc::Limits;
+///
+/// let limits = Limits::default().with_max_message_size(8 * 1024 * 1024);
+/// assert_eq!(limits.max_message_size(), 8 * 1024 * 1024);
+/// ```
+///
+/// `Limits` is `#[non_exhaustive]`: new limits may be added in minor
+/// releases. Struct-literal and functional-update construction are not
+/// available outside the crate; use the builder methods.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Limits {
-    /// Maximum size of the request body on the wire (before decompression).
-    ///
-    /// Applies to RPCs where the body is read in full (unary and server
-    /// streaming). Should be at least `max_message_size` to allow
-    /// uncompressed messages up to the message limit. Does not apply to
-    /// client/bidi streaming where messages are processed incrementally.
-    ///
-    /// Default: 4 MB (matches tonic/grpc-go).
-    pub max_request_body_size: usize,
-
-    /// Maximum size of a single message after decompression.
-    ///
-    /// This applies uniformly to both unary and streaming RPCs, and to both
-    /// compressed and uncompressed messages. Compressed payloads are bounded
-    /// during decompression — the decompressor will never allocate more than
-    /// this limit.
-    ///
-    /// Default: 4 MB.
-    pub max_message_size: usize,
-
-    /// Maximum memory a single decode may commit to repeated, map, string
-    /// and bytes *elements*.
-    ///
-    /// This is an amplification defence, and it is charged on element
-    /// footprint rather than on contents: a few bytes on the wire can ask
-    /// the decoder to materialize a very large number of small elements,
-    /// each with its own allocation overhead, while staying well under
-    /// `max_message_size`. A single large payload is unaffected however big
-    /// it grows, because its contents are not charged.
-    ///
-    /// Raise it for a trusted peer that legitimately sends messages with
-    /// very many small elements; lower it to tighten the defence.
-    ///
-    /// Default: 32 MiB (buffa's `DEFAULT_ELEMENT_MEMORY_LIMIT`).
-    pub element_memory_limit: usize,
+    max_request_body_size: usize,
+    max_message_size: usize,
+    element_memory_limit: usize,
 }
 
 impl Default for Limits {
@@ -530,36 +515,84 @@ impl Limits {
         }
     }
 
-    /// Set the maximum request body size (on-wire, before decompression).
+    // ---- builders ---------------------------------------------------------
+
+    /// Set the maximum size of the request body on the wire (before
+    /// decompression).
     ///
-    /// Applies to unary and server streaming RPCs where the body is buffered.
-    /// See [`Limits`] for details on the relationship between limits.
+    /// Applies to RPCs where the body is read in full (unary and server
+    /// streaming). Should be at least the message size limit to allow
+    /// uncompressed messages up to that limit. Does not apply to client/bidi
+    /// streaming where messages are processed incrementally.
+    ///
+    /// Read via [`Self::max_request_body_size`]. Default: 4 MB (matches
+    /// tonic/grpc-go).
     #[must_use]
-    pub fn max_request_body_size(mut self, size: usize) -> Self {
+    pub fn with_max_request_body_size(mut self, size: usize) -> Self {
         self.max_request_body_size = size;
         self
     }
 
-    /// Set the maximum message size (after decompression).
+    /// Set the maximum size of a single message after decompression.
     ///
-    /// This bounds individual messages in both unary and streaming RPCs.
-    /// It also serves as the decompression limit.
-    /// See [`Limits`] for details on the relationship between limits.
+    /// This applies uniformly to both unary and streaming RPCs, and to both
+    /// compressed and uncompressed messages. Compressed payloads are bounded
+    /// during decompression — the decompressor will never allocate more than
+    /// this limit.
+    ///
+    /// Read via [`Self::max_message_size`]. Default: 4 MB.
     #[must_use]
-    pub fn max_message_size(mut self, size: usize) -> Self {
+    pub fn with_max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = size;
         self
     }
 
     /// Set the maximum memory a single decode may commit to repeated, map,
-    /// string and bytes elements.
+    /// string and bytes *elements*.
     ///
-    /// See [`Limits`] for what this charges and why it is separate from
-    /// `max_message_size`.
+    /// This is an amplification defence, and it is charged on element
+    /// footprint rather than on contents: a few bytes on the wire can ask
+    /// the decoder to materialize a very large number of small elements,
+    /// each with its own allocation overhead, while staying well under the
+    /// message size limit. A single large payload is unaffected however big
+    /// it grows, because its contents are not charged.
+    ///
+    /// Raise it for a trusted peer that legitimately sends messages with
+    /// very many small elements; lower it to tighten the defence.
+    ///
+    /// Read via [`Self::element_memory_limit`]. Default: 32 MiB (buffa's
+    /// `DEFAULT_ELEMENT_MEMORY_LIMIT`).
     #[must_use]
-    pub fn element_memory_limit(mut self, bytes: usize) -> Self {
+    pub fn with_element_memory_limit(mut self, bytes: usize) -> Self {
         self.element_memory_limit = bytes;
         self
+    }
+
+    // ---- accessors --------------------------------------------------------
+
+    /// The maximum size of the request body on the wire, before decompression.
+    ///
+    /// Set via [`Self::with_max_request_body_size`].
+    #[must_use]
+    pub fn max_request_body_size(&self) -> usize {
+        self.max_request_body_size
+    }
+
+    /// The maximum size of a single message after decompression.
+    ///
+    /// Set via [`Self::with_max_message_size`].
+    #[must_use]
+    pub fn max_message_size(&self) -> usize {
+        self.max_message_size
+    }
+
+    /// The maximum memory a single decode may commit to repeated, map,
+    /// string and bytes elements.
+    ///
+    /// Set via [`Self::with_element_memory_limit`].
+    #[must_use]
+    pub fn element_memory_limit(&self) -> usize {
+        self.element_memory_limit
     }
 
     /// The buffa decode options these limits imply.
@@ -1209,7 +1242,7 @@ fn create_grpc_web_envelope_stream(
 ///
 /// ```rust,ignore
 /// let service = ConnectRpcService::new(router)
-///     .with_limits(Limits::default().max_message_size(8 * 1024 * 1024));
+///     .with_limits(Limits::default().with_max_message_size(8 * 1024 * 1024));
 /// ```
 pub struct ConnectRpcService<D = Router> {
     dispatcher: Arc<D>,
@@ -3393,6 +3426,44 @@ pub mod axum_integration {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every limit must survive the builder chain and come back out of the
+    /// accessor of the same name. Setting all three in one chain also pins
+    /// that no setter clobbers a sibling.
+    #[test]
+    fn limits_builders_round_trip_through_the_accessors() {
+        let limits = Limits::default()
+            .with_max_request_body_size(16 * 1024 * 1024)
+            .with_max_message_size(8 * 1024 * 1024)
+            .with_element_memory_limit(64 * 1024 * 1024);
+
+        assert_eq!(limits.max_request_body_size(), 16 * 1024 * 1024);
+        assert_eq!(limits.max_message_size(), 8 * 1024 * 1024);
+        assert_eq!(limits.element_memory_limit(), 64 * 1024 * 1024);
+
+        // `decode_options` reads the element budget, not one of its siblings.
+        assert_eq!(
+            limits.decode_options().element_memory_limit(),
+            64 * 1024 * 1024
+        );
+    }
+
+    /// The defaults an untouched `Limits` reports must be the documented
+    /// constants, so a caller who reads one back before setting it is not
+    /// misled about what the server is enforcing.
+    #[test]
+    fn default_limits_report_the_documented_defaults() {
+        let limits = Limits::default();
+        assert_eq!(
+            limits.max_request_body_size(),
+            DEFAULT_MAX_REQUEST_BODY_SIZE
+        );
+        assert_eq!(limits.max_message_size(), DEFAULT_MAX_MESSAGE_SIZE);
+        assert_eq!(
+            limits.element_memory_limit(),
+            buffa::DEFAULT_ELEMENT_MEMORY_LIMIT
+        );
+    }
 
     /// A payload at or above `envelope::MIN_CHAIN_SIZE` must reach the body
     /// frames by refcount, not by copy: the emitted data frame references

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1774,7 +1774,7 @@ impl CompressionProvider for MyCompression {
     ) -> Result<Box<dyn std::io::Read + 'a>, ConnectError> {
         // Return a reader that yields decompressed bytes. The framework
         // controls how much is read, so decompression is bounded by
-        // ConnectRpcService::max_message_size.
+        // Limits::max_message_size.
         // ...
     }
 }


### PR DESCRIPTION
Fixes #247

Renames the four config setters that carried no prefix — `Limits::{max_request_body_size, max_message_size, element_memory_limit}` and `CompressionPolicy::min_size` — to `with_`-prefixed forms, and makes the three `Limits` fields private with plain accessors.

**Breaking**, so it wants the 0.9.0 window, and taking both halves at once means the type is only broken once.

The naming was the smaller half. Every other config type in the crate uses `with_`, so a user who has learned it on `ClientConfig` or `Server` reaches for `limits.with_max_message_size(..)`, gets method-not-found, and has to read the source. The overlap with the public fields was the sharper problem: field and method shared an identifier, so there were two ways to set each value, while `#[non_exhaustive]` (which `Limits` also gains in 0.9.0) rules out the struct-update syntax that public fields would otherwise buy. `ClientConfig` — private fields, `with_` setters, plain accessors — is the shape this now follows, including the doc convention of cross-linking each setter and accessor to its partner.

The rename is not a silent break in either direction. A call site that kept the old setter name now resolves to a no-argument accessor, so passing a value is an arity error; a bare field read hits a private field. Every migration path is a compile error, which is what you want.

Issue #247 as I filed it claimed there were exactly three unprefixed setters. There were four — `CompressionPolicy::min_size` is the same shape and is called on the client side, so the issue's framing of these as "server config setters" was also wrong. Both corrected; the changelog fragment now claims only that these were the last config *types* whose setters were unprefixed, which is true. `ClientConfig::json`, `proto` and `compress_requests` remain unprefixed and are deliberately out of scope here.

`CompressionPolicy` needed the rename only — its fields were already private, and it has no read path to collide with the new name, so no accessor was added.

Ten `Limits` call sites and seven `min_size` sites are updated across the library, tests, conformance harness, rustdoc examples and the guide, along with the `ElementMemoryLimitExceeded` error text, which names the setter an operator should raise. One pre-existing unreleased changelog fragment is edited because its Rust example called a renamed setter, and one stale guide reference to a method that never existed is corrected.

One note on CI: two `handler::tests` element-budget tests fail on `main` right now, independently of this change — fixture rot from buffa 0.9.1, fixed by #239.
