### PR TITLE
client: validate streaming gRPC response content types

### DIFF
--- a/.changes/unreleased/Fixed-20260802-223500.yaml
+++ b/.changes/unreleased/Fixed-20260802-223500.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: |-
+  **Streaming gRPC responses now validate their declared content type during response initialization**.
+  Server-streaming calls reject a wrong gRPC / gRPC-Web protocol family or codec before returning a response stream, while bidirectional calls reject it on the first receive. Such responses previously entered normal stream processing, where they could fail later or appear to complete successfully. Existing compatibility behavior for missing and bare-family content types is unchanged.
+time: 2026-08-02T22:35:00-04:00

--- a/.changes/unreleased/Fixed-20260802-223500.yaml
+++ b/.changes/unreleased/Fixed-20260802-223500.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
 body: |-
   **Streaming gRPC responses now validate their declared content type during response initialization**.
-  Server-streaming calls reject a wrong gRPC / gRPC-Web protocol family or codec before returning a response stream, while bidirectional calls reject it on the first receive. Such responses previously entered normal stream processing, where they could fail later or appear to complete successfully. Existing compatibility behavior for missing and bare-family content types is unchanged.
+  Server-streaming calls reject a wrong gRPC / gRPC-Web protocol family or codec before returning a response stream, while bidirectional calls reject it on the first receive. Such responses previously entered normal stream processing, where they could fail later or appear to complete successfully. The check runs before a trailers-only `grpc-status` is read, as it already does on the unary path, so a reply in the wrong content-type family is rejected rather than believed for its status, and a non-2xx reply that is not speaking gRPC now names the offending content type after its HTTP status on streaming calls too. Existing compatibility behavior for missing and bare-family content types is unchanged.
 time: 2026-08-02T22:35:00-04:00

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2251,7 +2251,8 @@ where
     // An absent one is not: a proxy that drops `content-type` from its local
     // reply may still send `grpc-status`, so that reply is parsed and its
     // trailers-only status honoured below.
-    let content_type = validate_grpc_response_content_type(&resp_headers, config);
+    let content_type =
+        validate_grpc_response_content_type(&resp_headers, config.protocol, config.codec_format);
     let speaks_grpc = content_type.is_ok()
         && (resp_headers.contains_key(http::header::CONTENT_TYPE)
             || resp_headers.contains_key("grpc-status"));
@@ -2517,24 +2518,23 @@ where
 }
 
 /// Validate the `content-type` of a gRPC / gRPC-Web response against the
-/// client's configured protocol and codec, mirroring connect-go's
-/// `grpcValidateResponseContentType`.
+/// client's configured protocol and codec.
 ///
