### PR TITLE
interceptor: plumbing for re-runnable chains and lazily-encoded payloads

### DIFF
--- a/.changes/unreleased/Added-20260813-043124.yaml
+++ b/.changes/unreleased/Added-20260813-043124.yaml
@@ -21,8 +21,8 @@ body: |-
   - **`UnaryRequest::from_parts(ctx, payload)`** — constructor for the
     `#[non_exhaustive]` request from an existing `Payload`; `StreamRequest`
     is now `Clone`.
-  - **`Next` and `NextStream` are now `Clone`**, so an interceptor can run
-    the rest of the chain more than once (`next.clone().run(first)` then
+  - **`Next` is now `Clone`**, so a unary interceptor can run the rest of
+    the chain more than once (`next.clone().run(first)` then
     `next.run(second)`); the consuming `run(self)` keeps the single-call
     case explicit.
 time: 2026-08-13T04:31:36.268465697Z

--- a/.changes/unreleased/Added-20260813-043124.yaml
+++ b/.changes/unreleased/Added-20260813-043124.yaml
@@ -1,0 +1,28 @@
+kind: Added
+body: |-
+  Interceptor plumbing that a re-runnable (retry-style) chain and the upcoming
+  client-side interceptors both need. All additive; no dispatch behavior
+  changes:
+
+  - **`RequestContext::headers_mut()`** — mutable access to request headers,
+    the accessor an interceptor uses to inject auth or trace metadata before
+    `next.run(req)`. (`extensions_mut()` already existed; the docs claimed
+    headers were mutable but no public accessor allowed it.)
+  - **`Payload::from_message(msg, format)`** — the lazily-*encoded*
+    counterpart of `Payload::new`: wraps a typed message and encodes only when
+    `encoded()` runs, memoizing the result (a replacement set with
+    `set_message` is now also encoded at most once). Lets an interceptor
+    short-circuit with a synthesized response, and is how the client call
+    path will hand typed requests to the chain. `bytes()` is empty for such a
+    payload; `Payload`'s `Debug` output now labels that field `wire_len`.
+  - **`Payload::try_clone()`** and **`UnaryRequest::try_clone()`** — explicit
+    copies (encoded bytes, cloned context, empty decode cache) for an
+    interceptor that needs a second request.
+  - **`UnaryRequest::from_parts(ctx, payload)`** — constructor for the
+    `#[non_exhaustive]` request from an existing `Payload`; `StreamRequest`
+    is now `Clone`.
+  - **`Next` and `NextStream` are now `Clone`**, so an interceptor can run
+    the rest of the chain more than once (`next.clone().run(first)` then
+    `next.run(second)`); the consuming `run(self)` keeps the single-call
+    case explicit.
+time: 2026-08-13T04:31:36.268465697Z

--- a/.changes/unreleased/Added-20260813-043124.yaml
+++ b/.changes/unreleased/Added-20260813-043124.yaml
@@ -1,7 +1,7 @@
 kind: Added
 body: |-
-  Interceptor plumbing that a re-runnable (retry-style) chain and the upcoming
-  client-side interceptors both need. All additive; no dispatch behavior
+  Interceptor plumbing for a re-runnable (retry-style) chain and for
+  interceptors that synthesize a response. All additive; no dispatch behavior
   changes:
 
   - **`RequestContext::headers_mut()`** — mutable access to request headers,
@@ -12,9 +12,10 @@ body: |-
     counterpart of `Payload::new`: wraps a typed message and encodes only when
     `encoded()` runs, memoizing the result (a replacement set with
     `set_message` is now also encoded at most once). Lets an interceptor
-    short-circuit with a synthesized response, and is how the client call
-    path will hand typed requests to the chain. `bytes()` is empty for such a
-    payload; `Payload`'s `Debug` output now labels that field `wire_len`.
+    short-circuit with a synthesized response; the dispatch path re-encodes
+    it in the negotiated format if the two differ (`Payload::encoded_as`).
+    `bytes()` is empty for such a payload; `Payload`'s `Debug` output now
+    labels that field `wire_len`.
   - **`Payload::try_clone()`** and **`UnaryRequest::try_clone()`** — explicit
     copies (encoded bytes, cloned context, empty decode cache) for an
     interceptor that needs a second request.

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -264,22 +264,19 @@ impl std::fmt::Debug for InterceptorChain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // `dyn Interceptor` is not `Debug`; the count is what a reader of a
         // config/service dump actually wants.
-        f.debug_struct("InterceptorChain")
-            .field("len", &self.0.len())
-            .finish()
+        write!(f, "[dyn Interceptor; {}]", self.0.len())
     }
 }
 
 /// The continuation an [`Interceptor`] calls to run the rest of the chain.
 ///
 /// `Next` holds the still-to-run interceptors and the terminal handler.
-/// [`run`](Next::run) consumes it, so the common case — call it once —
-/// needs no ceremony, and not calling it at all short-circuits the chain.
+/// [`run`](Next::run) consumes it; not calling it short-circuits the chain.
 ///
-/// `Next` is also `Clone` (it is two shared references), for the
-/// interceptor that must run the rest of the chain more than once: a
-/// retry or a hedge. Clone *before* the first `run` and build each extra
-/// attempt's request with [`UnaryRequest::try_clone`]:
+/// `Next` is also `Clone` (two shared references) for the interceptor that
+/// must run the rest of the chain more than once — a retry or a hedge.
+/// Clone before the first `run` and copy the request with
+/// [`UnaryRequest::try_clone`]:
 ///
 /// ```rust,ignore
 /// let spare = req.try_clone()?;            // ctx clone + Payload::try_clone
@@ -308,11 +305,8 @@ impl<'a> Next<'a> {
     }
 
     /// Run the rest of the chain — the next interceptor if any, otherwise
-    /// the terminal handler — and return its response.
-    ///
-    /// Consumes `self`. To run the chain again (retry), call
-    /// `next.clone().run(..)` for the earlier attempts; each run re-invokes
-    /// everything below, including the handler on the server.
+    /// the terminal handler — and return its response. Consumes `self`;
+    /// see [`Next`] for re-running.
     ///
     /// # Errors
     ///
@@ -394,30 +388,19 @@ impl UnaryRequest {
         Self { ctx, payload }
     }
 
-    /// Build a `UnaryRequest` from a context and an existing [`Payload`].
-    ///
-    /// The struct is `#[non_exhaustive]`, so downstream code cannot use a
-    /// struct literal; this is the constructor for an interceptor that
-    /// assembles a request itself, e.g. around a typed message with
-    /// [`Payload::from_message`]. (For a retry copy, prefer
-    /// [`try_clone`](Self::try_clone).)
-    ///
-    /// Unlike [`new`](Self::new), the payload keeps **its own** decode
-    /// options rather than taking the context's. When wrapping untrusted
-    /// wire bytes on the server, carry the service limits across
-    /// explicitly:
-    /// `Payload::new(bytes, fmt).with_decode_options(ctx.decode_options().clone())`.
+    /// Build a `UnaryRequest` from a context and an existing [`Payload`]
+    /// (the struct is `#[non_exhaustive]`, so downstream code cannot use a
+    /// struct literal) — e.g. around a typed message with
+    /// [`Payload::from_message`]. Unlike [`new`](Self::new), does not apply
+    /// the context's decode limits to the payload; use `new` for untrusted
+    /// wire bytes. For a retry copy, use [`try_clone`](Self::try_clone).
     pub fn from_parts(ctx: RequestContext, payload: Payload) -> Self {
         Self { ctx, payload }
     }
 
-    /// Copy this request for another trip through the chain.
-    ///
-    /// Clones the context (headers, extensions, deadline, spec) and
-    /// [`Payload::try_clone`]s the body. This is the one call a retry or
-    /// hedging interceptor makes before its first `next.clone().run(req)`;
-    /// see [`Next`] for the full shape. The copies are independent:
-    /// header edits on one attempt do not leak into another.
+    /// Copy this request for another trip through the chain: clones the
+    /// context and [`Payload::try_clone`]s the body, so header edits on one
+    /// attempt do not leak into another. See [`Next`] for the retry shape.
     ///
     /// # Errors
     ///
@@ -608,12 +591,8 @@ where
 /// streaming chain.
 ///
 /// `NextStream` holds the still-to-run interceptors and the terminal
-/// handler. [`run`](NextStream::run) consumes it. Not calling it
-/// short-circuits. It is `Clone` for symmetry with [`Next`], but
-/// re-running a streaming chain is rarely practical: `run` consumes the
-/// inbound [`PayloadStream`], which cannot be cloned, so a second attempt
-/// needs an inbound stream you buffered or synthesized yourself.
-#[derive(Clone)]
+/// handler. [`run`](NextStream::run) consumes it: an interceptor can call
+/// `next.run(req, inbound)` at most once. Not calling it short-circuits.
 pub struct NextStream<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn StreamTerminal + 'a),
@@ -1432,16 +1411,18 @@ mod tests {
         assert_eq!(echoed.value, "hi", "retry carried the original body");
     }
 
