### PR TITLE
client: Http2ConnectionBuilder::local_address to pin the source address

### DIFF
--- a/.changes/unreleased/Added-20260807-163343.yaml
+++ b/.changes/unreleased/Added-20260807-163343.yaml
@@ -1,0 +1,20 @@
+kind: Added
+body: |-
+  **`Http2ConnectionBuilder::local_address(IpAddr)`** binds the built-in TCP
+  connector's socket to a local address before connecting, so every connection
+  the transport opens (including reconnects) originates from that address. For
+  multi-homed hosts where the peer keys on the source address it observes, or
+  where egress must leave a specific interface:
+
+  ```rust
+  let conn = Http2Connection::builder()
+      .local_address("10.1.2.3".parse()?)
+      .lazy_tls(uri, tls_config);
+  ```
+
+  Applied through hyper's `HttpConnector::set_local_address`; the resolved
+  peer addresses are filtered to the bound address's family, so a peer with no
+  address of that family fails to connect rather than connecting from a
+  kernel-chosen source. Like `tcp_connect_timeout`, it has no effect on the
+  custom-connector and Unix-socket terminals.
+time: 2026-08-07T16:33:43.772087144Z

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -31,6 +31,7 @@
 //! [h2 #531]: https://github.com/hyperium/h2/issues/531
 
 use std::future::Future;
