### PR TITLE
client: carry response metadata on every terminal error

### DIFF
--- a/.changes/unreleased/Fixed-20260723-222414.yaml
+++ b/.changes/unreleased/Fixed-20260723-222414.yaml
@@ -1,0 +1,24 @@
+kind: Fixed
+body: |-
+  **Terminal client errors now carry the response headers and trailers
+  consistently** ([#202]). A failed RPC reported through
+  `ServerStream::message()` — a Connect END_STREAM carrying an error, a gRPC
+  or gRPC-Web `grpc-status` error, a decode, decompression, transport or
+  deadline failure — arrives with `ConnectError::response_headers()`
+  populated, and with `ConnectError::trailers()` populated whenever
+  termination metadata was received. The same holds for the sticky replay on
+  a second `message()` call and for `ServerStream::error()`. Previously only
+  a few of these paths attached metadata, so whether a caller could read the
+  server's headers off an error depended on which protocol was in use and on
+  how the stream happened to fail. The Connect unary and client-streaming
+  parse paths gained the same guarantee — the content-type rejection, the
+  bounded body read, decompression and message decode all report the
+  metadata their response delivered. As before, the error's trailers exclude
+  `grpc-status`, `grpc-message` and `grpc-status-details-bin`, whose content
+  is already the error's code, message and details. That filter now also
+  applies on the Connect client-streaming path, so identical wire bytes give
+  identical `ConnectError::trailers()` whatever the call shape;
+  `ServerStream::trailers()` still reports the wire trailers verbatim.
+
+  [#202]: https://github.com/connectrpc/connect-rust/issues/202
+time: 2026-07-23T22:24:14.651900498-07:00

--- a/.changes/unreleased/Fixed-20260723-224245.yaml
+++ b/.changes/unreleased/Fixed-20260723-224245.yaml
@@ -1,0 +1,31 @@
+kind: Fixed
+body: |-
+  **A gateway propagating an upstream error could produce a response the
+  client could not read, losing the handler's error code** ([#202]). When a
+  handler returns a `ConnectError` that came back from a client call — the
+  ordinary gateway shape — that error carries the upstream response's
+  headers, and the server echoed them onto its own response verbatim.
+
+  Over Connect on HTTP/1.1 the consequence was total: the forwarded
+  `content-length` contradicted the body actually being written, hyper's
+  HTTP/1 encoder refused to serialize the response, and the connection
+  closed with zero bytes sent. Measured against connect-go v1.19.1, a
+  handler returning `permission_denied` surfaced at the caller as
+  `unavailable` with empty metadata, because a transport failure was all
+  the client ever saw; every handler error code collapsed the same way. A
+  forwarded `content-encoding: gzip` was a second, milder break — the
+  client tried to gunzip a plain-JSON error body, discarded it, and fell
+  back to the HTTP status. A forwarded `date` replaced the server's own,
+  since hyper emits no `Date` of its own once one is set, so responses
+  advertised the upstream's generation time.
+
+  The server now keeps its own value for any header it already set, which
+  is what kept two `content-type` values off the wire, and never forwards
+  names that describe the upstream rather than this response: the RFC 9110
+  hop-by-hop set, `content-length`, `content-type`, the content-coding
+  headers, `date`, and `grpc-status-details-bin`. All other header
+  metadata is forwarded unchanged, including every value of a multi-valued
+  name. Trailing metadata is unaffected by this change.
+
+  [#202]: https://github.com/connectrpc/connect-rust/issues/202
+time: 2026-07-23T22:42:45.469139238-07:00

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -177,6 +177,7 @@ use crate::error::ConnectError;
 use crate::error::ErrorCode;
 use crate::error::ErrorDetail;
 use crate::protocol::Protocol;
+use crate::protocol::hdr;
 
 /// Type alias for a boxed future, used in service implementations.
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -1817,6 +1818,25 @@ fn build_connect_get_query(
     query
 }
 
+/// Stamp a terminal error with the metadata its response delivered.
+///
+/// The response-parsing paths build errors several layers from the
+/// response — a bounded body read, a decompression provider, a codec — and
+/// none of those layers has the headers. Rather than teach each of them,
+/// the parse functions map their errors through this on the way out.
+fn with_response_metadata<'a>(
+    headers: &'a http::HeaderMap,
+    trailers: &'a http::HeaderMap,
+) -> impl Fn(ConnectError) -> ConnectError + 'a {
+    move |mut err| {
+        err.set_response_headers(headers.clone());
+        if !trailers.is_empty() {
+            err.set_trailers(trailers.clone());
+        }
+        err
+    }
+}
+
 /// Remap decompression error codes for payloads received from the server.
 ///
 /// The compression providers classify malformed input as `invalid_argument`
@@ -1960,10 +1980,10 @@ where
             } else {
                 ErrorCode::Unknown
             };
-            return Err(ConnectError::new(
-                code,
-                format!("unexpected content-type: {ct}"),
-            ));
+            let mut err = ConnectError::new(code, format!("unexpected content-type: {ct}"));
+            err.set_response_headers(resp_headers);
+            err.set_trailers(resp_trailers);
+            return Err(err);
         }
     }
 