+    /// An interceptor that overrides nothing: both hooks pass through.
+    struct Passthrough;
+    #[async_trait::async_trait]
+    impl Interceptor for Passthrough {}
+
     #[test]
     fn interceptor_chain_push_and_debug() {
-        struct Nop;
-        #[async_trait::async_trait]
-        impl Interceptor for Nop {}
         let mut chain = InterceptorChain::default();
         assert!(chain.is_empty());
         let shared = chain.clone();
-        let a: Arc<dyn Interceptor> = Arc::new(Nop);
-        let b: Arc<dyn Interceptor> = Arc::new(Nop);
+        let a: Arc<dyn Interceptor> = Arc::new(Passthrough);
+        let b: Arc<dyn Interceptor> = Arc::new(Passthrough);
         chain.push(Arc::clone(&a));
         chain.push(Arc::clone(&b));
         // Deref to slice; `push` appends, so first registered stays
@@ -1452,7 +1433,7 @@ mod tests {
         // `push` rebuilds; an earlier clone is unaffected (registration on
         // one handle must not retroactively change another).
         assert!(shared.is_empty());
-        assert!(format!("{chain:?}").contains("len: 2"), "{chain:?}");
+        assert_eq!(format!("{chain:?}"), "[dyn Interceptor; 2]");
     }
 
     /// `new` stamps the context's decode options onto the payload;
@@ -1484,9 +1465,6 @@ mod tests {
     /// metadata, not just the body.
     #[tokio::test]
     async fn passthrough_chain_preserves_response_metadata() {
-        struct Passthrough;
-        #[async_trait::async_trait]
-        impl Interceptor for Passthrough {}
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
         let resp = run_chain(&chain, req(), |_| async {
             let mut r = EncodedResponse::new(Bytes::from_static(b"x").into());
@@ -1838,9 +1816,6 @@ mod tests {
 
     #[tokio::test]
     async fn streaming_passthrough_preserves_items_and_metadata() {
-        struct Passthrough;
-        #[async_trait::async_trait]
-        impl Interceptor for Passthrough {}
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
         let resp = run_chain_streaming(
             &chain,
@@ -2232,9 +2207,6 @@ mod tests {
     /// collapses a 1-item outbound stream — through a passthrough chain.
     #[tokio::test]
     async fn streaming_intercepted_un_unifies_through_passthrough_chain() {
-        struct Passthrough;
-        #[async_trait::async_trait]
-        impl Interceptor for Passthrough {}
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
 
         // Server-streaming: single body in → 1-item inbound stream → terminal

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -289,6 +289,9 @@ impl std::fmt::Debug for InterceptorChain {
 /// Re-running dispatches the inner interceptors *and the terminal* again.
 /// On the server that means invoking the handler twice, so gate any
 /// re-run on [`Spec::idempotency_level`](crate::Spec::idempotency_level).
+/// Every attempt shares the one request deadline (a retry cannot extend
+/// it) and the one request tracing span; open a span per attempt if they
+/// need to be observable separately.
 #[derive(Clone)]
 pub struct Next<'a> {
     rest: &'a [Arc<dyn Interceptor>],
@@ -393,7 +396,8 @@ impl UnaryRequest {
     /// struct literal) — e.g. around a typed message with
     /// [`Payload::from_message`]. Unlike [`new`](Self::new), does not apply
     /// the context's decode limits to the payload; use `new` for untrusted
-    /// wire bytes. For a retry copy, use [`try_clone`](Self::try_clone).
+    /// wire bytes. For a retry copy, use [`try_clone`](Self::try_clone),
+    /// which keeps the limits.
     pub fn from_parts(ctx: RequestContext, payload: Payload) -> Self {
         Self { ctx, payload }
     }
@@ -446,6 +450,23 @@ impl UnaryResponse {
     pub fn into_encoded(self) -> Result<EncodedResponse, ConnectError> {
         Ok(Response {
             body: self.body.encoded()?.into(),
+            headers: self.headers,
+            trailers: self.trailers,
+            compress: self.compress,
+        })
+    }
+
+    /// [`into_encoded`](Self::into_encoded), but in the format the call
+    /// negotiated rather than the one the payload was built with, so an
+    /// interceptor that short-circuits with
+    /// [`Payload::from_message`] in the wrong format still answers the peer
+    /// in the format it asked for (see [`Payload::encoded_as`]).
+    pub(crate) fn into_encoded_as(
+        self,
+        format: CodecFormat,
+    ) -> Result<EncodedResponse, ConnectError> {
+        Ok(Response {
+            body: self.body.encoded_as(format)?.into(),
             headers: self.headers,
             trailers: self.trailers,
             compress: self.compress,
@@ -593,6 +614,9 @@ where
 /// `NextStream` holds the still-to-run interceptors and the terminal
 /// handler. [`run`](NextStream::run) consumes it: an interceptor can call
 /// `next.run(req, inbound)` at most once. Not calling it short-circuits.
+/// Unlike [`Next`], this is not `Clone`: the inbound stream is consumed as
+/// it is read and cannot be replayed, so a streaming chain runs once by
+/// construction.
 pub struct NextStream<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn StreamTerminal + 'a),
@@ -1020,7 +1044,7 @@ pub(crate) async fn call_unary_intercepted<D: crate::Dispatcher>(
     };
     let req = UnaryRequest::new(ctx, body, format);
     let resp = Next::new(interceptors, &terminal).run(req).await?;
-    resp.into_encoded()
+    resp.into_encoded_as(format)
 }
 
 /// `UnaryTerminal` that hands off to the dispatcher's `call_unary`.
@@ -1175,6 +1199,84 @@ mod tests {
             "p1",
             "diagnostic headers on a short-circuit error must survive the chain"
         );
+    }
+
+    /// A short-circuit response built in the wrong format is re-encoded in
+    /// the negotiated one, so the peer never receives proto bytes under a
+    /// JSON content-type (or vice versa).
+    #[cfg(feature = "json")]
+    #[tokio::test]
+    async fn call_unary_intercepted_answers_in_the_negotiated_format() {
+        struct Canned;
+        #[async_trait::async_trait]
+        impl Interceptor for Canned {
+            async fn intercept_unary(
+                &self,
+                _req: UnaryRequest,
+                _next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                // The obvious-but-wrong spelling: a proto payload on a JSON call.
+                Ok(Response::new(Payload::from_message(
+                    StringValue::from("canned"),
+                    CodecFormat::Proto,
+                )))
+            }
+        }
+        struct Unreached;
+        impl crate::Dispatcher for Unreached {
+            fn lookup(&self, _: &str) -> Option<crate::dispatcher::MethodDescriptor> {
+                None
+            }
+            fn call_unary(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Payload,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!("short-circuited")
+            }
+            fn call_server_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+            fn call_client_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!()
+            }
+            fn call_bidi_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Canned)];
+        let resp = call_unary_intercepted(
+            &Unreached,
+            &chain,
+            "svc/Method",
+            RequestContext::default(),
+            Bytes::from_static(b"{}"),
+            CodecFormat::Json,
+        )
+        .await
+        .unwrap();
+        let rt: StringValue = crate::codec::decode_json(&resp.body.into_contiguous()).unwrap();
+        assert_eq!(rt.value, "canned");
     }
 
     /// `call_unary_intercepted` propagates a short-circuit error verbatim,

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -232,11 +232,67 @@ where
     FnInterceptor(f)
 }
 
+/// An ordered, cheaply-cloneable list of interceptors, outermost first.
+///
+/// The one storage type both registration points use
+/// ([`ConnectRpcService`](crate::ConnectRpcService) today, the client
+/// config next). Backed by `Arc<[..]>` so cloning a service handle or a
+/// config is one refcount bump regardless of chain length; `push`
+/// rebuilds the slice, which is fine because registration is a cold path.
+/// Derefs to the slice so call sites pass `&chain` where
+/// `&[Arc<dyn Interceptor>]` is expected.
+#[derive(Clone, Default)]
+pub(crate) struct InterceptorChain(Arc<[Arc<dyn Interceptor>]>);
+
+impl InterceptorChain {
+    /// Append `interceptor` as the new innermost entry.
+    pub(crate) fn push(&mut self, interceptor: Arc<dyn Interceptor>) {
+        let mut v: Vec<Arc<dyn Interceptor>> = self.0.to_vec();
+        v.push(interceptor);
+        self.0 = Arc::from(v);
+    }
+}
+
+impl std::ops::Deref for InterceptorChain {
+    type Target = [Arc<dyn Interceptor>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for InterceptorChain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `dyn Interceptor` is not `Debug`; the count is what a reader of a
+        // config/service dump actually wants.
+        f.debug_struct("InterceptorChain")
+            .field("len", &self.0.len())
+            .finish()
+    }
+}
+
 /// The continuation an [`Interceptor`] calls to run the rest of the chain.
 ///
 /// `Next` holds the still-to-run interceptors and the terminal handler.
-/// [`run`](Next::run) consumes it: an interceptor can call `next.run(req)`
-/// at most once. Not calling it at all short-circuits the chain.
+/// [`run`](Next::run) consumes it, so the common case — call it once —
+/// needs no ceremony, and not calling it at all short-circuits the chain.
+///
+/// `Next` is also `Clone` (it is two shared references), for the
+/// interceptor that must run the rest of the chain more than once: a
+/// retry or a hedge. Clone *before* the first `run` and build each extra
+/// attempt's request with [`UnaryRequest::try_clone`]:
+///
+/// ```rust,ignore
+/// let spare = req.try_clone()?;            // ctx clone + Payload::try_clone
+/// match next.clone().run(req).await {
+///     Err(e) if e.code == ErrorCode::Unavailable => next.run(spare).await,
+///     done => done,
+/// }
+/// ```
+///
+/// Re-running dispatches the inner interceptors *and the terminal* again.
+/// On the server that means invoking the handler twice, so gate any
+/// re-run on [`Spec::idempotency_level`](crate::Spec::idempotency_level).
+#[derive(Clone)]
 pub struct Next<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn UnaryTerminal + 'a),
@@ -253,6 +309,10 @@ impl<'a> Next<'a> {
 
     /// Run the rest of the chain — the next interceptor if any, otherwise
     /// the terminal handler — and return its response.
+    ///
+    /// Consumes `self`. To run the chain again (retry), call
+    /// `next.clone().run(..)` for the earlier attempts; each run re-invokes
+    /// everything below, including the handler on the server.
     ///
     /// # Errors
     ///
@@ -297,23 +357,29 @@ pub(crate) trait UnaryTerminal: Send + Sync {
 /// Carries the dispatch [`RequestContext`] (headers, deadline,
 /// extensions, [`Spec`](crate::Spec), negotiated protocol) and the
 /// lazily-decoded body. Both fields are public so an interceptor can
-/// rewrite headers, inject extensions, or replace the message and pass
-/// the mutated request to [`Next::run`].
+/// rewrite headers ([`ctx.headers_mut()`](RequestContext::headers_mut)),
+/// inject extensions ([`ctx.extensions_mut()`](RequestContext::extensions_mut)),
+/// or replace the message ([`payload.set_message(..)`](Payload::set_message))
+/// and pass the mutated request to [`Next::run`].
 ///
-/// `ctx.spec` is `Some(..)` for generated `FooServiceServer<T>`
+/// `ctx.spec()` is `Some(..)` for generated `FooServiceServer<T>`
 /// dispatchers and for [`Router`](crate::Router) routes registered
 /// through the generated `register()`; it is `None` only for low-level
 /// manual registrations without a
 /// [`Router::with_spec`](crate::Router::with_spec) call.
 ///
 /// `#[non_exhaustive]` so future fields can be added without a
-/// breaking change. Construct with [`UnaryRequest::new`]; destructure
-/// with a trailing `..`.
+/// breaking change. Construct with [`UnaryRequest::new`] (from wire
+/// bytes) or [`UnaryRequest::from_parts`] (from a [`Payload`]); copy for
+/// a second attempt with [`UnaryRequest::try_clone`]; destructure with a
+/// trailing `..`.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct UnaryRequest {
-    /// The dispatch context. Mutating `ctx.headers` or `ctx.extensions`
-    /// before `next.run` propagates to the handler.
+    /// The dispatch context. Changes made through
+    /// [`headers_mut()`](RequestContext::headers_mut) or
+    /// [`extensions_mut()`](RequestContext::extensions_mut) before
+    /// `next.run` propagate to the handler.
     pub ctx: RequestContext,
     /// The lazily-decoded request body. Call
     /// [`set_message`](Payload::set_message) to replace it.
@@ -326,6 +392,42 @@ impl UnaryRequest {
     pub fn new(ctx: RequestContext, body: Bytes, format: CodecFormat) -> Self {
         let payload = Payload::new(body, format).with_decode_options(ctx.decode_options().clone());
         Self { ctx, payload }
+    }
+
+    /// Build a `UnaryRequest` from a context and an existing [`Payload`].
+    ///
+    /// The struct is `#[non_exhaustive]`, so downstream code cannot use a
+    /// struct literal; this is the constructor for an interceptor that
+    /// assembles a request itself, e.g. around a typed message with
+    /// [`Payload::from_message`]. (For a retry copy, prefer
+    /// [`try_clone`](Self::try_clone).)
+    ///
+    /// Unlike [`new`](Self::new), the payload keeps **its own** decode
+    /// options rather than taking the context's. When wrapping untrusted
+    /// wire bytes on the server, carry the service limits across
+    /// explicitly:
+    /// `Payload::new(bytes, fmt).with_decode_options(ctx.decode_options().clone())`.
+    pub fn from_parts(ctx: RequestContext, payload: Payload) -> Self {
+        Self { ctx, payload }
+    }
+
+    /// Copy this request for another trip through the chain.
+    ///
+    /// Clones the context (headers, extensions, deadline, spec) and
+    /// [`Payload::try_clone`]s the body. This is the one call a retry or
+    /// hedging interceptor makes before its first `next.clone().run(req)`;
+    /// see [`Next`] for the full shape. The copies are independent:
+    /// header edits on one attempt do not leak into another.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload holds a replacement that fails to
+    /// encode.
+    pub fn try_clone(&self) -> Result<Self, ConnectError> {
+        Ok(Self {
+            ctx: self.ctx.clone(),
+            payload: self.payload.try_clone()?,
+        })
     }
 }
 
@@ -391,11 +493,13 @@ pub type PayloadStream = BoxStream<Result<Payload, ConnectError>>;
 /// `#[non_exhaustive]` so future fields can be added without a breaking
 /// change. Construct with [`StreamRequest::new`]; destructure with a
 /// trailing `..`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct StreamRequest {
-    /// The dispatch context. Mutating `ctx.headers` or `ctx.extensions`
-    /// before `next.run` propagates to the handler.
+    /// The dispatch context. Changes made through
+    /// [`headers_mut()`](RequestContext::headers_mut) or
+    /// [`extensions_mut()`](RequestContext::extensions_mut) before
+    /// `next.run` propagate to the handler.
     pub ctx: RequestContext,
 }
 
@@ -504,8 +608,12 @@ where
 /// streaming chain.
 ///
 /// `NextStream` holds the still-to-run interceptors and the terminal
-/// handler. [`run`](NextStream::run) consumes it: an interceptor can call
-/// `next.run(req, inbound)` at most once. Not calling it short-circuits.
+/// handler. [`run`](NextStream::run) consumes it. Not calling it
+/// short-circuits. It is `Clone` for symmetry with [`Next`], but
+/// re-running a streaming chain is rarely practical: `run` consumes the
+/// inbound [`PayloadStream`], which cannot be cloned, so a second attempt
+/// needs an inbound stream you buffered or synthesized yourself.
+#[derive(Clone)]
 pub struct NextStream<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn StreamTerminal + 'a),
@@ -1221,6 +1329,154 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(resp.headers.get("x-fn").unwrap(), "1");
+    }
+
+    /// `Next` is `Clone`, so an interceptor can run the rest of the chain
+    /// more than once with a fresh request — the retry/hedge shape. Each
+    /// run reaches the inner interceptors and the terminal independently,
+    /// and request mutations (headers here) made per attempt are visible
+    /// below and do not leak between attempts.
+    #[tokio::test]
+    async fn next_is_rerunnable_for_retry() {
+        /// Fails the first attempt, succeeds afterwards; records the
+        /// `x-attempt` header each attempt carried and whether the
+        /// first-attempt-only marker leaked.
+        struct FlakyTerminal {
+            calls: Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl UnaryTerminal for FlakyTerminal {
+            async fn call(&self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError> {
+                let attempt = req
+                    .ctx
+                    .header("x-attempt")
+                    .map(|v| v.to_str().unwrap().to_owned())
+                    .unwrap_or_default();
+                let mut calls = self.calls.lock().unwrap();
+                calls.push(attempt);
+                if calls.len() == 1 {
+                    return Err(ConnectError::unavailable("first attempt fails"));
+                }
+                assert!(
+                    req.ctx.header("x-first-only").is_none(),
+                    "attempt contexts must be independent (ctx was cloned, not shared)"
+                );
+                // Echo the request body so the test can check the retry
+                // carried the same payload.
+                Ok(UnaryResponse::from_encoded(
+                    EncodedResponse::new(req.payload.encoded()?.into()),
+                    CodecFormat::Proto,
+                ))
+            }
+        }
+
+        struct RetryOnce;
+        #[async_trait::async_trait]
+        impl Interceptor for RetryOnce {
+            async fn intercept_unary(
+                &self,
+                req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                // Keep what a second attempt needs *before* moving `req`.
+                let mut second = req.try_clone()?;
+                let mut first = req;
+                first
+                    .ctx
+                    .headers_mut()
+                    .insert("x-attempt", "1".parse().unwrap());
+                first
+                    .ctx
+                    .headers_mut()
+                    .insert("x-first-only", "leak-check".parse().unwrap());
+                match next.clone().run(first).await {
+                    Err(e) if e.code == crate::ErrorCode::Unavailable => {
+                        second
+                            .ctx
+                            .headers_mut()
+                            .insert("x-attempt", "2".parse().unwrap());
+                        next.run(second).await
+                    }
+                    other => other,
+                }
+            }
+        }
+
+        // An inner interceptor proves the *whole* remaining chain re-runs,
+        // not just the terminal.
+        let inner_runs = Arc::new(Mutex::new(0u32));
+        struct Count(Arc<Mutex<u32>>);
+        #[async_trait::async_trait]
+        impl Interceptor for Count {
+            async fn intercept_unary(
+                &self,
+                req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                *self.0.lock().unwrap() += 1;
+                next.run(req).await
+            }
+        }
+
+        let chain: Vec<Arc<dyn Interceptor>> = vec![
+            Arc::new(RetryOnce),
+            Arc::new(Count(Arc::clone(&inner_runs))),
+        ];
+        let terminal = FlakyTerminal {
+            calls: Mutex::new(Vec::new()),
+        };
+        let resp = Next::new(&chain, &terminal).run(req()).await.unwrap();
+        assert_eq!(*terminal.calls.lock().unwrap(), vec!["1", "2"]);
+        assert_eq!(*inner_runs.lock().unwrap(), 2, "inner chain re-ran");
+        let echoed: StringValue = resp.body.message::<StringValue>().unwrap().clone();
+        assert_eq!(echoed.value, "hi", "retry carried the original body");
+    }
+
+    #[test]
+    fn interceptor_chain_push_and_debug() {
+        struct Nop;
+        #[async_trait::async_trait]
+        impl Interceptor for Nop {}
+        let mut chain = InterceptorChain::default();
+        assert!(chain.is_empty());
+        let shared = chain.clone();
+        let a: Arc<dyn Interceptor> = Arc::new(Nop);
+        let b: Arc<dyn Interceptor> = Arc::new(Nop);
+        chain.push(Arc::clone(&a));
+        chain.push(Arc::clone(&b));
+        // Deref to slice; `push` appends, so first registered stays
+        // outermost (index 0) — the documented ordering contract.
+        assert_eq!(chain.len(), 2);
+        assert!(Arc::ptr_eq(&chain[0], &a), "first registered is outermost");
+        assert!(Arc::ptr_eq(&chain[1], &b));
+        // `push` rebuilds; an earlier clone is unaffected (registration on
+        // one handle must not retroactively change another).
+        assert!(shared.is_empty());
+        assert!(format!("{chain:?}").contains("len: 2"), "{chain:?}");
+    }
+
+    /// `new` stamps the context's decode options onto the payload;
+    /// `from_parts` deliberately keeps the payload's own. Pinned so the
+    /// difference is a decision, not an accident.
+    #[test]
+    fn from_parts_keeps_payload_decode_options() {
+        let ctx = RequestContext::default()
+            .with_decode_options(buffa::DecodeOptions::new().with_recursion_limit(3));
+        let via_new = UnaryRequest::new(ctx.clone(), Bytes::new(), CodecFormat::Proto);
+        assert_eq!(
+            format!("{:?}", via_new.payload.decode_options()),
+            format!("{:?}", ctx.decode_options()),
+            "new: payload takes ctx options"
+        );
+        let payload = Payload::new(Bytes::new(), CodecFormat::Proto)
+            .with_decode_options(buffa::DecodeOptions::new().with_recursion_limit(9));
+        let want = format!("{:?}", payload.decode_options());
+        let via_parts = UnaryRequest::from_parts(ctx, payload);
+        assert_eq!(
+            format!("{:?}", via_parts.payload.decode_options()),
+            want,
+            "from_parts: payload keeps its own options"
+        );
     }
 
     /// Trailers and the compression hint must round-trip through a

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -128,20 +128,34 @@ where
 ///
 /// `Payload` is intentionally not `Clone`: a clone would either drop the
 /// decode cache (surprising) or duplicate it (defeating the laziness).
-/// Pass it by reference, or move it through the call chain. When a
-/// second body is genuinely needed (a retry interceptor), call
-/// [`try_clone`](Payload::try_clone), which is explicit about copying
-/// the encoded bytes and starting with an empty cache.
+/// Pass it by reference, or move it through the call chain; when a
+/// second body is genuinely needed, [`try_clone`](Payload::try_clone) is
+/// the explicit copy.
 pub struct Payload {
     bytes: Bytes,
     format: CodecFormat,
     decoded: OnceLock<Box<dyn AnyMessage>>,
-    replaced: Option<Box<dyn AnyMessage>>,
-    /// Memoized `replaced.encode(format)`, so `encoded()` / `try_clone()`
-    /// on a replaced or `from_message` payload encode at most once. Reset
-    /// by `set_message`. Unused while `replaced` is `None`.
-    replaced_encoded: OnceLock<Bytes>,
+    /// Boxed so a payload without a replacement (the server fast path)
+    /// carries one pointer, not the message box plus its encode memo.
+    replaced: Option<Box<Replacement>>,
     decode_options: buffa::DecodeOptions,
+}
+
+/// A message set by [`Payload::set_message`] / [`Payload::from_message`],
+/// with its wire encoding memoized on first [`Payload::encoded`]. A new
+/// replacement is a new `Replacement`, so the memo can never be stale.
+struct Replacement {
+    message: Box<dyn AnyMessage>,
+    encoded: OnceLock<Bytes>,
+}
+
+impl Replacement {
+    fn new(message: impl AnyMessage) -> Box<Self> {
+        Box::new(Self {
+            message: Box::new(message),
+            encoded: OnceLock::new(),
+        })
+    }
 }
 
 impl Payload {
@@ -153,7 +167,6 @@ impl Payload {
             format,
             decoded: OnceLock::new(),
             replaced: None,
-            replaced_encoded: OnceLock::new(),
             decode_options: buffa::DecodeOptions::new(),
         }
     }
@@ -178,22 +191,14 @@ impl Payload {
     /// Short-circuit example (a cache hit, a test double):
     /// `Ok(Response::new(Payload::from_message(reply, req.payload.format())))`.
     pub fn from_message<M: AnyMessage>(message: M, format: CodecFormat) -> Self {
-        Self {
-            bytes: Bytes::new(),
-            format,
-            decoded: OnceLock::new(),
-            replaced: Some(Box::new(message)),
-            replaced_encoded: OnceLock::new(),
-            decode_options: buffa::DecodeOptions::new(),
-        }
+        let mut payload = Self::new(Bytes::new(), format);
+        payload.replaced = Some(Replacement::new(message));
+        payload
     }
 
-    /// Produce an independent `Payload` carrying the same body.
-    ///
-    /// `Payload` is deliberately not `Clone` (see the type docs). This is
-    /// the explicit escape hatch for an interceptor that runs the rest of
-    /// the chain more than once — retry, hedging — and therefore needs a
-    /// second request body (see also
+    /// Produce an independent `Payload` carrying the same body — the
+    /// explicit copy for an interceptor that runs the rest of the chain
+    /// more than once (see
     /// [`UnaryRequest::try_clone`](crate::interceptor::UnaryRequest::try_clone)).
     /// The copy holds this payload's [`encoded`](Payload::encoded) bytes
     /// (a refcount bump; a replacement is encoded once and memoized on
@@ -211,14 +216,10 @@ impl Payload {
     ///
     /// Returns an error if encoding a replacement fails.
     pub fn try_clone(&self) -> Result<Self, ConnectError> {
-        Ok(Self {
-            bytes: self.encoded()?,
-            format: self.format,
-            decoded: OnceLock::new(),
-            replaced: None,
-            replaced_encoded: OnceLock::new(),
-            decode_options: self.decode_options.clone(),
-        })
+        Ok(
+            Self::new(self.encoded()?, self.format)
+                .with_decode_options(self.decode_options.clone()),
+        )
     }
 
     /// Attach the decode limits a typed accessor should honour.
@@ -277,6 +278,7 @@ impl Payload {
         M: Message + JsonSerialize + JsonDeserialize + 'static,
     {
         if let Some(replaced) = &self.replaced {
+            let replaced = &replaced.message;
             return replaced.as_any().downcast_ref::<M>().ok_or_else(|| {
                 ConnectError::internal(format!(
                     "payload replacement is a {}, not a {}",
@@ -351,6 +353,7 @@ impl Payload {
         M: Message + JsonDeserialize + 'static,
     {
         if let Some(replaced) = self.replaced {
+            let replaced = replaced.message;
             let type_name = replaced.type_name();
             return replaced
                 .into_any()
@@ -425,7 +428,7 @@ impl Payload {
             // payload's replacement needs a separate proto encode.
             let bytes = match self.format {
                 CodecFormat::Proto => self.encoded()?,
-                CodecFormat::Json => replaced.encode(CodecFormat::Proto)?,
+                CodecFormat::Json => replaced.message.encode(CodecFormat::Proto)?,
             };
             return OwnedView::decode(bytes).map_err(|e| {
                 ConnectError::internal(format!("failed to decode replacement as view: {e}"))
@@ -450,19 +453,12 @@ impl Payload {
     where
         M: AnyMessage,
     {
-        self.replaced = Some(Box::new(message));
-        // A memoized encode of the *previous* replacement must not be
-        // served for the new one.
-        if self.replaced_encoded.get().is_some() {
-            self.replaced_encoded = OnceLock::new();
-        }
+        self.replaced = Some(Replacement::new(message));
         // Drop the prior decode cache so the original message doesn't pin
         // memory for the Payload's lifetime. `replaced` is checked first,
         // so a stale cache would never be visible — this is purely a
         // memory concern.
-        if self.decoded.get().is_some() {
-            self.decoded = OnceLock::new();
-        }
+        self.decoded.take();
     }
 
     /// The wire bytes the dispatch path should actually send.
@@ -483,11 +479,11 @@ impl Payload {
         // Probe-then-set, as in `message()`: `get_or_try_init` is
         // unstable. Two racing callers both encode; one `set` wins and
         // both return equal bytes.
-        if let Some(cached) = self.replaced_encoded.get() {
+        if let Some(cached) = replaced.encoded.get() {
             return Ok(cached.clone());
         }
-        let bytes = replaced.encode(self.format)?;
-        let _ = self.replaced_encoded.set(bytes.clone());
+        let bytes = replaced.message.encode(self.format)?;
+        let _ = replaced.encoded.set(bytes.clone());
         Ok(bytes)
     }
 }
@@ -632,13 +628,7 @@ mod tests {
     /// typed access is a downcast, `encoded()` produces the wire form.
     #[test]
     fn from_message_is_lazily_encoded() {
-        let p = Payload::from_message(
-            StringValue {
-                value: "typed".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
+        let p = Payload::from_message(StringValue::from("typed"), CodecFormat::Proto);
         // The documented trap: `bytes()` is what was *received* (nothing);
         // `encoded()` is what will be *sent*.
         assert!(
@@ -675,26 +665,14 @@ mod tests {
     #[cfg(feature = "json")]
     #[test]
     fn from_message_encodes_in_requested_format() {
-        let p = Payload::from_message(
-            StringValue {
-                value: "j".into(),
-                ..Default::default()
-            },
-            CodecFormat::Json,
-        );
+        let p = Payload::from_message(StringValue::from("j"), CodecFormat::Json);
         let rt: StringValue = decode_json(&p.encoded().unwrap()).unwrap();
         assert_eq!(rt.value, "j");
     }
 
     #[test]
     fn from_message_wrong_type_is_internal_error() {
-        let p = Payload::from_message(
-            StringValue {
-                value: "s".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
+        let p = Payload::from_message(StringValue::from("s"), CodecFormat::Proto);
         let err = p
             .message::<buffa_types::google::protobuf::Int64Value>()
             .unwrap_err();
@@ -720,26 +698,11 @@ mod tests {
         assert_eq!(c.message::<StringValue>().unwrap().value, "orig");
 
         let mut replaced = proto_payload("orig");
-        replaced.set_message(StringValue {
-            value: "new".into(),
-            ..Default::default()
-        });
+        replaced.set_message(StringValue::from("new"));
         let c = replaced.try_clone().unwrap();
         assert!(c.replaced.is_none(), "replacement is baked into bytes");
         let rt: StringValue = crate::codec::decode_proto(c.bytes()).unwrap();
         assert_eq!(rt.value, "new");
-
-        // And from a lazily-encoded payload: the clone carries real bytes.
-        let lazy = Payload::from_message(
-            StringValue {
-                value: "lazy".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
-        let c = lazy.try_clone().unwrap();
-        assert!(!c.bytes().is_empty());
-        assert_eq!(c.message::<StringValue>().unwrap().value, "lazy");
     }
 
     /// A replacement (or `from_message` body) is encoded at most once:
@@ -747,13 +710,7 @@ mod tests {
     /// and `set_message` invalidates it.
     #[test]
     fn replacement_encode_is_memoized_and_invalidated() {
-        let mut p = Payload::from_message(
-            StringValue {
-                value: "once".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
+        let mut p = Payload::from_message(StringValue::from("once"), CodecFormat::Proto);
         let first = p.encoded().unwrap();
         let again = p.encoded().unwrap();
         assert!(
@@ -774,10 +731,7 @@ mod tests {
             "view should borrow the memoized bytes"
         );
 
-        p.set_message(StringValue {
-            value: "twice".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("twice"));
         let rt: StringValue = crate::codec::decode_proto(&p.encoded().unwrap()).unwrap();
         assert_eq!(rt.value, "twice", "set_message must invalidate the memo");
     }
@@ -805,17 +759,10 @@ mod tests {
     #[test]
     fn try_clone_json_replacement_is_wire_equal_not_api_equal() {
         let mut p = Payload::new(
-            encode_json(&StringValue {
-                value: "before".into(),
-                ..Default::default()
-            })
-            .unwrap(),
+            encode_json(&StringValue::from("before")).unwrap(),
             CodecFormat::Json,
         );
-        p.set_message(StringValue {
-            value: "after".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("after"));
         assert!(
             p.view::<StringValueView>().is_ok(),
             "original: replacement can be viewed"
@@ -902,16 +849,9 @@ mod tests {
     fn view_replaced_json_format_payload() {
         // A replacement is always re-encoded to proto for view(), so a
         // JSON-format payload with a replacement still views successfully.
-        let bytes = encode_json(&StringValue {
-            value: "before".into(),
-            ..Default::default()
-        })
-        .unwrap();
+        let bytes = encode_json(&StringValue::from("before")).unwrap();
         let mut p = Payload::new(bytes, CodecFormat::Json);
-        p.set_message(StringValue {
-            value: "after".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("after"));
         let v = p.view::<StringValueView>().unwrap();
         assert_eq!(v.reborrow().value, "after");
     }
@@ -919,14 +859,8 @@ mod tests {
     #[test]
     fn set_message_twice_supersedes() {
         let mut p = proto_payload("original");
-        p.set_message(StringValue {
-            value: "first".into(),
-            ..Default::default()
-        });
-        p.set_message(StringValue {
-            value: "second".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("first"));
+        p.set_message(StringValue::from("second"));
         let m: &StringValue = p.message().unwrap();
         assert_eq!(m.value, "second");
     }
@@ -960,10 +894,7 @@ mod tests {
         // proto. If `take_message` decoded the bytes instead of moving
         // the replacement out, this would error.
         let mut p = Payload::new(Bytes::from_static(&[0xff, 0xff, 0xff]), CodecFormat::Proto);
-        p.set_message(StringValue {
-            value: "replaced".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("replaced"));
         let m: StringValue = p.take_message().unwrap();
         assert_eq!(m.value, "replaced");
     }

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -6,8 +6,9 @@
 //! message eagerly would tax every call to pay for the rare interceptor
 //! that inspects fields.
 //!
-//! [`Payload`] solves this by holding the wire bytes (always available,
-//! reference-counted) and decoding to a typed message on first access.
+//! [`Payload`] solves this by holding the wire bytes (reference-counted)
+//! and decoding to a typed message on first access — or, when built from
+//! a typed message with [`Payload::from_message`], encoding on first need.
 //! Interceptors that want a typed message call [`Payload::message`]
 //! (owned, works for both proto and JSON wires) or [`Payload::view`]
 //! (zero-copy, proto only). Interceptors that want to *replace* the
@@ -99,9 +100,10 @@ where
 
 /// A lazily-decoded, replaceable RPC message body.
 ///
-/// A `Payload` always holds the wire-encoded body bytes ([`Bytes`], so
-/// clones are reference-counted) and the [`CodecFormat`] they came in.
-/// Typed access happens on demand:
+/// A `Payload` holds the wire-encoded body bytes ([`Bytes`], so clones
+/// are reference-counted) and the [`CodecFormat`] they came in — or, when
+/// built with [`from_message`](Payload::from_message), a typed message
+/// that is encoded only on demand. Typed access happens on demand:
 ///
 /// - [`message`](Payload::message) — decode once into an owned message,
 ///   cache it, return a borrow. Works for both `Proto` and `Json` wires.
@@ -116,8 +118,9 @@ where
 /// `Payload` is normally constructed by the dispatch path and received
 /// by user code through [`UnaryRequest`](crate::interceptor::UnaryRequest)
 /// and [`UnaryResponse`](crate::interceptor::UnaryResponse).
-/// [`Payload::new`] is `pub` so test fixtures and custom transports can
-/// build one directly.
+/// [`Payload::new`] (from wire bytes) and [`Payload::from_message`] (from
+/// a typed message) are `pub` so test fixtures, custom transports, and
+/// short-circuiting interceptors can build one directly.
 ///
 /// `message` borrows the cached owned decode; `view` returns a fresh
 /// self-contained [`OwnedView`] (a [`Bytes`] refcount bump, not a copy)
@@ -125,12 +128,19 @@ where
 ///
 /// `Payload` is intentionally not `Clone`: a clone would either drop the
 /// decode cache (surprising) or duplicate it (defeating the laziness).
-/// Pass it by reference, or move it through the call chain.
+/// Pass it by reference, or move it through the call chain. When a
+/// second body is genuinely needed (a retry interceptor), call
+/// [`try_clone`](Payload::try_clone), which is explicit about copying
+/// the encoded bytes and starting with an empty cache.
 pub struct Payload {
     bytes: Bytes,
     format: CodecFormat,
     decoded: OnceLock<Box<dyn AnyMessage>>,
     replaced: Option<Box<dyn AnyMessage>>,
+    /// Memoized `replaced.encode(format)`, so `encoded()` / `try_clone()`
+    /// on a replaced or `from_message` payload encode at most once. Reset
+    /// by `set_message`. Unused while `replaced` is `None`.
+    replaced_encoded: OnceLock<Bytes>,
     decode_options: buffa::DecodeOptions,
 }
 
@@ -143,8 +153,72 @@ impl Payload {
             format,
             decoded: OnceLock::new(),
             replaced: None,
+            replaced_encoded: OnceLock::new(),
             decode_options: buffa::DecodeOptions::new(),
         }
+    }
+
+    /// Wrap an owned message in a `Payload` without encoding it.
+    ///
+    /// This is the *lazily-encoded* counterpart of [`new`](Payload::new)
+    /// for a caller that starts from a typed message rather than wire
+    /// bytes — an interceptor synthesizing a response, or an outbound
+    /// request. The message is stored as the payload's replacement:
+    /// [`message`](Payload::message) and
+    /// [`take_message`](Payload::take_message) downcast it without a
+    /// decode, and [`encoded`](Payload::encoded) encodes it on first call
+    /// and memoizes the result, so later `encoded()` /
+    /// [`try_clone`](Payload::try_clone) calls are refcount bumps.
+    /// [`view`](Payload::view) encodes to proto and views it.
+    ///
+    /// [`bytes`](Payload::bytes) is **empty** for a payload built this way:
+    /// there are no peer-supplied wire bytes. Use
+    /// [`encoded`](Payload::encoded) for the bytes that will be sent.
+    ///
+    /// Short-circuit example (a cache hit, a test double):
+    /// `Ok(Response::new(Payload::from_message(reply, req.payload.format())))`.
+    pub fn from_message<M: AnyMessage>(message: M, format: CodecFormat) -> Self {
+        Self {
+            bytes: Bytes::new(),
+            format,
+            decoded: OnceLock::new(),
+            replaced: Some(Box::new(message)),
+            replaced_encoded: OnceLock::new(),
+            decode_options: buffa::DecodeOptions::new(),
+        }
+    }
+
+    /// Produce an independent `Payload` carrying the same body.
+    ///
+    /// `Payload` is deliberately not `Clone` (see the type docs). This is
+    /// the explicit escape hatch for an interceptor that runs the rest of
+    /// the chain more than once — retry, hedging — and therefore needs a
+    /// second request body (see also
+    /// [`UnaryRequest::try_clone`](crate::interceptor::UnaryRequest::try_clone)).
+    /// The copy holds this payload's [`encoded`](Payload::encoded) bytes
+    /// (a refcount bump; a replacement is encoded once and memoized on
+    /// `self` first), the same format and decode options, and an empty
+    /// decode cache.
+    ///
+    /// The copy is equivalent **on the wire**, not through the typed API:
+    /// it carries bytes, not the replacement, so on the copy
+    /// [`message`](Payload::message) / [`take_message`](Payload::take_message)
+    /// perform a real decode, a wrong-type read reports `InvalidArgument`
+    /// rather than `Internal`, and [`view`](Payload::view) follows the
+    /// [`format`](Payload::format) rule (errors for JSON).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encoding a replacement fails.
+    pub fn try_clone(&self) -> Result<Self, ConnectError> {
+        Ok(Self {
+            bytes: self.encoded()?,
+            format: self.format,
+            decoded: OnceLock::new(),
+            replaced: None,
+            replaced_encoded: OnceLock::new(),
+            decode_options: self.decode_options.clone(),
+        })
     }
 
     /// Attach the decode limits a typed accessor should honour.
@@ -165,9 +239,12 @@ impl Payload {
         &self.decode_options
     }
 
-    /// The original wire bytes the peer sent, **ignoring** any
-    /// replacement set with [`set_message`](Payload::set_message). For
-    /// the bytes the dispatch path will actually send downstream, use
+    /// The wire bytes as received, **ignoring** any replacement set with
+    /// [`set_message`](Payload::set_message) (so stale after one), and
+    /// **empty** for a payload built with
+    /// [`from_message`](Payload::from_message) — nothing was received. Do
+    /// not hash, sign, size-check, or log this as "the body"; for the
+    /// bytes the dispatch path will actually send, use
     /// [`encoded()`](Payload::encoded).
     pub fn bytes(&self) -> &Bytes {
         &self.bytes
@@ -307,11 +384,14 @@ impl Payload {
     ///
     /// Borrows directly from the wire bytes — no copy, no allocation
     /// beyond the [`Bytes`] refcount bump. If a replacement has been set
-    /// with [`set_message`](Payload::set_message), it is encoded to proto
-    /// (regardless of [`format`](Payload::format)) and decoded as a view
-    /// — note this re-encodes on **every** call (unlike
-    /// [`message`](Payload::message), there is no cache for views). Hold
-    /// onto the returned `OwnedView` rather than re-fetching in a loop.
+    /// with [`set_message`](Payload::set_message) (or the payload came
+    /// from [`from_message`](Payload::from_message)), it is encoded to
+    /// proto and decoded as a view. For a proto-format payload that
+    /// encode is the memoized [`encoded`](Payload::encoded); for a JSON
+    /// payload it is a separate proto encode on **every** call. Either
+    /// way the view decode itself is not cached (unlike
+    /// [`message`](Payload::message)), so hold onto the returned
+    /// `OwnedView` rather than re-fetching in a loop.
     ///
     /// # Errors
     ///
@@ -340,7 +420,13 @@ impl Payload {
             // small peer payload materializing a huge one, and a server-built
             // message can legitimately exceed it. `StreamMessage::from_message`
             // lifts the same limits for the same reason.
-            let bytes = replaced.encode(CodecFormat::Proto)?;
+            //
+            // Reuse the memoized wire encode when it *is* proto; a JSON
+            // payload's replacement needs a separate proto encode.
+            let bytes = match self.format {
+                CodecFormat::Proto => self.encoded()?,
+                CodecFormat::Json => replaced.encode(CodecFormat::Proto)?,
+            };
             return OwnedView::decode(bytes).map_err(|e| {
                 ConnectError::internal(format!("failed to decode replacement as view: {e}"))
             });
@@ -365,6 +451,11 @@ impl Payload {
         M: AnyMessage,
     {
         self.replaced = Some(Box::new(message));
+        // A memoized encode of the *previous* replacement must not be
+        // served for the new one.
+        if self.replaced_encoded.get().is_some() {
+            self.replaced_encoded = OnceLock::new();
+        }
         // Drop the prior decode cache so the original message doesn't pin
         // memory for the Payload's lifetime. `replaced` is checked first,
         // so a stale cache would never be visible — this is purely a
@@ -377,25 +468,37 @@ impl Payload {
     /// The wire bytes the dispatch path should actually send.
     ///
     /// Returns the original `bytes` (a cheap [`Bytes`] clone) unless a
-    /// replacement was set with [`set_message`](Payload::set_message),
-    /// in which case the replacement is re-encoded in the original
-    /// [`format`](Payload::format).
+    /// replacement was set with [`set_message`](Payload::set_message) or
+    /// the payload was built with [`from_message`](Payload::from_message),
+    /// in which case the message is encoded in [`format`](Payload::format)
+    /// on the first call and memoized — later calls are refcount bumps.
     ///
     /// # Errors
     ///
-    /// Returns an error if re-encoding a replacement fails.
+    /// Returns an error if encoding a replacement fails.
     pub fn encoded(&self) -> Result<Bytes, ConnectError> {
-        match &self.replaced {
-            Some(r) => r.encode(self.format),
-            None => Ok(self.bytes.clone()),
+        let Some(replaced) = &self.replaced else {
+            return Ok(self.bytes.clone());
+        };
+        // Probe-then-set, as in `message()`: `get_or_try_init` is
+        // unstable. Two racing callers both encode; one `set` wins and
+        // both return equal bytes.
+        if let Some(cached) = self.replaced_encoded.get() {
+            return Ok(cached.clone());
         }
+        let bytes = replaced.encode(self.format)?;
+        let _ = self.replaced_encoded.set(bytes.clone());
+        Ok(bytes)
     }
 }
 
 impl fmt::Debug for Payload {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `wire_len` (not `len`): it is the received-bytes length, which
+        // is 0 for a `from_message` payload and stale after `set_message`
+        // — `replaced: true` alongside it says the body lives elsewhere.
         f.debug_struct("Payload")
-            .field("len", &self.bytes.len())
+            .field("wire_len", &self.bytes.len())
             .field("format", &self.format)
             .field("decoded", &self.decoded.get().is_some())
             .field("replaced", &self.replaced.is_some())
@@ -523,6 +626,208 @@ mod tests {
             p.encoded().unwrap().as_ptr(),
             p.bytes().as_ptr()
         ));
+    }
+
+    /// `from_message` is the lazily-encoded constructor: no wire bytes,
+    /// typed access is a downcast, `encoded()` produces the wire form.
+    #[test]
+    fn from_message_is_lazily_encoded() {
+        let p = Payload::from_message(
+            StringValue {
+                value: "typed".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        // The documented trap: `bytes()` is what was *received* (nothing);
+        // `encoded()` is what will be *sent*.
+        assert!(
+            p.bytes().is_empty(),
+            "no peer bytes for a from_message payload"
+        );
+        assert!(
+            !p.encoded().unwrap().is_empty(),
+            "encoded() is the real body"
+        );
+        let dbg = format!("{p:?}");
+        assert!(
+            dbg.contains("wire_len: 0") && dbg.contains("replaced: true"),
+            "{dbg}"
+        );
+        assert_eq!(p.format(), CodecFormat::Proto);
+        // Typed read is a downcast of the stored message, not a decode of
+        // the (empty) bytes — a decode of `b""` would yield the default "".
+        let m: &StringValue = p.message().unwrap();
+        assert_eq!(m.value, "typed");
+        // View path encodes then views.
+        assert_eq!(
+            p.view::<StringValueView>().unwrap().reborrow().value,
+            "typed"
+        );
+        // Wire form round-trips.
+        let rt: StringValue = crate::codec::decode_proto(&p.encoded().unwrap()).unwrap();
+        assert_eq!(rt.value, "typed");
+        // take_message moves the stored message out without decoding.
+        let owned: StringValue = p.take_message().unwrap();
+        assert_eq!(owned.value, "typed");
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn from_message_encodes_in_requested_format() {
+        let p = Payload::from_message(
+            StringValue {
+                value: "j".into(),
+                ..Default::default()
+            },
+            CodecFormat::Json,
+        );
+        let rt: StringValue = decode_json(&p.encoded().unwrap()).unwrap();
+        assert_eq!(rt.value, "j");
+    }
+
+    #[test]
+    fn from_message_wrong_type_is_internal_error() {
+        let p = Payload::from_message(
+            StringValue {
+                value: "s".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        let err = p
+            .message::<buffa_types::google::protobuf::Int64Value>()
+            .unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Internal, "{err:?}");
+    }
+
+    /// `try_clone` of a wire payload shares the backing bytes and starts
+    /// with an empty cache; `try_clone` after a replacement bakes the
+    /// replacement into the copy's bytes.
+    #[test]
+    fn try_clone_copies_body_not_cache() {
+        let p = proto_payload("orig");
+        let _ = p.message::<StringValue>().unwrap(); // populate cache
+        let c = p.try_clone().unwrap();
+        assert!(
+            std::ptr::eq(c.bytes().as_ptr(), p.bytes().as_ptr()),
+            "no replacement: clone is a Bytes refcount bump"
+        );
+        assert!(
+            c.decoded.get().is_none(),
+            "clone starts with an empty cache"
+        );
+        assert_eq!(c.message::<StringValue>().unwrap().value, "orig");
+
+        let mut replaced = proto_payload("orig");
+        replaced.set_message(StringValue {
+            value: "new".into(),
+            ..Default::default()
+        });
+        let c = replaced.try_clone().unwrap();
+        assert!(c.replaced.is_none(), "replacement is baked into bytes");
+        let rt: StringValue = crate::codec::decode_proto(c.bytes()).unwrap();
+        assert_eq!(rt.value, "new");
+
+        // And from a lazily-encoded payload: the clone carries real bytes.
+        let lazy = Payload::from_message(
+            StringValue {
+                value: "lazy".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        let c = lazy.try_clone().unwrap();
+        assert!(!c.bytes().is_empty());
+        assert_eq!(c.message::<StringValue>().unwrap().value, "lazy");
+    }
+
+    /// A replacement (or `from_message` body) is encoded at most once:
+    /// `encoded()`, `try_clone()`, and proto `view()` all serve the memo,
+    /// and `set_message` invalidates it.
+    #[test]
+    fn replacement_encode_is_memoized_and_invalidated() {
+        let mut p = Payload::from_message(
+            StringValue {
+                value: "once".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        let first = p.encoded().unwrap();
+        let again = p.encoded().unwrap();
+        assert!(
+            std::ptr::eq(first.as_ptr(), again.as_ptr()),
+            "second encoded() must be a refcount bump, not a re-encode"
+        );
+        let clone = p.try_clone().unwrap();
+        assert!(
+            std::ptr::eq(clone.bytes().as_ptr(), first.as_ptr()),
+            "try_clone shares the memoized encode"
+        );
+        // Proto view reuses the memo too (its bytes borrow from it).
+        let v = p.view::<StringValueView>().unwrap();
+        let ptr = v.reborrow().value.as_ptr() as usize;
+        let range = first.as_ptr() as usize..first.as_ptr() as usize + first.len();
+        assert!(
+            range.contains(&ptr),
+            "view should borrow the memoized bytes"
+        );
+
+        p.set_message(StringValue {
+            value: "twice".into(),
+            ..Default::default()
+        });
+        let rt: StringValue = crate::codec::decode_proto(&p.encoded().unwrap()).unwrap();
+        assert_eq!(rt.value, "twice", "set_message must invalidate the memo");
+    }
+
+    /// `try_clone` keeps the decode options (the service's limits) rather
+    /// than resetting to buffa defaults. `DecodeOptions` has no `PartialEq`,
+    /// so compare a distinctive `Debug` rendering.
+    #[test]
+    fn try_clone_preserves_decode_options() {
+        let opts = buffa::DecodeOptions::new().with_recursion_limit(7);
+        let p = proto_payload("x").with_decode_options(opts.clone());
+        let c = p.try_clone().unwrap();
+        assert_eq!(format!("{:?}", c.decode_options()), format!("{:?}", opts));
+        assert_ne!(
+            format!("{:?}", c.decode_options()),
+            format!("{:?}", buffa::DecodeOptions::new()),
+            "fixture must differ from the default for this test to mean anything"
+        );
+    }
+
+    /// The typed-API divergence `try_clone` documents for JSON payloads:
+    /// the original (holding a replacement) can `view()`; the copy (holding
+    /// JSON bytes) cannot, but is identical on the wire.
+    #[cfg(feature = "json")]
+    #[test]
+    fn try_clone_json_replacement_is_wire_equal_not_api_equal() {
+        let mut p = Payload::new(
+            encode_json(&StringValue {
+                value: "before".into(),
+                ..Default::default()
+            })
+            .unwrap(),
+            CodecFormat::Json,
+        );
+        p.set_message(StringValue {
+            value: "after".into(),
+            ..Default::default()
+        });
+        assert!(
+            p.view::<StringValueView>().is_ok(),
+            "original: replacement can be viewed"
+        );
+        let c = p.try_clone().unwrap();
+        assert_eq!(c.encoded().unwrap(), p.encoded().unwrap(), "wire-equal");
+        assert_eq!(c.format(), CodecFormat::Json);
+        assert!(
+            c.view::<StringValueView>().is_err(),
+            "copy: JSON bytes cannot back a view"
+        );
+        assert_eq!(c.message::<StringValue>().unwrap().value, "after");
     }
 
     #[test]

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -206,7 +206,9 @@ impl Payload {
     /// decode cache.
     ///
     /// The copy is equivalent **on the wire**, not through the typed API:
-    /// it carries bytes, not the replacement, so on the copy
+    /// it carries bytes, not the replacement (a replacement's bytes keep
+    /// buffa's default decode limits rather than this payload's wire
+    /// limits, as [`view`](Payload::view) already grants them), so on the copy
     /// [`message`](Payload::message) / [`take_message`](Payload::take_message)
     /// perform a real decode, a wrong-type read reports `InvalidArgument`
     /// rather than `Internal`, and [`view`](Payload::view) follows the
@@ -216,10 +218,16 @@ impl Payload {
     ///
     /// Returns an error if encoding a replacement fails.
     pub fn try_clone(&self) -> Result<Self, ConnectError> {
-        Ok(
-            Self::new(self.encoded()?, self.format)
-                .with_decode_options(self.decode_options.clone()),
-        )
+        let copy = Self::new(self.encoded()?, self.format);
+        Ok(if self.replaced.is_some() {
+            // The body was encoded from a message this process holds, so the
+            // wire-facing limits (an amplification defence against peer
+            // bytes) do not apply to it — the same exemption `view` gives
+            // the replacement before the copy is taken.
+            copy
+        } else {
+            copy.with_decode_options(self.decode_options.clone())
+        })
     }
 
     /// Attach the decode limits a typed accessor should honour.
@@ -251,7 +259,9 @@ impl Payload {
         &self.bytes
     }
 
-    /// The codec format the wire bytes are encoded in.
+    /// The codec format of the body: the format the wire bytes arrived in,
+    /// or, for a [`from_message`](Payload::from_message) payload, the format
+    /// it will be encoded in.
     pub fn format(&self) -> CodecFormat {
         self.format
     }
@@ -410,8 +420,8 @@ impl Payload {
     /// - [`internal`](ConnectError::internal) if a replacement set with
     ///   [`set_message`](Payload::set_message) fails to re-encode or
     ///   decode as `V` — server-supplied data, so the asymmetry with the
-    ///   wire-bytes case is intentional. A replacement is decoded without
-    ///   the limits for the same reason.
+    ///   wire-bytes case is intentional. A replacement is decoded under
+    ///   buffa's defaults rather than these limits for the same reason.
     pub fn view<V>(&self) -> Result<OwnedView<V>, ConnectError>
     where
         V: MessageView<'static>,
@@ -483,8 +493,36 @@ impl Payload {
             return Ok(cached.clone());
         }
         let bytes = replaced.message.encode(self.format)?;
-        let _ = replaced.encoded.set(bytes.clone());
-        Ok(bytes)
+        // A racing loser returns the winner's allocation, so later
+        // `try_clone` / `view` calls share one memo.
+        Ok(replaced.encoded.get_or_init(|| bytes).clone())
+    }
+
+    /// The body encoded in `format`, which the dispatch path negotiated with
+    /// the peer and which may differ from this payload's own
+    /// [`format`](Payload::format).
+    ///
+    /// A payload built from a message is simply encoded in the requested
+    /// format (memoized only when it matches the payload's own format). A
+    /// payload carrying wire bytes in another format cannot be transcoded
+    /// without knowing its message type, so that is an error rather than a
+    /// body the peer cannot parse.
+    ///
+    /// # Errors
+    ///
+    /// `internal` if a replacement fails to encode, or if the payload holds
+    /// wire bytes in a format other than `format`.
+    pub fn encoded_as(&self, format: CodecFormat) -> Result<Bytes, ConnectError> {
+        if format == self.format {
+            return self.encoded();
+        }
+        match &self.replaced {
+            Some(replaced) => replaced.message.encode(format),
+            None => Err(ConnectError::internal(format!(
+                "payload carries {:?} wire bytes but the call negotiated {format:?}",
+                self.format
+            ))),
+        }
     }
 }
 
@@ -668,6 +706,32 @@ mod tests {
         let p = Payload::from_message(StringValue::from("j"), CodecFormat::Json);
         let rt: StringValue = decode_json(&p.encoded().unwrap()).unwrap();
         assert_eq!(rt.value, "j");
+    }
+
+    /// The dispatch path answers in the format the call negotiated, not the
+    /// one the interceptor happened to build the payload with.
+    #[cfg(feature = "json")]
+    #[test]
+    fn encoded_as_transcodes_a_message_payload() {
+        let p = Payload::from_message(StringValue::from("x"), CodecFormat::Proto);
+        let json = p.encoded_as(CodecFormat::Json).unwrap();
+        let rt: StringValue = decode_json(&json).unwrap();
+        assert_eq!(rt.value, "x");
+        // Same-format requests still hit the memo.
+        let a = p.encoded_as(CodecFormat::Proto).unwrap();
+        let b = p.encoded().unwrap();
+        assert!(std::ptr::eq(a.as_ptr(), b.as_ptr()));
+    }
+
+    #[test]
+    fn encoded_as_rejects_wire_bytes_in_another_format() {
+        let p = proto_payload("x");
+        let err = p.encoded_as(CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Internal, "{err:?}");
+        assert!(
+            err.message.as_deref().unwrap_or("").contains("negotiated"),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -160,14 +160,9 @@ impl RequestContext {
     /// negotiated compression) were resolved from the headers *before*
     /// interceptors ran; rewriting `connect-timeout-ms`, `grpc-timeout`,
     /// `content-type`, or `accept-encoding` here changes only what
-    /// downstream code reads, not dispatch behavior.
-    ///
-    /// # Note
-    ///
-    /// The same by-value caveat as [`extensions_mut`](Self::extensions_mut)
-    /// applies: a *handler* mutating its own `ctx` affects nothing
-    /// downstream. This accessor is for code that still holds the context
-    /// before dispatch continues.
+    /// downstream code reads, not dispatch behavior. As with
+    /// [`extensions_mut`](Self::extensions_mut), a *handler* mutating its
+    /// own by-value `ctx` affects nothing downstream.
     pub fn headers_mut(&mut self) -> &mut HeaderMap {
         &mut self.headers
     }

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -156,11 +156,13 @@ impl RequestContext {
     /// auth token, a propagated trace context, a tenant id. Inner
     /// interceptors and the handler see the mutated map.
     ///
-    /// Protocol-derived values (the [`deadline`](Self::deadline), codec,
-    /// negotiated compression) were resolved from the headers *before*
-    /// interceptors ran; rewriting `connect-timeout-ms`, `grpc-timeout`,
-    /// `content-type`, or `accept-encoding` here changes only what
-    /// downstream code reads, not dispatch behavior. As with
+    /// On the server, protocol-derived values (the
+    /// [`deadline`](Self::deadline), codec, negotiated compression) were
+    /// resolved from the headers *before* interceptors ran; rewriting
+    /// `connect-timeout-ms`, `grpc-timeout`, `content-type`, or
+    /// `accept-encoding` here changes only what downstream code reads, not
+    /// dispatch behavior. On a client-side chain the edited map is what goes
+    /// on the wire, so those headers are load-bearing there. As with
     /// [`extensions_mut`](Self::extensions_mut), a *handler* mutating its
     /// own by-value `ctx` affects nothing downstream.
     pub fn headers_mut(&mut self) -> &mut HeaderMap {

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -149,6 +149,29 @@ impl RequestContext {
         self.headers.get(key)
     }
 
+    /// Mutable access to the request headers.
+    ///
+    /// This is the hook an [`Interceptor`](crate::Interceptor) uses to add
+    /// or rewrite request metadata before calling `next.run(req)` — an
+    /// auth token, a propagated trace context, a tenant id. Inner
+    /// interceptors and the handler see the mutated map.
+    ///
+    /// Protocol-derived values (the [`deadline`](Self::deadline), codec,
+    /// negotiated compression) were resolved from the headers *before*
+    /// interceptors ran; rewriting `connect-timeout-ms`, `grpc-timeout`,
+    /// `content-type`, or `accept-encoding` here changes only what
+    /// downstream code reads, not dispatch behavior.
+    ///
+    /// # Note
+    ///
+    /// The same by-value caveat as [`extensions_mut`](Self::extensions_mut)
+    /// applies: a *handler* mutating its own `ctx` affects nothing
+    /// downstream. This accessor is for code that still holds the context
+    /// before dispatch continues.
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        &mut self.headers
+    }
+
     /// Absolute request deadline parsed from the protocol's timeout header
     /// (`Connect-Timeout-Ms` or `grpc-timeout`), if the client asserted one.
     ///
@@ -1568,6 +1591,23 @@ mod tests {
         let mut ctx = RequestContext::new(HeaderMap::new());
         ctx.extensions_mut().insert(Tag(1));
         assert_eq!(ctx.extensions().get::<Tag>(), Some(&Tag(1)));
+    }
+
+    #[test]
+    fn request_context_headers_mut() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-keep", HeaderValue::from_static("k"));
+        let mut ctx = RequestContext::new(headers);
+        ctx.headers_mut()
+            .insert("authorization", HeaderValue::from_static("Bearer t"));
+        assert_eq!(ctx.header("authorization").unwrap(), "Bearer t");
+        assert_eq!(
+            ctx.header("x-keep").unwrap(),
+            "k",
+            "existing entries survive"
+        );
+        ctx.headers_mut().remove("x-keep");
+        assert!(ctx.header("x-keep").is_none());
     }
 
     #[cfg(feature = "server")]

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -67,8 +67,8 @@ use crate::envelope::EnvelopeDecoder;
 use crate::error::ConnectError;
 use crate::handler::BoxStream;
 use crate::interceptor::{
-    Interceptor, call_bidi_streaming_intercepted, call_client_streaming_intercepted,
-    call_server_streaming_intercepted, call_unary_intercepted,
+    Interceptor, InterceptorChain, call_bidi_streaming_intercepted,
+    call_client_streaming_intercepted, call_server_streaming_intercepted, call_unary_intercepted,
 };
 use crate::protocol::Protocol;
 use crate::response::{EncodedResponse, RequestContext};
@@ -1321,9 +1321,9 @@ pub struct ConnectRpcService<D = Router> {
     compression: Arc<CompressionRegistry>,
     compression_policy: CompressionPolicy,
     deadline_policy: DeadlinePolicy,
-    /// Unary interceptor chain, outermost first. The `Arc<[..]>` is one
-    /// pointer to clone per request regardless of chain length.
-    interceptors: Arc<[Arc<dyn Interceptor>]>,
+    /// Interceptor chain, outermost first. One pointer to clone per
+    /// request regardless of chain length.
+    interceptors: InterceptorChain,
 }
 
 // Manual Clone impl because `#[derive(Clone)]` would add a `D: Clone` bound,
@@ -1336,7 +1336,7 @@ impl<D> Clone for ConnectRpcService<D> {
             compression: Arc::clone(&self.compression),
             compression_policy: self.compression_policy,
             deadline_policy: self.deadline_policy.clone(),
-            interceptors: Arc::clone(&self.interceptors),
+            interceptors: self.interceptors.clone(),
         }
     }
 }
@@ -1360,7 +1360,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
             compression: Arc::new(CompressionRegistry::default()),
             compression_policy: CompressionPolicy::default(),
             deadline_policy: DeadlinePolicy::new(),
-            interceptors: Arc::default(),
+            interceptors: InterceptorChain::default(),
         }
     }
 
@@ -1448,11 +1448,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
     /// which takes ownership and wraps for you.
     #[must_use]
     pub fn with_interceptor_arc(mut self, interceptor: Arc<dyn Interceptor>) -> Self {
-        // The Arc<[..]> is shared across cloned service handles; rebuild
-        // it on registration. Registration is a cold path.
-        let mut v: Vec<Arc<dyn Interceptor>> = self.interceptors.to_vec();
-        v.push(interceptor);
-        self.interceptors = Arc::from(v);
+        self.interceptors.push(interceptor);
         self
     }
 
@@ -1568,7 +1564,7 @@ where
         let compression = Arc::clone(&self.compression);
         let compression_policy = self.compression_policy;
         let deadline_policy = self.deadline_policy.clone();
-        let interceptors = Arc::clone(&self.interceptors);
+        let interceptors = self.interceptors.clone();
 
         // Only create and attach the tracing span when a subscriber would
         // actually observe it. For disabled-debug (the common production case),

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1026,7 +1026,7 @@ boundary, span builder, validator, or rate limiter actually wants.
 
 ```rust,ignore
 use connectrpc::interceptor::{UnaryRequest, UnaryResponse};
-use connectrpc::{ConnectError, Interceptor, Next};
+use connectrpc::{ConnectError, Interceptor, Next, Payload, Response};
 
 struct Logging;
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1081,11 +1081,11 @@ process-wide), use `with_interceptor_arc(Arc<dyn Interceptor>)`.
 ### Reading and rewriting the request
 
 `UnaryRequest` is `{ ctx: RequestContext, payload: Payload }`. Mutating
-`ctx` (headers, extensions) before `next.run` propagates to the handler.
-The `payload` is the request body — wire bytes plus a lazy decode
-cache. Most interceptors never read it; ones that do call
-`payload.message::<M>()` to decode once and cache, so the handler's
-decode is free:
+`ctx` through `ctx.headers_mut()` or `ctx.extensions_mut()` before
+`next.run` propagates to the handler. The `payload` is the request body
+— wire bytes plus a lazy decode cache. Most interceptors never read it;
+ones that do call `payload.message::<M>()` to decode once and cache, so
+the handler's decode is free:
 
 ```rust,ignore
 async fn intercept_unary(
@@ -1106,12 +1106,12 @@ async fn intercept_unary(
 }
 ```
 
-### Short-circuiting
+### Short-circuiting and re-running
 
 Returning without calling `next.run()` short-circuits the chain —
 neither inner interceptors nor the handler run. Returning `Err`
-surfaces the error on the protocol's normal error path, including
-any `response_headers` the error carries:
+surfaces the error on the protocol's normal error path, including any
+`response_headers` the error carries:
 
 ```rust,ignore
 async fn intercept_unary(
@@ -1129,6 +1129,30 @@ async fn intercept_unary(
     };
     self.tokens.verify(token)?;
     next.run(req).await
+}
+```
+
+Returning `Ok` without calling `next` works too. Build the body from a
+typed message with `Payload::from_message`, which encodes lazily in the
+request's wire format:
+
+```rust,ignore
+if let Some(reply) = self.cache.get(req.payload.message::<LookupRequest>()?) {
+    return Ok(Response::new(Payload::from_message(reply.clone(), req.payload.format())));
+}
+next.run(req).await
+```
+
+The opposite of short-circuiting is running the chain more than once.
+`Next` is `Clone`, and `UnaryRequest::try_clone()` copies the context and
+body, so a retry looks like this (gate it on `Spec::idempotency_level`;
+on the server a re-run invokes the handler again):
+
+```rust,ignore
+let spare = req.try_clone()?;
+match next.clone().run(req).await {
+    Err(e) if e.code == ErrorCode::Unavailable => next.run(spare).await,
+    done => done,
 }
 ```
 


### PR DESCRIPTION
First of a short stack adding client-side interceptors on the existing `Interceptor` trait. This PR is additive plumbing on the shared types; nothing on the dispatch path changes.

**Adds**

- `RequestContext::headers_mut()` so an interceptor can rewrite request headers (auth, trace propagation).
- `Payload::from_message(msg, format)`: a payload built from a typed message, encoded lazily (and once) on `encoded()`. Used for client requests later in the stack, and by interceptors that short-circuit with a synthesized response.
- `Payload::try_clone()`, `UnaryRequest::{from_parts, try_clone}`, and `Next: Clone`, which together let an interceptor run the rest of the chain more than once:
  ```rust
  let spare = req.try_clone()?;
  match next.clone().run(req).await {
      Err(e) if e.code == ErrorCode::Unavailable => next.run(spare).await,
      done => done,
  }
  ```
- Internal `InterceptorChain` newtype for the chain storage (`ConnectRpcService` now, `ClientConfig` next).

**Decisions**

- `Next` is `Clone` rather than `Copy`, so a re-run is an explicit `next.clone()`. `NextStream` stays non-`Clone` since an inbound stream can't be replayed.
- `Payload` stays non-`Clone`; `try_clone` is the explicit, wire-equivalent copy with a fresh decode cache.

Unit tests for each addition; lint, tests, and docs clean.