+use std::net::IpAddr;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -513,12 +514,14 @@ impl Http2Connection {
 /// The builder covers every [`Http2Connection`] transport: plaintext, TLS,
 /// caller-supplied connectors, and Unix sockets. HTTP/2 keep-alive and
 /// flow-control knobs are proxied directly; for hyper settings not surfaced
-/// here use [`h2_settings`](Self::h2_settings). [`tcp_connect_timeout`] is the
-/// per-address TCP bound on the built-in connector and is ignored by the
-/// custom-connector / Unix-socket terminals — use [`establishment_timeout`] there
-/// as the establishment bound.
+/// here use [`h2_settings`](Self::h2_settings). [`tcp_connect_timeout`] (the
+/// per-address TCP bound) and [`local_address`] (the source-address bind)
+/// configure the built-in connector and are ignored by the custom-connector /
+/// Unix-socket terminals — use [`establishment_timeout`] there as the
+/// establishment bound, and bind inside your own connector.
 ///
 /// [`tcp_connect_timeout`]: Self::tcp_connect_timeout
+/// [`local_address`]: Self::local_address
 /// [`establishment_timeout`]: Self::establishment_timeout
 ///
 /// [`CallOptions::with_timeout`]: super::CallOptions::with_timeout
@@ -527,6 +530,7 @@ impl Http2Connection {
 pub struct Http2ConnectionBuilder {
     tcp_connect_timeout: Option<Duration>,
     establishment_timeout: Option<Duration>,
+    local_address: Option<IpAddr>,
     h2_builder: hyper::client::conn::http2::Builder<hyper_util::rt::TokioExecutor>,
 }
 
@@ -563,6 +567,7 @@ impl Default for Http2ConnectionBuilder {
         Self {
             tcp_connect_timeout: Some(DEFAULT_TCP_CONNECT_TIMEOUT),
             establishment_timeout: Some(DEFAULT_ESTABLISHMENT_TIMEOUT),
+            local_address: None,
             h2_builder,
         }
     }
@@ -635,6 +640,33 @@ impl Http2ConnectionBuilder {
     /// can stall `poll_ready` indefinitely — the pre-0.8.0 behaviour.
     pub fn no_establishment_timeout(mut self) -> Self {
         self.establishment_timeout = None;
+        self
+    }
+
+    /// Bind the built-in connector's TCP socket to `addr` before connecting,
+    /// so every connection (including reconnects) originates from that local
+    /// address (IP only; the source port stays ephemeral). For multi-homed
+    /// hosts where the peer derives something from the source address it
+    /// observes, or where egress must leave a specific interface. Unset by
+    /// default: the kernel picks the source address from the route to the
+    /// peer.
+    ///
+    /// Applied via hyper's [`HttpConnector::set_local_address`][hyper-la].
+    /// The resolved peer addresses are filtered to `addr`'s family, so a peer
+    /// with no address of that family fails to connect (rather than
+    /// connecting from a kernel-chosen source); there is currently no
+    /// dual-stack variant. An address this host cannot bind fails every
+    /// connect with the bind error. Like
+    /// [`tcp_connect_timeout`](Self::tcp_connect_timeout), this is
+    /// **ignored** by the custom-connector / Unix-socket terminals.
+    /// [`HttpClientBuilder`](super::HttpClientBuilder) does not expose it; use
+    /// `Http2Connection` when you need a pinned source address.
+    ///
+    /// [hyper-la]: hyper_util::client::legacy::connect::HttpConnector::set_local_address
+    #[doc(alias = "bind")]
+    #[doc(alias = "source_address")]
+    pub fn local_address(mut self, addr: IpAddr) -> Self {
+        self.local_address = Some(addr);
         self
     }
 
@@ -786,9 +818,10 @@ impl Http2ConnectionBuilder {
     ///
     /// `establishment_timeout` bounds the connector's dial *and* the HTTP/2 preface
     /// as one wall-clock budget — the same semantics as the built-in
-    /// transports. `tcp_connect_timeout` is the per-address TCP bound on the
-    /// built-in connector and is **ignored** here; to bound the dial separately
-    /// from the preface, wrap the connector in `tower::timeout::Timeout`.
+    /// transports. `tcp_connect_timeout` and `local_address` configure the
+    /// built-in connector and are **ignored** here; to bound the dial separately
+    /// from the preface, wrap the connector in `tower::timeout::Timeout`, and
+    /// bind inside the connector if you need a source address.
     #[must_use]
     pub fn lazy_with_connector<C>(self, connector: C, authority: Uri) -> Http2Connection
     where
@@ -859,11 +892,16 @@ impl Http2ConnectionBuilder {
     }
 
     /// Built-in TCP connector with `nodelay` and the configured
-    /// `tcp_connect_timeout` applied. Mirrors `HttpClientBuilder::http_connector`.
+    /// `tcp_connect_timeout` / `local_address` applied. Mirrors
+    /// `HttpClientBuilder::http_connector` (which has no `local_address`).
     fn http_connector(&self) -> hyper_util::client::legacy::connect::HttpConnector {
         let mut connector = hyper_util::client::legacy::connect::HttpConnector::new();
         connector.set_nodelay(true);
         connector.set_connect_timeout(self.tcp_connect_timeout);
+        // The family filtering documented on `local_address` is hyper's
+        // happy-eyeballs path; with it disabled hyper skips a mismatched-family
+        // bind silently. `HttpConnector::new()` enables it — keep it that way.
+        connector.set_local_address(self.local_address);
         connector
     }
 
@@ -1562,6 +1600,49 @@ mod tests {
             .establishment_timeout(Duration::MAX);
         assert_eq!(max.tcp_connect_timeout, None);
         assert_eq!(max.establishment_timeout, None);
+    }
+
+    /// `local_address` is what the peer observes as the connection's source.
+    /// Linux routes all of 127/8 to `lo`, so 127.0.0.2 is bindable without
+    /// setup and distinguishable from the default 127.0.0.1 source; macOS/BSD
+    /// configure only 127.0.0.1 on loopback, hence the cfg.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn builder_local_address_is_the_observed_peer() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let uri: Uri = format!("http://{}", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+        let local: IpAddr = "127.0.0.2".parse().unwrap();
+        // TCP completes into the listen backlog and the plaintext h2c
+        // handshake resolves locally, so this finishes before `accept()` is
+        // polled — and a bind failure surfaces here as an error, not a hang.
+        let _conn = Http2Connection::builder()
+            .local_address(local)
+            .connect_plaintext(uri)
+            .await
+            .unwrap();
+        let (_stream, peer) = listener.accept().await.unwrap();
+        assert_eq!(peer.ip(), local);
+    }
+
+    /// A `local_address` whose family the peer has no address in fails the
+    /// connect rather than falling back to a kernel-chosen source. The peer
+    /// is a live v4 listener, so a fallback would *succeed* — `expect_err`
+    /// is what pins the no-fallback behaviour (and the happy-eyeballs
+    /// dependency noted in `http_connector`).
+    #[tokio::test]
+    async fn builder_local_address_family_mismatch_fails() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let uri: Uri = format!("http://{}", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+        let err = Http2Connection::builder()
+            .local_address("::1".parse().unwrap())
+            .connect_plaintext(uri)
+            .await
+            .expect_err("v6 local address to a v4-only peer must not connect");
+        assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
     }
 
     #[tokio::test]

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1591,6 +1591,8 @@ let conn = Http2Connection::builder()
 
 `Http2ConnectionBuilder` also proxies hyper's HTTP/2 keep-alive and flow-control knobs (`keep_alive_interval`, `keep_alive_timeout`, `keep_alive_while_idle`, `initial_stream_window_size`, `initial_connection_window_size`, `adaptive_window`), with a `TokioTimer` pre-wired so the keep-alive setters work without further plumbing. The `h2_settings(|b| ...)` escape hatch exposes the underlying hyper builder for knobs not surfaced directly. To restore the unbounded pre-0.8.0 behaviour, chain `.no_establishment_timeout().no_tcp_connect_timeout()`.
 
+On a multi-homed host, `Http2ConnectionBuilder::local_address(IpAddr)` binds the built-in connector's socket to one of the host's addresses before connecting, so the connection (and every reconnect) originates from that address — useful when the peer keys on the source address it observes, or when egress must leave a particular interface. The resolved peer addresses are filtered to that address's family; a peer with no address of that family fails to connect rather than connecting from a kernel-chosen source. Like `tcp_connect_timeout`, it applies only to the built-in TCP connector, not to the custom-connector / Unix-socket terminals. (`HttpClientBuilder` does not expose this; use `Http2Connection` when you need a pinned source address.)
+
 ### ClientConfig
 
 `ClientConfig` carries the base URI and per-call defaults that apply


### PR DESCRIPTION
## What

Adds `Http2ConnectionBuilder::local_address(IpAddr)`: bind the built-in TCP connector's socket to a local address before connecting, so every connection the transport opens — including reconnects — originates from that address.

```rust
let conn = Http2Connection::builder()
    .local_address("10.1.2.3".parse()?)
    .keep_alive_interval(Duration::from_secs(10))
    .lazy_tls(uri, tls_config);
```

## Why

On a multi-homed host the kernel chooses a connection's source address from the route to the peer. A caller that needs connections to come *from* a particular local address — the peer keys on the source address it observes, or egress has to leave a specific interface — currently has one option: `lazy_with_connector` with a hand-rolled connector. Because the custom-connector terminal runs no TLS step, that connector has to re-implement everything `lazy_tls` already does internally (TCP connect under the per-address bound, `nodelay`, clone the rustls config and force `h2` ALPN, pick the `ServerName`, handshake, reject a peer that didn't negotiate `h2`) just to insert one `bind()` — a by-value copy of this crate's establish path that nothing keeps in step when the built-in path moves (as it did in 0.8.0).

hyper-util's `HttpConnector` already has `set_local_address`; the builder just wasn't exposing it.

## API

- `Http2ConnectionBuilder::local_address(addr: IpAddr) -> Self`. Unset by default (kernel-chosen source, unchanged behaviour). Takes the address by value, matching the neighbouring `tcp_connect_timeout(Duration)` style; there is no default to opt out of, so no `no_local_address()`. `#[doc(alias = "bind")]` / `"source_address"` for discoverability.
- Applied in the private `http_connector()` alongside `nodelay` / `tcp_connect_timeout`, so it flows into `lazy_plaintext` / `connect_plaintext` / `lazy_tls` / `connect_tls` and re-applies on every `Reconnect` (the connector is re-invoked per connection).
- **Family mismatch fails, it does not fall back.** With `happy_eyeballs_timeout` set — `HttpConnector::new()`'s default, which `http_connector()` keeps — hyper's `split_by_preference` filters the resolved peer addresses to the bound address's family, so a peer with no address of that family yields `Unavailable` ("tcp connect error") without ever connecting from a kernel-chosen source. (With happy-eyeballs *disabled*, hyper's `bind_local_address` silently skips a mismatched bind; a comment at the `set_local_address` call records that dependency so nobody turns it off later, and a test pins the behaviour.) There is no dual-stack `(v4, v6)` variant yet; additive if someone needs it.
- An address the host cannot bind fails every connect with the bind error.
- Like `tcp_connect_timeout`, **ignored** by `lazy_with_connector` / `connect_with_connector` / `lazy_unix` / `connect_unix` (no built-in connector there). The builder's `# Scope` doc and `lazy_with_connector`'s doc, which previously enumerated `tcp_connect_timeout` as *the* ignored knob, now list both.
- `HttpClientBuilder` is deliberately **not** given the knob in this PR: its `http_connector()` is the same three lines so it's trivially additive, but there's no caller asking and the pooled client's connect is only observable through a full request, which makes the test heavier than the feature. The rustdoc and guide signpost from `HttpClientBuilder` to `Http2Connection` so the asymmetry reads as intentional. Happy to add it here if you'd rather have parity now.

## Validation

- `builder_local_address_is_the_observed_peer` (Linux-only: 127.0.0.2 is on `lo` without setup there, not on macOS/BSD): a real `connect_plaintext` bound to 127.0.0.2; the listener asserts `peer.ip() == 127.0.0.2`. Sequenced connect-then-accept so a bind failure is an error, not a hang.
- `builder_local_address_family_mismatch_fails`: `local_address(::1)` to a **live** `127.0.0.1` listener must be `Err(Unavailable)` — a fallback to a kernel-chosen source would *succeed* here, so `expect_err` is what proves no-fallback.
- `task lint`, `task test` (workspace, all features), `cargo doc -D warnings` clean. +111/−8, one changelog fragment, one guide paragraph.