@@ -1977,29 +1997,37 @@ where
         .max_message_size
         .unwrap_or(crate::service::DEFAULT_MAX_MESSAGE_SIZE);
 
-    let body = collect_body_bounded(response.into_body(), max_message_size).await?;
+    // Everything below fails after a complete response was received, so
+    // every error out of it carries that response's metadata.
+    let attach = with_response_metadata(&resp_headers, &resp_trailers);
+
+    let body = collect_body_bounded(response.into_body(), max_message_size)
+        .await
+        .map_err(&attach)?;
 
     let body = if let Some(encoding) = response_encoding {
         config
             .compression
             .decompress_with_limit(&encoding, body, max_message_size)
-            .map_err(map_response_decompression_error)?
+            .map_err(map_response_decompression_error)
+            .map_err(&attach)?
     } else {
         body
     };
 
     if body.len() > max_message_size {
-        return Err(ConnectError::new(
+        return Err(attach(ConnectError::new(
             ErrorCode::ResourceExhausted,
             format!(
                 "message size {} exceeds limit {}",
                 body.len(),
                 max_message_size
             ),
-        ));
+        )));
     }
 
-    let message = decode_response_view::<RespView>(body, config.codec_format)?;
+    let message = decode_response_view::<RespView>(body, config.codec_format).map_err(&attach)?;
+    drop(attach);
 
     Ok(UnaryResponse {
         headers: resp_headers,
@@ -2301,6 +2329,25 @@ struct StreamEnd {
 }
 
 impl StreamEnd {
+    /// Give a failed end the metadata the response already delivered: the
+    /// response headers, which a `ServerStream` cannot exist without, and
+    /// the trailing metadata whenever the end carried any. Applied at the
+    /// one site that writes the record rather than at each site that
+    /// builds one, so no construction path can forget it.
+    ///
+    /// `self.trailers` is the wire map, which on the gRPC shapes still
+    /// holds the status-bearing keys; the error gets the filtered view, so
+    /// this recomputes what `parse_grpc_error_from_trailers` already
+    /// derived rather than overwriting it with the raw set.
+    fn attach_metadata(&mut self, headers: &http::HeaderMap) {
+        if let Err(e) = &mut self.outcome {
+            e.set_response_headers(headers.clone());
+            if let Some(trailers) = &self.trailers {
+                e.set_trailers(error_metadata_from_trailers(trailers));
+            }
+        }
+    }
+
     fn replay<T>(&self) -> Result<Option<T>, ConnectError> {
         match &self.outcome {
             Ok(()) => Ok(None),
@@ -2442,6 +2489,10 @@ where
     /// matching grpc-go's treatment of each case. A Trailers-Only response
     /// carrying `grpc-status: 0` in the headers (empty body) is a clean
     /// end.
+    ///
+    /// Whatever the cause, the returned error carries the response
+    /// metadata: [`ConnectError::response_headers()`] always, and
+    /// [`ConnectError::trailers()`] whenever termination metadata arrived.
     pub async fn message<M>(&mut self) -> Result<Option<crate::StreamMessage<M>>, ConnectError>
     where
         // `M` is an output parameter pinned to `RespView`'s owned message —
@@ -2462,8 +2513,9 @@ where
             // The single writer of the terminal record. `message_inner`
             // cannot end the stream without producing one — "ended without
             // recording why" is unrepresentable.
-            Err(end) => {
+            Err(mut end) => {
                 debug_assert!(self.end.is_none(), "terminal record written twice");
+                end.attach_metadata(&self.headers);
                 self.end.get_or_insert(end).replay()
             }
         }
@@ -2761,10 +2813,7 @@ where
 
         let end_stream = match parse_connect_end_stream(&end_stream_data) {
             Ok(end_stream) => end_stream,
-            Err(mut e) => {
-                e.set_response_headers(self.headers.clone());
-                return e.into();
-            }
+            Err(e) => return e.into(),
         };
 
         let trailers = end_stream.metadata.map(|metadata| {
@@ -3971,7 +4020,12 @@ where
     let body_limit = max_msg_size
         .saturating_add(2 * crate::envelope::HEADER_SIZE)
         .saturating_add(RESPONSE_BUFFER_TRAILER_SLACK);
-    let body = collect_body_bounded(response.into_body(), body_limit).await?;
+    let body = collect_body_bounded(response.into_body(), body_limit)
+        .await
+        .map_err(with_response_metadata(
+            &resp_headers,
+            &http::HeaderMap::new(),
+        ))?;
 
     let (data, trailers) = parse_connect_client_stream_envelopes(
         body,
@@ -3980,7 +4034,9 @@ where
         max_msg_size,
         &resp_headers,
     )?;
-    let message = decode_response_view::<RespView>(data, config.codec_format)?;
+    // The trailers are parsed by now, so a decode failure reports them too.
+    let message = decode_response_view::<RespView>(data, config.codec_format)
+        .map_err(with_response_metadata(&resp_headers, &trailers))?;
 
     Ok(UnaryResponse {
         headers: resp_headers,
@@ -4005,12 +4061,32 @@ where
 /// decoded. A second data envelope is rejected before its payload is
 /// decompressed, so the client never spends decompression work or memory on
 /// more than the single message the RPC allows.
+///
+/// Every error out of here ends the RPC, so all of them carry the response
+/// headers — attached here rather than inside the scan, so no failure mode
+/// can omit them.
 fn parse_connect_client_stream_envelopes(
     body: Bytes,
     compression: &crate::compression::CompressionRegistry,
     encoding: Option<&str>,
     max_msg_size: usize,
     resp_headers: &http::HeaderMap,
+) -> Result<(Bytes, http::HeaderMap), ConnectError> {
+    scan_connect_client_stream_envelopes(body, compression, encoding, max_msg_size).map_err(
+        |mut err| {
+            err.set_response_headers(resp_headers.clone());
+            err
+        },
+    )
+}
+
+/// The envelope scan behind [`parse_connect_client_stream_envelopes`].
+/// Errors leave here without response headers; the caller attaches them.
+fn scan_connect_client_stream_envelopes(
+    body: Bytes,
+    compression: &crate::compression::CompressionRegistry,
+    encoding: Option<&str>,
+    max_msg_size: usize,
 ) -> Result<(Bytes, http::HeaderMap), ConnectError> {
     let mut buf = BytesMut::from(body.as_ref());
     let mut message: Option<Bytes> = None;
@@ -4036,10 +4112,7 @@ fn parse_connect_client_stream_envelopes(
                 envelope.data
             };
 
-            let end_stream = parse_connect_end_stream(&end_stream_data).map_err(|mut err| {
-                err.set_response_headers(resp_headers.clone());
-                err
-            })?;
+            let end_stream = parse_connect_end_stream(&end_stream_data)?;
 
             if let Some(metadata) = end_stream.metadata {
                 append_metadata_capped(&mut trailers, metadata);
@@ -4047,8 +4120,12 @@ fn parse_connect_client_stream_envelopes(
 
             if let Some(err) = end_stream.error {
                 let mut connect_error = end_stream_error_to_connect_error(err);
-                connect_error.set_response_headers(resp_headers.clone());
-                connect_error.set_trailers(trailers);
+                // Same filter as the server-streaming shape, so identical
+                // wire bytes give identical `ConnectError::trailers()`
+                // whichever kind of call carried them. A gateway that
+                // translates gRPC to Connect can put a `grpc-status` into
+                // END_STREAM metadata, and it means the same thing there.
+                connect_error.set_trailers(error_metadata_from_trailers(&trailers));
                 return Err(connect_error);
             }
 
@@ -4309,6 +4386,30 @@ fn add_streaming_request_headers(
     builder
 }
 
+/// The trailers that carry the status itself rather than user metadata.
+/// Their content reaches the caller as the error's `code`, `message` and
+/// `details`, so repeating them as metadata would duplicate the status and
+/// re-expose the raw `grpc-status-details-bin` bytes. The server side
+/// writes these same three names via `hdr`.
+fn is_status_trailer(name: &http::HeaderName) -> bool {
+    *name == hdr::GRPC_STATUS || *name == hdr::GRPC_MESSAGE || *name == hdr::GRPC_STATUS_DETAILS_BIN
+}
+
+/// The trailing metadata a terminal error should expose: the trailers that
+/// arrived, minus the status-bearing ones. `ServerStream::trailers()` still
+/// reports the wire trailers verbatim — the error's view and the stream's
+/// differ deliberately, and every write of an error's trailers on the
+/// response path goes through here so the two protocols agree.
+fn error_metadata_from_trailers(trailers: &http::HeaderMap) -> http::HeaderMap {
+    let mut out = http::HeaderMap::new();
+    for (key, value) in trailers {
+        if !is_status_trailer(key) {
+            out.append(key, value.clone());
+        }
+    }
+    out
+}
+
 /// Parse a gRPC error from HTTP/2 trailers or gRPC-Web trailer frame headers.
 fn parse_grpc_error_from_trailers(trailers: &http::HeaderMap) -> Option<ConnectError> {
     let raw = trailers.get("grpc-status")?;
@@ -4348,14 +4449,7 @@ fn parse_grpc_error_from_trailers(trailers: &http::HeaderMap) -> Option<ConnectE
         }
     }
 
-    // Include other trailers as error metadata
-    let out = err.trailers_mut();
-    for (key, value) in trailers.iter() {
-        let name = key.as_str();
-        if name != "grpc-status" && name != "grpc-message" && name != "grpc-status-details-bin" {
-            out.append(key, value.clone());
-        }
-    }
+    err.set_trailers(error_metadata_from_trailers(trailers));
 
     Some(err)
 }
@@ -5410,6 +5504,218 @@ mod tests {
             again.response_headers().get("x-from-headers").unwrap(),
             "yes"
         );
+    }
+
+    /// A server error carried by a well-formed Connect END_STREAM is still
+    /// an error the caller inspects for context: it must arrive with the
+    /// response headers and with the trailing metadata the same envelope
+    /// supplied, on the first read and on every sticky replay after it.
+    #[tokio::test]
+    async fn connect_end_stream_error_carries_response_metadata() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let mut body = BytesMut::new();
+        body.extend_from_slice(
+            &Envelope::end_stream(Bytes::from_static(
+                b"{\"error\":{\"code\":\"permission_denied\",\"message\":\"nope\"},\
+                  \"metadata\":{\"x-from-trailers\":[\"also\"]}}",
+            ))
+            .encode(),
+        );
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers,
+            body: Full::new(body.freeze()),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Connect,
+            max_message_size: Some(1024),
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("errored END_STREAM must surface as Err");
+        assert_eq!(err.code, ErrorCode::PermissionDenied);
+        assert_eq!(err.response_headers().get("x-from-headers").unwrap(), "yes");
+        assert_eq!(err.trailers().get("x-from-trailers").unwrap(), "also");
+
+        let again = stream
+            .message()
+            .await
+            .expect_err("terminal error is sticky");
+        assert_eq!(
+            again.response_headers().get("x-from-headers").unwrap(),
+            "yes"
+        );
+        assert_eq!(again.trailers().get("x-from-trailers").unwrap(), "also");
+
+        // The stored record is the same one `message()` replayed, so the
+        // post-hoc accessor cannot disagree with it.
+        let stored = stream.error().expect("terminal error stays inspectable");
+        assert_eq!(
+            stored.response_headers().get("x-from-headers").unwrap(),
+            "yes"
+        );
+        assert_eq!(stored.trailers().get("x-from-trailers").unwrap(), "also");
+    }
+
+    /// The same guarantee on the gRPC shape: a `grpc-status` error in the
+    /// trailers reaches the caller with the response headers attached, not
+    /// just the trailers it was parsed from.
+    ///
+    /// The error's metadata and the stream's trailers are deliberately
+    /// different views of the same frame: the status-bearing keys are
+    /// already the error's `code` and `message`, so they stay out of the
+    /// metadata while `trailers()` keeps reporting the wire map verbatim.
+    #[tokio::test]
+    async fn grpc_stream_error_carries_response_metadata() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "7".parse().unwrap()); // PERMISSION_DENIED
+        trailers.insert("grpc-message", "nope".parse().unwrap());
+        trailers.insert("x-from-trailers", "also".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(Frame::trailers(trailers))];
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers,
+            body: StreamBody::new(futures::stream::iter(frames)),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("grpc-status 7 must surface as Err");
+        assert_eq!(err.code, ErrorCode::PermissionDenied);
+        assert_eq!(err.message.as_deref(), Some("nope"));
+        assert_eq!(err.response_headers().get("x-from-headers").unwrap(), "yes");
+        assert_eq!(err.trailers().get("x-from-trailers").unwrap(), "also");
+
+        // The status keys stay out of the error metadata — they are the
+        // error's own code and message — but remain in the wire trailers.
+        for key in [
+            &hdr::GRPC_STATUS,
+            &hdr::GRPC_MESSAGE,
+            &hdr::GRPC_STATUS_DETAILS_BIN,
+        ] {
+            assert!(
+                !err.trailers().contains_key(key),
+                "{key} must not be duplicated into the error metadata"
+            );
+        }
+        let wire = stream.trailers().expect("wire trailers stay available");
+        assert_eq!(wire.get("grpc-status").unwrap(), "7");
+        assert_eq!(wire.get("x-from-trailers").unwrap(), "also");
+    }
+
+    /// The corner that makes the filter, not an "already has trailers"
+    /// check, the right guard: when the frame carries nothing but status
+    /// keys the curated metadata is legitimately empty, and the raw map
+    /// must not be substituted for it.
+    #[tokio::test]
+    async fn grpc_stream_error_metadata_is_empty_when_only_status_arrives() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "7".parse().unwrap());
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(Frame::trailers(trailers))];
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            headers,
+            body: StreamBody::new(futures::stream::iter(frames)),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Grpc,
+            max_message_size: Some(1024),
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("grpc-status 7 must surface as Err");
+        assert!(
+            err.trailers().is_empty(),
+            "status-only trailers carry no user metadata: {:?}",
+            err.trailers()
+        );
+        // The empty metadata must not read as "nothing was attached": the
+        // headers still arrive, which is what distinguishes the filtered
+        // map from a record that skipped attachment altogether.
+        assert_eq!(err.response_headers().get("x-from-headers").unwrap(), "yes");
+        assert!(
+            stream
+                .trailers()
+                .is_some_and(|t| t.contains_key("grpc-status")),
+            "the wire trailers are still reported verbatim"
+        );
+    }
+
+    /// A Connect unary response whose content-type is not the configured
+    /// codec's is rejected without reading the body. The rejection still
+    /// carries the headers (and the `trailer-`-prefixed metadata) that
+    /// arrived, so a caller can see what the intermediary actually sent.
+    #[tokio::test]
+    async fn connect_unary_content_type_rejection_carries_response_metadata() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let response = Response::builder()
+            .status(http::StatusCode::OK)
+            .header(http::header::CONTENT_TYPE, "text/html")
+            .header("x-from-headers", "yes")
+            .header("trailer-x-from-trailers", "also")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        let config = ClientConfig::new("http://localhost".parse().unwrap());
+        let err = parse_connect_unary_response::<_, StringValueView<'static>>(
+            response,
+            &config,
+            &CallOptions::default(),
+        )
+        .await
+        .expect_err("text/html is not a Connect response");
+
+        assert_eq!(err.code, ErrorCode::Unknown);
+        assert_eq!(err.response_headers().get("x-from-headers").unwrap(), "yes");
+        assert_eq!(err.trailers().get("x-from-trailers").unwrap(), "also");
     }
 
     /// Same contract for gRPC: an error in HTTP/2 trailers is a failed RPC
@@ -7551,6 +7857,42 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.code, ErrorCode::DataLoss, "unexpected error: {err}");
+    }
+
+    /// A corrupt END_STREAM payload fails before any trailing metadata can
+    /// be parsed, so the response headers are the only context the caller
+    /// gets — they must be there.
+    #[cfg(feature = "gzip")]
+    #[test]
+    fn client_stream_end_stream_decompression_failure_carries_headers() {
+        use crate::envelope::flags;
+
+        let registry = crate::compression::CompressionRegistry::default();
+
+        let mut body = Envelope::data(Bytes::from_static(b"only"))
+            .encode()
+            .to_vec();
+        body.extend_from_slice(
+            &Envelope {
+                flags: flags::COMPRESSED | flags::END_STREAM,
+                data: Bytes::from_static(b"not gzip data"),
+            }
+            .encode(),
+        );
+
+        let mut resp_headers = http::HeaderMap::new();
+        resp_headers.insert("x-from-headers", http::HeaderValue::from_static("yes"));
+
+        let err = parse_connect_client_stream_envelopes(
+            Bytes::from(body),
+            &registry,
+            Some("gzip"),
+            1024 * 1024,
+            &resp_headers,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::DataLoss, "unexpected error: {err}");
+        assert_eq!(err.response_headers().get("x-from-headers").unwrap(), "yes");
     }
 
     /// The response-path remap touches only the two decompression codes:

--- a/connectrpc/src/error.rs
+++ b/connectrpc/src/error.rs
@@ -308,11 +308,26 @@ impl ConnectError {
     }
 
     /// Borrow the response headers. Returns an empty map if none were set.
+    ///
+    /// On an error returned by a client call, these are the headers the
+    /// response arrived with. Every terminal error from a
+    /// [`ServerStream`](crate::client::ServerStream) carries them, whatever
+    /// the protocol and whatever ended the stream.
     pub fn response_headers(&self) -> &http::HeaderMap {
         self.response_headers.as_deref().unwrap_or(&EMPTY_HEADERS)
     }
 
     /// Borrow the response trailers. Returns an empty map if none were set.
+    ///
+    /// On an error returned by a client call, these are the trailing
+    /// metadata the RPC ended with, populated whenever any was received —
+    /// gRPC trailers or a Connect END_STREAM `metadata` object. The
+    /// status-bearing gRPC trailers (`grpc-status`, `grpc-message`,
+    /// `grpc-status-details-bin`) are excluded, because their content is
+    /// this error's [`code`](Self::code), message and
+    /// [`details`](Self::details);
+    /// [`ServerStream::trailers()`](crate::client::ServerStream::trailers)
+    /// reports the wire map verbatim if you need them.
     pub fn trailers(&self) -> &http::HeaderMap {
         self.trailers.as_deref().unwrap_or(&EMPTY_HEADERS)
     }

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -662,6 +662,78 @@ impl EndStreamResponse {
     }
 }
 