-/// Parameters (`; charset=...`) are stripped before comparison. The bare
-/// family types `application/grpc` / `application/grpc-web` are accepted for
-/// any codec, because the bare type means "proto by default" and proxies that
-/// synthesize trailers-only error responses (such as Envoy local replies)
-/// send it regardless of the request's subtype. A missing `content-type`
-/// header is also accepted, preserving this client's previous leniency. A
-/// same-family subtype that doesn't match the configured codec is rejected as
-/// `internal` (a broken server or intermediary); anything else is `unknown`
-/// (not a gRPC response at all), matching connect-go's classification.
+/// The family/error-code classification follows connect-go: same-family codec
+/// mismatches are `internal`, while responses outside the configured gRPC
+/// family are `unknown`. Connect-rust deliberately preserves its existing
+/// compatibility behavior: parameters are ignored, a missing header is
+/// accepted, and the bare `application/grpc` / `application/grpc-web` family
+/// is accepted for every configured codec. In particular, proxies such as
+/// Envoy can synthesize trailers-only replies using the bare family type
+/// regardless of the request subtype.
 fn validate_grpc_response_content_type(
     resp_headers: &http::HeaderMap,
-    config: &ClientConfig,
+    protocol: Protocol,
+    codec_format: CodecFormat,
 ) -> Result<(), ConnectError> {
     debug_assert!(
-        matches!(config.protocol, Protocol::Grpc | Protocol::GrpcWeb),
+        matches!(protocol, Protocol::Grpc | Protocol::GrpcWeb),
         "gRPC response content-type validation is only for gRPC/gRPC-Web"
     );
 
@@ -2547,10 +2547,9 @@ fn validate_grpc_response_content_type(
         .split_once(';')
         .map_or(ct, |(media_type, _params)| media_type)
         .trim();
-    let expected = config
-        .protocol
-        .response_content_type(config.codec_format, false);
-    let (bare, family_prefix) = match config.protocol {
+    // gRPC and gRPC-Web use the same response media type for every RPC shape.
+    let expected = protocol.response_content_type(codec_format, false);
+    let (bare, family_prefix) = match protocol {
         Protocol::Grpc => ("application/grpc", "application/grpc+"),
         Protocol::GrpcWeb => ("application/grpc-web", "application/grpc-web+"),
         // Unreachable per the debug_assert above; treat as valid rather than
@@ -3116,6 +3115,8 @@ where
 /// Returns immediately with an error if:
 /// - The request cannot be encoded or sent
 /// - The server responds with a non-200 status (protocol-level error)
+/// - A successful gRPC or gRPC-Web response declares a content type
+///   incompatible with the configured protocol or codec
 ///
 /// Errors that occur during the stream (e.g., in gRPC trailers or the
 /// END_STREAM envelope) are returned by [`ServerStream::message()`].
@@ -3215,9 +3216,10 @@ where
 /// Construct a [`ServerStream`] from a streaming HTTP response.
 ///
 /// Handles trailers-only gRPC error detection, non-200 Connect error body
-/// parsing, and response encoding extraction. Used by both [`call_server_stream`]
-/// (passing fields from `&ClientConfig`) and [`BidiStream::message`] (passing
-/// fields from its owned `StreamConfig` snapshot).
+/// parsing, successful gRPC-family content-type validation, and response
+/// encoding extraction. Used by both [`call_server_stream`] (passing fields
+/// from `&ClientConfig`) and [`BidiStream::message`] (passing fields from its
+/// owned `StreamConfig` snapshot).
 ///
 /// Takes individual config fields instead of `&ClientConfig` so callers that
 /// need to capture config by value (like `BidiStream`, which outlives the
@@ -3298,6 +3300,13 @@ where
         let mut err = ConnectError::new(code, format!("HTTP error {}", status.as_u16()));
         err.set_response_headers(response_headers);
         return Err(err);
+    }
+
+    match protocol {
+        Protocol::Grpc | Protocol::GrpcWeb => {
+            validate_grpc_response_content_type(&response_headers, protocol, codec_format)?;
+        }
+        Protocol::Connect => {}
     }
 
     // Get the response encoding for compressed envelopes (protocol-aware header)
@@ -4918,6 +4927,195 @@ fn append_metadata_capped(trailers: &mut http::HeaderMap, metadata: HashMap<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Clone)]
+    struct StaticResponseTransport {
+        headers: http::HeaderMap,
+    }
+
+    impl ClientTransport for StaticResponseTransport {
+        type ResponseBody = Full<Bytes>;
+        type Error = std::io::Error;
+
+        fn send(
+            &self,
+            _request: Request<ClientBody>,
+        ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
+            let headers = self.headers.clone();
+            Box::pin(async move {
+                let mut response = Response::builder()
+                    .status(http::StatusCode::OK)
+                    .body(Full::new(Bytes::new()))
+                    .unwrap();
+                *response.headers_mut() = headers;
+                Ok(response)
+            })
+        }
+    }
+
+    fn streaming_response(content_type: Option<&'static str>) -> Response<Full<Bytes>> {
+        let mut builder = Response::builder()
+            .status(http::StatusCode::OK)
+            .header("x-request-id", "abc123");
+        if let Some(content_type) = content_type {
+            builder = builder.header(http::header::CONTENT_TYPE, content_type);
+        }
+        builder.body(Full::new(Bytes::new())).unwrap()
+    }
+
+    #[tokio::test]
+    async fn streaming_grpc_response_content_type_rejects_mismatches() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let compression = CompressionRegistry::new();
+        let rejected = [
+            (
+                Protocol::Grpc,
+                CodecFormat::Proto,
+                "application/grpc-web+proto",
+                ErrorCode::Unknown,
+            ),
+            (
+                Protocol::GrpcWeb,
+                CodecFormat::Proto,
+                "application/grpc+proto",
+                ErrorCode::Unknown,
+            ),
+            (
+                Protocol::Grpc,
+                CodecFormat::Json,
+                "application/grpc+proto",
+                ErrorCode::Internal,
+            ),
+            (
+                Protocol::GrpcWeb,
+                CodecFormat::Json,
+                "application/grpc-web+proto",
+                ErrorCode::Internal,
+            ),
+        ];
+
+        for (protocol, codec_format, actual, expected_code) in rejected {
+            let expected = protocol.response_content_type(codec_format, false);
+            let err = make_server_stream::<_, StringValueView<'static>>(
+                streaming_response(Some(actual)),
+                protocol,
+                &compression,
+                codec_format,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect_err("incompatible content type must reject stream construction");
+
+            assert_eq!(err.code, expected_code, "content-type {actual}");
+            assert!(
+                err.message.as_deref().is_some_and(|message| {
+                    message.contains(actual) && message.contains(expected)
+                })
+            );
+            assert_eq!(err.response_headers()["x-request-id"], "abc123");
+            assert_eq!(err.response_headers()[http::header::CONTENT_TYPE], actual);
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_grpc_response_content_type_preserves_compatibility() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let compression = CompressionRegistry::new();
+        let accepted = [
+            (
+                Protocol::Grpc,
+                CodecFormat::Proto,
+                Some("application/grpc+proto"),
+            ),
+            (
+                Protocol::GrpcWeb,
+                CodecFormat::Json,
+                Some("application/grpc-web"),
+            ),
+            (
+                Protocol::Grpc,
+                CodecFormat::Json,
+                Some("application/grpc; charset=utf-8"),
+            ),
+            (Protocol::GrpcWeb, CodecFormat::Proto, None),
+        ];
+
+        for (protocol, codec_format, content_type) in accepted {
+            make_server_stream::<_, StringValueView<'static>>(
+                streaming_response(content_type),
+                protocol,
+                &compression,
+                codec_format,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("established compatibility case must remain accepted");
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_content_type_validation_preserves_http_status_precedence() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let response = Response::builder()
+            .status(http::StatusCode::BAD_GATEWAY)
+            .header(http::header::CONTENT_TYPE, "text/html")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let err = make_server_stream::<_, StringValueView<'static>>(
+            response,
+            Protocol::Grpc,
+            &CompressionRegistry::new(),
+            CodecFormat::Proto,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("HTTP status must be classified before content type");
+
+        assert_eq!(err.code, ErrorCode::Unavailable);
+        assert!(
+            err.message
+                .as_deref()
+                .is_some_and(|message| message.starts_with("HTTP error 502"))
+        );
+    }
+
+    #[tokio::test]
+    async fn call_server_stream_rejects_cross_protocol_trailers_only_response() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/grpc-web+proto"),
+        );
+        headers.insert("grpc-status", http::HeaderValue::from_static("0"));
+        let transport = StaticResponseTransport { headers };
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        let err = call_server_stream::<_, StringValue, StringValueView<'static>>(
+            &transport,
+            &config,
+            "test.Service",
+            "ServerStream",
+            StringValue::from("hello"),
+            CallOptions::default(),
+        )
+        .await
+        .expect_err("wrong-family response must fail before a ServerStream is returned");
+
+        assert_eq!(err.code, ErrorCode::Unknown);
+    }
 
     #[test]
     fn overflow_payload_is_internal_at_response_decode() {
@@ -8066,8 +8264,9 @@ mod tests {
         let config =
             ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
 
-        let err = validate_grpc_response_content_type(&headers, &config)
-            .expect_err("non-gRPC content type must be rejected");
+        let err =
+            validate_grpc_response_content_type(&headers, config.protocol, config.codec_format)
+                .expect_err("non-gRPC content type must be rejected");
         assert_eq!(err.code, ErrorCode::Unknown);
         assert_eq!(
             err.message.as_deref(),
@@ -8083,8 +8282,12 @@ mod tests {
     fn grpc_response_content_type_accepts_missing_header() {
         let config =
             ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
-        validate_grpc_response_content_type(&http::HeaderMap::new(), &config)
-            .expect("missing content-type must remain accepted");
+        validate_grpc_response_content_type(
+            &http::HeaderMap::new(),
+            config.protocol,
+            config.codec_format,
+        )
+        .expect("missing content-type must remain accepted");
     }
 
     #[test]
@@ -8100,7 +8303,7 @@ mod tests {
         let config = ClientConfig::new("http://localhost".parse().unwrap())
             .with_protocol(Protocol::Grpc)
             .with_codec_format(CodecFormat::Json);
-        validate_grpc_response_content_type(&headers, &config)
+        validate_grpc_response_content_type(&headers, config.protocol, config.codec_format)
             .expect("bare application/grpc must be accepted for a json-codec client");
     }
 
@@ -8113,7 +8316,7 @@ mod tests {
         );
         let config =
             ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
-        validate_grpc_response_content_type(&headers, &config)
+        validate_grpc_response_content_type(&headers, config.protocol, config.codec_format)
             .expect("bare application/grpc-web must be accepted as proto");
     }
 
@@ -8127,8 +8330,9 @@ mod tests {
         let config =
             ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::GrpcWeb);
 
-        let err = validate_grpc_response_content_type(&headers, &config)
-            .expect_err("gRPC-Web client must reject plain gRPC content type");
+        let err =
+            validate_grpc_response_content_type(&headers, config.protocol, config.codec_format)
+                .expect_err("gRPC-Web client must reject plain gRPC content type");
         assert_eq!(err.code, ErrorCode::Unknown);
         assert_eq!(
             err.message.as_deref(),

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2240,43 +2240,7 @@ where
     let status = response.status();
     let resp_headers = response.headers().clone();
 
-    // grpc-go decides gRPC-ness from the content-type and then discards the
-    // HTTP status entirely; connect-go decides from the HTTP status and never
-    // reads the gRPC one. This sits between them: a non-2xx reply that is not
-    // speaking gRPC reports its HTTP status, because that is the code telling
-    // the caller whether to retry, and a `text/html` rejection would flatten
-    // every proxy failure to `unknown`.
-    //
-    // A wrong content-type is positive evidence the peer is not speaking gRPC.
-    // An absent one is not: a proxy that drops `content-type` from its local
-    // reply may still send `grpc-status`, so that reply is parsed and its
-    // trailers-only status honoured below.
-    let content_type =
-        validate_grpc_response_content_type(&resp_headers, config.protocol, config.codec_format);
-    let speaks_grpc = content_type.is_ok()
-        && (resp_headers.contains_key(http::header::CONTENT_TYPE)
-            || resp_headers.contains_key("grpc-status"));
-    if !status.is_success() && !speaks_grpc {
-        return Err(match content_type {
-            // Reuse the rejection: it already carries the response headers, and
-            // its message becomes the detail on the HTTP status.
-            Err(mut err) => {
-                let detail = err.message.take().unwrap_or_default();
-                err.code = http_status_to_error_code(status);
-                err.message = Some(format!("HTTP error {}: {detail}", status.as_u16()));
-                err
-            }
-            Ok(()) => {
-                let mut err = ConnectError::new(
-                    http_status_to_error_code(status),
-                    format!("HTTP error {}", status.as_u16()),
-                );
-                err.set_response_headers(resp_headers);
-                err
-            }
-        });
-    }
-    content_type?;
+    check_grpc_response_head(status, &resp_headers, config.protocol, config.codec_format)?;
 
     // Check for unsupported compression before reading the body
     let response_encoding = resp_headers
@@ -2572,6 +2536,58 @@ fn validate_grpc_response_content_type(
     );
     err.set_response_headers(resp_headers.clone());
     Err(err)
+}
+
+/// Gate a gRPC / gRPC-Web response on its HTTP status and `content-type`
+/// before anything reads `grpc-status`, so the unary and streaming parsers
+/// classify the same response head the same way.
+///
+/// grpc-go decides gRPC-ness from the content-type and then discards the HTTP
+/// status entirely; connect-go decides from the HTTP status and never reads
+/// the gRPC one. This sits between them: a non-2xx reply that is not speaking
+/// gRPC reports its HTTP status, because that is the code telling the caller
+/// whether to retry, and a `text/html` rejection would flatten every proxy
+/// failure to `unknown`.
+///
+/// A wrong content-type is positive evidence the peer is not speaking gRPC,
+/// so it is rejected here even when a `grpc-status` header is present. An
+/// absent one is not: a proxy that drops `content-type` from its local reply
+/// may still send `grpc-status`, so that reply passes and its trailers-only
+/// status is honoured by the caller.
+///
+/// Callers must have established a gRPC-family `protocol`; see
+/// [`validate_grpc_response_content_type`].
+fn check_grpc_response_head(
+    status: http::StatusCode,
+    resp_headers: &http::HeaderMap,
+    protocol: Protocol,
+    codec_format: CodecFormat,
+) -> Result<(), ConnectError> {
+    let content_type = validate_grpc_response_content_type(resp_headers, protocol, codec_format);
+    let speaks_grpc = content_type.is_ok()
+        && (resp_headers.contains_key(http::header::CONTENT_TYPE)
+            || resp_headers.contains_key("grpc-status"));
+    if !status.is_success() && !speaks_grpc {
+        return Err(match content_type {
+            // Reuse the rejection: it already carries the response headers, and
+            // its message becomes the detail on the HTTP status.
+            Err(mut err) => {
+                let detail = err.message.take().unwrap_or_default();
+                err.code = http_status_to_error_code(status);
+                err.message = Some(format!("HTTP error {}: {detail}", status.as_u16()));
+                err
+            }
+            Ok(()) => {
+                let mut err = ConnectError::new(
+                    http_status_to_error_code(status),
+                    format!("HTTP error {}", status.as_u16()),
+                );
+                err.set_response_headers(resp_headers.clone());
+                err
+            }
+        });
+    }
+    content_type
 }
 
 /// Terminal record for a client stream: why it ended and what trailing
@@ -3215,9 +3231,10 @@ where
 
 /// Construct a [`ServerStream`] from a streaming HTTP response.
 ///
-/// Handles trailers-only gRPC error detection, non-200 Connect error body
-/// parsing, successful gRPC-family content-type validation, and response
-/// encoding extraction. Used by both [`call_server_stream`] (passing fields
+/// Handles gRPC-family HTTP-status and content-type gating (shared with the
+/// unary path via [`check_grpc_response_head`]), trailers-only gRPC error
+/// detection, non-200 Connect error body parsing, and response encoding
+/// extraction. Used by both [`call_server_stream`] (passing fields
 /// from `&ClientConfig`) and [`BidiStream::message`] (passing fields from its
 /// owned `StreamConfig` snapshot).
 ///
@@ -3242,12 +3259,15 @@ where
     let response_headers = response.headers().clone();
     let status = response.status();
 
-    // For gRPC, check for trailers-only error response
-    if matches!(protocol, Protocol::Grpc | Protocol::GrpcWeb)
-        && let Some(mut err) = parse_grpc_error_from_trailers(&response_headers)
-    {
-        err.set_response_headers(response_headers);
-        return Err(err);
+    if matches!(protocol, Protocol::Grpc | Protocol::GrpcWeb) {
+        // Same precedence as the unary path: HTTP status and content-type are
+        // settled before `grpc-status` is read, so a trailers-only reply in
+        // the wrong content-type family is rejected rather than believed.
+        check_grpc_response_head(status, &response_headers, protocol, codec_format)?;
+        if let Some(mut err) = parse_grpc_error_from_trailers(&response_headers) {
+            err.set_response_headers(response_headers);
+            return Err(err);
+        }
     }
 
     // Non-200 responses are protocol errors
@@ -3300,13 +3320,6 @@ where
         let mut err = ConnectError::new(code, format!("HTTP error {}", status.as_u16()));
         err.set_response_headers(response_headers);
         return Err(err);
-    }
-
-    match protocol {
-        Protocol::Grpc | Protocol::GrpcWeb => {
-            validate_grpc_response_content_type(&response_headers, protocol, codec_format)?;
-        }
-        Protocol::Connect => {}
     }
 
     // Get the response encoding for compressed envelopes (protocol-aware header)
@@ -5041,7 +5054,19 @@ mod tests {
                 CodecFormat::Json,
                 Some("application/grpc; charset=utf-8"),
             ),
+            (
+                Protocol::Grpc,
+                CodecFormat::Json,
+                Some("application/grpc+json"),
+            ),
             (Protocol::GrpcWeb, CodecFormat::Proto, None),
+            // Connect streaming is not content-type-gated here; a mismatch
+            // surfaces later as an end-of-stream or decode failure.
+            (
+                Protocol::Connect,
+                CodecFormat::Proto,
+                Some("application/grpc+proto"),
+            ),
         ];
 
         for (protocol, codec_format, content_type) in accepted {
@@ -5081,11 +5106,87 @@ mod tests {
         .expect_err("HTTP status must be classified before content type");
 
         assert_eq!(err.code, ErrorCode::Unavailable);
-        assert!(
-            err.message
-                .as_deref()
-                .is_some_and(|message| message.starts_with("HTTP error 502"))
+        assert_eq!(
+            err.message.as_deref(),
+            Some(
+                "HTTP error 502: unexpected content-type: text/html (expected application/grpc+proto)"
+            )
         );
+    }
+
+    /// The unary and streaming parsers see the same response head and must
+    /// classify it the same way: HTTP status and content-type are settled
+    /// before `grpc-status` is read, so a trailers-only reply in the wrong
+    /// family is rejected on its content-type rather than believed for its
+    /// status, while a proxy reply that plausibly speaks gRPC keeps its status.
+    #[tokio::test]
+    async fn unary_and_streaming_classify_a_grpc_response_head_identically() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        // (HTTP status, content-type, grpc-status) -> expected code
+        let cases: [(u16, Option<&str>, Option<&str>, ErrorCode); 5] = [
+            // Wrong family outranks the status it carries.
+            (
+                200,
+                Some("application/grpc-web+proto"),
+                Some("3"),
+                ErrorCode::Unknown,
+            ),
+            // Non-2xx that is not speaking gRPC reports the HTTP status.
+            (503, Some("text/html"), None, ErrorCode::Unavailable),
+            (503, None, None, ErrorCode::Unavailable),
+            // Non-2xx that plausibly speaks gRPC keeps its trailers-only status,
+            // with or without a content-type (a proxy may drop it).
+            (
+                503,
+                Some("application/grpc"),
+                Some("3"),
+                ErrorCode::InvalidArgument,
+            ),
+            (503, None, Some("3"), ErrorCode::InvalidArgument),
+        ];
+        let config =
+            ClientConfig::new("http://localhost".parse().unwrap()).with_protocol(Protocol::Grpc);
+
+        for (status, content_type, grpc_status, expected) in cases {
+            let head = || {
+                let mut b = Response::builder().status(status);
+                if let Some(ct) = content_type {
+                    b = b.header(http::header::CONTENT_TYPE, ct);
+                }
+                if let Some(gs) = grpc_status {
+                    b = b
+                        .header("grpc-status", gs)
+                        .header("grpc-message", "from the peer");
+                }
+                b.body(Full::new(Bytes::new())).unwrap()
+            };
+            let case = format!("{status} {content_type:?} {grpc_status:?}");
+
+            let streaming = make_server_stream::<_, StringValueView<'static>>(
+                head(),
+                config.protocol,
+                &config.compression,
+                config.codec_format,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect_err(&case);
+            let unary = parse_grpc_unary_response::<_, StringValueView<'static>>(
+                head(),
+                &config,
+                &CallOptions::default(),
+                None,
+            )
+            .await
+            .expect_err(&case);
+
+            assert_eq!(streaming.code, expected, "streaming {case}");
+            assert_eq!(unary.code, expected, "unary {case}");
+            assert_eq!(streaming.message, unary.message, "{case}");
+        }
     }
 
     #[tokio::test]
@@ -8294,7 +8395,8 @@ mod tests {
     fn grpc_response_content_type_accepts_bare_for_json_codec() {
         // Proxies that synthesize trailers-only error replies (e.g. Envoy)
         // send bare `application/grpc` regardless of the request subtype, so
-        // the bare type must be accepted for every codec, as in connect-go.
+        // the bare type is accepted for every codec (connect-go accepts it
+        // only for proto).
         let mut headers = http::HeaderMap::new();
         headers.insert(
             http::header::CONTENT_TYPE,


### PR DESCRIPTION
## What this does

Server-streaming and bidi receive initialization did not validate that a successful response's `content-type` matched the configured gRPC family or codec. In the trailers-only regression, a gRPC client accepted `application/grpc-web+proto`: `call_server_stream` returned `Ok(ServerStream)`, then `message()` returned `Ok(None)`.

`make_server_stream` now reuses the unary validator after response-status classification and before encoding or stream construction. Missing and bare-family content types remain accepted; Connect and non-200 HTTP precedence are unchanged.

Fixes #203.

## Verification

| Check | Result |
| --- | --- |
| public trailers-only witness | unpatched `Ok(ServerStream)` then `Ok(None)`; patched `Unknown` before stream exposure |
| ordinary response heads | family and codec mismatches rejected without `grpc-status`; headers and compatibility cases preserved |
| mutation proof | six mutants killed: deleted or conditional validation, hard-coded selectors, wrong ordering, and wrong call site |
| #1123 runner | 1,462 gRPC and 2,854 gRPC-Web cases passed with zero failures |

## Review map

- `validate_grpc_response_content_type`: takes protocol and codec directly.
- `make_server_stream`: shared server-streaming and bidi validation seam.
- Tests and changelog: rejection and compatibility tests, HTTP 502 precedence, and the public false-success regression.