+/// Response headers that may never be carried from a propagated error
+/// onto this response. Three classes, none of which describe the response
+/// being built.
+///
+/// Hop-by-hop headers (RFC 9110 §7.6.1) belong to the connection the error
+/// arrived on. Body-framing headers would misdescribe our own body: a
+/// forwarded `content-length` makes hyper's HTTP/1 encoder refuse to
+/// serialize the response at all, and a forwarded content coding tells the
+/// client to decode bytes that were never encoded. `date` would report the
+/// upstream's generation time as ours — hyper emits no `Date` of its own
+/// once one is set, so the false value is the only one on the wire.
+///
+/// `grpc-status-details-bin` is here because the server writes its status
+/// into the trailers, never the header block, so the already-set rule in
+/// `echo_error_headers` cannot save it the way it saves `grpc-status` and
+/// `grpc-message` on the trailers-only path.
+fn is_unforwardable_header(name: &http::HeaderName) -> bool {
+    static KEEP_ALIVE: http::HeaderName = http::HeaderName::from_static("keep-alive");
+
+    // Hop-by-hop: scoped to a single connection.
+    *name == header::CONNECTION
+        || *name == KEEP_ALIVE
+        || *name == header::PROXY_AUTHENTICATE
+        || *name == header::PROXY_AUTHORIZATION
+        || *name == header::TE
+        || *name == header::TRAILER
+        || *name == header::TRANSFER_ENCODING
+        || *name == header::UPGRADE
+        // Body framing: describes bytes other than the ones we write.
+        || *name == header::CONTENT_LENGTH
+        || *name == header::CONTENT_TYPE
+        || *name == header::CONTENT_ENCODING
+        || *name == crate::protocol::hdr::GRPC_ENCODING
+        || *name == crate::protocol::hdr::CONNECT_CONTENT_ENCODING
+        // Provenance and status.
+        || *name == header::DATE
+        || *name == crate::protocol::hdr::GRPC_STATUS_DETAILS_BIN
+}
+
+/// Echo an error's response headers onto a response being built.
+///
+/// A `ConnectError` that came back from a client call carries the headers
+/// of the response it was parsed from, so a handler that propagates one —
+/// the ordinary `client.call(..).await?` in a gateway — is asking to
+/// re-emit another connection's headers. Two rules keep that from
+/// corrupting this response. A header this response already set wins,
+/// because `Builder::header` appends rather than replaces, and a second
+/// `content-type` on the wire is a framing error rather than extra
+/// metadata. Connection-scoped headers are dropped outright. Everything
+/// else is the server metadata the caller meant to forward, and passes
+/// through unchanged.
+fn echo_error_headers(
+    mut response: http::response::Builder,
+    err: &ConnectError,
+) -> http::response::Builder {
+    // Snapshot before appending: a multi-valued error header must still
+    // append all of its values, so the test cannot be against the map as
+    // it grows.
+    let already_set: Vec<http::HeaderName> = response
+        .headers_ref()
+        .map(|headers| headers.keys().cloned().collect())
+        .unwrap_or_default();
+
+    for (key, value) in err.response_headers() {
+        if is_unforwardable_header(key) || already_set.contains(key) {
+            continue;
+        }
+        response = response.header(key, value);
+    }
+    response
+}
+
 /// Create a streaming error response.
 ///
 /// For streaming RPCs, errors should still return HTTP 200 with the error
@@ -704,14 +776,12 @@ fn connect_streaming_error_response(
         _reader_task: None,
     };
 
-    let mut response = Response::builder().status(StatusCode::OK).header(
+    let response = Response::builder().status(StatusCode::OK).header(
         header::CONTENT_TYPE,
         Protocol::Connect.response_content_type(codec_format, true),
     );
 
-    for (key, value) in err.response_headers() {
-        response = response.header(key, value);
-    }
+    let response = echo_error_headers(response, err);
 
     response.body(body).unwrap_or_else(|_| {
         Response::new(StreamingResponseBody {
@@ -774,9 +844,7 @@ fn grpc_error_response(
         }
     }
 
-    for (key, value) in err.response_headers() {
-        response = response.header(key, value);
-    }
+    let response = echo_error_headers(response, err);
 
     response.body(body).unwrap_or_else(|_| {
         Response::new(StreamingResponseBody {
@@ -2051,9 +2119,7 @@ where
                 response = response.header(&GRPC_MESSAGE, val);
             }
         }
-        for (key, value) in err.response_headers() {
-            response = response.header(key, value);
-        }
+        let response = echo_error_headers(response, err);
         let body = GrpcUnaryBody {
             data: None,
             payload: std::collections::VecDeque::new(),
@@ -3227,14 +3293,12 @@ fn error_response(err: ConnectError) -> Response<Full<Bytes>> {
     let status = err.http_status();
     let body = err.to_json();
 
-    let mut response = Response::builder()
+    let response = Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, content_type::JSON);
 
     // Add response headers from the error
-    for (key, value) in err.response_headers() {
-        response = response.header(key, value);
-    }
+    let response = echo_error_headers(response, &err);
 
     // Add trailers as trailer- prefixed headers
     let response = add_trailers(response, err.trailers());
@@ -5409,5 +5473,111 @@ mod tests {
             .expect("tests run inside a tokio runtime")
             .await
             .expect("reader task must not panic");
+    }
+
+    /// An error propagated out of a client call carries the upstream
+    /// response's headers, and a gateway handler returns it as its own
+    /// error. Echoing that block verbatim would put a second
+    /// `content-type` on the wire and describe this response's body with
+    /// the upstream's framing, so the server's own headers win and the
+    /// unforwardable ones are dropped — while the server metadata the
+    /// caller wanted forwarded still gets through.
+    ///
+    /// `content-length` is the one that actually breaks a client: hyper's
+    /// HTTP/1 encoder refuses to serialize a response whose declared
+    /// length contradicts the body, closing the connection with nothing
+    /// written, so the caller sees a transport failure rather than the
+    /// handler's error code.
+    fn upstream_error() -> ConnectError {
+        let mut upstream = http::HeaderMap::new();
+        upstream.insert(
+            header::CONTENT_TYPE,
+            "application/grpc+proto".parse().unwrap(),
+        );
+        upstream.insert(header::CONTENT_LENGTH, "4096".parse().unwrap());
+        upstream.insert(header::CONNECTION, "close".parse().unwrap());
+        upstream.insert(header::TRANSFER_ENCODING, "chunked".parse().unwrap());
+        upstream.insert(
+            header::DATE,
+            "Thu, 01 Jan 1970 00:00:00 GMT".parse().unwrap(),
+        );
+        upstream.insert(
+            crate::protocol::hdr::GRPC_ENCODING.clone(),
+            "gzip".parse().unwrap(),
+        );
+        // An upstream status proto whose code contradicts the one we send.
+        upstream.insert(
+            crate::protocol::hdr::GRPC_STATUS_DETAILS_BIN.clone(),
+            "CAcSBW5vcGU".parse().unwrap(),
+        );
+        upstream.insert("x-upstream-region", "eu-west-1".parse().unwrap());
+        upstream.append("x-upstream-tag", "a".parse().unwrap());
+        upstream.append("x-upstream-tag", "b".parse().unwrap());
+
+        let mut err = ConnectError::unavailable("upstream is down");
+        err.set_response_headers(upstream);
+        err
+    }
+
+    fn assert_safe_echo(headers: &http::HeaderMap, expected_content_type: &str) {
+        assert_eq!(
+            headers.get_all(header::CONTENT_TYPE).iter().count(),
+            1,
+            "exactly one content-type must reach the wire: {headers:?}"
+        );
+        assert_eq!(
+            headers.get(header::CONTENT_TYPE).unwrap(),
+            expected_content_type
+        );
+        for dropped in [
+            header::CONTENT_LENGTH,
+            header::CONNECTION,
+            header::TRANSFER_ENCODING,
+            header::DATE,
+            crate::protocol::hdr::GRPC_ENCODING.clone(),
+            crate::protocol::hdr::GRPC_STATUS_DETAILS_BIN.clone(),
+        ] {
+            assert!(
+                !headers.contains_key(&dropped),
+                "{dropped} describes the upstream response and must not be forwarded"
+            );
+        }
+
+        // The point of attaching headers to an error is that this survives.
+        assert_eq!(headers.get("x-upstream-region").unwrap(), "eu-west-1");
+        let tags: Vec<_> = headers
+            .get_all("x-upstream-tag")
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(tags, ["a", "b"], "multi-valued metadata keeps every value");
+    }
+
+    #[test]
+    fn propagated_upstream_headers_do_not_corrupt_the_connect_unary_response() {
+        let response = error_response(upstream_error());
+        assert_safe_echo(response.headers(), content_type::JSON);
+    }
+
+    #[test]
+    fn propagated_upstream_headers_do_not_corrupt_the_connect_streaming_response() {
+        let response =
+            streaming_error_response(&upstream_error(), Protocol::Connect, CodecFormat::Proto);
+        assert_safe_echo(
+            response.headers(),
+            Protocol::Connect.response_content_type(CodecFormat::Proto, true),
+        );
+    }
+
+    #[test]
+    fn propagated_upstream_headers_do_not_corrupt_the_grpc_streaming_response() {
+        let response =
+            streaming_error_response(&upstream_error(), Protocol::Grpc, CodecFormat::Proto);
+        assert_safe_echo(
+            response.headers(),
+            Protocol::Grpc.response_content_type(CodecFormat::Proto, true),
+        );
+        // The trailers-only status headers are the server's own and stay.
+        assert_eq!(response.headers().get(&GRPC_STATUS).unwrap(), "14");
     }
 }


### PR DESCRIPTION
Fixes #202

Terminal client errors now carry the response headers whenever they were received, and the trailers whenever they were parsed, regardless of stream shape or protocol.

The inventory in #202 listed four sites where an error dropped metadata its sibling path preserved. Rather than adding `set_response_headers` at each, the metadata is attached where the terminal record is written, so the rule holds by construction: `ServerStream::message()` has the only write, and every `StreamEnd` funnels through it — carried END_STREAM errors, decompression failures, the `classify_grpc_end` variants and the `parse_grpc_error_from_trailers` results. The explicit call added by #201 is now redundant and removed. Writing the metadata in rather than applying it on read matters because `ServerStream::error()` reads the stored record directly. The remaining bare sites on the Connect unary and client-streaming paths are covered too, so "consistently" means what it says.

Item 5 in the issue is untouched; it needs a `'static` bound on the body error type and is tracked as #237.

**The choke point initially clobbered curated trailers.** `parse_grpc_error_from_trailers` deliberately excludes the gRPC status keys from error metadata, and attaching the raw map on top re-exposed them. Guarding on "already set" would have been unsound — trailers carrying only `grpc-status` produce a legitimately empty curated map — so the filter is extracted and the choke point recomputes it, which is idempotent on the gRPC path and a no-op on Connect.

## The server-side half, and why it is here

Attaching upstream headers to streaming errors would have widened a framing bug that already existed on the unary paths, so it is fixed rather than shipped and filed.

Our server echoed `err.response_headers()` onto the wire with a builder that *appends*. Driven against **connect-go v1.19.1** and **grpc-go v1.81.1**, with a per-header bisect, that is not hygiene — it is a hard break. A gateway propagating an upstream failure over Connect on HTTP/1.1 emits a response hyper cannot serialize at all: **the connection closes with zero bytes written**, connect-go reports `unexpected EOF` with empty metadata, and a handler's `permission_denied` reaches the caller as `unavailable`. Every error code collapses the same way, because all the client ever sees is a transport failure. `content-length` is the sole culprit. An echoed `content-encoding` is a second, milder break — connect-go tries to gunzip the plain-JSON error body and falls back to the HTTP status — and an echoed `date` displaces the one hyper would otherwise set, so the response carries a false generation time.

`echo_error_headers` applies two rules: a header the response already set wins, and names that would describe something other than this response are dropped — hop-by-hop, body framing, provenance, status-bearing. Legitimate metadata is unaffected: `x-upstream-region` and **both** values of a multi-valued `x-upstream-tag` arrive at every client on every shape, which is the case the snapshot-before-append logic could plausibly have broken.

Dropping `grpc-encoding` was checked rather than assumed. grpc-go only consults it when a frame's compressed flag is set, and these responses have no data frames, so an echoed one is inert today — confirmed, including under `AcceptCompressors("identity")`, which makes grpc-go police the advertised encoding. It becomes live the moment a response carries both the echoed encoding and a message frame, and the Connect analogue of the same class already is.

**Trailing metadata is still echoed unfiltered.** The same class exists one frame later, but fixing it needs a policy rather than a predicate — provenance is not derivable where the filtering happens, the obvious signal is remotely drivable, and the source-selection branch has the same bug one level up. An attempt to fix it here was reverted for those reasons and is now #263.

## Verification

Conformance: server 3600/0, server Connect+TLS 2396/0, client Connect 2580/0, client gRPC-Web 2838/0. The gRPC client suite fails 1-4 cases in `Timeouts` across four runs with a different set each time; base flakes identically, including one clean run.

`duplicate_metadata.yaml` is the case worth naming — it echoes multi-valued `x-custom-header` onto error responses across all four RPC kinds. Conformance never asks a server to echo a connection-scoped header, though, and never echoes a name the server also sets, so neither new rule is exercised by the suite; unit tests and the interop harness cover those.

One note on CI: two `handler::tests` element-budget tests fail on `main` right now, independently of this change — fixture rot from buffa 0.9.1, fixed by #239.
