### PR TITLE
client: identify the RPC by Spec in call_*; clients pass FOO_SPEC.with_origin(Client)

### DIFF
--- a/.changes/unreleased/Added-20260813-043124.yaml
+++ b/.changes/unreleased/Added-20260813-043124.yaml
@@ -21,8 +21,8 @@ body: |-
   - **`UnaryRequest::from_parts(ctx, payload)`** — constructor for the
     `#[non_exhaustive]` request from an existing `Payload`; `StreamRequest`
     is now `Clone`.
-  - **`Next` and `NextStream` are now `Clone`**, so an interceptor can run
-    the rest of the chain more than once (`next.clone().run(first)` then
+  - **`Next` is now `Clone`**, so a unary interceptor can run the rest of
+    the chain more than once (`next.clone().run(first)` then
     `next.run(second)`); the consuming `run(self)` keeps the single-call
     case explicit.
 time: 2026-08-13T04:31:36.268465697Z

--- a/.changes/unreleased/Added-20260813-043124.yaml
+++ b/.changes/unreleased/Added-20260813-043124.yaml
@@ -1,0 +1,28 @@
+kind: Added
+body: |-
+  Interceptor plumbing that a re-runnable (retry-style) chain and the upcoming
+  client-side interceptors both need. All additive; no dispatch behavior
+  changes:
+
+  - **`RequestContext::headers_mut()`** — mutable access to request headers,
+    the accessor an interceptor uses to inject auth or trace metadata before
+    `next.run(req)`. (`extensions_mut()` already existed; the docs claimed
+    headers were mutable but no public accessor allowed it.)
+  - **`Payload::from_message(msg, format)`** — the lazily-*encoded*
+    counterpart of `Payload::new`: wraps a typed message and encodes only when
+    `encoded()` runs, memoizing the result (a replacement set with
+    `set_message` is now also encoded at most once). Lets an interceptor
+    short-circuit with a synthesized response, and is how the client call
+    path will hand typed requests to the chain. `bytes()` is empty for such a
+    payload; `Payload`'s `Debug` output now labels that field `wire_len`.
+  - **`Payload::try_clone()`** and **`UnaryRequest::try_clone()`** — explicit
+    copies (encoded bytes, cloned context, empty decode cache) for an
+    interceptor that needs a second request.
+  - **`UnaryRequest::from_parts(ctx, payload)`** — constructor for the
+    `#[non_exhaustive]` request from an existing `Payload`; `StreamRequest`
+    is now `Clone`.
+  - **`Next` and `NextStream` are now `Clone`**, so an interceptor can run
+    the rest of the chain more than once (`next.clone().run(first)` then
+    `next.run(second)`); the consuming `run(self)` keeps the single-call
+    case explicit.
+time: 2026-08-13T04:31:36.268465697Z

--- a/.changes/unreleased/Added-20260813-043124.yaml
+++ b/.changes/unreleased/Added-20260813-043124.yaml
@@ -1,7 +1,7 @@
 kind: Added
 body: |-
-  Interceptor plumbing that a re-runnable (retry-style) chain and the upcoming
-  client-side interceptors both need. All additive; no dispatch behavior
+  Interceptor plumbing for a re-runnable (retry-style) chain and for
+  interceptors that synthesize a response. All additive; no dispatch behavior
   changes:
 
   - **`RequestContext::headers_mut()`** — mutable access to request headers,
@@ -12,9 +12,10 @@ body: |-
     counterpart of `Payload::new`: wraps a typed message and encodes only when
     `encoded()` runs, memoizing the result (a replacement set with
     `set_message` is now also encoded at most once). Lets an interceptor
-    short-circuit with a synthesized response, and is how the client call
-    path will hand typed requests to the chain. `bytes()` is empty for such a
-    payload; `Payload`'s `Debug` output now labels that field `wire_len`.
+    short-circuit with a synthesized response; the dispatch path re-encodes
+    it in the negotiated format if the two differ (`Payload::encoded_as`).
+    `bytes()` is empty for such a payload; `Payload`'s `Debug` output now
+    labels that field `wire_len`.
   - **`Payload::try_clone()`** and **`UnaryRequest::try_clone()`** — explicit
     copies (encoded bytes, cloned context, empty decode cache) for an
     interceptor that needs a second request.

--- a/.changes/unreleased/Changed-20260813-154238.yaml
+++ b/.changes/unreleased/Changed-20260813-154238.yaml
@@ -14,6 +14,8 @@ body: |-
   to
 
   ```rust
+  use connectrpc::{Spec, SpecOrigin, StreamType};
+
   call_unary(&t, &cfg, GREET_SERVICE_GREET_SPEC.with_origin(SpecOrigin::Client), req, opts)
   // or, without generated code:
   call_unary(&t, &cfg, Spec::client("/pkg.GreetService/Greet", StreamType::Unary), req, opts)
@@ -29,7 +31,8 @@ body: |-
   caller whose method names arrive at runtime should intern each distinct
   procedure once rather than leak per call (see the `Spec::client` docs); an
   entry point given a spec of the wrong stream shape or a server-origin spec
-  now returns an `Internal` error before sending anything. The value a client
+  now returns an `Internal` error before sending anything, as does a procedure
+  that is not a valid URI path. The value a client
   interceptor sees is not `==` to the generated constant (its `origin`
   differs); the new `Spec::same_method` compares method identity across
   sides. Regenerate checked-in code with `task generate:all`.

--- a/.changes/unreleased/Changed-20260813-154238.yaml
+++ b/.changes/unreleased/Changed-20260813-154238.yaml
@@ -14,26 +14,23 @@ body: |-
   to
 
   ```rust
-  call_unary(&t, &cfg, GREET_SERVICE_GREET_CLIENT_SPEC, req, opts)
+  call_unary(&t, &cfg, GREET_SERVICE_GREET_SPEC.with_origin(SpecOrigin::Client), req, opts)
   // or, without generated code:
   call_unary(&t, &cfg, Spec::client("/pkg.GreetService/Greet", StreamType::Unary), req, opts)
   ```
 
-  Code generation now emits a `pub const <SERVICE>_<METHOD>_CLIENT_SPEC: Spec`
-  per method (origin `SpecOrigin::Client`, gated with the client feature when
-  `gate_client_feature` is set) next to the existing server-side
-  `<SERVICE>_<METHOD>_SPEC`, and generated client methods pass it through.
-  This is what lets the upcoming client-side interceptors see the method's
-  stream type and idempotency level, not just its path.
+  Generated client methods now pass their method's existing
+  `<SERVICE>_<METHOD>_SPEC` constant with `origin` flipped via the new
+  `Spec::with_origin(SpecOrigin::Client)`. This is what lets the upcoming
+  client-side interceptors see the method's stream type and idempotency
+  level, not just its path.
 
   Notes for hand-written callers: `Spec::client` takes a `&'static str`, so a
   caller whose method names arrive at runtime should intern each distinct
   procedure once rather than leak per call (see the `Spec::client` docs); an
-  entry point given a spec of the wrong stream shape or origin now returns an
-  `Internal` error before sending anything. The server and client constants
-  for one method are not `==` (their `origin` differs); the new
-  `Spec::same_method` compares method identity across sides. Code generation
-  also now fails with a clear message if two methods of one service would
-  produce the same constant name (e.g. `Get` and `GetClient`). Regenerate
-  checked-in code with `task generate:all`.
+  entry point given a spec of the wrong stream shape or a server-origin spec
+  now returns an `Internal` error before sending anything. The value a client
+  interceptor sees is not `==` to the generated constant (its `origin`
+  differs); the new `Spec::same_method` compares method identity across
+  sides. Regenerate checked-in code with `task generate:all`.
 time: 2026-08-13T15:42:38.580786038Z

--- a/.changes/unreleased/Changed-20260813-154238.yaml
+++ b/.changes/unreleased/Changed-20260813-154238.yaml
@@ -1,0 +1,39 @@
+kind: Changed
+body: |-
+  **Breaking (low-level client API):** the `connectrpc::client::call_unary`,
+  `call_unary_get`, `call_server_stream`, `call_client_stream`, and
+  `call_bidi_stream` free functions now take a `spec: Spec` in place of the
+  `service: &str, method: &str` pair. Generated clients are the callers in
+  practice and are updated by regenerating (automatic for `connectrpc-build`
+  users); a hand-written caller changes
+
+  ```rust
+  call_unary(&t, &cfg, "pkg.GreetService", "Greet", req, opts)
+  ```
+
+  to
+
+  ```rust
+  call_unary(&t, &cfg, GREET_SERVICE_GREET_CLIENT_SPEC, req, opts)
+  // or, without generated code:
+  call_unary(&t, &cfg, Spec::client("/pkg.GreetService/Greet", StreamType::Unary), req, opts)
+  ```
+
+  Code generation now emits a `pub const <SERVICE>_<METHOD>_CLIENT_SPEC: Spec`
+  per method (origin `SpecOrigin::Client`, gated with the client feature when
+  `gate_client_feature` is set) next to the existing server-side
+  `<SERVICE>_<METHOD>_SPEC`, and generated client methods pass it through.
+  This is what lets the upcoming client-side interceptors see the method's
+  stream type and idempotency level, not just its path.
+
+  Notes for hand-written callers: `Spec::client` takes a `&'static str`, so a
+  caller whose method names arrive at runtime should intern each distinct
+  procedure once rather than leak per call (see the `Spec::client` docs); an
+  entry point given a spec of the wrong stream shape or origin now returns an
+  `Internal` error before sending anything. The server and client constants
+  for one method are not `==` (their `origin` differs); the new
+  `Spec::same_method` compares method identity across sides. Code generation
+  also now fails with a clear message if two methods of one service would
+  produce the same constant name (e.g. `Get` and `GetClient`). Regenerate
+  checked-in code with `task generate:all`.
+time: 2026-08-13T15:42:38.580786038Z

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -164,140 +164,74 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const BENCH_SERVICE_SERVICE_NAME: &str = "bench.v1.BenchService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Unary` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Unary` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `BENCH_SERVICE_UNARY_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const BENCH_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/Unary",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `BENCH_SERVICE_UNARY_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const BENCH_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/Unary",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `ServerStream` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerStream` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const BENCH_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `BENCH_SERVICE_SERVER_STREAM_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/ServerStream",
-        ::connectrpc::StreamType::ServerStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `ClientStream` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `ClientStream` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const BENCH_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/ClientStream",
         ::connectrpc::StreamType::ClientStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `BENCH_SERVICE_CLIENT_STREAM_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/ClientStream",
-        ::connectrpc::StreamType::ClientStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `BidiStream` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `BidiStream` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const BENCH_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `BENCH_SERVICE_BIDI_STREAM_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/BidiStream",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `LogUnary` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `LogUnary` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const BENCH_SERVICE_LOG_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/LogUnary",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `BENCH_SERVICE_LOG_UNARY_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/LogUnary",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `LogUnaryOwned` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `LogUnaryOwned` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `BENCH_SERVICE_LOG_UNARY_OWNED_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const BENCH_SERVICE_LOG_UNARY_OWNED_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/bench.v1.BenchService/LogUnaryOwned",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `BENCH_SERVICE_LOG_UNARY_OWNED_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const BENCH_SERVICE_LOG_UNARY_OWNED_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BenchService/LogUnaryOwned",
         ::connectrpc::StreamType::Unary,
     )
@@ -1030,7 +964,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_UNARY_CLIENT_SPEC,
+                BENCH_SERVICE_UNARY_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1068,7 +1002,8 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC,
+                BENCH_SERVICE_SERVER_STREAM_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1138,7 +1073,8 @@ where
         ::connectrpc::client::call_client_stream(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
+                BENCH_SERVICE_CLIENT_STREAM_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 requests,
                 options,
             )
@@ -1172,7 +1108,8 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC,
+                BENCH_SERVICE_BIDI_STREAM_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 options,
             )
             .await
@@ -1211,7 +1148,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC,
+                BENCH_SERVICE_LOG_UNARY_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1251,7 +1189,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_LOG_UNARY_OWNED_CLIENT_SPEC,
+                BENCH_SERVICE_LOG_UNARY_OWNED_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1260,25 +1199,14 @@ where
 }
 /// Full service name for this service.
 pub const ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.EchoService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Echo` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Echo` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `ECHO_SERVICE_ECHO_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/bench.v1.EchoService/Echo",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `ECHO_SERVICE_ECHO_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const ECHO_SERVICE_ECHO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.EchoService/Echo",
         ::connectrpc::StreamType::Unary,
     )
@@ -1669,7 +1597,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                ECHO_SERVICE_ECHO_CLIENT_SPEC,
+                ECHO_SERVICE_ECHO_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1678,25 +1606,14 @@ where
 }
 /// Full service name for this service.
 pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.v1.LogIngestService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Ingest` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Ingest` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/bench.v1.LogIngestService/Ingest",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `LOG_INGEST_SERVICE_INGEST_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,
     )
@@ -2087,7 +2004,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC,
+                LOG_INGEST_SERVICE_INGEST_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -164,73 +164,37 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const BENCH_SERVICE_SERVICE_NAME: &str = "bench.v1.BenchService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Unary` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Unary` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const BENCH_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/Unary",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `ServerStream` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerStream` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const BENCH_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `ClientStream` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `ClientStream` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const BENCH_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/ClientStream",
         ::connectrpc::StreamType::ClientStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `BidiStream` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `BidiStream` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const BENCH_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `LogUnary` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `LogUnary` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const BENCH_SERVICE_LOG_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/LogUnary",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `LogUnaryOwned` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `LogUnaryOwned` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const BENCH_SERVICE_LOG_UNARY_OWNED_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/LogUnaryOwned",
         ::connectrpc::StreamType::Unary,
@@ -1199,13 +1163,7 @@ where
 }
 /// Full service name for this service.
 pub const ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.EchoService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Echo` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Echo` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.EchoService/Echo",
         ::connectrpc::StreamType::Unary,
@@ -1606,13 +1564,7 @@ where
 }
 /// Full service name for this service.
 pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.v1.LogIngestService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Ingest` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Ingest` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -178,6 +178,15 @@ pub const BENCH_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::ser
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `BENCH_SERVICE_UNARY_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const BENCH_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/Unary",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `ServerStream` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -188,6 +197,15 @@ pub const BENCH_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::ser
 /// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
 /// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/bench.v1.BenchService/ServerStream",
+        ::connectrpc::StreamType::ServerStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `BENCH_SERVICE_SERVER_STREAM_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BenchService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
     )
@@ -206,6 +224,15 @@ pub const BENCH_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::S
         ::connectrpc::StreamType::ClientStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `BENCH_SERVICE_CLIENT_STREAM_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/ClientStream",
+        ::connectrpc::StreamType::ClientStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `BidiStream` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -216,6 +243,15 @@ pub const BENCH_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::S
 /// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
 /// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/bench.v1.BenchService/BidiStream",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `BENCH_SERVICE_BIDI_STREAM_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BenchService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
     )
@@ -234,6 +270,15 @@ pub const BENCH_SERVICE_LOG_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec:
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `BENCH_SERVICE_LOG_UNARY_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/LogUnary",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `LogUnaryOwned` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -248,79 +293,10 @@ pub const BENCH_SERVICE_LOG_UNARY_OWNED_SPEC: ::connectrpc::Spec = ::connectrpc:
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Unary` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `BENCH_SERVICE_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const BENCH_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/Unary",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerStream` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `BENCH_SERVICE_SERVER_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/ServerStream",
-        ::connectrpc::StreamType::ServerStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `ClientStream` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `BENCH_SERVICE_CLIENT_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/ClientStream",
-        ::connectrpc::StreamType::ClientStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `BidiStream` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `BENCH_SERVICE_BIDI_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/BidiStream",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `LogUnary` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `BENCH_SERVICE_LOG_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/bench.v1.BenchService/LogUnary",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `LogUnaryOwned` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `BENCH_SERVICE_LOG_UNARY_OWNED_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `BENCH_SERVICE_LOG_UNARY_OWNED_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const BENCH_SERVICE_LOG_UNARY_OWNED_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BenchService/LogUnaryOwned",
         ::connectrpc::StreamType::Unary,
@@ -1298,14 +1274,10 @@ pub const ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::serve
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Echo` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `ECHO_SERVICE_ECHO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `ECHO_SERVICE_ECHO_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const ECHO_SERVICE_ECHO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.EchoService/Echo",
         ::connectrpc::StreamType::Unary,
@@ -1720,14 +1692,10 @@ pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spe
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Ingest` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `LOG_INGEST_SERVICE_INGEST_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `LOG_INGEST_SERVICE_INGEST_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/bench.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench.__connect.rs
@@ -168,6 +168,11 @@ pub const BENCH_SERVICE_SERVICE_NAME: &str = "bench.v1.BenchService";
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `BENCH_SERVICE_UNARY_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/Unary",
         ::connectrpc::StreamType::Unary,
@@ -177,6 +182,11 @@ pub const BENCH_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::ser
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
@@ -186,6 +196,11 @@ pub const BENCH_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::S
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/ClientStream",
         ::connectrpc::StreamType::ClientStream,
@@ -195,6 +210,11 @@ pub const BENCH_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::S
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
@@ -204,6 +224,11 @@ pub const BENCH_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spe
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_LOG_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BenchService/LogUnary",
         ::connectrpc::StreamType::Unary,
@@ -213,7 +238,90 @@ pub const BENCH_SERVICE_LOG_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec:
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `BENCH_SERVICE_LOG_UNARY_OWNED_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const BENCH_SERVICE_LOG_UNARY_OWNED_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/bench.v1.BenchService/LogUnaryOwned",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Unary` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `BENCH_SERVICE_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const BENCH_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/Unary",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerStream` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `BENCH_SERVICE_SERVER_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/ServerStream",
+        ::connectrpc::StreamType::ServerStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `ClientStream` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `BENCH_SERVICE_CLIENT_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/ClientStream",
+        ::connectrpc::StreamType::ClientStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `BidiStream` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `BENCH_SERVICE_BIDI_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/BidiStream",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `LogUnary` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `BENCH_SERVICE_LOG_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/bench.v1.BenchService/LogUnary",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `LogUnaryOwned` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `BENCH_SERVICE_LOG_UNARY_OWNED_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const BENCH_SERVICE_LOG_UNARY_OWNED_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BenchService/LogUnaryOwned",
         ::connectrpc::StreamType::Unary,
     )
@@ -946,8 +1054,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_SERVICE_NAME,
-                "Unary",
+                BENCH_SERVICE_UNARY_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -985,8 +1092,7 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_SERVICE_NAME,
-                "ServerStream",
+                BENCH_SERVICE_SERVER_STREAM_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -1056,8 +1162,7 @@ where
         ::connectrpc::client::call_client_stream(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_SERVICE_NAME,
-                "ClientStream",
+                BENCH_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
                 requests,
                 options,
             )
@@ -1091,8 +1196,7 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_SERVICE_NAME,
-                "BidiStream",
+                BENCH_SERVICE_BIDI_STREAM_CLIENT_SPEC,
                 options,
             )
             .await
@@ -1131,8 +1235,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_SERVICE_NAME,
-                "LogUnary",
+                BENCH_SERVICE_LOG_UNARY_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -1172,8 +1275,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BENCH_SERVICE_SERVICE_NAME,
-                "LogUnaryOwned",
+                BENCH_SERVICE_LOG_UNARY_OWNED_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -1186,7 +1288,25 @@ pub const ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.EchoService";
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `ECHO_SERVICE_ECHO_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/bench.v1.EchoService/Echo",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Echo` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `ECHO_SERVICE_ECHO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const ECHO_SERVICE_ECHO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.EchoService/Echo",
         ::connectrpc::StreamType::Unary,
     )
@@ -1577,8 +1697,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                ECHO_SERVICE_SERVICE_NAME,
-                "Echo",
+                ECHO_SERVICE_ECHO_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -1591,7 +1710,25 @@ pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.v1.LogIngestService";
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/bench.v1.LogIngestService/Ingest",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Ingest` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `LOG_INGEST_SERVICE_INGEST_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,
     )
@@ -1982,8 +2119,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                LOG_INGEST_SERVICE_SERVICE_NAME,
-                "Ingest",
+                LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -46,7 +46,25 @@ pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.noutf8.v1.LogIngestServ
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/bench.noutf8.v1.LogIngestService/Ingest",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Ingest` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `LOG_INGEST_SERVICE_INGEST_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.noutf8.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,
     )
@@ -446,8 +464,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                LOG_INGEST_SERVICE_SERVICE_NAME,
-                "Ingest",
+                LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -42,13 +42,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.noutf8.v1.LogIngestService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Ingest` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Ingest` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.noutf8.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -56,14 +56,10 @@ pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spe
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Ingest` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `LOG_INGEST_SERVICE_INGEST_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `LOG_INGEST_SERVICE_INGEST_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.noutf8.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
+++ b/benches/rpc/src/generated/connect/bench_noutf8.__connect.rs
@@ -42,25 +42,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const LOG_INGEST_SERVICE_SERVICE_NAME: &str = "bench.noutf8.v1.LogIngestService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Ingest` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Ingest` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const LOG_INGEST_SERVICE_INGEST_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/bench.noutf8.v1.LogIngestService/Ingest",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `LOG_INGEST_SERVICE_INGEST_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.noutf8.v1.LogIngestService/Ingest",
         ::connectrpc::StreamType::Unary,
     )
@@ -460,7 +449,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                LOG_INGEST_SERVICE_INGEST_CLIENT_SPEC,
+                LOG_INGEST_SERVICE_INGEST_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -38,13 +38,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const BLOAT_ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.BloatEchoService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Echo` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Echo` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const BLOAT_ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/bench.v1.BloatEchoService/Echo",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -38,25 +38,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const BLOAT_ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.BloatEchoService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Echo` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Echo` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `BLOAT_ECHO_SERVICE_ECHO_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const BLOAT_ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/bench.v1.BloatEchoService/Echo",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `BLOAT_ECHO_SERVICE_ECHO_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const BLOAT_ECHO_SERVICE_ECHO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BloatEchoService/Echo",
         ::connectrpc::StreamType::Unary,
     )
@@ -449,7 +438,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BLOAT_ECHO_SERVICE_ECHO_CLIENT_SPEC,
+                BLOAT_ECHO_SERVICE_ECHO_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -42,7 +42,25 @@ pub const BLOAT_ECHO_SERVICE_SERVICE_NAME: &str = "bench.v1.BloatEchoService";
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `BLOAT_ECHO_SERVICE_ECHO_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const BLOAT_ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/bench.v1.BloatEchoService/Echo",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Echo` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `BLOAT_ECHO_SERVICE_ECHO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const BLOAT_ECHO_SERVICE_ECHO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BloatEchoService/Echo",
         ::connectrpc::StreamType::Unary,
     )
@@ -435,8 +453,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                BLOAT_ECHO_SERVICE_SERVICE_NAME,
-                "Echo",
+                BLOAT_ECHO_SERVICE_ECHO_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
+++ b/benches/rpc/src/generated/connect/echo_bloat.__connect.rs
@@ -52,14 +52,10 @@ pub const BLOAT_ECHO_SERVICE_ECHO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec:
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Echo` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `BLOAT_ECHO_SERVICE_ECHO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `BLOAT_ECHO_SERVICE_ECHO_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const BLOAT_ECHO_SERVICE_ECHO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/bench.v1.BloatEchoService/Echo",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -38,13 +38,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const FILTER_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.filter.v1.FilterService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Redact` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Redact` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const FILTER_SERVICE_REDACT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.filter.v1.FilterService/Redact",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -38,25 +38,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const FILTER_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.filter.v1.FilterService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Redact` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Redact` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `FILTER_SERVICE_REDACT_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const FILTER_SERVICE_REDACT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/anthropic.connectrpc.filter.v1.FilterService/Redact",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `FILTER_SERVICE_REDACT_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const FILTER_SERVICE_REDACT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.filter.v1.FilterService/Redact",
         ::connectrpc::StreamType::Unary,
     )
@@ -462,7 +451,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                FILTER_SERVICE_REDACT_CLIENT_SPEC,
+                FILTER_SERVICE_REDACT_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -52,14 +52,10 @@ pub const FILTER_SERVICE_REDACT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::s
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Redact` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `FILTER_SERVICE_REDACT_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `FILTER_SERVICE_REDACT_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const FILTER_SERVICE_REDACT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.filter.v1.FilterService/Redact",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/filter.__connect.rs
+++ b/benches/rpc/src/generated/connect/filter.__connect.rs
@@ -42,7 +42,25 @@ pub const FILTER_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.filter.v1.Fi
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `FILTER_SERVICE_REDACT_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const FILTER_SERVICE_REDACT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/anthropic.connectrpc.filter.v1.FilterService/Redact",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Redact` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `FILTER_SERVICE_REDACT_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const FILTER_SERVICE_REDACT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.filter.v1.FilterService/Redact",
         ::connectrpc::StreamType::Unary,
     )
@@ -448,8 +466,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                FILTER_SERVICE_SERVICE_NAME,
-                "Redact",
+                FILTER_SERVICE_REDACT_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -42,25 +42,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const FORTUNE_SERVICE_SERVICE_NAME: &str = "fortune.v1.FortuneService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `GetFortunes` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `GetFortunes` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `FORTUNE_SERVICE_GET_FORTUNES_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const FORTUNE_SERVICE_GET_FORTUNES_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/fortune.v1.FortuneService/GetFortunes",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `FORTUNE_SERVICE_GET_FORTUNES_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const FORTUNE_SERVICE_GET_FORTUNES_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/fortune.v1.FortuneService/GetFortunes",
         ::connectrpc::StreamType::Unary,
     )
@@ -461,7 +450,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                FORTUNE_SERVICE_GET_FORTUNES_CLIENT_SPEC,
+                FORTUNE_SERVICE_GET_FORTUNES_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -46,7 +46,25 @@ pub const FORTUNE_SERVICE_SERVICE_NAME: &str = "fortune.v1.FortuneService";
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `FORTUNE_SERVICE_GET_FORTUNES_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const FORTUNE_SERVICE_GET_FORTUNES_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/fortune.v1.FortuneService/GetFortunes",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `GetFortunes` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `FORTUNE_SERVICE_GET_FORTUNES_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const FORTUNE_SERVICE_GET_FORTUNES_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/fortune.v1.FortuneService/GetFortunes",
         ::connectrpc::StreamType::Unary,
     )
@@ -447,8 +465,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                FORTUNE_SERVICE_SERVICE_NAME,
-                "GetFortunes",
+                FORTUNE_SERVICE_GET_FORTUNES_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -56,14 +56,10 @@ pub const FORTUNE_SERVICE_GET_FORTUNES_SPEC: ::connectrpc::Spec = ::connectrpc::
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `GetFortunes` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `FORTUNE_SERVICE_GET_FORTUNES_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `FORTUNE_SERVICE_GET_FORTUNES_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const FORTUNE_SERVICE_GET_FORTUNES_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/fortune.v1.FortuneService/GetFortunes",
         ::connectrpc::StreamType::Unary,

--- a/benches/rpc/src/generated/connect/fortune.__connect.rs
+++ b/benches/rpc/src/generated/connect/fortune.__connect.rs
@@ -42,13 +42,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const FORTUNE_SERVICE_SERVICE_NAME: &str = "fortune.v1.FortuneService";
-/// Static [`Spec`](::connectrpc::Spec) for the `GetFortunes` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `GetFortunes` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const FORTUNE_SERVICE_GET_FORTUNES_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/fortune.v1.FortuneService/GetFortunes",
         ::connectrpc::StreamType::Unary,

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -21,7 +21,7 @@ use connectrpc::client::{
 use connectrpc::error::{ConnectError, ErrorCode};
 use connectrpc::rustls;
 use connectrpc::{
-    CodecFormat, CompressionRegistry,
+    CodecFormat, CompressionRegistry, Spec, StreamType as RpcStreamType,
     compression::{GzipProvider, ZstdProvider},
 };
 use connectrpc_conformance::ClientCompatRequest;
@@ -49,6 +49,60 @@ use tracing_subscriber::EnvFilter;
 // ============================================================================
 // ConformanceTransport — wraps low-level hyper connections as a ClientTransport
 // ============================================================================
+
+/// Resolve the runner-supplied `(service, method)` strings to a client
+/// [`Spec`].
+///
+/// This binary is the rare *dynamic* caller of the `call_*` entry points:
+/// method names arrive at runtime from the test runner. Every request the
+/// runner actually sends targets `ConformanceService`, so it maps onto one
+/// of the generated `*_CLIENT_SPEC` constants (matched on procedure *and*
+/// stream shape, so a runner method routed to a differently-shaped entry
+/// point falls through rather than tripping the runtime's spec check; the
+/// constants also carry the right idempotency level). Anything else gets an
+/// ad-hoc `Spec` so the call still goes out and the server can answer
+/// `Unimplemented`, as the reference client does. `Spec::procedure` is
+/// `&'static str`, so ad-hoc procedures are **interned**: each distinct
+/// `(procedure, shape)` is leaked once and reused, which is the pattern a
+/// production dynamic client should copy (leaking per call would grow
+/// without bound).
+fn client_spec(service: &str, method: &str, stream_type: RpcStreamType) -> Spec {
+    use connectrpc_conformance::{
+        CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
+    };
+    const KNOWN: [Spec; 6] = [
+        CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
+        CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC,
+    ];
+    static AD_HOC: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<(String, RpcStreamType), Spec>>,
+    > = std::sync::OnceLock::new();
+
+    let procedure = format!("/{service}/{method}");
+    if let Some(spec) = KNOWN
+        .iter()
+        .copied()
+        .find(|spec| spec.procedure == procedure && spec.stream_type == stream_type)
+    {
+        return spec;
+    }
+    let mut interned = AD_HOC
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *interned
+        .entry((procedure, stream_type))
+        .or_insert_with_key(|(procedure, stream_type)| {
+            Spec::client(Box::leak(procedure.clone().into_boxed_str()), *stream_type)
+        })
+}
 
 /// Transport that opens a fresh TCP (+ optional TLS) connection per request.
 ///
@@ -524,6 +578,7 @@ async fn do_unary_call(
     // Dispatch based on method to get correct types. Use GET if the request
     // asks for it (Connect protocol only — call_unary_get will error otherwise).
     let use_get = req.use_get_http_method;
+    let spec = client_spec(service, method, RpcStreamType::Unary);
 
     // Macro: picks call_unary or call_unary_get based on use_get. Avoids
     // duplicating the three match arms for the GET/POST choice.
@@ -531,14 +586,12 @@ async fn do_unary_call(
         ($req_ty:ty, $resp_view:ty, $request:expr) => {
             if use_get {
                 call_unary_get::<_, $req_ty, $resp_view>(
-                    &transport, &config, service, method, $request, options,
+                    &transport, &config, spec, $request, options,
                 )
                 .await?
             } else {
-                call_unary::<_, $req_ty, $resp_view>(
-                    &transport, &config, service, method, $request, options,
-                )
-                .await?
+                call_unary::<_, $req_ty, $resp_view>(&transport, &config, spec, $request, options)
+                    .await?
             }
         };
     }
@@ -737,7 +790,11 @@ async fn do_server_stream_call(
     // Make the call -- this sends the request and returns a stream handle
     let stream_result = async {
         call_server_stream::<_, ServerStreamRequest, ServerStreamResponseView<'static>>(
-            &transport, &config, service, method, request, options,
+            &transport,
+            &config,
+            client_spec(service, method, RpcStreamType::ServerStream),
+            request,
+            options,
         )
         .await
     };
@@ -1041,8 +1098,7 @@ async fn do_client_stream_call(
         let resp = call_client_stream::<_, ClientStreamRequest, ClientStreamResponseView<'static>>(
             &transport,
             &config,
-            service,
-            method,
+            client_spec(service, method, RpcStreamType::ClientStream),
             futures::stream::iter(requests),
             options,
         )
@@ -1212,7 +1268,10 @@ async fn do_bidi_stream_call(
     // call_bidi_stream docs.
     let mut stream =
         match call_bidi_stream::<_, BidiStreamRequest, BidiStreamResponseView<'static>>(
-            &transport, &config, service, method, options,
+            &transport,
+            &config,
+            client_spec(service, method, RpcStreamType::BidiStream),
+            options,
         )
         .await
         {

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -21,7 +21,7 @@ use connectrpc::client::{
 use connectrpc::error::{ConnectError, ErrorCode};
 use connectrpc::rustls;
 use connectrpc::{
-    CodecFormat, CompressionRegistry, Spec,
+    CodecFormat, CompressionRegistry, Spec, SpecOrigin,
     compression::{GzipProvider, ZstdProvider},
 };
 use connectrpc_conformance::ClientCompatRequest;
@@ -40,10 +40,9 @@ use connectrpc_conformance::{
     ServerStreamResponseView, UnaryResponseView,
 };
 use connectrpc_conformance::{
-    CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
-    CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
-    CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
-    CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
+    CONFORMANCE_SERVICE_BIDI_STREAM_SPEC, CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC,
+    CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC, CONFORMANCE_SERVICE_SERVER_STREAM_SPEC,
+    CONFORMANCE_SERVICE_UNARY_SPEC, CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC,
 };
 use hyper::Request;
 use hyper::Response;
@@ -528,7 +527,7 @@ async fn do_unary_call(
 
     // Macro: picks call_unary or call_unary_get based on use_get. Avoids
     // duplicating the three match arms for the GET/POST choice. Each arm
-    // passes the generated `*_CLIENT_SPEC` for its method.
+    // passes the generated `*_SPEC` for its method, as a client.
     macro_rules! do_call {
         ($spec:expr, $req_ty:ty, $resp_view:ty, $request:expr) => {
             if use_get {
@@ -550,7 +549,7 @@ async fn do_unary_call(
                 let request = UnaryRequest::decode_from_slice(proto_bytes)
                     .map_err(|e| ConnectError::internal(format!("decode request: {e}")))?;
                 let resp = do_call!(
-                    CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
+                    CONFORMANCE_SERVICE_UNARY_SPEC.with_origin(SpecOrigin::Client),
                     UnaryRequest,
                     UnaryResponseView<'static>,
                     request
@@ -568,7 +567,7 @@ async fn do_unary_call(
                 let request = IdempotentUnaryRequest::decode_from_slice(proto_bytes)
                     .map_err(|e| ConnectError::internal(format!("decode request: {e}")))?;
                 let resp = do_call!(
-                    CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
+                    CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC.with_origin(SpecOrigin::Client),
                     IdempotentUnaryRequest,
                     IdempotentUnaryResponseView<'static>,
                     request
@@ -589,7 +588,7 @@ async fn do_unary_call(
                 // `Spec::client`).
                 use connectrpc_conformance::UnaryRequest;
                 let spec = if other == "Unimplemented" {
-                    CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC
+                    CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC.with_origin(SpecOrigin::Client)
                 } else {
                     let procedure =
                         format!("/connectrpc.conformance.v1.ConformanceService/{other}");
@@ -752,7 +751,7 @@ async fn do_server_stream_call(
         call_server_stream::<_, ServerStreamRequest, ServerStreamResponseView<'static>>(
             &transport,
             &config,
-            CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC,
+            CONFORMANCE_SERVICE_SERVER_STREAM_SPEC.with_origin(SpecOrigin::Client),
             request,
             options,
         )
@@ -1051,7 +1050,7 @@ async fn do_client_stream_call(
         let resp = call_client_stream::<_, ClientStreamRequest, ClientStreamResponseView<'static>>(
             &transport,
             &config,
-            CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
+            CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC.with_origin(SpecOrigin::Client),
             futures::stream::iter(requests),
             options,
         )
@@ -1218,7 +1217,7 @@ async fn do_bidi_stream_call(
         match call_bidi_stream::<_, BidiStreamRequest, BidiStreamResponseView<'static>>(
             &transport,
             &config,
-            CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC,
+            CONFORMANCE_SERVICE_BIDI_STREAM_SPEC.with_origin(SpecOrigin::Client),
             options,
         )
         .await

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -24,6 +24,7 @@ use connectrpc::{
     CodecFormat, CompressionRegistry, Spec, SpecOrigin,
     compression::{GzipProvider, ZstdProvider},
 };
+use connectrpc_conformance::CONFORMANCE_SERVICE_SERVICE_NAME;
 use connectrpc_conformance::ClientCompatRequest;
 use connectrpc_conformance::ClientResponseResult;
 use connectrpc_conformance::Codec;
@@ -458,6 +459,27 @@ async fn execute_request(req: &ClientCompatRequest) -> ExecResult {
 // do_unary_call -- uses the library's call_unary via ConformanceTransport
 // ============================================================================
 
+/// The generated constant for the RPC `req` addresses, flipped to the client
+/// side — or, should a future suite name a different service or method, an
+/// ad-hoc client `Spec` of the same stream shape, so the request is never
+/// silently sent to the generated RPC instead. Leaked per call; fine in a
+/// test binary (a production dynamic caller should intern, see
+/// `Spec::client`).
+fn client_spec(req: &ClientCompatRequest, default: Spec) -> Spec {
+    let service = req
+        .service
+        .as_deref()
+        .unwrap_or(CONFORMANCE_SERVICE_SERVICE_NAME);
+    let method = req.method.as_deref().unwrap_or(default.method());
+    if service == CONFORMANCE_SERVICE_SERVICE_NAME && method == default.method() {
+        return default.with_origin(SpecOrigin::Client);
+    }
+    Spec::client(
+        Box::leak(format!("/{service}/{method}").into_boxed_str()),
+        default.stream_type,
+    )
+}
+
 /// Perform a unary RPC call using the library.
 async fn do_unary_call(
     req: &ClientCompatRequest,
@@ -549,7 +571,7 @@ async fn do_unary_call(
                 let request = UnaryRequest::decode_from_slice(proto_bytes)
                     .map_err(|e| ConnectError::internal(format!("decode request: {e}")))?;
                 let resp = do_call!(
-                    CONFORMANCE_SERVICE_UNARY_SPEC.with_origin(SpecOrigin::Client),
+                    client_spec(req, CONFORMANCE_SERVICE_UNARY_SPEC),
                     UnaryRequest,
                     UnaryResponseView<'static>,
                     request
@@ -567,7 +589,7 @@ async fn do_unary_call(
                 let request = IdempotentUnaryRequest::decode_from_slice(proto_bytes)
                     .map_err(|e| ConnectError::internal(format!("decode request: {e}")))?;
                 let resp = do_call!(
-                    CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC.with_origin(SpecOrigin::Client),
+                    client_spec(req, CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC),
                     IdempotentUnaryRequest,
                     IdempotentUnaryResponseView<'static>,
                     request
@@ -588,12 +610,14 @@ async fn do_unary_call(
                 // `Spec::client`).
                 use connectrpc_conformance::UnaryRequest;
                 let spec = if other == "Unimplemented" {
-                    CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC.with_origin(SpecOrigin::Client)
+                    client_spec(req, CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC)
                 } else {
-                    let procedure =
-                        format!("/connectrpc.conformance.v1.ConformanceService/{other}");
+                    let service = req
+                        .service
+                        .as_deref()
+                        .unwrap_or(CONFORMANCE_SERVICE_SERVICE_NAME);
                     Spec::client(
-                        Box::leak(procedure.into_boxed_str()),
+                        Box::leak(format!("/{service}/{other}").into_boxed_str()),
                         connectrpc::StreamType::Unary,
                     )
                 };
@@ -751,7 +775,7 @@ async fn do_server_stream_call(
         call_server_stream::<_, ServerStreamRequest, ServerStreamResponseView<'static>>(
             &transport,
             &config,
-            CONFORMANCE_SERVICE_SERVER_STREAM_SPEC.with_origin(SpecOrigin::Client),
+            client_spec(req, CONFORMANCE_SERVICE_SERVER_STREAM_SPEC),
             request,
             options,
         )
@@ -1050,7 +1074,7 @@ async fn do_client_stream_call(
         let resp = call_client_stream::<_, ClientStreamRequest, ClientStreamResponseView<'static>>(
             &transport,
             &config,
-            CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC.with_origin(SpecOrigin::Client),
+            client_spec(req, CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC),
             futures::stream::iter(requests),
             options,
         )
@@ -1217,7 +1241,7 @@ async fn do_bidi_stream_call(
         match call_bidi_stream::<_, BidiStreamRequest, BidiStreamResponseView<'static>>(
             &transport,
             &config,
-            CONFORMANCE_SERVICE_BIDI_STREAM_SPEC.with_origin(SpecOrigin::Client),
+            client_spec(req, CONFORMANCE_SERVICE_BIDI_STREAM_SPEC),
             options,
         )
         .await

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -21,7 +21,7 @@ use connectrpc::client::{
 use connectrpc::error::{ConnectError, ErrorCode};
 use connectrpc::rustls;
 use connectrpc::{
-    CodecFormat, CompressionRegistry, Spec, StreamType as RpcStreamType,
+    CodecFormat, CompressionRegistry, Spec,
     compression::{GzipProvider, ZstdProvider},
 };
 use connectrpc_conformance::ClientCompatRequest;
@@ -39,6 +39,12 @@ use connectrpc_conformance::{
     BidiStreamResponseView, ClientStreamResponseView, IdempotentUnaryResponseView,
     ServerStreamResponseView, UnaryResponseView,
 };
+use connectrpc_conformance::{
+    CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
+    CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
+    CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
+    CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
+};
 use hyper::Request;
 use hyper::Response;
 use hyper_util::rt::TokioIo;
@@ -49,60 +55,6 @@ use tracing_subscriber::EnvFilter;
 // ============================================================================
 // ConformanceTransport — wraps low-level hyper connections as a ClientTransport
 // ============================================================================
-
-/// Resolve the runner-supplied `(service, method)` strings to a client
-/// [`Spec`].
-///
-/// This binary is the rare *dynamic* caller of the `call_*` entry points:
-/// method names arrive at runtime from the test runner. Every request the
-/// runner actually sends targets `ConformanceService`, so it maps onto one
-/// of the generated `*_CLIENT_SPEC` constants (matched on procedure *and*
-/// stream shape, so a runner method routed to a differently-shaped entry
-/// point falls through rather than tripping the runtime's spec check; the
-/// constants also carry the right idempotency level). Anything else gets an
-/// ad-hoc `Spec` so the call still goes out and the server can answer
-/// `Unimplemented`, as the reference client does. `Spec::procedure` is
-/// `&'static str`, so ad-hoc procedures are **interned**: each distinct
-/// `(procedure, shape)` is leaked once and reused, which is the pattern a
-/// production dynamic client should copy (leaking per call would grow
-/// without bound).
-fn client_spec(service: &str, method: &str, stream_type: RpcStreamType) -> Spec {
-    use connectrpc_conformance::{
-        CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC, CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
-    };
-    const KNOWN: [Spec; 6] = [
-        CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
-        CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC,
-    ];
-    static AD_HOC: std::sync::OnceLock<
-        std::sync::Mutex<std::collections::HashMap<(String, RpcStreamType), Spec>>,
-    > = std::sync::OnceLock::new();
-
-    let procedure = format!("/{service}/{method}");
-    if let Some(spec) = KNOWN
-        .iter()
-        .copied()
-        .find(|spec| spec.procedure == procedure && spec.stream_type == stream_type)
-    {
-        return spec;
-    }
-    let mut interned = AD_HOC
-        .get_or_init(Default::default)
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    *interned
-        .entry((procedure, stream_type))
-        .or_insert_with_key(|(procedure, stream_type)| {
-            Spec::client(Box::leak(procedure.clone().into_boxed_str()), *stream_type)
-        })
-}
 
 /// Transport that opens a fresh TCP (+ optional TLS) connection per request.
 ///
@@ -518,11 +470,6 @@ async fn do_unary_call(
 ) -> Result<ClientResponseResult> {
     let use_tls = !req.server_tls_cert.is_empty();
 
-    // Determine service and method
-    let service = req
-        .service
-        .as_deref()
-        .unwrap_or("connectrpc.conformance.v1.ConformanceService");
     let method = req.method.as_deref().unwrap_or("Unary");
 
     let transport = ConformanceTransport::from_request(req, http_version);
@@ -578,19 +525,19 @@ async fn do_unary_call(
     // Dispatch based on method to get correct types. Use GET if the request
     // asks for it (Connect protocol only — call_unary_get will error otherwise).
     let use_get = req.use_get_http_method;
-    let spec = client_spec(service, method, RpcStreamType::Unary);
 
     // Macro: picks call_unary or call_unary_get based on use_get. Avoids
-    // duplicating the three match arms for the GET/POST choice.
+    // duplicating the three match arms for the GET/POST choice. Each arm
+    // passes the generated `*_CLIENT_SPEC` for its method.
     macro_rules! do_call {
-        ($req_ty:ty, $resp_view:ty, $request:expr) => {
+        ($spec:expr, $req_ty:ty, $resp_view:ty, $request:expr) => {
             if use_get {
                 call_unary_get::<_, $req_ty, $resp_view>(
-                    &transport, &config, spec, $request, options,
+                    &transport, &config, $spec, $request, options,
                 )
                 .await?
             } else {
-                call_unary::<_, $req_ty, $resp_view>(&transport, &config, spec, $request, options)
+                call_unary::<_, $req_ty, $resp_view>(&transport, &config, $spec, $request, options)
                     .await?
             }
         };
@@ -602,7 +549,12 @@ async fn do_unary_call(
                 use connectrpc_conformance::UnaryRequest;
                 let request = UnaryRequest::decode_from_slice(proto_bytes)
                     .map_err(|e| ConnectError::internal(format!("decode request: {e}")))?;
-                let resp = do_call!(UnaryRequest, UnaryResponseView<'static>, request);
+                let resp = do_call!(
+                    CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
+                    UnaryRequest,
+                    UnaryResponseView<'static>,
+                    request
+                );
                 let (headers, message, trailers) = resp.into_owned_parts();
                 let payload = if message.payload.is_set() {
                     message.payload.as_option().unwrap().clone()
@@ -616,6 +568,7 @@ async fn do_unary_call(
                 let request = IdempotentUnaryRequest::decode_from_slice(proto_bytes)
                     .map_err(|e| ConnectError::internal(format!("decode request: {e}")))?;
                 let resp = do_call!(
+                    CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
                     IdempotentUnaryRequest,
                     IdempotentUnaryResponseView<'static>,
                     request
@@ -628,11 +581,25 @@ async fn do_unary_call(
                 };
                 Ok((headers, payload, trailers))
             }
-            _ => {
-                // Unknown method (e.g., "Unimplemented") -- use UnaryRequest as best-effort
+            other => {
+                // "Unimplemented" is a real method with a generated Spec; any
+                // other name (never sent by the suite) gets an ad-hoc Spec so
+                // the call still goes out. Leaked per call — fine in a test
+                // binary; a production dynamic caller should intern (see
+                // `Spec::client`).
                 use connectrpc_conformance::UnaryRequest;
+                let spec = if other == "Unimplemented" {
+                    CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC
+                } else {
+                    let procedure =
+                        format!("/connectrpc.conformance.v1.ConformanceService/{other}");
+                    Spec::client(
+                        Box::leak(procedure.into_boxed_str()),
+                        connectrpc::StreamType::Unary,
+                    )
+                };
                 let request = UnaryRequest::decode_from_slice(proto_bytes).unwrap_or_default();
-                let resp = do_call!(UnaryRequest, UnaryResponseView<'static>, request);
+                let resp = do_call!(spec, UnaryRequest, UnaryResponseView<'static>, request);
                 let (headers, message, trailers) = resp.into_owned_parts();
                 let payload = if message.payload.is_set() {
                     message.payload.as_option().unwrap().clone()
@@ -728,13 +695,6 @@ async fn do_server_stream_call(
 ) -> Result<ClientResponseResult> {
     let use_tls = !req.server_tls_cert.is_empty();
 
-    // Determine service and method
-    let service = req
-        .service
-        .as_deref()
-        .unwrap_or("connectrpc.conformance.v1.ConformanceService");
-    let method = req.method.as_deref().unwrap_or("ServerStream");
-
     let transport = ConformanceTransport::from_request(req, http_version);
 
     // Build client config. For streaming, only register the requested
@@ -792,7 +752,7 @@ async fn do_server_stream_call(
         call_server_stream::<_, ServerStreamRequest, ServerStreamResponseView<'static>>(
             &transport,
             &config,
-            client_spec(service, method, RpcStreamType::ServerStream),
+            CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC,
             request,
             options,
         )
@@ -1036,13 +996,6 @@ async fn do_client_stream_call(
 ) -> Result<ClientResponseResult> {
     let use_tls = !req.server_tls_cert.is_empty();
 
-    // Determine service and method
-    let service = req
-        .service
-        .as_deref()
-        .unwrap_or("connectrpc.conformance.v1.ConformanceService");
-    let method = req.method.as_deref().unwrap_or("ClientStream");
-
     let transport = ConformanceTransport::from_request(req, http_version);
 
     // Build client config (streaming — only requested encoding).
@@ -1098,7 +1051,7 @@ async fn do_client_stream_call(
         let resp = call_client_stream::<_, ClientStreamRequest, ClientStreamResponseView<'static>>(
             &transport,
             &config,
-            client_spec(service, method, RpcStreamType::ClientStream),
+            CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
             futures::stream::iter(requests),
             options,
         )
@@ -1206,11 +1159,6 @@ async fn do_bidi_stream_call(
     use connectrpc_conformance::BidiStreamRequest;
 
     let use_tls = !req.server_tls_cert.is_empty();
-    let service = req
-        .service
-        .as_deref()
-        .unwrap_or("connectrpc.conformance.v1.ConformanceService");
-    let method = req.method.as_deref().unwrap_or("BidiStream");
 
     let transport = ConformanceTransport::from_request(req, http_version);
 
@@ -1270,7 +1218,7 @@ async fn do_bidi_stream_call(
         match call_bidi_stream::<_, BidiStreamRequest, BidiStreamResponseView<'static>>(
             &transport,
             &config,
-            client_spec(service, method, RpcStreamType::BidiStream),
+            CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC,
             options,
         )
         .await

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -312,73 +312,37 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const CONFORMANCE_SERVICE_SERVICE_NAME: &str = "connectrpc.conformance.v1.ConformanceService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Unary` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Unary` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const CONFORMANCE_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/Unary",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `ServerStream` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerStream` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const CONFORMANCE_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `ClientStream` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `ClientStream` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/ClientStream",
         ::connectrpc::StreamType::ClientStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `BidiStream` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `BidiStream` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const CONFORMANCE_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `Unimplemented` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Unimplemented` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/Unimplemented",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `IdempotentUnary` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `IdempotentUnary` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary",
         ::connectrpc::StreamType::Unary,

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -316,6 +316,11 @@ pub const CONFORMANCE_SERVICE_SERVICE_NAME: &str = "connectrpc.conformance.v1.Co
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/Unary",
         ::connectrpc::StreamType::Unary,
@@ -325,6 +330,11 @@ pub const CONFORMANCE_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spe
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
@@ -334,6 +344,11 @@ pub const CONFORMANCE_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connect
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/ClientStream",
         ::connectrpc::StreamType::ClientStream,
@@ -343,6 +358,11 @@ pub const CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connect
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
@@ -352,6 +372,11 @@ pub const CONFORMANCE_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrp
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/Unimplemented",
         ::connectrpc::StreamType::Unary,
@@ -361,7 +386,90 @@ pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC: ::connectrpc::Spec = ::connect
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Unary` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `CONFORMANCE_SERVICE_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/Unary",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerStream` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `CONFORMANCE_SERVICE_SERVER_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/ServerStream",
+        ::connectrpc::StreamType::ServerStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `ClientStream` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/ClientStream",
+        ::connectrpc::StreamType::ClientStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `BidiStream` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `CONFORMANCE_SERVICE_BIDI_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/BidiStream",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Unimplemented` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/Unimplemented",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `IdempotentUnary` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary",
         ::connectrpc::StreamType::Unary,
     )
@@ -1238,8 +1346,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_SERVICE_NAME,
-                "Unary",
+                CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -1281,8 +1388,7 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_SERVICE_NAME,
-                "ServerStream",
+                CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -1356,8 +1462,7 @@ where
         ::connectrpc::client::call_client_stream(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_SERVICE_NAME,
-                "ClientStream",
+                CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
                 requests,
                 options,
             )
@@ -1395,8 +1500,7 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_SERVICE_NAME,
-                "BidiStream",
+                CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC,
                 options,
             )
             .await
@@ -1439,8 +1543,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_SERVICE_NAME,
-                "Unimplemented",
+                CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -1484,8 +1587,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_SERVICE_NAME,
-                "IdempotentUnary",
+                CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -312,140 +312,74 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const CONFORMANCE_SERVICE_SERVICE_NAME: &str = "connectrpc.conformance.v1.ConformanceService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Unary` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Unary` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const CONFORMANCE_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/Unary",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `CONFORMANCE_SERVICE_UNARY_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/Unary",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `ServerStream` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerStream` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const CONFORMANCE_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `CONFORMANCE_SERVICE_SERVER_STREAM_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/ServerStream",
-        ::connectrpc::StreamType::ServerStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `ClientStream` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `ClientStream` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/ClientStream",
         ::connectrpc::StreamType::ClientStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/ClientStream",
-        ::connectrpc::StreamType::ClientStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `BidiStream` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `BidiStream` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const CONFORMANCE_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `CONFORMANCE_SERVICE_BIDI_STREAM_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/BidiStream",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Unimplemented` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Unimplemented` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.conformance.v1.ConformanceService/Unimplemented",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/Unimplemented",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `IdempotentUnary` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `IdempotentUnary` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Client-side sibling of `CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary",
         ::connectrpc::StreamType::Unary,
     )
@@ -1322,7 +1256,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC,
+                CONFORMANCE_SERVICE_UNARY_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1364,7 +1299,8 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC,
+                CONFORMANCE_SERVICE_SERVER_STREAM_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1438,7 +1374,8 @@ where
         ::connectrpc::client::call_client_stream(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC,
+                CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 requests,
                 options,
             )
@@ -1476,7 +1413,8 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC,
+                CONFORMANCE_SERVICE_BIDI_STREAM_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 options,
             )
             .await
@@ -1519,7 +1457,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC,
+                CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1563,7 +1502,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC,
+                CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
+++ b/conformance/src/generated/connect/connectrpc.conformance.v1.service.__connect.rs
@@ -326,6 +326,15 @@ pub const CONFORMANCE_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spe
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `CONFORMANCE_SERVICE_UNARY_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/Unary",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `ServerStream` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -336,6 +345,15 @@ pub const CONFORMANCE_SERVICE_UNARY_SPEC: ::connectrpc::Spec = ::connectrpc::Spe
 /// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
 /// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_SERVER_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/connectrpc.conformance.v1.ConformanceService/ServerStream",
+        ::connectrpc::StreamType::ServerStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `CONFORMANCE_SERVICE_SERVER_STREAM_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.conformance.v1.ConformanceService/ServerStream",
         ::connectrpc::StreamType::ServerStream,
     )
@@ -354,6 +372,15 @@ pub const CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connect
         ::connectrpc::StreamType::ClientStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/ClientStream",
+        ::connectrpc::StreamType::ClientStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `BidiStream` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -364,6 +391,15 @@ pub const CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC: ::connectrpc::Spec = ::connect
 /// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
 /// `procedure` to match this method on either side.
 pub const CONFORMANCE_SERVICE_BIDI_STREAM_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/connectrpc.conformance.v1.ConformanceService/BidiStream",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `CONFORMANCE_SERVICE_BIDI_STREAM_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.conformance.v1.ConformanceService/BidiStream",
         ::connectrpc::StreamType::BidiStream,
     )
@@ -382,6 +418,15 @@ pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC: ::connectrpc::Spec = ::connect
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.conformance.v1.ConformanceService/Unimplemented",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `IdempotentUnary` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -396,79 +441,10 @@ pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC: ::connectrpc::Spec = ::conn
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Unary` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `CONFORMANCE_SERVICE_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const CONFORMANCE_SERVICE_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/Unary",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerStream` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `CONFORMANCE_SERVICE_SERVER_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const CONFORMANCE_SERVICE_SERVER_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/ServerStream",
-        ::connectrpc::StreamType::ServerStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `ClientStream` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `CONFORMANCE_SERVICE_CLIENT_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const CONFORMANCE_SERVICE_CLIENT_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/ClientStream",
-        ::connectrpc::StreamType::ClientStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `BidiStream` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `CONFORMANCE_SERVICE_BIDI_STREAM_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const CONFORMANCE_SERVICE_BIDI_STREAM_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/BidiStream",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Unimplemented` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `CONFORMANCE_SERVICE_UNIMPLEMENTED_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const CONFORMANCE_SERVICE_UNIMPLEMENTED_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.conformance.v1.ConformanceService/Unimplemented",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `IdempotentUnary` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const CONFORMANCE_SERVICE_IDEMPOTENT_UNARY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary",
         ::connectrpc::StreamType::Unary,

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -904,9 +904,8 @@ mod tests {
             .expect("read gated __connect.rs");
         let cfg_count = gated.matches("#[cfg(feature = \"client\")]").count();
         assert_eq!(
-            cfg_count, 6,
-            "expected exactly 6 cfg attrs (client struct + impl + one \
-             `*_CLIENT_SPEC` const per each of the fixture's 4 methods) with \
+            cfg_count, 2,
+            "expected exactly 2 cfg attrs (struct + impl) with \
              gate_client_feature=true; got {cfg_count}:\n{gated}"
         );
         // Sanity: the server-side trait + ext trait must not be gated.
@@ -937,9 +936,9 @@ mod tests {
             .expect("read custom __connect.rs");
         let custom_count = custom.matches("#[cfg(feature = \"grpc-client\")]").count();
         assert_eq!(
-            custom_count, 6,
-            "expected exactly 6 custom cfg attrs (struct + impl + 4 method \
-             consts); got {custom_count}:\n{custom}"
+            custom_count, 2,
+            "expected exactly 2 custom cfg attrs (struct + impl); got \
+             {custom_count}:\n{custom}"
         );
         assert!(
             !custom.contains("#[cfg(feature = \"client\")]"),

--- a/connectrpc-build/src/lib.rs
+++ b/connectrpc-build/src/lib.rs
@@ -904,8 +904,9 @@ mod tests {
             .expect("read gated __connect.rs");
         let cfg_count = gated.matches("#[cfg(feature = \"client\")]").count();
         assert_eq!(
-            cfg_count, 2,
-            "expected exactly 2 cfg attrs (struct + impl) with \
+            cfg_count, 6,
+            "expected exactly 6 cfg attrs (client struct + impl + one \
+             `*_CLIENT_SPEC` const per each of the fixture's 4 methods) with \
              gate_client_feature=true; got {cfg_count}:\n{gated}"
         );
         // Sanity: the server-side trait + ext trait must not be gated.
@@ -936,9 +937,9 @@ mod tests {
             .expect("read custom __connect.rs");
         let custom_count = custom.matches("#[cfg(feature = \"grpc-client\")]").count();
         assert_eq!(
-            custom_count, 2,
-            "expected exactly 2 custom cfg attrs (struct + impl); got \
-             {custom_count}:\n{custom}"
+            custom_count, 6,
+            "expected exactly 6 custom cfg attrs (struct + impl + 4 method \
+             consts); got {custom_count}:\n{custom}"
         );
         assert!(
             !custom.contains("#[cfg(feature = \"client\")]"),

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1302,18 +1302,26 @@ fn generate_all_message_encodable_impls(
 /// Generate code for a single service.
 /// Reject RPC method sets whose generated Rust identifiers collide.
 ///
-/// Each proto method `Foo` produces both `foo` and `foo_with_options` on the
-/// client. Two methods that normalize to the same snake_case name (e.g.
-/// `GetFoo` and `get_foo`), or one whose snake form equals another's
-/// `_with_options` form, would emit duplicate definitions and fail to
+/// Each proto method `Foo` produces `foo` and `foo_with_options` on the
+/// client and the module-scope constants `{SVC}_FOO_SPEC` /
+/// `{SVC}_FOO_CLIENT_SPEC`. Two methods that normalize to the same
+/// snake_case name (e.g. `GetFoo` and `get_foo`), or one whose snake form
+/// equals another's plus a generated suffix (`Get` + `GetWithOptions`;
+/// `Get` + `GetClient`, whose client and server `Spec` constants are both
+/// `{SVC}_GET_CLIENT_SPEC`), would emit duplicate definitions and fail to
 /// compile with an error pointing at generated code rather than the proto.
 fn check_method_collisions(service_name: &str, service: &ServiceDescriptorProto) -> Result<()> {
     let mut seen: HashMap<String, String> = HashMap::new();
     for m in &service.method {
         let proto_name = m.name.as_deref().unwrap_or("");
         let snake = proto_name.to_snake_case();
-        let with_opts = format!("{snake}_with_options");
-        for ident in [snake.as_str(), with_opts.as_str()] {
+        let idents = [
+            snake.clone(),
+            format!("{snake}_with_options"),
+            format!("{snake}_spec"),
+            format!("{snake}_client_spec"),
+        ];
+        for ident in &idents {
             if let Some(prev) = seen.get(ident) {
                 anyhow::bail!(
                     "service {service_name}: RPC methods {prev:?} and {proto_name:?} \
@@ -1321,8 +1329,9 @@ fn check_method_collisions(service_name: &str, service: &ServiceDescriptorProto)
                 );
             }
         }
-        seen.insert(snake, proto_name.to_string());
-        seen.insert(with_opts, proto_name.to_string());
+        for ident in idents {
+            seen.insert(ident, proto_name.to_string());
+        }
     }
     Ok(())
 }
@@ -1667,15 +1676,11 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
         TokenStream::new()
     };
 
-    // Per-method `Spec` constants. Stable, allocation-free metadata that the
-    // dispatcher threads into `RequestContext::spec` and that user code can
-    // reference directly (e.g. for tracing labels or routing tables). The
-    // client siblings are what generated client methods pass to `call_*`;
-    // they are gated with the client feature like every other client item.
-    check_module_const_collisions(service, &service_name_const)?;
-    let spec_consts = generate_spec_consts(&full_service_name, service);
-    let client_spec_consts =
-        generate_client_spec_consts(&full_service_name, service, &client_cfg_attr);
+    // Per-method `Spec` constants (server + client sibling). Stable,
+    // allocation-free metadata that the dispatcher threads into
+    // `RequestContext::spec`, that generated client methods pass to `call_*`,
+    // and that user code can reference directly.
+    let spec_consts = generate_spec_consts(&full_service_name, service, &client_cfg_attr);
 
     Ok(quote! {
         // -----------------------------------------------------------------------------
@@ -1686,8 +1691,6 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
         pub const #service_name_const: &str = #full_service_name;
 
         #(#spec_consts)*
-
-        #(#client_spec_consts)*
 
         #service_doc_tokens
         #[allow(clippy::type_complexity)]
@@ -1773,165 +1776,36 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
     })
 }
 
-/// Construct the identifier for a per-method server-side `Spec` constant.
-///
-/// The name is derived from the service and method names, e.g.
-/// `ELIZA_SERVICE_SAY_SPEC` for `ElizaService.Say`. Lives at module scope;
-/// the client sibling is [`method_client_spec_const_ident`].
+/// Construct the identifier for a per-method module-scope constant:
+/// `{SERVICE}_{METHOD}_{suffix}`, e.g. `ELIZA_SERVICE_SAY_SPEC` /
+/// `ELIZA_SERVICE_SAY_CLIENT_SPEC` for `ElizaService.Say`.
+fn method_const_ident(service: &ServiceDescriptorProto, method_name: &str, suffix: &str) -> Ident {
+    let service_name = service.name.as_deref().unwrap_or("");
+    format_ident!(
+        "{}_{}_{suffix}",
+        service_name.to_snake_case().to_uppercase(),
+        method_name.to_snake_case().to_uppercase()
+    )
+}
+
+/// `{SERVICE}_{METHOD}_SPEC`, the server-side constant.
 fn method_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) -> Ident {
-    let service_name = service.name.as_deref().unwrap_or("");
-    format_ident!(
-        "{}_{}_SPEC",
-        service_name.to_snake_case().to_uppercase(),
-        method_name.to_snake_case().to_uppercase()
-    )
+    method_const_ident(service, method_name, "SPEC")
 }
 
-/// Construct the identifier for a per-method client-side `Spec` constant,
-/// e.g. `ELIZA_SERVICE_SAY_CLIENT_SPEC` for `ElizaService.Say`.
+/// `{SERVICE}_{METHOD}_CLIENT_SPEC`, the client-side constant.
 fn method_client_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) -> Ident {
-    let service_name = service.name.as_deref().unwrap_or("");
-    format_ident!(
-        "{}_{}_CLIENT_SPEC",
-        service_name.to_snake_case().to_uppercase(),
-        method_name.to_snake_case().to_uppercase()
-    )
+    method_const_ident(service, method_name, "CLIENT_SPEC")
 }
 
-/// Fail generation when two module-scope constants of one service would get
-/// the same identifier.
-///
-/// The per-method constants are `{SVC}_{METHOD}_SPEC` (server) and
-/// `{SVC}_{METHOD}_CLIENT_SPEC` (client), next to `{SVC}_SERVICE_NAME`.
-/// Because method names are snake-cased and upper-cased, distinct proto
-/// methods can collapse to one identifier: `Get` + `GetClient` both yield
-/// `X_GET_CLIENT_SPEC`; `FooBar` + `Foo_Bar` both yield `X_FOO_BAR_SPEC`.
-/// Without this check the consumer crate fails with an E0428 that points at
-/// generated code, not at the proto. The error names both colliding items.
-fn check_module_const_collisions(
-    service: &ServiceDescriptorProto,
-    service_name_const: &Ident,
-) -> Result<()> {
-    let mut seen: HashMap<String, String> = HashMap::new();
-    seen.insert(
-        service_name_const.to_string(),
-        "the service-name constant".to_owned(),
-    );
-    for m in &service.method {
-        let method_name = m.name.as_deref().unwrap_or("");
-        for (ident, what) in [
-            (
-                method_spec_const_ident(service, method_name),
-                "server Spec constant",
-            ),
-            (
-                method_client_spec_const_ident(service, method_name),
-                "client Spec constant",
-            ),
-        ] {
-            let owner = format!("the {what} for method `{method_name}`");
-            if let Some(prev) = seen.insert(ident.to_string(), owner.clone()) {
-                anyhow::bail!(
-                    "service `{}`: generated constant `{ident}` would be emitted twice \
-                     ({prev}, and {owner}); rename one of the methods",
-                    service.name.as_deref().unwrap_or("")
-                );
-            }
-        }
-    }
-    Ok(())
-}
-
-/// The descriptor-derived arguments of a method's `Spec`, as tokens. Shared
-/// by the server and client constant emitters so the two can never disagree.
-struct MethodSpecParts {
-    /// `"/package.Service/Method"` literal.
-    procedure: String,
-    /// `::connectrpc::StreamType::…` path.
-    stream_type: TokenStream,
-    /// `::connectrpc::IdempotencyLevel::…` path.
-    idempotency_level: TokenStream,
-}
-
-fn method_spec_parts(full_service_name: &str, m: &MethodDescriptorProto) -> MethodSpecParts {
-    let method_name = m.name.as_deref().unwrap_or("");
-    let procedure = format!("/{full_service_name}/{method_name}");
-    let cs = m.client_streaming.unwrap_or(false);
-    let ss = m.server_streaming.unwrap_or(false);
-    let stream_type = match (cs, ss) {
-        (true, true) => quote! { ::connectrpc::StreamType::BidiStream },
-        (true, false) => quote! { ::connectrpc::StreamType::ClientStream },
-        (false, true) => quote! { ::connectrpc::StreamType::ServerStream },
-        (false, false) => quote! { ::connectrpc::StreamType::Unary },
-    };
-    let idempotency_level = match m.options.idempotency_level {
-        Some(IdempotencyLevel::NO_SIDE_EFFECTS) => {
-            quote! { ::connectrpc::IdempotencyLevel::NoSideEffects }
-        }
-        Some(IdempotencyLevel::IDEMPOTENT) => {
-            quote! { ::connectrpc::IdempotencyLevel::Idempotent }
-        }
-        _ => quote! { ::connectrpc::IdempotencyLevel::Unknown },
-    };
-    MethodSpecParts {
-        procedure,
-        stream_type,
-        idempotency_level,
-    }
-}
-
-/// Emit one server-side `pub const … : ::connectrpc::Spec` per method.
-///
-/// Each constant captures the method's procedure path, stream type, and
-/// idempotency level. Constructed via `Spec::server(...)` so
-/// `Spec::origin == SpecOrigin::Server`. Referenced by the generated
-/// `Dispatcher::lookup` impl and stable public API for user code. The
-/// client siblings come from [`generate_client_spec_consts`].
+/// Emit the per-method `pub const … : ::connectrpc::Spec` pair: the
+/// server-side `{SVC}_{METHOD}_SPEC` (`Spec::server`, referenced by the
+/// generated `Dispatcher::lookup`) and its client sibling
+/// `{SVC}_{METHOD}_CLIENT_SPEC` (`Spec::client`, passed by generated client
+/// methods to `::connectrpc::client::call_*` and carrying `client_cfg_attr`
+/// like every other client item). Both are built from the same descriptor
+/// facts in one place so they cannot disagree.
 fn generate_spec_consts(
-    full_service_name: &str,
-    service: &ServiceDescriptorProto,
-) -> Vec<TokenStream> {
-    service
-        .method
-        .iter()
-        .map(|m| {
-            let method_name = m.name.as_deref().unwrap_or("");
-            let spec_const = method_spec_const_ident(service, method_name);
-            let client_const = method_client_spec_const_ident(service, method_name);
-            let MethodSpecParts {
-                procedure,
-                stream_type,
-                idempotency_level,
-            } = method_spec_parts(full_service_name, m);
-            let doc = format!(
-                "Static [`Spec`](::connectrpc::Spec) for the server-side `{method_name}` RPC.\n\n\
-                 The dispatcher surfaces this on\n\
-                 [`RequestContext::spec`](::connectrpc::RequestContext::spec).\n\n\
-                 Client sibling: `{client_const}`. The two are not `==` (their\n\
-                 [`origin`](::connectrpc::Spec::origin) differs); use\n\
-                 [`Spec::same_method`](::connectrpc::Spec::same_method) or compare\n\
-                 `procedure` to match this method on either side."
-            );
-            let doc_tokens = doc_attrs(&doc);
-            quote! {
-                #doc_tokens
-                pub const #spec_const: ::connectrpc::Spec =
-                    ::connectrpc::Spec::server(#procedure, #stream_type)
-                        .with_idempotency_level(#idempotency_level);
-            }
-        })
-        .collect()
-}
-
-/// Emit one client-side `pub const … : ::connectrpc::Spec` per method.
-///
-/// Same descriptor facts as [`generate_spec_consts`], constructed via
-/// `Spec::client(...)` so `Spec::origin == SpecOrigin::Client`. Generated
-/// client methods pass these to `::connectrpc::client::call_*`; user code
-/// can compare against them in a client-side interceptor. Each constant
-/// carries `client_cfg_attr` (empty unless `gate_client_feature` is set),
-/// like every other client-side item.
-fn generate_client_spec_consts(
     full_service_name: &str,
     service: &ServiceDescriptorProto,
     client_cfg_attr: &TokenStream,
@@ -1941,27 +1815,50 @@ fn generate_client_spec_consts(
         .iter()
         .map(|m| {
             let method_name = m.name.as_deref().unwrap_or("");
-            let spec_const = method_client_spec_const_ident(service, method_name);
             let server_const = method_spec_const_ident(service, method_name);
-            let MethodSpecParts {
-                procedure,
-                stream_type,
-                idempotency_level,
-            } = method_spec_parts(full_service_name, m);
-            let doc = format!(
-                "Static [`Spec`](::connectrpc::Spec) for the client-side `{method_name}` RPC.\n\n\
-                 The generated client passes this to the runtime, so it is the value a\n\
-                 client-side interceptor observes. It differs from the server-side\n\
-                 `{server_const}` only in [`origin`](::connectrpc::Spec::origin),\n\
-                 so the two are **not** `==`; use\n\
+            let client_const = method_client_spec_const_ident(service, method_name);
+            let procedure = format!("/{full_service_name}/{method_name}");
+            let cs = m.client_streaming.unwrap_or(false);
+            let ss = m.server_streaming.unwrap_or(false);
+            let stream_type = match (cs, ss) {
+                (true, true) => quote! { ::connectrpc::StreamType::BidiStream },
+                (true, false) => quote! { ::connectrpc::StreamType::ClientStream },
+                (false, true) => quote! { ::connectrpc::StreamType::ServerStream },
+                (false, false) => quote! { ::connectrpc::StreamType::Unary },
+            };
+            let idempotency_level = match m.options.idempotency_level {
+                Some(IdempotencyLevel::NO_SIDE_EFFECTS) => {
+                    quote! { ::connectrpc::IdempotencyLevel::NoSideEffects }
+                }
+                Some(IdempotencyLevel::IDEMPOTENT) => {
+                    quote! { ::connectrpc::IdempotencyLevel::Idempotent }
+                }
+                _ => quote! { ::connectrpc::IdempotencyLevel::Unknown },
+            };
+            let server_doc = doc_attrs(&format!(
+                "Static [`Spec`](::connectrpc::Spec) for the server-side `{method_name}` RPC.\n\n\
+                 The dispatcher surfaces this on\n\
+                 [`RequestContext::spec`](::connectrpc::RequestContext::spec).\n\n\
+                 Client sibling: `{client_const}`. The two are not `==` (their\n\
+                 [`origin`](::connectrpc::Spec::origin) differs); use\n\
                  [`Spec::same_method`](::connectrpc::Spec::same_method) or compare\n\
-                 `procedure` to match this method regardless of side."
-            );
-            let doc_tokens = doc_attrs(&doc);
+                 `procedure` to match this method on either side."
+            ));
+            let client_doc = doc_attrs(&format!(
+                "Client-side sibling of `{server_const}` (same method,\n\
+                 [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):\n\
+                 what generated client methods pass to the runtime and what a\n\
+                 client-side interceptor observes."
+            ));
             quote! {
-                #doc_tokens
+                #server_doc
+                pub const #server_const: ::connectrpc::Spec =
+                    ::connectrpc::Spec::server(#procedure, #stream_type)
+                        .with_idempotency_level(#idempotency_level);
+
+                #client_doc
                 #client_cfg_attr
-                pub const #spec_const: ::connectrpc::Spec =
+                pub const #client_const: ::connectrpc::Spec =
                     ::connectrpc::Spec::client(#procedure, #stream_type)
                         .with_idempotency_level(#idempotency_level);
             }
@@ -2381,7 +2278,7 @@ fn generate_client_method(
 ) -> Result<TokenStream> {
     let method_name = method.name.as_deref().unwrap_or("");
     // The module-scope `*_CLIENT_SPEC` constant this method passes to the
-    // runtime (see `generate_client_spec_consts`).
+    // runtime (see `generate_spec_consts`).
     let spec_const = method_client_spec_const_ident(service, method_name);
     let method_snake = make_field_ident(&method_name.to_snake_case());
     let method_with_opts = format_ident!("{}_with_options", method_name.to_snake_case());
@@ -5082,8 +4979,9 @@ mod tests {
             "ECHO_SERVICE_SAY_SPEC"
         );
 
-        let consts = generate_spec_consts("pkg.EchoService", &service);
-        assert_eq!(consts.len(), 4, "one const per method");
+        let gate = quote! { #[cfg(feature = "client")] };
+        let consts = generate_spec_consts("pkg.EchoService", &service, &gate);
+        assert_eq!(consts.len(), 4, "one server+client pair per method");
 
         let render = |ts: &TokenStream| {
             let file = syn::parse2::<syn::File>(ts.clone()).expect("const should parse");
@@ -5094,6 +4992,30 @@ mod tests {
         assert!(say.contains(r#""/pkg.EchoService/Say""#), "{say}");
         assert!(say.contains("StreamType::Unary"), "{say}");
         assert!(say.contains("IdempotencyLevel::NoSideEffects"), "{say}");
+        // The client sibling rides in the same block: `_CLIENT_SPEC` name,
+        // `Spec::client`, and the gate attribute on the client item only.
+        assert_eq!(
+            method_client_spec_const_ident(&service, "Say").to_string(),
+            "ECHO_SERVICE_SAY_CLIENT_SPEC"
+        );
+        assert!(
+            say.contains("pub const ECHO_SERVICE_SAY_CLIENT_SPEC"),
+            "{say}"
+        );
+        assert!(say.contains("Spec::client("), "{say}");
+        assert_eq!(
+            say.matches("#[cfg(feature = \"client\")]").count(),
+            1,
+            "{say}"
+        );
+        let cfg_at = say.find("#[cfg(").unwrap();
+        assert!(
+            cfg_at > say.find("ECHO_SERVICE_SAY_SPEC").unwrap(),
+            "gate is on the client const: {say}"
+        );
+        let ungated =
+            render(&generate_spec_consts("pkg.EchoService", &service, &TokenStream::new())[0]);
+        assert!(!ungated.contains("#[cfg("), "{ungated}");
 
         let subscribe = render(&consts[1]);
         assert!(
@@ -5111,46 +5033,11 @@ mod tests {
 
         let chat = render(&consts[3]);
         assert!(chat.contains("StreamType::BidiStream"), "{chat}");
-
-        // Client siblings: same facts, `Spec::client`, `_CLIENT_SPEC` name,
-        // and the gate attribute passed in lands on the item itself.
-        assert_eq!(
-            method_client_spec_const_ident(&service, "Say").to_string(),
-            "ECHO_SERVICE_SAY_CLIENT_SPEC"
-        );
-        let gate = quote! { #[cfg(feature = "client")] };
-        let client_consts = generate_client_spec_consts("pkg.EchoService", &service, &gate);
-        assert_eq!(client_consts.len(), 4, "one client const per method");
-        let say = render(&client_consts[0]);
-        assert!(
-            say.contains("pub const ECHO_SERVICE_SAY_CLIENT_SPEC"),
-            "{say}"
-        );
-        assert!(say.contains("Spec::client("), "{say}");
-        assert!(say.contains(r#""/pkg.EchoService/Say""#), "{say}");
-        assert!(say.contains("StreamType::Unary"), "{say}");
-        assert!(say.contains("IdempotencyLevel::NoSideEffects"), "{say}");
-        assert!(say.contains("#[cfg(feature = \"client\")]"), "{say}");
-        let subscribe = render(&client_consts[1]);
-        assert!(
-            subscribe.contains("StreamType::ServerStream"),
-            "{subscribe}"
-        );
-        assert!(
-            subscribe.contains("IdempotencyLevel::Idempotent"),
-            "{subscribe}"
-        );
-        assert!(render(&client_consts[2]).contains("StreamType::ClientStream"));
-        assert!(render(&client_consts[3]).contains("StreamType::BidiStream"));
-        // Ungated emission carries no cfg attr.
-        let ungated = generate_client_spec_consts("pkg.EchoService", &service, &TokenStream::new());
-        assert!(!render(&ungated[0]).contains("#[cfg("));
     }
 
-    /// Two proto methods whose generated constant identifiers coincide
-    /// (`Get`'s client const and `GetClient`'s server const are both
-    /// `X_GET_CLIENT_SPEC`) fail generation with an error naming both,
-    /// instead of emitting a module the consumer cannot compile.
+    /// `Get` + `GetClient` would both produce `X_GET_CLIENT_SPEC` (one's
+    /// client const, the other's server const); generation fails naming
+    /// both methods instead of emitting a module the consumer cannot compile.
     #[test]
     fn colliding_spec_const_names_are_rejected() {
         let m = |name: &str| MethodDescriptorProto {
@@ -5164,31 +5051,22 @@ mod tests {
             method: vec![m("Get"), m("GetClient")],
             ..Default::default()
         };
-        let err = check_module_const_collisions(&service, &format_ident!("X_SERVICE_NAME"))
-            .expect_err("Get + GetClient collide on X_GET_CLIENT_SPEC");
-        let msg = err.to_string();
-        assert!(msg.contains("X_GET_CLIENT_SPEC"), "{msg}");
+        let msg = check_method_collisions("X", &service)
+            .expect_err("Get + GetClient collide on get_client_spec")
+            .to_string();
+        assert!(msg.contains("get_client_spec"), "{msg}");
         assert!(
-            msg.contains("`Get`") && msg.contains("`GetClient`"),
+            msg.contains("\"Get\"") && msg.contains("\"GetClient\""),
             "{msg}"
         );
 
-        // The pre-existing server-only hazard is covered too: distinct proto
-        // names that snake/upper-case to one identifier.
-        let service = ServiceDescriptorProto {
-            name: Some("X".into()),
-            method: vec![m("FooBar"), m("Foo_Bar")],
-            ..Default::default()
-        };
-        assert!(check_module_const_collisions(&service, &format_ident!("X_SERVICE_NAME")).is_err());
-
-        // And the ordinary case passes.
+        // The ordinary case, including a method literally named `Client`, passes.
         let service = ServiceDescriptorProto {
             name: Some("X".into()),
             method: vec![m("Get"), m("Put"), m("Client")],
             ..Default::default()
         };
-        check_module_const_collisions(&service, &format_ident!("X_SERVICE_NAME")).unwrap();
+        check_method_collisions("X", &service).unwrap();
     }
 
     /// Generated client methods identify the RPC to the runtime by the

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1570,15 +1570,7 @@ fn generate_service(
     let client_methods: Vec<TokenStream> = service
         .method
         .iter()
-        .map(|m| {
-            generate_client_method(
-                &service_name_const,
-                &full_service_name,
-                m,
-                resolver,
-                package,
-            )
-        })
+        .map(|m| generate_client_method(service, &full_service_name, m, resolver, package))
         .collect::<Result<Vec<_>>>()?;
 
     // Generate monomorphic FooServiceServer<T> dispatcher.
@@ -1677,8 +1669,13 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
 
     // Per-method `Spec` constants. Stable, allocation-free metadata that the
     // dispatcher threads into `RequestContext::spec` and that user code can
-    // reference directly (e.g. for tracing labels or routing tables).
+    // reference directly (e.g. for tracing labels or routing tables). The
+    // client siblings are what generated client methods pass to `call_*`;
+    // they are gated with the client feature like every other client item.
+    check_module_const_collisions(service, &service_name_const)?;
     let spec_consts = generate_spec_consts(&full_service_name, service);
+    let client_spec_consts =
+        generate_client_spec_consts(&full_service_name, service, &client_cfg_attr);
 
     Ok(quote! {
         // -----------------------------------------------------------------------------
@@ -1689,6 +1686,8 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
         pub const #service_name_const: &str = #full_service_name;
 
         #(#spec_consts)*
+
+        #(#client_spec_consts)*
 
         #service_doc_tokens
         #[allow(clippy::type_complexity)]
@@ -1774,12 +1773,11 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
     })
 }
 
-/// Construct the identifier for a per-method `Spec` constant.
+/// Construct the identifier for a per-method server-side `Spec` constant.
 ///
 /// The name is derived from the service and method names, e.g.
-/// `ELIZA_SERVICE_SAY_SPEC` for `ElizaService.Say`. Lives at module scope so
-/// both the server dispatcher and (later) the generated client can reference
-/// the same constant.
+/// `ELIZA_SERVICE_SAY_SPEC` for `ElizaService.Say`. Lives at module scope;
+/// the client sibling is [`method_client_spec_const_ident`].
 fn method_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) -> Ident {
     let service_name = service.name.as_deref().unwrap_or("");
     format_ident!(
@@ -1789,14 +1787,106 @@ fn method_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) 
     )
 }
 
-/// Emit one `pub const … : ::connectrpc::Spec` per method.
+/// Construct the identifier for a per-method client-side `Spec` constant,
+/// e.g. `ELIZA_SERVICE_SAY_CLIENT_SPEC` for `ElizaService.Say`.
+fn method_client_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) -> Ident {
+    let service_name = service.name.as_deref().unwrap_or("");
+    format_ident!(
+        "{}_{}_CLIENT_SPEC",
+        service_name.to_snake_case().to_uppercase(),
+        method_name.to_snake_case().to_uppercase()
+    )
+}
+
+/// Fail generation when two module-scope constants of one service would get
+/// the same identifier.
+///
+/// The per-method constants are `{SVC}_{METHOD}_SPEC` (server) and
+/// `{SVC}_{METHOD}_CLIENT_SPEC` (client), next to `{SVC}_SERVICE_NAME`.
+/// Because method names are snake-cased and upper-cased, distinct proto
+/// methods can collapse to one identifier: `Get` + `GetClient` both yield
+/// `X_GET_CLIENT_SPEC`; `FooBar` + `Foo_Bar` both yield `X_FOO_BAR_SPEC`.
+/// Without this check the consumer crate fails with an E0428 that points at
+/// generated code, not at the proto. The error names both colliding items.
+fn check_module_const_collisions(
+    service: &ServiceDescriptorProto,
+    service_name_const: &Ident,
+) -> Result<()> {
+    let mut seen: HashMap<String, String> = HashMap::new();
+    seen.insert(
+        service_name_const.to_string(),
+        "the service-name constant".to_owned(),
+    );
+    for m in &service.method {
+        let method_name = m.name.as_deref().unwrap_or("");
+        for (ident, what) in [
+            (
+                method_spec_const_ident(service, method_name),
+                "server Spec constant",
+            ),
+            (
+                method_client_spec_const_ident(service, method_name),
+                "client Spec constant",
+            ),
+        ] {
+            let owner = format!("the {what} for method `{method_name}`");
+            if let Some(prev) = seen.insert(ident.to_string(), owner.clone()) {
+                anyhow::bail!(
+                    "service `{}`: generated constant `{ident}` would be emitted twice \
+                     ({prev}, and {owner}); rename one of the methods",
+                    service.name.as_deref().unwrap_or("")
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The descriptor-derived arguments of a method's `Spec`, as tokens. Shared
+/// by the server and client constant emitters so the two can never disagree.
+struct MethodSpecParts {
+    /// `"/package.Service/Method"` literal.
+    procedure: String,
+    /// `::connectrpc::StreamType::…` path.
+    stream_type: TokenStream,
+    /// `::connectrpc::IdempotencyLevel::…` path.
+    idempotency_level: TokenStream,
+}
+
+fn method_spec_parts(full_service_name: &str, m: &MethodDescriptorProto) -> MethodSpecParts {
+    let method_name = m.name.as_deref().unwrap_or("");
+    let procedure = format!("/{full_service_name}/{method_name}");
+    let cs = m.client_streaming.unwrap_or(false);
+    let ss = m.server_streaming.unwrap_or(false);
+    let stream_type = match (cs, ss) {
+        (true, true) => quote! { ::connectrpc::StreamType::BidiStream },
+        (true, false) => quote! { ::connectrpc::StreamType::ClientStream },
+        (false, true) => quote! { ::connectrpc::StreamType::ServerStream },
+        (false, false) => quote! { ::connectrpc::StreamType::Unary },
+    };
+    let idempotency_level = match m.options.idempotency_level {
+        Some(IdempotencyLevel::NO_SIDE_EFFECTS) => {
+            quote! { ::connectrpc::IdempotencyLevel::NoSideEffects }
+        }
+        Some(IdempotencyLevel::IDEMPOTENT) => {
+            quote! { ::connectrpc::IdempotencyLevel::Idempotent }
+        }
+        _ => quote! { ::connectrpc::IdempotencyLevel::Unknown },
+    };
+    MethodSpecParts {
+        procedure,
+        stream_type,
+        idempotency_level,
+    }
+}
+
+/// Emit one server-side `pub const … : ::connectrpc::Spec` per method.
 ///
 /// Each constant captures the method's procedure path, stream type, and
 /// idempotency level. Constructed via `Spec::server(...)` so
-/// `Spec::origin == SpecOrigin::Server`; a future generated client will
-/// emit a sibling constant via `Spec::client(...)`. The constants are
-/// referenced by the generated `Dispatcher::lookup` impl and are also
-/// stable public API for user code.
+/// `Spec::origin == SpecOrigin::Server`. Referenced by the generated
+/// `Dispatcher::lookup` impl and stable public API for user code. The
+/// client siblings come from [`generate_client_spec_consts`].
 fn generate_spec_consts(
     full_service_name: &str,
     service: &ServiceDescriptorProto,
@@ -1807,34 +1897,72 @@ fn generate_spec_consts(
         .map(|m| {
             let method_name = m.name.as_deref().unwrap_or("");
             let spec_const = method_spec_const_ident(service, method_name);
-            let procedure = format!("/{full_service_name}/{method_name}");
-            let cs = m.client_streaming.unwrap_or(false);
-            let ss = m.server_streaming.unwrap_or(false);
-            let stream_type = match (cs, ss) {
-                (true, true) => quote! { ::connectrpc::StreamType::BidiStream },
-                (true, false) => quote! { ::connectrpc::StreamType::ClientStream },
-                (false, true) => quote! { ::connectrpc::StreamType::ServerStream },
-                (false, false) => quote! { ::connectrpc::StreamType::Unary },
-            };
-            let idempotency_level = match m.options.idempotency_level {
-                Some(IdempotencyLevel::NO_SIDE_EFFECTS) => {
-                    quote! { ::connectrpc::IdempotencyLevel::NoSideEffects }
-                }
-                Some(IdempotencyLevel::IDEMPOTENT) => {
-                    quote! { ::connectrpc::IdempotencyLevel::Idempotent }
-                }
-                _ => quote! { ::connectrpc::IdempotencyLevel::Unknown },
-            };
+            let client_const = method_client_spec_const_ident(service, method_name);
+            let MethodSpecParts {
+                procedure,
+                stream_type,
+                idempotency_level,
+            } = method_spec_parts(full_service_name, m);
             let doc = format!(
                 "Static [`Spec`](::connectrpc::Spec) for the server-side `{method_name}` RPC.\n\n\
                  The dispatcher surfaces this on\n\
-                 [`RequestContext::spec`](::connectrpc::RequestContext::spec)."
+                 [`RequestContext::spec`](::connectrpc::RequestContext::spec).\n\n\
+                 Client sibling: `{client_const}`. The two are not `==` (their\n\
+                 [`origin`](::connectrpc::Spec::origin) differs); use\n\
+                 [`Spec::same_method`](::connectrpc::Spec::same_method) or compare\n\
+                 `procedure` to match this method on either side."
             );
             let doc_tokens = doc_attrs(&doc);
             quote! {
                 #doc_tokens
                 pub const #spec_const: ::connectrpc::Spec =
                     ::connectrpc::Spec::server(#procedure, #stream_type)
+                        .with_idempotency_level(#idempotency_level);
+            }
+        })
+        .collect()
+}
+
+/// Emit one client-side `pub const … : ::connectrpc::Spec` per method.
+///
+/// Same descriptor facts as [`generate_spec_consts`], constructed via
+/// `Spec::client(...)` so `Spec::origin == SpecOrigin::Client`. Generated
+/// client methods pass these to `::connectrpc::client::call_*`; user code
+/// can compare against them in a client-side interceptor. Each constant
+/// carries `client_cfg_attr` (empty unless `gate_client_feature` is set),
+/// like every other client-side item.
+fn generate_client_spec_consts(
+    full_service_name: &str,
+    service: &ServiceDescriptorProto,
+    client_cfg_attr: &TokenStream,
+) -> Vec<TokenStream> {
+    service
+        .method
+        .iter()
+        .map(|m| {
+            let method_name = m.name.as_deref().unwrap_or("");
+            let spec_const = method_client_spec_const_ident(service, method_name);
+            let server_const = method_spec_const_ident(service, method_name);
+            let MethodSpecParts {
+                procedure,
+                stream_type,
+                idempotency_level,
+            } = method_spec_parts(full_service_name, m);
+            let doc = format!(
+                "Static [`Spec`](::connectrpc::Spec) for the client-side `{method_name}` RPC.\n\n\
+                 The generated client passes this to the runtime, so it is the value a\n\
+                 client-side interceptor observes. It differs from the server-side\n\
+                 `{server_const}` only in [`origin`](::connectrpc::Spec::origin),\n\
+                 so the two are **not** `==`; use\n\
+                 [`Spec::same_method`](::connectrpc::Spec::same_method) or compare\n\
+                 `procedure` to match this method regardless of side."
+            );
+            let doc_tokens = doc_attrs(&doc);
+            quote! {
+                #doc_tokens
+                #client_cfg_attr
+                pub const #spec_const: ::connectrpc::Spec =
+                    ::connectrpc::Spec::client(#procedure, #stream_type)
                         .with_idempotency_level(#idempotency_level);
             }
         })
@@ -2245,13 +2373,16 @@ fn generate_trait_method(
 /// ClientConfig defaults, so the no-options variant still picks up any
 /// client-wide defaults the user configured.
 fn generate_client_method(
-    service_name_const: &Ident,
+    service: &ServiceDescriptorProto,
     full_service_name: &str,
     method: &MethodDescriptorProto,
     resolver: &TypeResolver<'_>,
     package: &str,
 ) -> Result<TokenStream> {
     let method_name = method.name.as_deref().unwrap_or("");
+    // The module-scope `*_CLIENT_SPEC` constant this method passes to the
+    // runtime (see `generate_client_spec_consts`).
+    let spec_const = method_client_spec_const_ident(service, method_name);
     let method_snake = make_field_ident(&method_name.to_snake_case());
     let method_with_opts = format_ident!("{}_with_options", method_name.to_snake_case());
     let input_type = resolver.rust_type(method.input_type.as_deref().unwrap_or(""), package)?;
@@ -2304,7 +2435,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_client_stream(
                 &self.transport, &self.config,
-                #service_name_const, #method_name,
+                #spec_const,
                 requests, options,
             ).await
         };
@@ -2325,7 +2456,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_bidi_stream(
                 &self.transport, &self.config,
-                #service_name_const, #method_name, options,
+                #spec_const, options,
             ).await
         };
         short_args = quote! {};
@@ -2342,7 +2473,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_server_stream(
                 &self.transport, &self.config,
-                #service_name_const, #method_name,
+                #spec_const,
                 request, options,
             ).await
         };
@@ -2360,7 +2491,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_unary(
                 &self.transport, &self.config,
-                #service_name_const, #method_name,
+                #spec_const,
                 request, options,
             ).await
         };
@@ -3875,16 +4006,21 @@ mod tests {
     #[test]
     fn client_items_gated_when_opt_in() {
         // When `gate_client_feature` is set, the `FooClient` struct +
-        // impl carry `#[cfg(feature = "client")]`. Exactly two attrs:
-        // one on the struct, one on the impl block. (All `_with_options`
-        // methods live inside the impl and inherit the gate.)
+        // impl carry `#[cfg(feature = "client")]`, and so does each
+        // per-method `*_CLIENT_SPEC` constant. The minimal service has one
+        // method: struct + impl + one const = three attrs. (All
+        // `_with_options` methods live inside the impl and inherit the gate.)
         let out = format_minimal_service(true);
         let cfg_count = out.matches("#[cfg(feature = \"client\")]").count();
         assert_eq!(
-            cfg_count, 2,
-            "expected exactly two #[cfg(feature = \"client\")] attrs (one on \
-             `pub struct PingServiceClient`, one on its `impl<T>` block); got \
-             {cfg_count}:\n{out}"
+            cfg_count, 3,
+            "expected exactly three #[cfg(feature = \"client\")] attrs (struct \
+             `PingServiceClient`, its `impl<T>` block, `PING_SERVICE_PING_CLIENT_SPEC`); \
+             got {cfg_count}:\n{out}"
+        );
+        assert!(
+            out.contains("#[cfg(feature = \"client\")]\npub const PING_SERVICE_PING_CLIENT_SPEC"),
+            "the client Spec const must carry the gate directly:\n{out}"
         );
     }
 
@@ -3893,10 +4029,10 @@ mod tests {
         let out = format_minimal_service_with_client_feature_name(true, "grpc-client");
         let cfg_count = out.matches("#[cfg(feature = \"grpc-client\")]").count();
         assert_eq!(
-            cfg_count, 2,
-            "expected exactly two #[cfg(feature = \"grpc-client\")] attrs \
-             (one on `pub struct PingServiceClient`, one on its `impl<T>` \
-             block); got {cfg_count}:\n{out}"
+            cfg_count, 3,
+            "expected exactly three #[cfg(feature = \"grpc-client\")] attrs \
+             (struct `PingServiceClient`, its `impl<T>` block, the one \
+             `*_CLIENT_SPEC` const); got {cfg_count}:\n{out}"
         );
         assert!(
             !out.contains("#[cfg(feature = \"client\")]"),
@@ -4260,9 +4396,9 @@ mod tests {
         let out = format_token_stream(&ts).unwrap();
         let cfg_count = out.matches("#[cfg(feature = \"client\")]").count();
         assert_eq!(
-            cfg_count, 4,
-            "expected 4 client cfg attrs (2 per service * 2 services); got \
-             {cfg_count}:\n{out}"
+            cfg_count, 6,
+            "expected 6 client cfg attrs (struct + impl + 1 method const, per \
+             service, * 2 services); got {cfg_count}:\n{out}"
         );
         // Both client structs are present, both gated.
         for client_struct in ["pub struct AlphaClient", "pub struct BetaClient"] {
@@ -4315,9 +4451,9 @@ mod tests {
         let content = connect_file.content.as_deref().unwrap_or_default();
         let cfg_count = content.matches("#[cfg(feature = \"grpc-client\")]").count();
         assert_eq!(
-            cfg_count, 2,
-            "expected custom feature gate on generated client struct and impl; got \
-             {cfg_count}:\n{content}"
+            cfg_count, 3,
+            "expected custom feature gate on generated client struct, impl, and the \
+             one `*_CLIENT_SPEC` const; got {cfg_count}:\n{content}"
         );
         assert!(
             !content.contains("#[cfg(feature = \"client\")]"),
@@ -4975,6 +5111,108 @@ mod tests {
 
         let chat = render(&consts[3]);
         assert!(chat.contains("StreamType::BidiStream"), "{chat}");
+
+        // Client siblings: same facts, `Spec::client`, `_CLIENT_SPEC` name,
+        // and the gate attribute passed in lands on the item itself.
+        assert_eq!(
+            method_client_spec_const_ident(&service, "Say").to_string(),
+            "ECHO_SERVICE_SAY_CLIENT_SPEC"
+        );
+        let gate = quote! { #[cfg(feature = "client")] };
+        let client_consts = generate_client_spec_consts("pkg.EchoService", &service, &gate);
+        assert_eq!(client_consts.len(), 4, "one client const per method");
+        let say = render(&client_consts[0]);
+        assert!(
+            say.contains("pub const ECHO_SERVICE_SAY_CLIENT_SPEC"),
+            "{say}"
+        );
+        assert!(say.contains("Spec::client("), "{say}");
+        assert!(say.contains(r#""/pkg.EchoService/Say""#), "{say}");
+        assert!(say.contains("StreamType::Unary"), "{say}");
+        assert!(say.contains("IdempotencyLevel::NoSideEffects"), "{say}");
+        assert!(say.contains("#[cfg(feature = \"client\")]"), "{say}");
+        let subscribe = render(&client_consts[1]);
+        assert!(
+            subscribe.contains("StreamType::ServerStream"),
+            "{subscribe}"
+        );
+        assert!(
+            subscribe.contains("IdempotencyLevel::Idempotent"),
+            "{subscribe}"
+        );
+        assert!(render(&client_consts[2]).contains("StreamType::ClientStream"));
+        assert!(render(&client_consts[3]).contains("StreamType::BidiStream"));
+        // Ungated emission carries no cfg attr.
+        let ungated = generate_client_spec_consts("pkg.EchoService", &service, &TokenStream::new());
+        assert!(!render(&ungated[0]).contains("#[cfg("));
+    }
+
+    /// Two proto methods whose generated constant identifiers coincide
+    /// (`Get`'s client const and `GetClient`'s server const are both
+    /// `X_GET_CLIENT_SPEC`) fail generation with an error naming both,
+    /// instead of emitting a module the consumer cannot compile.
+    #[test]
+    fn colliding_spec_const_names_are_rejected() {
+        let m = |name: &str| MethodDescriptorProto {
+            name: Some(name.into()),
+            input_type: Some(".pkg.Req".into()),
+            output_type: Some(".pkg.Resp".into()),
+            ..Default::default()
+        };
+        let service = ServiceDescriptorProto {
+            name: Some("X".into()),
+            method: vec![m("Get"), m("GetClient")],
+            ..Default::default()
+        };
+        let err = check_module_const_collisions(&service, &format_ident!("X_SERVICE_NAME"))
+            .expect_err("Get + GetClient collide on X_GET_CLIENT_SPEC");
+        let msg = err.to_string();
+        assert!(msg.contains("X_GET_CLIENT_SPEC"), "{msg}");
+        assert!(
+            msg.contains("`Get`") && msg.contains("`GetClient`"),
+            "{msg}"
+        );
+
+        // The pre-existing server-only hazard is covered too: distinct proto
+        // names that snake/upper-case to one identifier.
+        let service = ServiceDescriptorProto {
+            name: Some("X".into()),
+            method: vec![m("FooBar"), m("Foo_Bar")],
+            ..Default::default()
+        };
+        assert!(check_module_const_collisions(&service, &format_ident!("X_SERVICE_NAME")).is_err());
+
+        // And the ordinary case passes.
+        let service = ServiceDescriptorProto {
+            name: Some("X".into()),
+            method: vec![m("Get"), m("Put"), m("Client")],
+            ..Default::default()
+        };
+        check_module_const_collisions(&service, &format_ident!("X_SERVICE_NAME")).unwrap();
+    }
+
+    /// Generated client methods identify the RPC to the runtime by the
+    /// module-scope `*_CLIENT_SPEC` constant, not by service/method strings.
+    #[test]
+    fn client_methods_pass_client_spec_const() {
+        let out = format_minimal_service(false);
+        assert!(
+            out.contains("pub const PING_SERVICE_PING_CLIENT_SPEC: ::connectrpc::Spec"),
+            "{out}"
+        );
+        // The unary call site: transport, config, then the const.
+        let call = out
+            .find("::connectrpc::client::call_unary(")
+            .expect("minimal service has a unary client method");
+        let window = &out[call..(call + 200).min(out.len())];
+        assert!(
+            window.contains("PING_SERVICE_PING_CLIENT_SPEC"),
+            "call_unary must receive the client Spec const:\n{window}"
+        );
+        assert!(
+            !window.contains("PING_SERVICE_SERVICE_NAME"),
+            "the (service, method) string pair is gone from client call sites:\n{window}"
+        );
     }
 
     #[test]

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1303,13 +1303,12 @@ fn generate_all_message_encodable_impls(
 /// Reject RPC method sets whose generated Rust identifiers collide.
 ///
 /// Each proto method `Foo` produces `foo` and `foo_with_options` on the
-/// client and the module-scope constants `{SVC}_FOO_SPEC` /
-/// `{SVC}_FOO_CLIENT_SPEC`. Two methods that normalize to the same
-/// snake_case name (e.g. `GetFoo` and `get_foo`), or one whose snake form
-/// equals another's plus a generated suffix (`Get` + `GetWithOptions`;
-/// `Get` + `GetClient`, whose client and server `Spec` constants are both
-/// `{SVC}_GET_CLIENT_SPEC`), would emit duplicate definitions and fail to
-/// compile with an error pointing at generated code rather than the proto.
+/// client and the module-scope constant `{SVC}_FOO_SPEC`. Two methods that
+/// normalize to the same snake_case name (e.g. `GetFoo` and `get_foo`), or
+/// one whose snake form equals another's plus a generated suffix (`Get` +
+/// `GetWithOptions`; `Get` + `GetSpec`), would emit duplicate definitions
+/// and fail to compile with an error pointing at generated code rather than
+/// the proto.
 fn check_method_collisions(service_name: &str, service: &ServiceDescriptorProto) -> Result<()> {
     let mut seen: HashMap<String, String> = HashMap::new();
     for m in &service.method {
@@ -1319,7 +1318,6 @@ fn check_method_collisions(service_name: &str, service: &ServiceDescriptorProto)
             snake.clone(),
             format!("{snake}_with_options"),
             format!("{snake}_spec"),
-            format!("{snake}_client_spec"),
         ];
         for ident in &idents {
             if let Some(prev) = seen.get(ident) {
@@ -1676,11 +1674,11 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
         TokenStream::new()
     };
 
-    // Per-method `Spec` constants (server + client sibling). Stable,
-    // allocation-free metadata that the dispatcher threads into
-    // `RequestContext::spec`, that generated client methods pass to `call_*`,
-    // and that user code can reference directly.
-    let spec_consts = generate_spec_consts(&full_service_name, service, &client_cfg_attr);
+    // Per-method `Spec` constants. Stable, allocation-free metadata that the
+    // dispatcher threads into `RequestContext::spec`, that generated client
+    // methods pass to `call_*` (with `origin` flipped to `Client`), and that
+    // user code can reference directly.
+    let spec_consts = generate_spec_consts(&full_service_name, service);
 
     Ok(quote! {
         // -----------------------------------------------------------------------------
@@ -1776,47 +1774,36 @@ methods (`msg.name()`) or `.view()`, or convert with `.to_owned_message()`."#
     })
 }
 
-/// Construct the identifier for a per-method module-scope constant:
-/// `{SERVICE}_{METHOD}_{suffix}`, e.g. `ELIZA_SERVICE_SAY_SPEC` /
-/// `ELIZA_SERVICE_SAY_CLIENT_SPEC` for `ElizaService.Say`.
-fn method_const_ident(service: &ServiceDescriptorProto, method_name: &str, suffix: &str) -> Ident {
+/// Construct the identifier for the per-method `Spec` constant,
+/// `{SERVICE}_{METHOD}_SPEC`, e.g. `ELIZA_SERVICE_SAY_SPEC` for
+/// `ElizaService.Say`. Referenced by the generated `Dispatcher::lookup` and,
+/// with `.with_origin(SpecOrigin::Client)`, by generated client methods.
+fn method_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) -> Ident {
     let service_name = service.name.as_deref().unwrap_or("");
     format_ident!(
-        "{}_{}_{suffix}",
+        "{}_{}_SPEC",
         service_name.to_snake_case().to_uppercase(),
         method_name.to_snake_case().to_uppercase()
     )
 }
 
-/// `{SERVICE}_{METHOD}_SPEC`, the server-side constant.
-fn method_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) -> Ident {
-    method_const_ident(service, method_name, "SPEC")
-}
-
-/// `{SERVICE}_{METHOD}_CLIENT_SPEC`, the client-side constant.
-fn method_client_spec_const_ident(service: &ServiceDescriptorProto, method_name: &str) -> Ident {
-    method_const_ident(service, method_name, "CLIENT_SPEC")
-}
-
-/// Emit the per-method `pub const … : ::connectrpc::Spec` pair: the
-/// server-side `{SVC}_{METHOD}_SPEC` (`Spec::server`, referenced by the
-/// generated `Dispatcher::lookup`) and its client sibling
-/// `{SVC}_{METHOD}_CLIENT_SPEC` (`Spec::client`, passed by generated client
-/// methods to `::connectrpc::client::call_*` and carrying `client_cfg_attr`
-/// like every other client item). Both are built from the same descriptor
-/// facts in one place so they cannot disagree.
+/// Emit one `pub const … : ::connectrpc::Spec` per method.
+///
+/// Each constant captures the method's procedure path, stream type, and
+/// idempotency level, constructed via `Spec::server(...)`. It is the single
+/// source of a method's static facts: the dispatcher surfaces it on
+/// `RequestContext::spec`, and generated client methods pass the same
+/// constant with `origin` flipped to `Client`.
 fn generate_spec_consts(
     full_service_name: &str,
     service: &ServiceDescriptorProto,
-    client_cfg_attr: &TokenStream,
 ) -> Vec<TokenStream> {
     service
         .method
         .iter()
         .map(|m| {
             let method_name = m.name.as_deref().unwrap_or("");
-            let server_const = method_spec_const_ident(service, method_name);
-            let client_const = method_client_spec_const_ident(service, method_name);
+            let spec_const = method_spec_const_ident(service, method_name);
             let procedure = format!("/{full_service_name}/{method_name}");
             let cs = m.client_streaming.unwrap_or(false);
             let ss = m.server_streaming.unwrap_or(false);
@@ -1835,31 +1822,18 @@ fn generate_spec_consts(
                 }
                 _ => quote! { ::connectrpc::IdempotencyLevel::Unknown },
             };
-            let server_doc = doc_attrs(&format!(
-                "Static [`Spec`](::connectrpc::Spec) for the server-side `{method_name}` RPC.\n\n\
+            let doc = doc_attrs(&format!(
+                "Static [`Spec`](::connectrpc::Spec) for the `{method_name}` RPC.\n\n\
                  The dispatcher surfaces this on\n\
-                 [`RequestContext::spec`](::connectrpc::RequestContext::spec).\n\n\
-                 Client sibling: `{client_const}`. The two are not `==` (their\n\
-                 [`origin`](::connectrpc::Spec::origin) differs); use\n\
-                 [`Spec::same_method`](::connectrpc::Spec::same_method) or compare\n\
-                 `procedure` to match this method on either side."
-            ));
-            let client_doc = doc_attrs(&format!(
-                "Client-side sibling of `{server_const}` (same method,\n\
-                 [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):\n\
-                 what generated client methods pass to the runtime and what a\n\
-                 client-side interceptor observes."
+                 [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated\n\
+                 client passes it with [`origin`](::connectrpc::Spec::origin) set to\n\
+                 [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with\n\
+                 [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`."
             ));
             quote! {
-                #server_doc
-                pub const #server_const: ::connectrpc::Spec =
+                #doc
+                pub const #spec_const: ::connectrpc::Spec =
                     ::connectrpc::Spec::server(#procedure, #stream_type)
-                        .with_idempotency_level(#idempotency_level);
-
-                #client_doc
-                #client_cfg_attr
-                pub const #client_const: ::connectrpc::Spec =
-                    ::connectrpc::Spec::client(#procedure, #stream_type)
                         .with_idempotency_level(#idempotency_level);
             }
         })
@@ -2277,9 +2251,10 @@ fn generate_client_method(
     package: &str,
 ) -> Result<TokenStream> {
     let method_name = method.name.as_deref().unwrap_or("");
-    // The module-scope `*_CLIENT_SPEC` constant this method passes to the
-    // runtime (see `generate_spec_consts`).
-    let spec_const = method_client_spec_const_ident(service, method_name);
+    // The method's module-scope `*_SPEC` constant, passed to the runtime with
+    // `origin` flipped to `Client` (see `generate_spec_consts`).
+    let spec_const = method_spec_const_ident(service, method_name);
+    let client_spec = quote! { #spec_const.with_origin(::connectrpc::SpecOrigin::Client) };
     let method_snake = make_field_ident(&method_name.to_snake_case());
     let method_with_opts = format_ident!("{}_with_options", method_name.to_snake_case());
     let input_type = resolver.rust_type(method.input_type.as_deref().unwrap_or(""), package)?;
@@ -2332,7 +2307,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_client_stream(
                 &self.transport, &self.config,
-                #spec_const,
+                #client_spec,
                 requests, options,
             ).await
         };
@@ -2353,7 +2328,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_bidi_stream(
                 &self.transport, &self.config,
-                #spec_const, options,
+                #client_spec, options,
             ).await
         };
         short_args = quote! {};
@@ -2370,7 +2345,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_server_stream(
                 &self.transport, &self.config,
-                #spec_const,
+                #client_spec,
                 request, options,
             ).await
         };
@@ -2388,7 +2363,7 @@ fn generate_client_method(
         call_body = quote! {
             ::connectrpc::client::call_unary(
                 &self.transport, &self.config,
-                #spec_const,
+                #client_spec,
                 request, options,
             ).await
         };
@@ -3903,21 +3878,16 @@ mod tests {
     #[test]
     fn client_items_gated_when_opt_in() {
         // When `gate_client_feature` is set, the `FooClient` struct +
-        // impl carry `#[cfg(feature = "client")]`, and so does each
-        // per-method `*_CLIENT_SPEC` constant. The minimal service has one
-        // method: struct + impl + one const = three attrs. (All
-        // `_with_options` methods live inside the impl and inherit the gate.)
+        // impl carry `#[cfg(feature = "client")]`. Exactly two attrs:
+        // one on the struct, one on the impl block. (All `_with_options`
+        // methods live inside the impl and inherit the gate.)
         let out = format_minimal_service(true);
         let cfg_count = out.matches("#[cfg(feature = \"client\")]").count();
         assert_eq!(
-            cfg_count, 3,
-            "expected exactly three #[cfg(feature = \"client\")] attrs (struct \
-             `PingServiceClient`, its `impl<T>` block, `PING_SERVICE_PING_CLIENT_SPEC`); \
-             got {cfg_count}:\n{out}"
-        );
-        assert!(
-            out.contains("#[cfg(feature = \"client\")]\npub const PING_SERVICE_PING_CLIENT_SPEC"),
-            "the client Spec const must carry the gate directly:\n{out}"
+            cfg_count, 2,
+            "expected exactly two #[cfg(feature = \"client\")] attrs (one on \
+             `pub struct PingServiceClient`, one on its `impl<T>` block); got \
+             {cfg_count}:\n{out}"
         );
     }
 
@@ -3926,10 +3896,10 @@ mod tests {
         let out = format_minimal_service_with_client_feature_name(true, "grpc-client");
         let cfg_count = out.matches("#[cfg(feature = \"grpc-client\")]").count();
         assert_eq!(
-            cfg_count, 3,
-            "expected exactly three #[cfg(feature = \"grpc-client\")] attrs \
-             (struct `PingServiceClient`, its `impl<T>` block, the one \
-             `*_CLIENT_SPEC` const); got {cfg_count}:\n{out}"
+            cfg_count, 2,
+            "expected exactly two #[cfg(feature = \"grpc-client\")] attrs \
+             (one on `pub struct PingServiceClient`, one on its `impl<T>` \
+             block); got {cfg_count}:\n{out}"
         );
         assert!(
             !out.contains("#[cfg(feature = \"client\")]"),
@@ -4293,9 +4263,9 @@ mod tests {
         let out = format_token_stream(&ts).unwrap();
         let cfg_count = out.matches("#[cfg(feature = \"client\")]").count();
         assert_eq!(
-            cfg_count, 6,
-            "expected 6 client cfg attrs (struct + impl + 1 method const, per \
-             service, * 2 services); got {cfg_count}:\n{out}"
+            cfg_count, 4,
+            "expected 4 client cfg attrs (2 per service * 2 services); got \
+             {cfg_count}:\n{out}"
         );
         // Both client structs are present, both gated.
         for client_struct in ["pub struct AlphaClient", "pub struct BetaClient"] {
@@ -4348,9 +4318,9 @@ mod tests {
         let content = connect_file.content.as_deref().unwrap_or_default();
         let cfg_count = content.matches("#[cfg(feature = \"grpc-client\")]").count();
         assert_eq!(
-            cfg_count, 3,
-            "expected custom feature gate on generated client struct, impl, and the \
-             one `*_CLIENT_SPEC` const; got {cfg_count}:\n{content}"
+            cfg_count, 2,
+            "expected custom feature gate on generated client struct and impl; got \
+             {cfg_count}:\n{content}"
         );
         assert!(
             !content.contains("#[cfg(feature = \"client\")]"),
@@ -4979,9 +4949,8 @@ mod tests {
             "ECHO_SERVICE_SAY_SPEC"
         );
 
-        let gate = quote! { #[cfg(feature = "client")] };
-        let consts = generate_spec_consts("pkg.EchoService", &service, &gate);
-        assert_eq!(consts.len(), 4, "one server+client pair per method");
+        let consts = generate_spec_consts("pkg.EchoService", &service);
+        assert_eq!(consts.len(), 4, "one const per method");
 
         let render = |ts: &TokenStream| {
             let file = syn::parse2::<syn::File>(ts.clone()).expect("const should parse");
@@ -4992,30 +4961,9 @@ mod tests {
         assert!(say.contains(r#""/pkg.EchoService/Say""#), "{say}");
         assert!(say.contains("StreamType::Unary"), "{say}");
         assert!(say.contains("IdempotencyLevel::NoSideEffects"), "{say}");
-        // The client sibling rides in the same block: `_CLIENT_SPEC` name,
-        // `Spec::client`, and the gate attribute on the client item only.
-        assert_eq!(
-            method_client_spec_const_ident(&service, "Say").to_string(),
-            "ECHO_SERVICE_SAY_CLIENT_SPEC"
-        );
-        assert!(
-            say.contains("pub const ECHO_SERVICE_SAY_CLIENT_SPEC"),
-            "{say}"
-        );
-        assert!(say.contains("Spec::client("), "{say}");
-        assert_eq!(
-            say.matches("#[cfg(feature = \"client\")]").count(),
-            1,
-            "{say}"
-        );
-        let cfg_at = say.find("#[cfg(").unwrap();
-        assert!(
-            cfg_at > say.find("ECHO_SERVICE_SAY_SPEC").unwrap(),
-            "gate is on the client const: {say}"
-        );
-        let ungated =
-            render(&generate_spec_consts("pkg.EchoService", &service, &TokenStream::new())[0]);
-        assert!(!ungated.contains("#[cfg("), "{ungated}");
+        // One constant per method: no client sibling is emitted.
+        assert!(!say.contains("CLIENT_SPEC"), "{say}");
+        assert!(!say.contains("Spec::client("), "{say}");
 
         let subscribe = render(&consts[1]);
         assert!(
@@ -5035,9 +4983,9 @@ mod tests {
         assert!(chat.contains("StreamType::BidiStream"), "{chat}");
     }
 
-    /// `Get` + `GetClient` would both produce `X_GET_CLIENT_SPEC` (one's
-    /// client const, the other's server const); generation fails naming
-    /// both methods instead of emitting a module the consumer cannot compile.
+    /// `Get` + `GetSpec` collide (`get_spec` is both `Get`'s constant stem
+    /// and `GetSpec`'s method name); generation fails naming both methods
+    /// instead of emitting a module the consumer cannot compile.
     #[test]
     fn colliding_spec_const_names_are_rejected() {
         let m = |name: &str| MethodDescriptorProto {
@@ -5048,44 +4996,45 @@ mod tests {
         };
         let service = ServiceDescriptorProto {
             name: Some("X".into()),
-            method: vec![m("Get"), m("GetClient")],
+            method: vec![m("Get"), m("GetSpec")],
             ..Default::default()
         };
         let msg = check_method_collisions("X", &service)
-            .expect_err("Get + GetClient collide on get_client_spec")
+            .expect_err("Get + GetSpec collide on get_spec")
             .to_string();
-        assert!(msg.contains("get_client_spec"), "{msg}");
+        assert!(msg.contains("get_spec"), "{msg}");
         assert!(
-            msg.contains("\"Get\"") && msg.contains("\"GetClient\""),
+            msg.contains("\"Get\"") && msg.contains("\"GetSpec\""),
             "{msg}"
         );
 
-        // The ordinary case, including a method literally named `Client`, passes.
+        // The ordinary case, including methods named `Client` and `Spec`, passes.
         let service = ServiceDescriptorProto {
             name: Some("X".into()),
-            method: vec![m("Get"), m("Put"), m("Client")],
+            method: vec![m("Get"), m("Put"), m("Client"), m("Spec")],
             ..Default::default()
         };
         check_method_collisions("X", &service).unwrap();
     }
 
     /// Generated client methods identify the RPC to the runtime by the
-    /// module-scope `*_CLIENT_SPEC` constant, not by service/method strings.
+    /// module-scope `*_SPEC` constant with `origin` flipped to `Client`, not
+    /// by service/method strings.
     #[test]
-    fn client_methods_pass_client_spec_const() {
+    fn client_methods_pass_spec_const_as_client() {
         let out = format_minimal_service(false);
         assert!(
-            out.contains("pub const PING_SERVICE_PING_CLIENT_SPEC: ::connectrpc::Spec"),
-            "{out}"
+            !out.contains("CLIENT_SPEC"),
+            "no client sibling const: {out}"
         );
-        // The unary call site: transport, config, then the const.
+        // The unary call site: transport, config, then the const as client.
         let call = out
             .find("::connectrpc::client::call_unary(")
             .expect("minimal service has a unary client method");
-        let window = &out[call..(call + 200).min(out.len())];
+        let window = &out[call..(call + 240).min(out.len())];
         assert!(
-            window.contains("PING_SERVICE_PING_CLIENT_SPEC"),
-            "call_unary must receive the client Spec const:\n{window}"
+            window.contains("PING_SERVICE_PING_SPEC.with_origin(::connectrpc::SpecOrigin::Client)"),
+            "call_unary must receive the Spec const with client origin:\n{window}"
         );
         assert!(
             !window.contains("PING_SERVICE_SERVICE_NAME"),

--- a/connectrpc-codegen/src/codegen.rs
+++ b/connectrpc-codegen/src/codegen.rs
@@ -1314,11 +1314,7 @@ fn check_method_collisions(service_name: &str, service: &ServiceDescriptorProto)
     for m in &service.method {
         let proto_name = m.name.as_deref().unwrap_or("");
         let snake = proto_name.to_snake_case();
-        let idents = [
-            snake.clone(),
-            format!("{snake}_with_options"),
-            format!("{snake}_spec"),
-        ];
+        let idents = [snake.clone(), format!("{snake}_with_options")];
         for ident in &idents {
             if let Some(prev) = seen.get(ident) {
                 anyhow::bail!(
@@ -1823,12 +1819,10 @@ fn generate_spec_consts(
                 _ => quote! { ::connectrpc::IdempotencyLevel::Unknown },
             };
             let doc = doc_attrs(&format!(
-                "Static [`Spec`](::connectrpc::Spec) for the `{method_name}` RPC.\n\n\
-                 The dispatcher surfaces this on\n\
-                 [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated\n\
-                 client passes it with [`origin`](::connectrpc::Spec::origin) set to\n\
-                 [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with\n\
-                 [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`."
+                "Static [`Spec`](::connectrpc::Spec) for the `{method_name}` RPC, as seen \
+                 by the server; the generated client passes it with \
+                 [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with \
+                 [`Spec::same_method`](::connectrpc::Spec::same_method))."
             ));
             quote! {
                 #doc
@@ -4983,11 +4977,11 @@ mod tests {
         assert!(chat.contains("StreamType::BidiStream"), "{chat}");
     }
 
-    /// `Get` + `GetSpec` collide (`get_spec` is both `Get`'s constant stem
-    /// and `GetSpec`'s method name); generation fails naming both methods
-    /// instead of emitting a module the consumer cannot compile.
+    /// `Get` + `GetSpec` do not collide: their constants are `X_GET_SPEC` and
+    /// `X_GET_SPEC_SPEC`, and `get_spec` is only ever a client method name.
+    /// Methods named `Client` and `Spec` are ordinary too.
     #[test]
-    fn colliding_spec_const_names_are_rejected() {
+    fn spec_const_names_do_not_collide_with_method_names() {
         let m = |name: &str| MethodDescriptorProto {
             name: Some(name.into()),
             input_type: Some(".pkg.Req".into()),
@@ -4996,22 +4990,7 @@ mod tests {
         };
         let service = ServiceDescriptorProto {
             name: Some("X".into()),
-            method: vec![m("Get"), m("GetSpec")],
-            ..Default::default()
-        };
-        let msg = check_method_collisions("X", &service)
-            .expect_err("Get + GetSpec collide on get_spec")
-            .to_string();
-        assert!(msg.contains("get_spec"), "{msg}");
-        assert!(
-            msg.contains("\"Get\"") && msg.contains("\"GetSpec\""),
-            "{msg}"
-        );
-
-        // The ordinary case, including methods named `Client` and `Spec`, passes.
-        let service = ServiceDescriptorProto {
-            name: Some("X".into()),
-            method: vec![m("Get"), m("Put"), m("Client"), m("Spec")],
+            method: vec![m("Get"), m("GetSpec"), m("Put"), m("Client"), m("Spec")],
             ..Default::default()
         };
         check_method_collisions("X", &service).unwrap();

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -42,25 +42,13 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const HEALTH_SERVICE_NAME: &str = "grpc.health.v1.Health";
-/// Static [`Spec`](::connectrpc::Spec) for the `Check` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Check` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const HEALTH_CHECK_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/grpc.health.v1.Health/Check",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `Watch` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Watch` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const HEALTH_WATCH_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/grpc.health.v1.Health/Watch",
         ::connectrpc::StreamType::ServerStream,

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -56,6 +56,16 @@ pub const HEALTH_CHECK_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `HEALTH_CHECK_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+#[cfg(feature = "client")]
+pub const HEALTH_CHECK_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/grpc.health.v1.Health/Check",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `Watch` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -70,28 +80,10 @@ pub const HEALTH_WATCH_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         ::connectrpc::StreamType::ServerStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Check` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `HEALTH_CHECK_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-#[cfg(feature = "client")]
-pub const HEALTH_CHECK_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/grpc.health.v1.Health/Check",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Watch` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `HEALTH_WATCH_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `HEALTH_WATCH_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 #[cfg(feature = "client")]
 pub const HEALTH_WATCH_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.health.v1.Health/Watch",

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -42,50 +42,26 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const HEALTH_SERVICE_NAME: &str = "grpc.health.v1.Health";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Check` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Check` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `HEALTH_CHECK_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const HEALTH_CHECK_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/grpc.health.v1.Health/Check",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `HEALTH_CHECK_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-#[cfg(feature = "client")]
-pub const HEALTH_CHECK_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/grpc.health.v1.Health/Check",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Watch` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Watch` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `HEALTH_WATCH_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const HEALTH_WATCH_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/grpc.health.v1.Health/Watch",
-        ::connectrpc::StreamType::ServerStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `HEALTH_WATCH_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-#[cfg(feature = "client")]
-pub const HEALTH_WATCH_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.health.v1.Health/Watch",
         ::connectrpc::StreamType::ServerStream,
     )
@@ -585,7 +561,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                HEALTH_CHECK_CLIENT_SPEC,
+                HEALTH_CHECK_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -624,7 +600,7 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                HEALTH_WATCH_CLIENT_SPEC,
+                HEALTH_WATCH_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
+++ b/connectrpc-health/src/generated/connect/grpc.health.v1.health.__connect.rs
@@ -46,6 +46,11 @@ pub const HEALTH_SERVICE_NAME: &str = "grpc.health.v1.Health";
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `HEALTH_CHECK_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const HEALTH_CHECK_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/grpc.health.v1.Health/Check",
         ::connectrpc::StreamType::Unary,
@@ -55,7 +60,40 @@ pub const HEALTH_CHECK_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `HEALTH_WATCH_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const HEALTH_WATCH_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/grpc.health.v1.Health/Watch",
+        ::connectrpc::StreamType::ServerStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Check` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `HEALTH_CHECK_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+#[cfg(feature = "client")]
+pub const HEALTH_CHECK_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/grpc.health.v1.Health/Check",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Watch` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `HEALTH_WATCH_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+#[cfg(feature = "client")]
+pub const HEALTH_WATCH_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.health.v1.Health/Watch",
         ::connectrpc::StreamType::ServerStream,
     )
@@ -555,8 +593,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                HEALTH_SERVICE_NAME,
-                "Check",
+                HEALTH_CHECK_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -595,8 +632,7 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                HEALTH_SERVICE_NAME,
-                "Watch",
+                HEALTH_WATCH_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -52,26 +52,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1.ServerReflection";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `ServerReflectionInfo` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerReflectionInfo` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-#[cfg(feature = "client")]
-pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
         ::connectrpc::StreamType::BidiStream,
     )
@@ -463,7 +451,8 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC,
+                SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 options,
             )
             .await

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -66,14 +66,10 @@ pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerReflectionInfo` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 #[cfg(feature = "client")]
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -56,7 +56,26 @@ pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1.ServerRefle
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerReflectionInfo` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+#[cfg(feature = "client")]
+pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
         ::connectrpc::StreamType::BidiStream,
     )
@@ -448,8 +467,7 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                SERVER_REFLECTION_SERVICE_NAME,
-                "ServerReflectionInfo",
+                SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC,
                 options,
             )
             .await

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1.reflection.__connect.rs
@@ -52,13 +52,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1.ServerReflection";
-/// Static [`Spec`](::connectrpc::Spec) for the `ServerReflectionInfo` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerReflectionInfo` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
         ::connectrpc::StreamType::BidiStream,

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -54,13 +54,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1alpha.ServerReflection";
-/// Static [`Spec`](::connectrpc::Spec) for the `ServerReflectionInfo` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerReflectionInfo` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
         ::connectrpc::StreamType::BidiStream,

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -68,14 +68,10 @@ pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerReflectionInfo` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 #[cfg(feature = "client")]
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -58,7 +58,26 @@ pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1alpha.Server
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `ServerReflectionInfo` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+#[cfg(feature = "client")]
+pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
         ::connectrpc::StreamType::BidiStream,
     )
@@ -450,8 +469,7 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                SERVER_REFLECTION_SERVICE_NAME,
-                "ServerReflectionInfo",
+                SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC,
                 options,
             )
             .await

--- a/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
+++ b/connectrpc-reflection/src/generated/connect/grpc.reflection.v1alpha.reflection.__connect.rs
@@ -54,26 +54,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const SERVER_REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1alpha.ServerReflection";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `ServerReflectionInfo` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `ServerReflectionInfo` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-#[cfg(feature = "client")]
-pub const SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
         ::connectrpc::StreamType::BidiStream,
     )
@@ -465,7 +453,8 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                SERVER_REFLECTION_SERVER_REFLECTION_INFO_CLIENT_SPEC,
+                SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 options,
             )
             .await

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -866,7 +866,10 @@ pub struct ClientConfig {
 impl ClientConfig {
     /// Create a new client configuration with the given base URI.
     ///
-    /// Uses Connect protocol with protobuf encoding by default.
+    /// Uses Connect protocol with protobuf encoding by default. Request
+    /// URIs are the base's scheme, authority and path prefix (trailing
+    /// slash trimmed) followed by the method's `/package.Service/Method`;
+    /// a query string on the base URI is not carried over.
     pub fn new(base_uri: Uri) -> Self {
         Self {
             base_uri,
@@ -1471,7 +1474,12 @@ fn procedure_uri(
     use http::uri::PathAndQuery;
     let base_path = config.base_uri.path().trim_end_matches('/');
     let path_and_query = if base_path.is_empty() && query.is_none() {
-        PathAndQuery::from_static(procedure)
+        // `from_static` would panic on a byte that is illegal in a path (a
+        // space, `#`, non-ASCII); `check_client_spec` only checks the slash
+        // shape, so validate here and report it like every other bad URI.
+        // `Bytes::from_static` keeps this branch allocation-free.
+        PathAndQuery::from_maybe_shared(Bytes::from_static(procedure.as_bytes()))
+            .map_err(|e| ConnectError::internal(format!("invalid request path: {e}")))?
     } else {
         let mut s = String::with_capacity(
             base_path.len() + procedure.len() + query.map_or(0, |q| q.len() + 1),

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1453,25 +1453,48 @@ fn client_deadline(timeout: Option<Duration>, protocol: Protocol) -> Option<std:
         .and_then(|t| std::time::Instant::now().checked_add(t))
 }
 
-/// Build the request URI for `spec` against `config.base_uri`, with an
+/// Build the request URI for `procedure` against `config.base_uri`, with an
 /// optional query string (the Connect GET path).
 ///
-/// `Spec::procedure` carries the leading slash (`/pkg.Service/Method`), so it
-/// is appended to the base verbatim after trimming any trailing slash there.
-/// Callers run [`check_client_spec`] first, which guarantees the slash.
+/// Reuses the base URI's already-parsed scheme and authority and only builds
+/// a new path-and-query: any path prefix on the base (trailing slash
+/// trimmed) followed by `procedure`, which carries its own leading slash
+/// (callers run [`check_client_spec`] first). A query string on the *base*
+/// URI is not carried over. In the common case — no base path prefix, no
+/// query — the path is the `&'static` procedure itself and nothing is
+/// allocated.
 fn procedure_uri(
     config: &ClientConfig,
-    spec: Spec,
+    procedure: &'static str,
     query: Option<&str>,
 ) -> Result<Uri, ConnectError> {
-    let base = config.base_uri.to_string();
-    let base = base.trim_end_matches('/');
-    let uri = match query {
-        Some(q) => format!("{base}{}?{q}", spec.procedure),
-        None => format!("{base}{}", spec.procedure),
+    use http::uri::PathAndQuery;
+    let base_path = config.base_uri.path().trim_end_matches('/');
+    let path_and_query = if base_path.is_empty() && query.is_none() {
+        PathAndQuery::from_static(procedure)
+    } else {
+        let mut s = String::with_capacity(
+            base_path.len() + procedure.len() + query.map_or(0, |q| q.len() + 1),
+        );
+        s.push_str(base_path);
+        s.push_str(procedure);
+        if let Some(q) = query {
+            s.push('?');
+            s.push_str(q);
+        }
+        PathAndQuery::from_maybe_shared(Bytes::from(s))
+            .map_err(|e| ConnectError::internal(format!("invalid request path: {e}")))?
     };
-    uri.parse()
-        .map_err(|e| ConnectError::internal(format!("invalid request URI {uri:?}: {e}")))
+    let mut parts = http::uri::Parts::default();
+    parts.scheme = config.base_uri.scheme().cloned();
+    parts.authority = config.base_uri.authority().cloned();
+    parts.path_and_query = Some(path_and_query);
+    Uri::from_parts(parts).map_err(|e| {
+        ConnectError::internal(format!(
+            "invalid request URI from base {}: {e}",
+            config.base_uri
+        ))
+    })
 }
 
 /// The entry point that matches a stream shape, for error messages.
@@ -1487,11 +1510,10 @@ fn entry_point_for(stream_type: StreamType) -> &'static str {
 /// Validate a caller-supplied [`Spec`] against the entry point it reached.
 ///
 /// Generated clients always pass a matching `*_CLIENT_SPEC`; these checks
-/// exist for hand-written callers, where the three mistakes below would
-/// otherwise surface far from their cause (a protocol error from the server,
-/// a client interceptor observing `SpecOrigin::Server`, or a mangled request
-/// URI). All are caller bugs, so the error is `Internal`. The cost is three
-/// comparisons per call in every build profile.
+/// exist for hand-written callers, where the mistakes below would otherwise
+/// surface far from their cause (a protocol error from the server, a client
+/// interceptor observing `SpecOrigin::Server`, a mangled request URI). All
+/// are caller bugs, so the error is `Internal`, in every build profile.
 fn check_client_spec(
     spec: Spec,
     expected: StreamType,
@@ -1512,9 +1534,9 @@ fn check_client_spec(
             spec.procedure,
         )));
     }
-    if !spec.procedure.starts_with('/') {
+    if !crate::spec::procedure_is_well_formed(spec.procedure) {
         return Err(ConnectError::internal(format!(
-            "Spec::procedure {:?} must start with '/' (\"/package.Service/Method\")",
+            "Spec::procedure {:?} must look like \"/package.Service/Method\"",
             spec.procedure,
         )));
     }
@@ -1793,9 +1815,11 @@ where
 ///
 /// # Errors
 ///
-/// Besides transport, protocol, and decode failures: `Internal` if `spec`
-/// is not a client-side [`StreamType::Unary`] spec with a `/`-prefixed
-/// procedure — a caller bug that generated clients cannot produce.
+/// Besides transport, protocol, and decode failures: `Internal`, before
+/// anything is sent, if `spec` is not a client-side [`StreamType::Unary`]
+/// spec with a well-formed procedure — a caller bug that generated clients
+/// cannot produce. The other entry points apply the same check for their
+/// stream shape.
 pub async fn call_unary<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
@@ -1812,7 +1836,7 @@ where
 {
     check_client_spec(spec, StreamType::Unary, "call_unary")?;
     let options = effective_options(config, options);
-    let uri = procedure_uri(config, spec, None)?;
+    let uri = procedure_uri(config, spec.procedure, None)?;
 
     // Encode the request body
     let body = match config.codec_format {
@@ -1929,9 +1953,8 @@ where
 ///
 /// # Errors
 ///
-/// Returns `invalid_argument` if `config.protocol` is not `Connect`, and
-/// `Internal` if `spec` is not a client-side unary spec (see
-/// [`call_unary`]).
+/// Returns `invalid_argument` if `config.protocol` is not `Connect`;
+/// `Internal` for a mismatched `spec` (see [`call_unary`]).
 pub async fn call_unary_get<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
@@ -2001,7 +2024,7 @@ where
     let query =
         build_connect_get_query(use_base64, compressed_with, encoding_name, &encoded_message);
 
-    let uri = procedure_uri(config, spec, Some(&query))?;
+    let uri = procedure_uri(config, spec.procedure, Some(&query))?;
 
     let deadline = client_deadline(options.timeout, Protocol::Connect);
 
@@ -3213,8 +3236,7 @@ where
 /// # Errors
 ///
 /// Returns immediately with an error if:
-/// - `spec` is not a client-side server-streaming spec (`Internal`; a
-///   caller bug generated clients cannot produce)
+/// - `spec` is mismatched (`Internal`, see [`call_unary`])
 /// - The request cannot be encoded or sent
 /// - The server responds with a non-200 status (protocol-level error)
 /// - A successful gRPC or gRPC-Web response declares a content type
@@ -3244,7 +3266,7 @@ where
 {
     check_client_spec(spec, StreamType::ServerStream, "call_server_stream")?;
     let options = effective_options(config, options);
-    let uri = procedure_uri(config, spec, None)?;
+    let uri = procedure_uri(config, spec.procedure, None)?;
 
     // Encode the request body
     let body = match config.codec_format {
@@ -4050,9 +4072,8 @@ where
 ///
 /// # Errors
 ///
-/// Returns `Internal` before opening the stream if `spec` is not a
-/// client-side bidi-streaming spec (a caller bug generated clients cannot
-/// produce). Transport and protocol errors surface from
+/// Returns `Internal` before opening the stream for a mismatched `spec`
+/// (see [`call_unary`]). Transport and protocol errors surface from
 /// [`BidiStream::message`].
 ///
 /// # Example
@@ -4080,7 +4101,7 @@ where
 {
     check_client_spec(spec, StreamType::BidiStream, "call_bidi_stream")?;
     let options = effective_options(config, options);
-    let uri = procedure_uri(config, spec, None)?;
+    let uri = procedure_uri(config, spec.procedure, None)?;
 
     // Set up the channel-backed request body. Channel depth 32 matches
     // typical h2 stream window; sends beyond this backpressure naturally.
@@ -4204,8 +4225,8 @@ where
 /// Returns an error if a request message cannot be encoded, the transport
 /// fails, the whole-call deadline expires, the server responds with an
 /// error, the response cannot be decoded, or (`Internal`, before anything
-/// is sent) `spec` is not a client-side [`StreamType::ClientStream`] spec
-/// — see [`call_unary`] for how `spec` identifies the method.
+/// is sent) `spec` is mismatched — see [`call_unary`] for how `spec`
+/// identifies the method.
 pub async fn call_client_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
@@ -4222,7 +4243,7 @@ where
 {
     check_client_spec(spec, StreamType::ClientStream, "call_client_stream")?;
     let options = effective_options(config, options);
-    let uri = procedure_uri(config, spec, None)?;
+    let uri = procedure_uri(config, spec.procedure, None)?;
 
     let compression_for_encoder = config.request_compression.as_ref().map(|enc| {
         (
@@ -8859,23 +8880,33 @@ mod tests {
     /// the same wire path the old `{base}/{service}/{method}` produced.
     #[test]
     fn procedure_uri_joins_base_and_procedure() {
-        let spec = Spec::client("/pkg.Svc/Do", StreamType::Unary);
-        for base in ["http://h:8080", "http://h:8080/", "http://h:8080/prefix/"] {
+        const P: &str = "/pkg.Svc/Do";
+        for base in [
+            "http://h:8080",
+            "http://h:8080/",
+            "http://h:8080/prefix/",
+            "https://[::1]:8443/prefix",
+        ] {
             let config = ClientConfig::new(base.parse().unwrap());
-            let uri = procedure_uri(&config, spec, None).unwrap();
+            let uri = procedure_uri(&config, P, None).unwrap();
             let want = format!("{}/pkg.Svc/Do", base.trim_end_matches('/'));
             assert_eq!(uri.to_string(), want, "base {base}");
         }
         let config = ClientConfig::new("http://h".parse().unwrap());
-        let uri = procedure_uri(&config, spec, Some("connect=v1&encoding=proto")).unwrap();
-        assert_eq!(uri.path(), "/pkg.Svc/Do");
+        let uri = procedure_uri(&config, P, Some("connect=v1&encoding=proto")).unwrap();
+        assert_eq!(uri.path(), P);
         assert_eq!(uri.query(), Some("connect=v1&encoding=proto"));
+        // A query on the *base* URI is dropped rather than spliced into the
+        // path (string concatenation used to produce "/?a=1/pkg.Svc/Do").
+        let config = ClientConfig::new("http://h/?a=1".parse().unwrap());
+        let uri = procedure_uri(&config, P, None).unwrap();
+        assert_eq!((uri.path(), uri.query()), (P, None));
     }
 
     /// `check_client_spec` accepts exactly a client-side spec of the entry
-    /// point's stream shape with a `/`-prefixed procedure, and each of the
-    /// three caller bugs it rejects gets an `Internal` error that says what
-    /// to do instead — in every build profile, not just debug.
+    /// point's stream shape, and each caller bug it rejects gets an
+    /// `Internal` error that says what to do instead — in every build
+    /// profile, not just debug.
     #[test]
     fn check_client_spec_table() {
         use StreamType::*;
@@ -8910,20 +8941,9 @@ mod tests {
                 .contains("server-side Spec"),
             "{err:?}"
         );
-        // Missing leading slash (only constructible in release, where
-        // `Spec::client`'s own debug assertion is compiled out).
-        #[cfg(not(debug_assertions))]
-        {
-            let err = check_client_spec(Spec::client("pkg.Svc/M", Unary), Unary, "call_unary")
-                .unwrap_err();
-            assert!(
-                err.message
-                    .as_deref()
-                    .unwrap_or_default()
-                    .contains("must start with '/'"),
-                "{err:?}"
-            );
-        }
+        // Malformed procedures share `spec::procedure_is_well_formed` with
+        // `Spec::client`'s debug assertion (tested in spec.rs); a `Spec` that
+        // fails it cannot be built here in a debug test binary.
     }
 
     /// End to end through a public entry point: the check runs before any
@@ -8944,13 +8964,6 @@ mod tests {
         .await
         .expect_err("mismatched spec must fail fast");
         assert_eq!(err.code, ErrorCode::Internal, "{err:?}");
-        assert!(
-            err.message
-                .as_deref()
-                .unwrap_or_default()
-                .contains("use call_server_stream"),
-            "{err:?}"
-        );
     }
 
     // ========================================================================

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -178,6 +178,7 @@ use crate::error::ErrorCode;
 use crate::error::ErrorDetail;
 use crate::protocol::Protocol;
 use crate::protocol::hdr;
+use crate::spec::{Spec, SpecOrigin, StreamType};
 
 /// Type alias for a boxed future, used in service implementations.
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -1452,6 +1453,74 @@ fn client_deadline(timeout: Option<Duration>, protocol: Protocol) -> Option<std:
         .and_then(|t| std::time::Instant::now().checked_add(t))
 }
 
+/// Build the request URI for `spec` against `config.base_uri`, with an
+/// optional query string (the Connect GET path).
+///
+/// `Spec::procedure` carries the leading slash (`/pkg.Service/Method`), so it
+/// is appended to the base verbatim after trimming any trailing slash there.
+/// Callers run [`check_client_spec`] first, which guarantees the slash.
+fn procedure_uri(
+    config: &ClientConfig,
+    spec: Spec,
+    query: Option<&str>,
+) -> Result<Uri, ConnectError> {
+    let base = config.base_uri.to_string();
+    let base = base.trim_end_matches('/');
+    let uri = match query {
+        Some(q) => format!("{base}{}?{q}", spec.procedure),
+        None => format!("{base}{}", spec.procedure),
+    };
+    uri.parse()
+        .map_err(|e| ConnectError::internal(format!("invalid request URI {uri:?}: {e}")))
+}
+
+/// The entry point that matches a stream shape, for error messages.
+fn entry_point_for(stream_type: StreamType) -> &'static str {
+    match stream_type {
+        StreamType::Unary => "call_unary",
+        StreamType::ClientStream => "call_client_stream",
+        StreamType::ServerStream => "call_server_stream",
+        StreamType::BidiStream => "call_bidi_stream",
+    }
+}
+
+/// Validate a caller-supplied [`Spec`] against the entry point it reached.
+///
+/// Generated clients always pass a matching `*_CLIENT_SPEC`; these checks
+/// exist for hand-written callers, where the three mistakes below would
+/// otherwise surface far from their cause (a protocol error from the server,
+/// a client interceptor observing `SpecOrigin::Server`, or a mangled request
+/// URI). All are caller bugs, so the error is `Internal`. The cost is three
+/// comparisons per call in every build profile.
+fn check_client_spec(
+    spec: Spec,
+    expected: StreamType,
+    entry_point: &str,
+) -> Result<(), ConnectError> {
+    if spec.stream_type != expected {
+        return Err(ConnectError::internal(format!(
+            "{entry_point} called with a {:?} Spec for {}; use {}",
+            spec.stream_type,
+            spec.procedure,
+            entry_point_for(spec.stream_type),
+        )));
+    }
+    if spec.origin != SpecOrigin::Client {
+        return Err(ConnectError::internal(format!(
+            "{entry_point} called with a server-side Spec for {}; pass the generated \
+             *_CLIENT_SPEC constant or Spec::client(..)",
+            spec.procedure,
+        )));
+    }
+    if !spec.procedure.starts_with('/') {
+        return Err(ConnectError::internal(format!(
+            "Spec::procedure {:?} must start with '/' (\"/package.Service/Method\")",
+            spec.procedure,
+        )));
+    }
+    Ok(())
+}
+
 /// Enforce a client-side deadline by wrapping a future in `timeout_at`.
 ///
 /// gRPC deadline semantics: the deadline applies to the **entire call** from
@@ -1713,11 +1782,24 @@ where
 ///
 /// This is the core function used by generated clients to make RPC calls.
 /// It handles encoding, compression, and protocol details.
+///
+/// `spec` identifies the method. Generated clients pass their per-method
+/// `*_CLIENT_SPEC` constant; a hand-written caller builds one with
+/// [`Spec::client("/pkg.Service/Method", StreamType::Unary)`](Spec::client),
+/// chaining [`with_idempotency_level`](Spec::with_idempotency_level) when
+/// known (see [`Spec::client`] for callers whose method names are only
+/// known at runtime). The request path is `spec.procedure` under
+/// `config.base_uri`.
+///
+/// # Errors
+///
+/// Besides transport, protocol, and decode failures: `Internal` if `spec`
+/// is not a client-side [`StreamType::Unary`] spec with a `/`-prefixed
+/// procedure — a caller bug that generated clients cannot produce.
 pub async fn call_unary<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
-    service: &str,
-    method: &str,
+    spec: Spec,
     request: Req,
     options: CallOptions,
 ) -> Result<UnaryResponse<OwnedView<RespView>>, ConnectError>
@@ -1728,15 +1810,9 @@ where
     RespView: MessageView<'static> + Send,
     RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
+    check_client_spec(spec, StreamType::Unary, "call_unary")?;
     let options = effective_options(config, options);
-
-    // Build the full URI from base_uri and service/method path
-    let base_str = config.base_uri.to_string();
-    let base_str = base_str.trim_end_matches('/');
-    let full_uri = format!("{base_str}/{service}/{method}");
-    let uri: Uri = full_uri
-        .parse()
-        .map_err(|e| ConnectError::internal(format!("invalid URI: {e}")))?;
+    let uri = procedure_uri(config, spec, None)?;
 
     // Encode the request body
     let body = match config.codec_format {
@@ -1840,6 +1916,10 @@ where
 /// side-effect-free queries. Only the Connect protocol supports this;
 /// gRPC/gRPC-Web are POST-only.
 ///
+/// `spec` identifies the method as for [`call_unary`]. Its
+/// [`idempotency_level`](Spec::idempotency_level) is **not** consulted:
+/// choosing GET is the caller's decision.
+///
 /// # Deterministic encoding
 ///
 /// For effective caching, the encoded message should be deterministic (same
@@ -1849,12 +1929,13 @@ where
 ///
 /// # Errors
 ///
-/// Returns `invalid_argument` if `config.protocol` is not `Connect`.
+/// Returns `invalid_argument` if `config.protocol` is not `Connect`, and
+/// `Internal` if `spec` is not a client-side unary spec (see
+/// [`call_unary`]).
 pub async fn call_unary_get<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
-    service: &str,
-    method: &str,
+    spec: Spec,
     request: Req,
     options: CallOptions,
 ) -> Result<UnaryResponse<OwnedView<RespView>>, ConnectError>
@@ -1865,6 +1946,7 @@ where
     RespView: MessageView<'static> + Send,
     RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
+    check_client_spec(spec, StreamType::Unary, "call_unary_get")?;
     // Connect GET is a Connect-protocol-only feature.
     if !matches!(config.protocol, Protocol::Connect) {
         return Err(ConnectError::invalid_argument(
@@ -1873,10 +1955,6 @@ where
     }
 
     let options = effective_options(config, options);
-
-    // Build the base URI (no query yet)
-    let base_str = config.base_uri.to_string();
-    let base_str = base_str.trim_end_matches('/');
 
     // Encode the request body
     let body = match config.codec_format {
@@ -1923,10 +2001,7 @@ where
     let query =
         build_connect_get_query(use_base64, compressed_with, encoding_name, &encoded_message);
 
-    let full_uri = format!("{base_str}/{service}/{method}?{query}");
-    let uri: Uri = full_uri
-        .parse()
-        .map_err(|e| ConnectError::internal(format!("invalid GET URI: {e}")))?;
+    let uri = procedure_uri(config, spec, Some(&query))?;
 
     let deadline = client_deadline(options.timeout, Protocol::Connect);
 
@@ -2670,7 +2745,7 @@ enum BodyPoll {
 /// # Example
 ///
 /// ```rust,ignore
-/// let mut stream = call_server_stream(&transport, &config, "svc", "method", req, CallOptions::default()).await?;
+/// let mut stream = call_server_stream(&transport, &config, SVC_METHOD_CLIENT_SPEC, req, CallOptions::default()).await?;
 /// println!("headers: {:?}", stream.headers());
 /// while let Some(msg) = stream.message().await? {
 ///     println!("got message: {:?}", msg);
@@ -3132,9 +3207,14 @@ where
 /// messages incrementally as they arrive. Use [`ServerStream::message()`] to
 /// read messages one at a time.
 ///
+/// `spec` identifies the method as for [`call_unary`], with
+/// [`StreamType::ServerStream`].
+///
 /// # Errors
 ///
 /// Returns immediately with an error if:
+/// - `spec` is not a client-side server-streaming spec (`Internal`; a
+///   caller bug generated clients cannot produce)
 /// - The request cannot be encoded or sent
 /// - The server responds with a non-200 status (protocol-level error)
 /// - A successful gRPC or gRPC-Web response declares a content type
@@ -3151,8 +3231,7 @@ where
 pub async fn call_server_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
-    service: &str,
-    method: &str,
+    spec: Spec,
     request: Req,
     options: CallOptions,
 ) -> Result<ServerStream<T::ResponseBody, RespView>, ConnectError>
@@ -3163,15 +3242,9 @@ where
     RespView: MessageView<'static> + Send,
     RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
+    check_client_spec(spec, StreamType::ServerStream, "call_server_stream")?;
     let options = effective_options(config, options);
-
-    // Build the full URI from base_uri and service/method path
-    let base_str = config.base_uri.to_string();
-    let base_str = base_str.trim_end_matches('/');
-    let full_uri = format!("{base_str}/{service}/{method}");
-    let uri: Uri = full_uri
-        .parse()
-        .map_err(|e| ConnectError::internal(format!("invalid URI: {e}")))?;
+    let uri = procedure_uri(config, spec, None)?;
 
     // Encode the request body
     let body = match config.codec_format {
@@ -3524,7 +3597,7 @@ enum RecvState<B, RespView> {
 /// # Example
 ///
 /// ```rust,ignore
-/// let mut stream = call_bidi_stream(&transport, &config, "svc", "method", CallOptions::default()).await?;
+/// let mut stream = call_bidi_stream(&transport, &config, SVC_METHOD_CLIENT_SPEC, CallOptions::default()).await?;
 /// stream.send(request1).await?;
 /// stream.send(request2).await?;
 /// stream.close_send();
@@ -3972,11 +4045,21 @@ where
 /// [`BidiStream::message`] call — this supports full-duplex servers that
 /// wait for the first request message before sending response headers.
 ///
+/// `spec` identifies the method as for [`call_unary`], with
+/// [`StreamType::BidiStream`].
+///
+/// # Errors
+///
+/// Returns `Internal` before opening the stream if `spec` is not a
+/// client-side bidi-streaming spec (a caller bug generated clients cannot
+/// produce). Transport and protocol errors surface from
+/// [`BidiStream::message`].
+///
 /// # Example
 ///
 /// ```rust,ignore
 /// let mut stream = call_bidi_stream::<_, MyReq, MyRespView>(
-///     &transport, &config, "my.Service", "Method", CallOptions::default(),
+///     &transport, &config, MY_SERVICE_METHOD_CLIENT_SPEC, CallOptions::default(),
 /// ).await?;
 /// stream.send(req).await?;
 /// stream.close_send();
@@ -3985,8 +4068,7 @@ where
 pub async fn call_bidi_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
-    service: &str,
-    method: &str,
+    spec: Spec,
     options: CallOptions,
 ) -> Result<BidiStream<T::ResponseBody, Req, RespView>, ConnectError>
 where
@@ -3996,15 +4078,9 @@ where
     RespView: MessageView<'static> + Send,
     RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
+    check_client_spec(spec, StreamType::BidiStream, "call_bidi_stream")?;
     let options = effective_options(config, options);
-
-    // Build the full URI from base_uri and service/method path
-    let base_str = config.base_uri.to_string();
-    let base_str = base_str.trim_end_matches('/');
-    let full_uri = format!("{base_str}/{service}/{method}");
-    let uri: Uri = full_uri
-        .parse()
-        .map_err(|e| ConnectError::internal(format!("invalid URI: {e}")))?;
+    let uri = procedure_uri(config, spec, None)?;
 
     // Set up the channel-backed request body. Channel depth 32 matches
     // typical h2 stream window; sends beyond this backpressure naturally.
@@ -4101,7 +4177,7 @@ where
 ///
 /// ```rust,ignore
 /// let resp = call_client_stream(
-///     &transport, &config, "svc", "Method",
+///     &transport, &config, SVC_METHOD_CLIENT_SPEC,
 ///     connectrpc::stream_iter(vec![req1, req2]),
 ///     CallOptions::default(),
 /// ).await?;
@@ -4127,12 +4203,13 @@ where
 ///
 /// Returns an error if a request message cannot be encoded, the transport
 /// fails, the whole-call deadline expires, the server responds with an
-/// error, or the response cannot be decoded.
+/// error, the response cannot be decoded, or (`Internal`, before anything
+/// is sent) `spec` is not a client-side [`StreamType::ClientStream`] spec
+/// — see [`call_unary`] for how `spec` identifies the method.
 pub async fn call_client_stream<T, Req, RespView>(
     transport: &T,
     config: &ClientConfig,
-    service: &str,
-    method: &str,
+    spec: Spec,
     requests: impl ClientRequestStream<Req>,
     options: CallOptions,
 ) -> Result<UnaryResponse<OwnedView<RespView>>, ConnectError>
@@ -4143,15 +4220,9 @@ where
     RespView: MessageView<'static> + Send,
     RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
+    check_client_spec(spec, StreamType::ClientStream, "call_client_stream")?;
     let options = effective_options(config, options);
-
-    // Build the full URI from base_uri and service/method path
-    let base_str = config.base_uri.to_string();
-    let base_str = base_str.trim_end_matches('/');
-    let full_uri = format!("{base_str}/{service}/{method}");
-    let uri: Uri = full_uri
-        .parse()
-        .map_err(|e| ConnectError::internal(format!("invalid URI: {e}")))?;
+    let uri = procedure_uri(config, spec, None)?;
 
     let compression_for_encoder = config.request_compression.as_ref().map(|enc| {
         (
@@ -5213,8 +5284,7 @@ mod tests {
         let err = call_server_stream::<_, StringValue, StringValueView<'static>>(
             &transport,
             &config,
-            "test.Service",
-            "ServerStream",
+            Spec::client("/test.Service/ServerStream", StreamType::ServerStream),
             StringValue::from("hello"),
             CallOptions::default(),
         )
@@ -6916,8 +6986,7 @@ mod tests {
         let err = call_unary::<_, StringValue, StringValueView<'static>>(
             &client,
             &config,
-            "test.Service",
-            "Unary",
+            Spec::client("/test.Service/Unary", StreamType::Unary),
             StringValue::from("hello"),
             CallOptions::default(),
         )
@@ -6937,8 +7006,7 @@ mod tests {
         let err = call_unary_get::<_, StringValue, StringValueView<'static>>(
             &client,
             &config,
-            "test.Service",
-            "UnaryGet",
+            Spec::client("/test.Service/UnaryGet", StreamType::Unary),
             StringValue::from("hello"),
             CallOptions::default(),
         )
@@ -6958,8 +7026,7 @@ mod tests {
         let err = call_server_stream::<_, StringValue, StringValueView<'static>>(
             &client,
             &config,
-            "test.Service",
-            "ServerStream",
+            Spec::client("/test.Service/ServerStream", StreamType::ServerStream),
             StringValue::from("hello"),
             CallOptions::default(),
         )
@@ -6979,8 +7046,7 @@ mod tests {
         let mut stream = call_bidi_stream::<_, StringValue, StringValueView<'static>>(
             &client,
             &config,
-            "test.Service",
-            "Bidi",
+            Spec::client("/test.Service/Bidi", StreamType::BidiStream),
             CallOptions::default(),
         )
         .await
@@ -7007,8 +7073,7 @@ mod tests {
         let err = call_client_stream::<_, StringValue, StringValueView<'static>>(
             &client,
             &config,
-            "test.Service",
-            "ClientStream",
+            Spec::client("/test.Service/ClientStream", StreamType::ClientStream),
             futures::stream::iter([StringValue::from("hello")]),
             CallOptions::default(),
         )
@@ -7129,8 +7194,7 @@ mod tests {
             call_client_stream::<_, StringValue, StringValueView<'static>>(
                 &transport,
                 &config,
-                "test.Service",
-                "ClientStream",
+                Spec::client("/test.Service/ClientStream", StreamType::ClientStream),
                 futures::stream::empty::<StringValue>(),
                 CallOptions::default().with_timeout(Duration::from_millis(100)),
             ),
@@ -7176,8 +7240,7 @@ mod tests {
             call_client_stream::<_, StringValue, StringValueView<'static>>(
                 &transport,
                 &config,
-                "test.Service",
-                "ClientStream",
+                Spec::client("/test.Service/ClientStream", StreamType::ClientStream),
                 futures::stream::empty::<StringValue>(),
                 CallOptions::default(),
             ),
@@ -7221,8 +7284,7 @@ mod tests {
             call_client_stream::<_, StringValue, StringValueView<'static>>(
                 &transport,
                 &config,
-                "test.Service",
-                "ClientStream",
+                Spec::client("/test.Service/ClientStream", StreamType::ClientStream),
                 stream_iter(requests),
                 CallOptions::default().with_timeout(Duration::from_millis(100)),
             ),
@@ -7298,8 +7360,7 @@ mod tests {
         let response = call_client_stream::<_, StringValue, StringValueView<'static>>(
             &transport,
             &config,
-            "test.Service",
-            "ClientStream",
+            Spec::client("/test.Service/ClientStream", StreamType::ClientStream),
             stream_iter([StringValue::from("req")]),
             CallOptions::default(),
         )
@@ -7335,8 +7396,7 @@ mod tests {
         let err = call_client_stream::<_, StringValue, StringValueView<'static>>(
             &FailingTransport,
             &config,
-            "test.Service",
-            "ClientStream",
+            Spec::client("/test.Service/ClientStream", StreamType::ClientStream),
             stream_iter([StringValue::from("req")]),
             CallOptions::default(),
         )
@@ -8788,6 +8848,109 @@ mod tests {
             add_unary_request_headers(builder, &config, Some(Duration::from_millis(500)), None);
         let req = builder.body(()).unwrap();
         assert_eq!(req.headers().get("grpc-timeout").unwrap(), "500m");
+    }
+
+    // ========================================================================
+    // procedure_uri / Spec plumbing
+    // ========================================================================
+
+    /// `Spec::procedure` carries the leading slash, so the request path is
+    /// base + procedure with any trailing slash on the base collapsed —
+    /// the same wire path the old `{base}/{service}/{method}` produced.
+    #[test]
+    fn procedure_uri_joins_base_and_procedure() {
+        let spec = Spec::client("/pkg.Svc/Do", StreamType::Unary);
+        for base in ["http://h:8080", "http://h:8080/", "http://h:8080/prefix/"] {
+            let config = ClientConfig::new(base.parse().unwrap());
+            let uri = procedure_uri(&config, spec, None).unwrap();
+            let want = format!("{}/pkg.Svc/Do", base.trim_end_matches('/'));
+            assert_eq!(uri.to_string(), want, "base {base}");
+        }
+        let config = ClientConfig::new("http://h".parse().unwrap());
+        let uri = procedure_uri(&config, spec, Some("connect=v1&encoding=proto")).unwrap();
+        assert_eq!(uri.path(), "/pkg.Svc/Do");
+        assert_eq!(uri.query(), Some("connect=v1&encoding=proto"));
+    }
+
+    /// `check_client_spec` accepts exactly a client-side spec of the entry
+    /// point's stream shape with a `/`-prefixed procedure, and each of the
+    /// three caller bugs it rejects gets an `Internal` error that says what
+    /// to do instead — in every build profile, not just debug.
+    #[test]
+    fn check_client_spec_table() {
+        use StreamType::*;
+        for st in [Unary, ClientStream, ServerStream, BidiStream] {
+            let ok = Spec::client("/pkg.Svc/M", st);
+            assert!(
+                check_client_spec(ok, st, entry_point_for(st)).is_ok(),
+                "{st:?}"
+            );
+        }
+        // Wrong entry point: names the right one.
+        let err = check_client_spec(
+            Spec::client("/pkg.Svc/Watch", ServerStream),
+            Unary,
+            "call_unary",
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::Internal);
+        let msg = err.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains("call_unary called with a ServerStream Spec for /pkg.Svc/Watch")
+                && msg.contains("use call_server_stream"),
+            "{msg}"
+        );
+        // Server-side spec on a client call.
+        let err =
+            check_client_spec(Spec::server("/pkg.Svc/M", Unary), Unary, "call_unary").unwrap_err();
+        assert!(
+            err.message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("server-side Spec"),
+            "{err:?}"
+        );
+        // Missing leading slash (only constructible in release, where
+        // `Spec::client`'s own debug assertion is compiled out).
+        #[cfg(not(debug_assertions))]
+        {
+            let err = check_client_spec(Spec::client("pkg.Svc/M", Unary), Unary, "call_unary")
+                .unwrap_err();
+            assert!(
+                err.message
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("must start with '/'"),
+                "{err:?}"
+            );
+        }
+    }
+
+    /// End to end through a public entry point: the check runs before any
+    /// transport work, so no request is attempted.
+    #[cfg(feature = "client")]
+    #[tokio::test]
+    async fn wrong_stream_type_spec_is_internal_error_before_send() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+        let config = ClientConfig::new("http://unused.invalid".parse().unwrap());
+        let err = call_unary::<_, StringValue, StringValueView<'static>>(
+            &HttpClient::plaintext(),
+            &config,
+            Spec::client("/pkg.Svc/Watch", StreamType::ServerStream),
+            StringValue::from("x"),
+            CallOptions::default(),
+        )
+        .await
+        .expect_err("mismatched spec must fail fast");
+        assert_eq!(err.code, ErrorCode::Internal, "{err:?}");
+        assert!(
+            err.message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("use call_server_stream"),
+            "{err:?}"
+        );
     }
 
     // ========================================================================

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -1509,7 +1509,7 @@ fn entry_point_for(stream_type: StreamType) -> &'static str {
 
 /// Validate a caller-supplied [`Spec`] against the entry point it reached.
 ///
-/// Generated clients always pass a matching `*_CLIENT_SPEC`; these checks
+/// Generated clients always pass a matching client-origin spec; these checks
 /// exist for hand-written callers, where the mistakes below would otherwise
 /// surface far from their cause (a protocol error from the server, a client
 /// interceptor observing `SpecOrigin::Server`, a mangled request URI). All
@@ -1529,8 +1529,8 @@ fn check_client_spec(
     }
     if spec.origin != SpecOrigin::Client {
         return Err(ConnectError::internal(format!(
-            "{entry_point} called with a server-side Spec for {}; pass the generated \
-             *_CLIENT_SPEC constant or Spec::client(..)",
+            "{entry_point} called with a server-side Spec for {}; pass \
+             FOO_SPEC.with_origin(SpecOrigin::Client) or Spec::client(..)",
             spec.procedure,
         )));
     }
@@ -1805,8 +1805,11 @@ where
 /// This is the core function used by generated clients to make RPC calls.
 /// It handles encoding, compression, and protocol details.
 ///
-/// `spec` identifies the method. Generated clients pass their per-method
-/// `*_CLIENT_SPEC` constant; a hand-written caller builds one with
+/// `spec` identifies the method and must have
+/// [`SpecOrigin::Client`]. Generated clients pass
+/// their per-method `*_SPEC` constant with
+/// [`.with_origin(SpecOrigin::Client)`](Spec::with_origin); a hand-written
+/// caller does the same, or builds one with
 /// [`Spec::client("/pkg.Service/Method", StreamType::Unary)`](Spec::client),
 /// chaining [`with_idempotency_level`](Spec::with_idempotency_level) when
 /// known (see [`Spec::client`] for callers whose method names are only
@@ -2768,7 +2771,7 @@ enum BodyPoll {
 /// # Example
 ///
 /// ```rust,ignore
-/// let mut stream = call_server_stream(&transport, &config, SVC_METHOD_CLIENT_SPEC, req, CallOptions::default()).await?;
+/// let mut stream = call_server_stream(&transport, &config, SVC_METHOD_SPEC.with_origin(SpecOrigin::Client), req, CallOptions::default()).await?;
 /// println!("headers: {:?}", stream.headers());
 /// while let Some(msg) = stream.message().await? {
 ///     println!("got message: {:?}", msg);
@@ -3619,7 +3622,7 @@ enum RecvState<B, RespView> {
 /// # Example
 ///
 /// ```rust,ignore
-/// let mut stream = call_bidi_stream(&transport, &config, SVC_METHOD_CLIENT_SPEC, CallOptions::default()).await?;
+/// let mut stream = call_bidi_stream(&transport, &config, SVC_METHOD_SPEC.with_origin(SpecOrigin::Client), CallOptions::default()).await?;
 /// stream.send(request1).await?;
 /// stream.send(request2).await?;
 /// stream.close_send();
@@ -4080,7 +4083,7 @@ where
 ///
 /// ```rust,ignore
 /// let mut stream = call_bidi_stream::<_, MyReq, MyRespView>(
-///     &transport, &config, MY_SERVICE_METHOD_CLIENT_SPEC, CallOptions::default(),
+///     &transport, &config, MY_SERVICE_METHOD_SPEC.with_origin(SpecOrigin::Client), CallOptions::default(),
 /// ).await?;
 /// stream.send(req).await?;
 /// stream.close_send();
@@ -4198,7 +4201,7 @@ where
 ///
 /// ```rust,ignore
 /// let resp = call_client_stream(
-///     &transport, &config, SVC_METHOD_CLIENT_SPEC,
+///     &transport, &config, SVC_METHOD_SPEC.with_origin(SpecOrigin::Client),
 ///     connectrpc::stream_iter(vec![req1, req2]),
 ///     CallOptions::default(),
 /// ).await?;

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -264,22 +264,19 @@ impl std::fmt::Debug for InterceptorChain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // `dyn Interceptor` is not `Debug`; the count is what a reader of a
         // config/service dump actually wants.
-        f.debug_struct("InterceptorChain")
-            .field("len", &self.0.len())
-            .finish()
+        write!(f, "[dyn Interceptor; {}]", self.0.len())
     }
 }
 
 /// The continuation an [`Interceptor`] calls to run the rest of the chain.
 ///
 /// `Next` holds the still-to-run interceptors and the terminal handler.
-/// [`run`](Next::run) consumes it, so the common case — call it once —
-/// needs no ceremony, and not calling it at all short-circuits the chain.
+/// [`run`](Next::run) consumes it; not calling it short-circuits the chain.
 ///
-/// `Next` is also `Clone` (it is two shared references), for the
-/// interceptor that must run the rest of the chain more than once: a
-/// retry or a hedge. Clone *before* the first `run` and build each extra
-/// attempt's request with [`UnaryRequest::try_clone`]:
+/// `Next` is also `Clone` (two shared references) for the interceptor that
+/// must run the rest of the chain more than once — a retry or a hedge.
+/// Clone before the first `run` and copy the request with
+/// [`UnaryRequest::try_clone`]:
 ///
 /// ```rust,ignore
 /// let spare = req.try_clone()?;            // ctx clone + Payload::try_clone
@@ -308,11 +305,8 @@ impl<'a> Next<'a> {
     }
 
     /// Run the rest of the chain — the next interceptor if any, otherwise
-    /// the terminal handler — and return its response.
-    ///
-    /// Consumes `self`. To run the chain again (retry), call
-    /// `next.clone().run(..)` for the earlier attempts; each run re-invokes
-    /// everything below, including the handler on the server.
+    /// the terminal handler — and return its response. Consumes `self`;
+    /// see [`Next`] for re-running.
     ///
     /// # Errors
     ///
@@ -394,30 +388,19 @@ impl UnaryRequest {
         Self { ctx, payload }
     }
 
-    /// Build a `UnaryRequest` from a context and an existing [`Payload`].
-    ///
-    /// The struct is `#[non_exhaustive]`, so downstream code cannot use a
-    /// struct literal; this is the constructor for an interceptor that
-    /// assembles a request itself, e.g. around a typed message with
-    /// [`Payload::from_message`]. (For a retry copy, prefer
-    /// [`try_clone`](Self::try_clone).)
-    ///
-    /// Unlike [`new`](Self::new), the payload keeps **its own** decode
-    /// options rather than taking the context's. When wrapping untrusted
-    /// wire bytes on the server, carry the service limits across
-    /// explicitly:
-    /// `Payload::new(bytes, fmt).with_decode_options(ctx.decode_options().clone())`.
+    /// Build a `UnaryRequest` from a context and an existing [`Payload`]
+    /// (the struct is `#[non_exhaustive]`, so downstream code cannot use a
+    /// struct literal) — e.g. around a typed message with
+    /// [`Payload::from_message`]. Unlike [`new`](Self::new), does not apply
+    /// the context's decode limits to the payload; use `new` for untrusted
+    /// wire bytes. For a retry copy, use [`try_clone`](Self::try_clone).
     pub fn from_parts(ctx: RequestContext, payload: Payload) -> Self {
         Self { ctx, payload }
     }
 
-    /// Copy this request for another trip through the chain.
-    ///
-    /// Clones the context (headers, extensions, deadline, spec) and
-    /// [`Payload::try_clone`]s the body. This is the one call a retry or
-    /// hedging interceptor makes before its first `next.clone().run(req)`;
-    /// see [`Next`] for the full shape. The copies are independent:
-    /// header edits on one attempt do not leak into another.
+    /// Copy this request for another trip through the chain: clones the
+    /// context and [`Payload::try_clone`]s the body, so header edits on one
+    /// attempt do not leak into another. See [`Next`] for the retry shape.
     ///
     /// # Errors
     ///
@@ -608,12 +591,8 @@ where
 /// streaming chain.
 ///
 /// `NextStream` holds the still-to-run interceptors and the terminal
-/// handler. [`run`](NextStream::run) consumes it. Not calling it
-/// short-circuits. It is `Clone` for symmetry with [`Next`], but
-/// re-running a streaming chain is rarely practical: `run` consumes the
-/// inbound [`PayloadStream`], which cannot be cloned, so a second attempt
-/// needs an inbound stream you buffered or synthesized yourself.
-#[derive(Clone)]
+/// handler. [`run`](NextStream::run) consumes it: an interceptor can call
+/// `next.run(req, inbound)` at most once. Not calling it short-circuits.
 pub struct NextStream<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn StreamTerminal + 'a),
@@ -1432,16 +1411,18 @@ mod tests {
         assert_eq!(echoed.value, "hi", "retry carried the original body");
     }
 
+    /// An interceptor that overrides nothing: both hooks pass through.
+    struct Passthrough;
+    #[async_trait::async_trait]
+    impl Interceptor for Passthrough {}
+
     #[test]
     fn interceptor_chain_push_and_debug() {
-        struct Nop;
-        #[async_trait::async_trait]
-        impl Interceptor for Nop {}
         let mut chain = InterceptorChain::default();
         assert!(chain.is_empty());
         let shared = chain.clone();
-        let a: Arc<dyn Interceptor> = Arc::new(Nop);
-        let b: Arc<dyn Interceptor> = Arc::new(Nop);
+        let a: Arc<dyn Interceptor> = Arc::new(Passthrough);
+        let b: Arc<dyn Interceptor> = Arc::new(Passthrough);
         chain.push(Arc::clone(&a));
         chain.push(Arc::clone(&b));
         // Deref to slice; `push` appends, so first registered stays
@@ -1452,7 +1433,7 @@ mod tests {
         // `push` rebuilds; an earlier clone is unaffected (registration on
         // one handle must not retroactively change another).
         assert!(shared.is_empty());
-        assert!(format!("{chain:?}").contains("len: 2"), "{chain:?}");
+        assert_eq!(format!("{chain:?}"), "[dyn Interceptor; 2]");
     }
 
     /// `new` stamps the context's decode options onto the payload;
@@ -1484,9 +1465,6 @@ mod tests {
     /// metadata, not just the body.
     #[tokio::test]
     async fn passthrough_chain_preserves_response_metadata() {
-        struct Passthrough;
-        #[async_trait::async_trait]
-        impl Interceptor for Passthrough {}
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
         let resp = run_chain(&chain, req(), |_| async {
             let mut r = EncodedResponse::new(Bytes::from_static(b"x").into());
@@ -1838,9 +1816,6 @@ mod tests {
 
     #[tokio::test]
     async fn streaming_passthrough_preserves_items_and_metadata() {
-        struct Passthrough;
-        #[async_trait::async_trait]
-        impl Interceptor for Passthrough {}
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
         let resp = run_chain_streaming(
             &chain,
@@ -2232,9 +2207,6 @@ mod tests {
     /// collapses a 1-item outbound stream — through a passthrough chain.
     #[tokio::test]
     async fn streaming_intercepted_un_unifies_through_passthrough_chain() {
-        struct Passthrough;
-        #[async_trait::async_trait]
-        impl Interceptor for Passthrough {}
         let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Passthrough)];
 
         // Server-streaming: single body in → 1-item inbound stream → terminal

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -289,6 +289,9 @@ impl std::fmt::Debug for InterceptorChain {
 /// Re-running dispatches the inner interceptors *and the terminal* again.
 /// On the server that means invoking the handler twice, so gate any
 /// re-run on [`Spec::idempotency_level`](crate::Spec::idempotency_level).
+/// Every attempt shares the one request deadline (a retry cannot extend
+/// it) and the one request tracing span; open a span per attempt if they
+/// need to be observable separately.
 #[derive(Clone)]
 pub struct Next<'a> {
     rest: &'a [Arc<dyn Interceptor>],
@@ -393,7 +396,8 @@ impl UnaryRequest {
     /// struct literal) — e.g. around a typed message with
     /// [`Payload::from_message`]. Unlike [`new`](Self::new), does not apply
     /// the context's decode limits to the payload; use `new` for untrusted
-    /// wire bytes. For a retry copy, use [`try_clone`](Self::try_clone).
+    /// wire bytes. For a retry copy, use [`try_clone`](Self::try_clone),
+    /// which keeps the limits.
     pub fn from_parts(ctx: RequestContext, payload: Payload) -> Self {
         Self { ctx, payload }
     }
@@ -446,6 +450,23 @@ impl UnaryResponse {
     pub fn into_encoded(self) -> Result<EncodedResponse, ConnectError> {
         Ok(Response {
             body: self.body.encoded()?.into(),
+            headers: self.headers,
+            trailers: self.trailers,
+            compress: self.compress,
+        })
+    }
+
+    /// [`into_encoded`](Self::into_encoded), but in the format the call
+    /// negotiated rather than the one the payload was built with, so an
+    /// interceptor that short-circuits with
+    /// [`Payload::from_message`] in the wrong format still answers the peer
+    /// in the format it asked for (see [`Payload::encoded_as`]).
+    pub(crate) fn into_encoded_as(
+        self,
+        format: CodecFormat,
+    ) -> Result<EncodedResponse, ConnectError> {
+        Ok(Response {
+            body: self.body.encoded_as(format)?.into(),
             headers: self.headers,
             trailers: self.trailers,
             compress: self.compress,
@@ -593,6 +614,9 @@ where
 /// `NextStream` holds the still-to-run interceptors and the terminal
 /// handler. [`run`](NextStream::run) consumes it: an interceptor can call
 /// `next.run(req, inbound)` at most once. Not calling it short-circuits.
+/// Unlike [`Next`], this is not `Clone`: the inbound stream is consumed as
+/// it is read and cannot be replayed, so a streaming chain runs once by
+/// construction.
 pub struct NextStream<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn StreamTerminal + 'a),
@@ -1020,7 +1044,7 @@ pub(crate) async fn call_unary_intercepted<D: crate::Dispatcher>(
     };
     let req = UnaryRequest::new(ctx, body, format);
     let resp = Next::new(interceptors, &terminal).run(req).await?;
-    resp.into_encoded()
+    resp.into_encoded_as(format)
 }
 
 /// `UnaryTerminal` that hands off to the dispatcher's `call_unary`.
@@ -1175,6 +1199,84 @@ mod tests {
             "p1",
             "diagnostic headers on a short-circuit error must survive the chain"
         );
+    }
+
+    /// A short-circuit response built in the wrong format is re-encoded in
+    /// the negotiated one, so the peer never receives proto bytes under a
+    /// JSON content-type (or vice versa).
+    #[cfg(feature = "json")]
+    #[tokio::test]
+    async fn call_unary_intercepted_answers_in_the_negotiated_format() {
+        struct Canned;
+        #[async_trait::async_trait]
+        impl Interceptor for Canned {
+            async fn intercept_unary(
+                &self,
+                _req: UnaryRequest,
+                _next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                // The obvious-but-wrong spelling: a proto payload on a JSON call.
+                Ok(Response::new(Payload::from_message(
+                    StringValue::from("canned"),
+                    CodecFormat::Proto,
+                )))
+            }
+        }
+        struct Unreached;
+        impl crate::Dispatcher for Unreached {
+            fn lookup(&self, _: &str) -> Option<crate::dispatcher::MethodDescriptor> {
+                None
+            }
+            fn call_unary(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Payload,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!("short-circuited")
+            }
+            fn call_server_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: Bytes,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+            fn call_client_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::UnaryResult {
+                unreachable!()
+            }
+            fn call_bidi_streaming(
+                &self,
+                _: &str,
+                _: RequestContext,
+                _: crate::dispatcher::RequestStream,
+                _: CodecFormat,
+            ) -> crate::dispatcher::StreamingResult {
+                unreachable!()
+            }
+        }
+        let chain: Vec<Arc<dyn Interceptor>> = vec![Arc::new(Canned)];
+        let resp = call_unary_intercepted(
+            &Unreached,
+            &chain,
+            "svc/Method",
+            RequestContext::default(),
+            Bytes::from_static(b"{}"),
+            CodecFormat::Json,
+        )
+        .await
+        .unwrap();
+        let rt: StringValue = crate::codec::decode_json(&resp.body.into_contiguous()).unwrap();
+        assert_eq!(rt.value, "canned");
     }
 
     /// `call_unary_intercepted` propagates a short-circuit error verbatim,

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -232,11 +232,67 @@ where
     FnInterceptor(f)
 }
 
+/// An ordered, cheaply-cloneable list of interceptors, outermost first.
+///
+/// The one storage type both registration points use
+/// ([`ConnectRpcService`](crate::ConnectRpcService) today, the client
+/// config next). Backed by `Arc<[..]>` so cloning a service handle or a
+/// config is one refcount bump regardless of chain length; `push`
+/// rebuilds the slice, which is fine because registration is a cold path.
+/// Derefs to the slice so call sites pass `&chain` where
+/// `&[Arc<dyn Interceptor>]` is expected.
+#[derive(Clone, Default)]
+pub(crate) struct InterceptorChain(Arc<[Arc<dyn Interceptor>]>);
+
+impl InterceptorChain {
+    /// Append `interceptor` as the new innermost entry.
+    pub(crate) fn push(&mut self, interceptor: Arc<dyn Interceptor>) {
+        let mut v: Vec<Arc<dyn Interceptor>> = self.0.to_vec();
+        v.push(interceptor);
+        self.0 = Arc::from(v);
+    }
+}
+
+impl std::ops::Deref for InterceptorChain {
+    type Target = [Arc<dyn Interceptor>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for InterceptorChain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `dyn Interceptor` is not `Debug`; the count is what a reader of a
+        // config/service dump actually wants.
+        f.debug_struct("InterceptorChain")
+            .field("len", &self.0.len())
+            .finish()
+    }
+}
+
 /// The continuation an [`Interceptor`] calls to run the rest of the chain.
 ///
 /// `Next` holds the still-to-run interceptors and the terminal handler.
-/// [`run`](Next::run) consumes it: an interceptor can call `next.run(req)`
-/// at most once. Not calling it at all short-circuits the chain.
+/// [`run`](Next::run) consumes it, so the common case — call it once —
+/// needs no ceremony, and not calling it at all short-circuits the chain.
+///
+/// `Next` is also `Clone` (it is two shared references), for the
+/// interceptor that must run the rest of the chain more than once: a
+/// retry or a hedge. Clone *before* the first `run` and build each extra
+/// attempt's request with [`UnaryRequest::try_clone`]:
+///
+/// ```rust,ignore
+/// let spare = req.try_clone()?;            // ctx clone + Payload::try_clone
+/// match next.clone().run(req).await {
+///     Err(e) if e.code == ErrorCode::Unavailable => next.run(spare).await,
+///     done => done,
+/// }
+/// ```
+///
+/// Re-running dispatches the inner interceptors *and the terminal* again.
+/// On the server that means invoking the handler twice, so gate any
+/// re-run on [`Spec::idempotency_level`](crate::Spec::idempotency_level).
+#[derive(Clone)]
 pub struct Next<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn UnaryTerminal + 'a),
@@ -253,6 +309,10 @@ impl<'a> Next<'a> {
 
     /// Run the rest of the chain — the next interceptor if any, otherwise
     /// the terminal handler — and return its response.
+    ///
+    /// Consumes `self`. To run the chain again (retry), call
+    /// `next.clone().run(..)` for the earlier attempts; each run re-invokes
+    /// everything below, including the handler on the server.
     ///
     /// # Errors
     ///
@@ -297,23 +357,29 @@ pub(crate) trait UnaryTerminal: Send + Sync {
 /// Carries the dispatch [`RequestContext`] (headers, deadline,
 /// extensions, [`Spec`](crate::Spec), negotiated protocol) and the
 /// lazily-decoded body. Both fields are public so an interceptor can
-/// rewrite headers, inject extensions, or replace the message and pass
-/// the mutated request to [`Next::run`].
+/// rewrite headers ([`ctx.headers_mut()`](RequestContext::headers_mut)),
+/// inject extensions ([`ctx.extensions_mut()`](RequestContext::extensions_mut)),
+/// or replace the message ([`payload.set_message(..)`](Payload::set_message))
+/// and pass the mutated request to [`Next::run`].
 ///
-/// `ctx.spec` is `Some(..)` for generated `FooServiceServer<T>`
+/// `ctx.spec()` is `Some(..)` for generated `FooServiceServer<T>`
 /// dispatchers and for [`Router`](crate::Router) routes registered
 /// through the generated `register()`; it is `None` only for low-level
 /// manual registrations without a
 /// [`Router::with_spec`](crate::Router::with_spec) call.
 ///
 /// `#[non_exhaustive]` so future fields can be added without a
-/// breaking change. Construct with [`UnaryRequest::new`]; destructure
-/// with a trailing `..`.
+/// breaking change. Construct with [`UnaryRequest::new`] (from wire
+/// bytes) or [`UnaryRequest::from_parts`] (from a [`Payload`]); copy for
+/// a second attempt with [`UnaryRequest::try_clone`]; destructure with a
+/// trailing `..`.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct UnaryRequest {
-    /// The dispatch context. Mutating `ctx.headers` or `ctx.extensions`
-    /// before `next.run` propagates to the handler.
+    /// The dispatch context. Changes made through
+    /// [`headers_mut()`](RequestContext::headers_mut) or
+    /// [`extensions_mut()`](RequestContext::extensions_mut) before
+    /// `next.run` propagate to the handler.
     pub ctx: RequestContext,
     /// The lazily-decoded request body. Call
     /// [`set_message`](Payload::set_message) to replace it.
@@ -326,6 +392,42 @@ impl UnaryRequest {
     pub fn new(ctx: RequestContext, body: Bytes, format: CodecFormat) -> Self {
         let payload = Payload::new(body, format).with_decode_options(ctx.decode_options().clone());
         Self { ctx, payload }
+    }
+
+    /// Build a `UnaryRequest` from a context and an existing [`Payload`].
+    ///
+    /// The struct is `#[non_exhaustive]`, so downstream code cannot use a
+    /// struct literal; this is the constructor for an interceptor that
+    /// assembles a request itself, e.g. around a typed message with
+    /// [`Payload::from_message`]. (For a retry copy, prefer
+    /// [`try_clone`](Self::try_clone).)
+    ///
+    /// Unlike [`new`](Self::new), the payload keeps **its own** decode
+    /// options rather than taking the context's. When wrapping untrusted
+    /// wire bytes on the server, carry the service limits across
+    /// explicitly:
+    /// `Payload::new(bytes, fmt).with_decode_options(ctx.decode_options().clone())`.
+    pub fn from_parts(ctx: RequestContext, payload: Payload) -> Self {
+        Self { ctx, payload }
+    }
+
+    /// Copy this request for another trip through the chain.
+    ///
+    /// Clones the context (headers, extensions, deadline, spec) and
+    /// [`Payload::try_clone`]s the body. This is the one call a retry or
+    /// hedging interceptor makes before its first `next.clone().run(req)`;
+    /// see [`Next`] for the full shape. The copies are independent:
+    /// header edits on one attempt do not leak into another.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload holds a replacement that fails to
+    /// encode.
+    pub fn try_clone(&self) -> Result<Self, ConnectError> {
+        Ok(Self {
+            ctx: self.ctx.clone(),
+            payload: self.payload.try_clone()?,
+        })
     }
 }
 
@@ -391,11 +493,13 @@ pub type PayloadStream = BoxStream<Result<Payload, ConnectError>>;
 /// `#[non_exhaustive]` so future fields can be added without a breaking
 /// change. Construct with [`StreamRequest::new`]; destructure with a
 /// trailing `..`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct StreamRequest {
-    /// The dispatch context. Mutating `ctx.headers` or `ctx.extensions`
-    /// before `next.run` propagates to the handler.
+    /// The dispatch context. Changes made through
+    /// [`headers_mut()`](RequestContext::headers_mut) or
+    /// [`extensions_mut()`](RequestContext::extensions_mut) before
+    /// `next.run` propagate to the handler.
     pub ctx: RequestContext,
 }
 
@@ -504,8 +608,12 @@ where
 /// streaming chain.
 ///
 /// `NextStream` holds the still-to-run interceptors and the terminal
-/// handler. [`run`](NextStream::run) consumes it: an interceptor can call
-/// `next.run(req, inbound)` at most once. Not calling it short-circuits.
+/// handler. [`run`](NextStream::run) consumes it. Not calling it
+/// short-circuits. It is `Clone` for symmetry with [`Next`], but
+/// re-running a streaming chain is rarely practical: `run` consumes the
+/// inbound [`PayloadStream`], which cannot be cloned, so a second attempt
+/// needs an inbound stream you buffered or synthesized yourself.
+#[derive(Clone)]
 pub struct NextStream<'a> {
     rest: &'a [Arc<dyn Interceptor>],
     terminal: &'a (dyn StreamTerminal + 'a),
@@ -1221,6 +1329,154 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(resp.headers.get("x-fn").unwrap(), "1");
+    }
+
+    /// `Next` is `Clone`, so an interceptor can run the rest of the chain
+    /// more than once with a fresh request — the retry/hedge shape. Each
+    /// run reaches the inner interceptors and the terminal independently,
+    /// and request mutations (headers here) made per attempt are visible
+    /// below and do not leak between attempts.
+    #[tokio::test]
+    async fn next_is_rerunnable_for_retry() {
+        /// Fails the first attempt, succeeds afterwards; records the
+        /// `x-attempt` header each attempt carried and whether the
+        /// first-attempt-only marker leaked.
+        struct FlakyTerminal {
+            calls: Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl UnaryTerminal for FlakyTerminal {
+            async fn call(&self, req: UnaryRequest) -> Result<UnaryResponse, ConnectError> {
+                let attempt = req
+                    .ctx
+                    .header("x-attempt")
+                    .map(|v| v.to_str().unwrap().to_owned())
+                    .unwrap_or_default();
+                let mut calls = self.calls.lock().unwrap();
+                calls.push(attempt);
+                if calls.len() == 1 {
+                    return Err(ConnectError::unavailable("first attempt fails"));
+                }
+                assert!(
+                    req.ctx.header("x-first-only").is_none(),
+                    "attempt contexts must be independent (ctx was cloned, not shared)"
+                );
+                // Echo the request body so the test can check the retry
+                // carried the same payload.
+                Ok(UnaryResponse::from_encoded(
+                    EncodedResponse::new(req.payload.encoded()?.into()),
+                    CodecFormat::Proto,
+                ))
+            }
+        }
+
+        struct RetryOnce;
+        #[async_trait::async_trait]
+        impl Interceptor for RetryOnce {
+            async fn intercept_unary(
+                &self,
+                req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                // Keep what a second attempt needs *before* moving `req`.
+                let mut second = req.try_clone()?;
+                let mut first = req;
+                first
+                    .ctx
+                    .headers_mut()
+                    .insert("x-attempt", "1".parse().unwrap());
+                first
+                    .ctx
+                    .headers_mut()
+                    .insert("x-first-only", "leak-check".parse().unwrap());
+                match next.clone().run(first).await {
+                    Err(e) if e.code == crate::ErrorCode::Unavailable => {
+                        second
+                            .ctx
+                            .headers_mut()
+                            .insert("x-attempt", "2".parse().unwrap());
+                        next.run(second).await
+                    }
+                    other => other,
+                }
+            }
+        }
+
+        // An inner interceptor proves the *whole* remaining chain re-runs,
+        // not just the terminal.
+        let inner_runs = Arc::new(Mutex::new(0u32));
+        struct Count(Arc<Mutex<u32>>);
+        #[async_trait::async_trait]
+        impl Interceptor for Count {
+            async fn intercept_unary(
+                &self,
+                req: UnaryRequest,
+                next: Next<'_>,
+            ) -> Result<UnaryResponse, ConnectError> {
+                *self.0.lock().unwrap() += 1;
+                next.run(req).await
+            }
+        }
+
+        let chain: Vec<Arc<dyn Interceptor>> = vec![
+            Arc::new(RetryOnce),
+            Arc::new(Count(Arc::clone(&inner_runs))),
+        ];
+        let terminal = FlakyTerminal {
+            calls: Mutex::new(Vec::new()),
+        };
+        let resp = Next::new(&chain, &terminal).run(req()).await.unwrap();
+        assert_eq!(*terminal.calls.lock().unwrap(), vec!["1", "2"]);
+        assert_eq!(*inner_runs.lock().unwrap(), 2, "inner chain re-ran");
+        let echoed: StringValue = resp.body.message::<StringValue>().unwrap().clone();
+        assert_eq!(echoed.value, "hi", "retry carried the original body");
+    }
+
+    #[test]
+    fn interceptor_chain_push_and_debug() {
+        struct Nop;
+        #[async_trait::async_trait]
+        impl Interceptor for Nop {}
+        let mut chain = InterceptorChain::default();
+        assert!(chain.is_empty());
+        let shared = chain.clone();
+        let a: Arc<dyn Interceptor> = Arc::new(Nop);
+        let b: Arc<dyn Interceptor> = Arc::new(Nop);
+        chain.push(Arc::clone(&a));
+        chain.push(Arc::clone(&b));
+        // Deref to slice; `push` appends, so first registered stays
+        // outermost (index 0) — the documented ordering contract.
+        assert_eq!(chain.len(), 2);
+        assert!(Arc::ptr_eq(&chain[0], &a), "first registered is outermost");
+        assert!(Arc::ptr_eq(&chain[1], &b));
+        // `push` rebuilds; an earlier clone is unaffected (registration on
+        // one handle must not retroactively change another).
+        assert!(shared.is_empty());
+        assert!(format!("{chain:?}").contains("len: 2"), "{chain:?}");
+    }
+
+    /// `new` stamps the context's decode options onto the payload;
+    /// `from_parts` deliberately keeps the payload's own. Pinned so the
+    /// difference is a decision, not an accident.
+    #[test]
+    fn from_parts_keeps_payload_decode_options() {
+        let ctx = RequestContext::default()
+            .with_decode_options(buffa::DecodeOptions::new().with_recursion_limit(3));
+        let via_new = UnaryRequest::new(ctx.clone(), Bytes::new(), CodecFormat::Proto);
+        assert_eq!(
+            format!("{:?}", via_new.payload.decode_options()),
+            format!("{:?}", ctx.decode_options()),
+            "new: payload takes ctx options"
+        );
+        let payload = Payload::new(Bytes::new(), CodecFormat::Proto)
+            .with_decode_options(buffa::DecodeOptions::new().with_recursion_limit(9));
+        let want = format!("{:?}", payload.decode_options());
+        let via_parts = UnaryRequest::from_parts(ctx, payload);
+        assert_eq!(
+            format!("{:?}", via_parts.payload.decode_options()),
+            want,
+            "from_parts: payload keeps its own options"
+        );
     }
 
     /// Trailers and the compression hint must round-trip through a

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -128,20 +128,34 @@ where
 ///
 /// `Payload` is intentionally not `Clone`: a clone would either drop the
 /// decode cache (surprising) or duplicate it (defeating the laziness).
-/// Pass it by reference, or move it through the call chain. When a
-/// second body is genuinely needed (a retry interceptor), call
-/// [`try_clone`](Payload::try_clone), which is explicit about copying
-/// the encoded bytes and starting with an empty cache.
+/// Pass it by reference, or move it through the call chain; when a
+/// second body is genuinely needed, [`try_clone`](Payload::try_clone) is
+/// the explicit copy.
 pub struct Payload {
     bytes: Bytes,
     format: CodecFormat,
     decoded: OnceLock<Box<dyn AnyMessage>>,
-    replaced: Option<Box<dyn AnyMessage>>,
-    /// Memoized `replaced.encode(format)`, so `encoded()` / `try_clone()`
-    /// on a replaced or `from_message` payload encode at most once. Reset
-    /// by `set_message`. Unused while `replaced` is `None`.
-    replaced_encoded: OnceLock<Bytes>,
+    /// Boxed so a payload without a replacement (the server fast path)
+    /// carries one pointer, not the message box plus its encode memo.
+    replaced: Option<Box<Replacement>>,
     decode_options: buffa::DecodeOptions,
+}
+
+/// A message set by [`Payload::set_message`] / [`Payload::from_message`],
+/// with its wire encoding memoized on first [`Payload::encoded`]. A new
+/// replacement is a new `Replacement`, so the memo can never be stale.
+struct Replacement {
+    message: Box<dyn AnyMessage>,
+    encoded: OnceLock<Bytes>,
+}
+
+impl Replacement {
+    fn new(message: impl AnyMessage) -> Box<Self> {
+        Box::new(Self {
+            message: Box::new(message),
+            encoded: OnceLock::new(),
+        })
+    }
 }
 
 impl Payload {
@@ -153,7 +167,6 @@ impl Payload {
             format,
             decoded: OnceLock::new(),
             replaced: None,
-            replaced_encoded: OnceLock::new(),
             decode_options: buffa::DecodeOptions::new(),
         }
     }
@@ -178,22 +191,14 @@ impl Payload {
     /// Short-circuit example (a cache hit, a test double):
     /// `Ok(Response::new(Payload::from_message(reply, req.payload.format())))`.
     pub fn from_message<M: AnyMessage>(message: M, format: CodecFormat) -> Self {
-        Self {
-            bytes: Bytes::new(),
-            format,
-            decoded: OnceLock::new(),
-            replaced: Some(Box::new(message)),
-            replaced_encoded: OnceLock::new(),
-            decode_options: buffa::DecodeOptions::new(),
-        }
+        let mut payload = Self::new(Bytes::new(), format);
+        payload.replaced = Some(Replacement::new(message));
+        payload
     }
 
-    /// Produce an independent `Payload` carrying the same body.
-    ///
-    /// `Payload` is deliberately not `Clone` (see the type docs). This is
-    /// the explicit escape hatch for an interceptor that runs the rest of
-    /// the chain more than once — retry, hedging — and therefore needs a
-    /// second request body (see also
+    /// Produce an independent `Payload` carrying the same body — the
+    /// explicit copy for an interceptor that runs the rest of the chain
+    /// more than once (see
     /// [`UnaryRequest::try_clone`](crate::interceptor::UnaryRequest::try_clone)).
     /// The copy holds this payload's [`encoded`](Payload::encoded) bytes
     /// (a refcount bump; a replacement is encoded once and memoized on
@@ -211,14 +216,10 @@ impl Payload {
     ///
     /// Returns an error if encoding a replacement fails.
     pub fn try_clone(&self) -> Result<Self, ConnectError> {
-        Ok(Self {
-            bytes: self.encoded()?,
-            format: self.format,
-            decoded: OnceLock::new(),
-            replaced: None,
-            replaced_encoded: OnceLock::new(),
-            decode_options: self.decode_options.clone(),
-        })
+        Ok(
+            Self::new(self.encoded()?, self.format)
+                .with_decode_options(self.decode_options.clone()),
+        )
     }
 
     /// Attach the decode limits a typed accessor should honour.
@@ -277,6 +278,7 @@ impl Payload {
         M: Message + JsonSerialize + JsonDeserialize + 'static,
     {
         if let Some(replaced) = &self.replaced {
+            let replaced = &replaced.message;
             return replaced.as_any().downcast_ref::<M>().ok_or_else(|| {
                 ConnectError::internal(format!(
                     "payload replacement is a {}, not a {}",
@@ -351,6 +353,7 @@ impl Payload {
         M: Message + JsonDeserialize + 'static,
     {
         if let Some(replaced) = self.replaced {
+            let replaced = replaced.message;
             let type_name = replaced.type_name();
             return replaced
                 .into_any()
@@ -425,7 +428,7 @@ impl Payload {
             // payload's replacement needs a separate proto encode.
             let bytes = match self.format {
                 CodecFormat::Proto => self.encoded()?,
-                CodecFormat::Json => replaced.encode(CodecFormat::Proto)?,
+                CodecFormat::Json => replaced.message.encode(CodecFormat::Proto)?,
             };
             return OwnedView::decode(bytes).map_err(|e| {
                 ConnectError::internal(format!("failed to decode replacement as view: {e}"))
@@ -450,19 +453,12 @@ impl Payload {
     where
         M: AnyMessage,
     {
-        self.replaced = Some(Box::new(message));
-        // A memoized encode of the *previous* replacement must not be
-        // served for the new one.
-        if self.replaced_encoded.get().is_some() {
-            self.replaced_encoded = OnceLock::new();
-        }
+        self.replaced = Some(Replacement::new(message));
         // Drop the prior decode cache so the original message doesn't pin
         // memory for the Payload's lifetime. `replaced` is checked first,
         // so a stale cache would never be visible — this is purely a
         // memory concern.
-        if self.decoded.get().is_some() {
-            self.decoded = OnceLock::new();
-        }
+        self.decoded.take();
     }
 
     /// The wire bytes the dispatch path should actually send.
@@ -483,11 +479,11 @@ impl Payload {
         // Probe-then-set, as in `message()`: `get_or_try_init` is
         // unstable. Two racing callers both encode; one `set` wins and
         // both return equal bytes.
-        if let Some(cached) = self.replaced_encoded.get() {
+        if let Some(cached) = replaced.encoded.get() {
             return Ok(cached.clone());
         }
-        let bytes = replaced.encode(self.format)?;
-        let _ = self.replaced_encoded.set(bytes.clone());
+        let bytes = replaced.message.encode(self.format)?;
+        let _ = replaced.encoded.set(bytes.clone());
         Ok(bytes)
     }
 }
@@ -632,13 +628,7 @@ mod tests {
     /// typed access is a downcast, `encoded()` produces the wire form.
     #[test]
     fn from_message_is_lazily_encoded() {
-        let p = Payload::from_message(
-            StringValue {
-                value: "typed".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
+        let p = Payload::from_message(StringValue::from("typed"), CodecFormat::Proto);
         // The documented trap: `bytes()` is what was *received* (nothing);
         // `encoded()` is what will be *sent*.
         assert!(
@@ -675,26 +665,14 @@ mod tests {
     #[cfg(feature = "json")]
     #[test]
     fn from_message_encodes_in_requested_format() {
-        let p = Payload::from_message(
-            StringValue {
-                value: "j".into(),
-                ..Default::default()
-            },
-            CodecFormat::Json,
-        );
+        let p = Payload::from_message(StringValue::from("j"), CodecFormat::Json);
         let rt: StringValue = decode_json(&p.encoded().unwrap()).unwrap();
         assert_eq!(rt.value, "j");
     }
 
     #[test]
     fn from_message_wrong_type_is_internal_error() {
-        let p = Payload::from_message(
-            StringValue {
-                value: "s".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
+        let p = Payload::from_message(StringValue::from("s"), CodecFormat::Proto);
         let err = p
             .message::<buffa_types::google::protobuf::Int64Value>()
             .unwrap_err();
@@ -720,26 +698,11 @@ mod tests {
         assert_eq!(c.message::<StringValue>().unwrap().value, "orig");
 
         let mut replaced = proto_payload("orig");
-        replaced.set_message(StringValue {
-            value: "new".into(),
-            ..Default::default()
-        });
+        replaced.set_message(StringValue::from("new"));
         let c = replaced.try_clone().unwrap();
         assert!(c.replaced.is_none(), "replacement is baked into bytes");
         let rt: StringValue = crate::codec::decode_proto(c.bytes()).unwrap();
         assert_eq!(rt.value, "new");
-
-        // And from a lazily-encoded payload: the clone carries real bytes.
-        let lazy = Payload::from_message(
-            StringValue {
-                value: "lazy".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
-        let c = lazy.try_clone().unwrap();
-        assert!(!c.bytes().is_empty());
-        assert_eq!(c.message::<StringValue>().unwrap().value, "lazy");
     }
 
     /// A replacement (or `from_message` body) is encoded at most once:
@@ -747,13 +710,7 @@ mod tests {
     /// and `set_message` invalidates it.
     #[test]
     fn replacement_encode_is_memoized_and_invalidated() {
-        let mut p = Payload::from_message(
-            StringValue {
-                value: "once".into(),
-                ..Default::default()
-            },
-            CodecFormat::Proto,
-        );
+        let mut p = Payload::from_message(StringValue::from("once"), CodecFormat::Proto);
         let first = p.encoded().unwrap();
         let again = p.encoded().unwrap();
         assert!(
@@ -774,10 +731,7 @@ mod tests {
             "view should borrow the memoized bytes"
         );
 
-        p.set_message(StringValue {
-            value: "twice".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("twice"));
         let rt: StringValue = crate::codec::decode_proto(&p.encoded().unwrap()).unwrap();
         assert_eq!(rt.value, "twice", "set_message must invalidate the memo");
     }
@@ -805,17 +759,10 @@ mod tests {
     #[test]
     fn try_clone_json_replacement_is_wire_equal_not_api_equal() {
         let mut p = Payload::new(
-            encode_json(&StringValue {
-                value: "before".into(),
-                ..Default::default()
-            })
-            .unwrap(),
+            encode_json(&StringValue::from("before")).unwrap(),
             CodecFormat::Json,
         );
-        p.set_message(StringValue {
-            value: "after".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("after"));
         assert!(
             p.view::<StringValueView>().is_ok(),
             "original: replacement can be viewed"
@@ -902,16 +849,9 @@ mod tests {
     fn view_replaced_json_format_payload() {
         // A replacement is always re-encoded to proto for view(), so a
         // JSON-format payload with a replacement still views successfully.
-        let bytes = encode_json(&StringValue {
-            value: "before".into(),
-            ..Default::default()
-        })
-        .unwrap();
+        let bytes = encode_json(&StringValue::from("before")).unwrap();
         let mut p = Payload::new(bytes, CodecFormat::Json);
-        p.set_message(StringValue {
-            value: "after".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("after"));
         let v = p.view::<StringValueView>().unwrap();
         assert_eq!(v.reborrow().value, "after");
     }
@@ -919,14 +859,8 @@ mod tests {
     #[test]
     fn set_message_twice_supersedes() {
         let mut p = proto_payload("original");
-        p.set_message(StringValue {
-            value: "first".into(),
-            ..Default::default()
-        });
-        p.set_message(StringValue {
-            value: "second".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("first"));
+        p.set_message(StringValue::from("second"));
         let m: &StringValue = p.message().unwrap();
         assert_eq!(m.value, "second");
     }
@@ -960,10 +894,7 @@ mod tests {
         // proto. If `take_message` decoded the bytes instead of moving
         // the replacement out, this would error.
         let mut p = Payload::new(Bytes::from_static(&[0xff, 0xff, 0xff]), CodecFormat::Proto);
-        p.set_message(StringValue {
-            value: "replaced".into(),
-            ..Default::default()
-        });
+        p.set_message(StringValue::from("replaced"));
         let m: StringValue = p.take_message().unwrap();
         assert_eq!(m.value, "replaced");
     }

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -6,8 +6,9 @@
 //! message eagerly would tax every call to pay for the rare interceptor
 //! that inspects fields.
 //!
-//! [`Payload`] solves this by holding the wire bytes (always available,
-//! reference-counted) and decoding to a typed message on first access.
+//! [`Payload`] solves this by holding the wire bytes (reference-counted)
+//! and decoding to a typed message on first access — or, when built from
+//! a typed message with [`Payload::from_message`], encoding on first need.
 //! Interceptors that want a typed message call [`Payload::message`]
 //! (owned, works for both proto and JSON wires) or [`Payload::view`]
 //! (zero-copy, proto only). Interceptors that want to *replace* the
@@ -99,9 +100,10 @@ where
 
 /// A lazily-decoded, replaceable RPC message body.
 ///
-/// A `Payload` always holds the wire-encoded body bytes ([`Bytes`], so
-/// clones are reference-counted) and the [`CodecFormat`] they came in.
-/// Typed access happens on demand:
+/// A `Payload` holds the wire-encoded body bytes ([`Bytes`], so clones
+/// are reference-counted) and the [`CodecFormat`] they came in — or, when
+/// built with [`from_message`](Payload::from_message), a typed message
+/// that is encoded only on demand. Typed access happens on demand:
 ///
 /// - [`message`](Payload::message) — decode once into an owned message,
 ///   cache it, return a borrow. Works for both `Proto` and `Json` wires.
@@ -116,8 +118,9 @@ where
 /// `Payload` is normally constructed by the dispatch path and received
 /// by user code through [`UnaryRequest`](crate::interceptor::UnaryRequest)
 /// and [`UnaryResponse`](crate::interceptor::UnaryResponse).
-/// [`Payload::new`] is `pub` so test fixtures and custom transports can
-/// build one directly.
+/// [`Payload::new`] (from wire bytes) and [`Payload::from_message`] (from
+/// a typed message) are `pub` so test fixtures, custom transports, and
+/// short-circuiting interceptors can build one directly.
 ///
 /// `message` borrows the cached owned decode; `view` returns a fresh
 /// self-contained [`OwnedView`] (a [`Bytes`] refcount bump, not a copy)
@@ -125,12 +128,19 @@ where
 ///
 /// `Payload` is intentionally not `Clone`: a clone would either drop the
 /// decode cache (surprising) or duplicate it (defeating the laziness).
-/// Pass it by reference, or move it through the call chain.
+/// Pass it by reference, or move it through the call chain. When a
+/// second body is genuinely needed (a retry interceptor), call
+/// [`try_clone`](Payload::try_clone), which is explicit about copying
+/// the encoded bytes and starting with an empty cache.
 pub struct Payload {
     bytes: Bytes,
     format: CodecFormat,
     decoded: OnceLock<Box<dyn AnyMessage>>,
     replaced: Option<Box<dyn AnyMessage>>,
+    /// Memoized `replaced.encode(format)`, so `encoded()` / `try_clone()`
+    /// on a replaced or `from_message` payload encode at most once. Reset
+    /// by `set_message`. Unused while `replaced` is `None`.
+    replaced_encoded: OnceLock<Bytes>,
     decode_options: buffa::DecodeOptions,
 }
 
@@ -143,8 +153,72 @@ impl Payload {
             format,
             decoded: OnceLock::new(),
             replaced: None,
+            replaced_encoded: OnceLock::new(),
             decode_options: buffa::DecodeOptions::new(),
         }
+    }
+
+    /// Wrap an owned message in a `Payload` without encoding it.
+    ///
+    /// This is the *lazily-encoded* counterpart of [`new`](Payload::new)
+    /// for a caller that starts from a typed message rather than wire
+    /// bytes — an interceptor synthesizing a response, or an outbound
+    /// request. The message is stored as the payload's replacement:
+    /// [`message`](Payload::message) and
+    /// [`take_message`](Payload::take_message) downcast it without a
+    /// decode, and [`encoded`](Payload::encoded) encodes it on first call
+    /// and memoizes the result, so later `encoded()` /
+    /// [`try_clone`](Payload::try_clone) calls are refcount bumps.
+    /// [`view`](Payload::view) encodes to proto and views it.
+    ///
+    /// [`bytes`](Payload::bytes) is **empty** for a payload built this way:
+    /// there are no peer-supplied wire bytes. Use
+    /// [`encoded`](Payload::encoded) for the bytes that will be sent.
+    ///
+    /// Short-circuit example (a cache hit, a test double):
+    /// `Ok(Response::new(Payload::from_message(reply, req.payload.format())))`.
+    pub fn from_message<M: AnyMessage>(message: M, format: CodecFormat) -> Self {
+        Self {
+            bytes: Bytes::new(),
+            format,
+            decoded: OnceLock::new(),
+            replaced: Some(Box::new(message)),
+            replaced_encoded: OnceLock::new(),
+            decode_options: buffa::DecodeOptions::new(),
+        }
+    }
+
+    /// Produce an independent `Payload` carrying the same body.
+    ///
+    /// `Payload` is deliberately not `Clone` (see the type docs). This is
+    /// the explicit escape hatch for an interceptor that runs the rest of
+    /// the chain more than once — retry, hedging — and therefore needs a
+    /// second request body (see also
+    /// [`UnaryRequest::try_clone`](crate::interceptor::UnaryRequest::try_clone)).
+    /// The copy holds this payload's [`encoded`](Payload::encoded) bytes
+    /// (a refcount bump; a replacement is encoded once and memoized on
+    /// `self` first), the same format and decode options, and an empty
+    /// decode cache.
+    ///
+    /// The copy is equivalent **on the wire**, not through the typed API:
+    /// it carries bytes, not the replacement, so on the copy
+    /// [`message`](Payload::message) / [`take_message`](Payload::take_message)
+    /// perform a real decode, a wrong-type read reports `InvalidArgument`
+    /// rather than `Internal`, and [`view`](Payload::view) follows the
+    /// [`format`](Payload::format) rule (errors for JSON).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encoding a replacement fails.
+    pub fn try_clone(&self) -> Result<Self, ConnectError> {
+        Ok(Self {
+            bytes: self.encoded()?,
+            format: self.format,
+            decoded: OnceLock::new(),
+            replaced: None,
+            replaced_encoded: OnceLock::new(),
+            decode_options: self.decode_options.clone(),
+        })
     }
 
     /// Attach the decode limits a typed accessor should honour.
@@ -165,9 +239,12 @@ impl Payload {
         &self.decode_options
     }
 
-    /// The original wire bytes the peer sent, **ignoring** any
-    /// replacement set with [`set_message`](Payload::set_message). For
-    /// the bytes the dispatch path will actually send downstream, use
+    /// The wire bytes as received, **ignoring** any replacement set with
+    /// [`set_message`](Payload::set_message) (so stale after one), and
+    /// **empty** for a payload built with
+    /// [`from_message`](Payload::from_message) — nothing was received. Do
+    /// not hash, sign, size-check, or log this as "the body"; for the
+    /// bytes the dispatch path will actually send, use
     /// [`encoded()`](Payload::encoded).
     pub fn bytes(&self) -> &Bytes {
         &self.bytes
@@ -307,11 +384,14 @@ impl Payload {
     ///
     /// Borrows directly from the wire bytes — no copy, no allocation
     /// beyond the [`Bytes`] refcount bump. If a replacement has been set
-    /// with [`set_message`](Payload::set_message), it is encoded to proto
-    /// (regardless of [`format`](Payload::format)) and decoded as a view
-    /// — note this re-encodes on **every** call (unlike
-    /// [`message`](Payload::message), there is no cache for views). Hold
-    /// onto the returned `OwnedView` rather than re-fetching in a loop.
+    /// with [`set_message`](Payload::set_message) (or the payload came
+    /// from [`from_message`](Payload::from_message)), it is encoded to
+    /// proto and decoded as a view. For a proto-format payload that
+    /// encode is the memoized [`encoded`](Payload::encoded); for a JSON
+    /// payload it is a separate proto encode on **every** call. Either
+    /// way the view decode itself is not cached (unlike
+    /// [`message`](Payload::message)), so hold onto the returned
+    /// `OwnedView` rather than re-fetching in a loop.
     ///
     /// # Errors
     ///
@@ -340,7 +420,13 @@ impl Payload {
             // small peer payload materializing a huge one, and a server-built
             // message can legitimately exceed it. `StreamMessage::from_message`
             // lifts the same limits for the same reason.
-            let bytes = replaced.encode(CodecFormat::Proto)?;
+            //
+            // Reuse the memoized wire encode when it *is* proto; a JSON
+            // payload's replacement needs a separate proto encode.
+            let bytes = match self.format {
+                CodecFormat::Proto => self.encoded()?,
+                CodecFormat::Json => replaced.encode(CodecFormat::Proto)?,
+            };
             return OwnedView::decode(bytes).map_err(|e| {
                 ConnectError::internal(format!("failed to decode replacement as view: {e}"))
             });
@@ -365,6 +451,11 @@ impl Payload {
         M: AnyMessage,
     {
         self.replaced = Some(Box::new(message));
+        // A memoized encode of the *previous* replacement must not be
+        // served for the new one.
+        if self.replaced_encoded.get().is_some() {
+            self.replaced_encoded = OnceLock::new();
+        }
         // Drop the prior decode cache so the original message doesn't pin
         // memory for the Payload's lifetime. `replaced` is checked first,
         // so a stale cache would never be visible — this is purely a
@@ -377,25 +468,37 @@ impl Payload {
     /// The wire bytes the dispatch path should actually send.
     ///
     /// Returns the original `bytes` (a cheap [`Bytes`] clone) unless a
-    /// replacement was set with [`set_message`](Payload::set_message),
-    /// in which case the replacement is re-encoded in the original
-    /// [`format`](Payload::format).
+    /// replacement was set with [`set_message`](Payload::set_message) or
+    /// the payload was built with [`from_message`](Payload::from_message),
+    /// in which case the message is encoded in [`format`](Payload::format)
+    /// on the first call and memoized — later calls are refcount bumps.
     ///
     /// # Errors
     ///
-    /// Returns an error if re-encoding a replacement fails.
+    /// Returns an error if encoding a replacement fails.
     pub fn encoded(&self) -> Result<Bytes, ConnectError> {
-        match &self.replaced {
-            Some(r) => r.encode(self.format),
-            None => Ok(self.bytes.clone()),
+        let Some(replaced) = &self.replaced else {
+            return Ok(self.bytes.clone());
+        };
+        // Probe-then-set, as in `message()`: `get_or_try_init` is
+        // unstable. Two racing callers both encode; one `set` wins and
+        // both return equal bytes.
+        if let Some(cached) = self.replaced_encoded.get() {
+            return Ok(cached.clone());
         }
+        let bytes = replaced.encode(self.format)?;
+        let _ = self.replaced_encoded.set(bytes.clone());
+        Ok(bytes)
     }
 }
 
 impl fmt::Debug for Payload {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `wire_len` (not `len`): it is the received-bytes length, which
+        // is 0 for a `from_message` payload and stale after `set_message`
+        // — `replaced: true` alongside it says the body lives elsewhere.
         f.debug_struct("Payload")
-            .field("len", &self.bytes.len())
+            .field("wire_len", &self.bytes.len())
             .field("format", &self.format)
             .field("decoded", &self.decoded.get().is_some())
             .field("replaced", &self.replaced.is_some())
@@ -523,6 +626,208 @@ mod tests {
             p.encoded().unwrap().as_ptr(),
             p.bytes().as_ptr()
         ));
+    }
+
+    /// `from_message` is the lazily-encoded constructor: no wire bytes,
+    /// typed access is a downcast, `encoded()` produces the wire form.
+    #[test]
+    fn from_message_is_lazily_encoded() {
+        let p = Payload::from_message(
+            StringValue {
+                value: "typed".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        // The documented trap: `bytes()` is what was *received* (nothing);
+        // `encoded()` is what will be *sent*.
+        assert!(
+            p.bytes().is_empty(),
+            "no peer bytes for a from_message payload"
+        );
+        assert!(
+            !p.encoded().unwrap().is_empty(),
+            "encoded() is the real body"
+        );
+        let dbg = format!("{p:?}");
+        assert!(
+            dbg.contains("wire_len: 0") && dbg.contains("replaced: true"),
+            "{dbg}"
+        );
+        assert_eq!(p.format(), CodecFormat::Proto);
+        // Typed read is a downcast of the stored message, not a decode of
+        // the (empty) bytes — a decode of `b""` would yield the default "".
+        let m: &StringValue = p.message().unwrap();
+        assert_eq!(m.value, "typed");
+        // View path encodes then views.
+        assert_eq!(
+            p.view::<StringValueView>().unwrap().reborrow().value,
+            "typed"
+        );
+        // Wire form round-trips.
+        let rt: StringValue = crate::codec::decode_proto(&p.encoded().unwrap()).unwrap();
+        assert_eq!(rt.value, "typed");
+        // take_message moves the stored message out without decoding.
+        let owned: StringValue = p.take_message().unwrap();
+        assert_eq!(owned.value, "typed");
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn from_message_encodes_in_requested_format() {
+        let p = Payload::from_message(
+            StringValue {
+                value: "j".into(),
+                ..Default::default()
+            },
+            CodecFormat::Json,
+        );
+        let rt: StringValue = decode_json(&p.encoded().unwrap()).unwrap();
+        assert_eq!(rt.value, "j");
+    }
+
+    #[test]
+    fn from_message_wrong_type_is_internal_error() {
+        let p = Payload::from_message(
+            StringValue {
+                value: "s".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        let err = p
+            .message::<buffa_types::google::protobuf::Int64Value>()
+            .unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Internal, "{err:?}");
+    }
+
+    /// `try_clone` of a wire payload shares the backing bytes and starts
+    /// with an empty cache; `try_clone` after a replacement bakes the
+    /// replacement into the copy's bytes.
+    #[test]
+    fn try_clone_copies_body_not_cache() {
+        let p = proto_payload("orig");
+        let _ = p.message::<StringValue>().unwrap(); // populate cache
+        let c = p.try_clone().unwrap();
+        assert!(
+            std::ptr::eq(c.bytes().as_ptr(), p.bytes().as_ptr()),
+            "no replacement: clone is a Bytes refcount bump"
+        );
+        assert!(
+            c.decoded.get().is_none(),
+            "clone starts with an empty cache"
+        );
+        assert_eq!(c.message::<StringValue>().unwrap().value, "orig");
+
+        let mut replaced = proto_payload("orig");
+        replaced.set_message(StringValue {
+            value: "new".into(),
+            ..Default::default()
+        });
+        let c = replaced.try_clone().unwrap();
+        assert!(c.replaced.is_none(), "replacement is baked into bytes");
+        let rt: StringValue = crate::codec::decode_proto(c.bytes()).unwrap();
+        assert_eq!(rt.value, "new");
+
+        // And from a lazily-encoded payload: the clone carries real bytes.
+        let lazy = Payload::from_message(
+            StringValue {
+                value: "lazy".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        let c = lazy.try_clone().unwrap();
+        assert!(!c.bytes().is_empty());
+        assert_eq!(c.message::<StringValue>().unwrap().value, "lazy");
+    }
+
+    /// A replacement (or `from_message` body) is encoded at most once:
+    /// `encoded()`, `try_clone()`, and proto `view()` all serve the memo,
+    /// and `set_message` invalidates it.
+    #[test]
+    fn replacement_encode_is_memoized_and_invalidated() {
+        let mut p = Payload::from_message(
+            StringValue {
+                value: "once".into(),
+                ..Default::default()
+            },
+            CodecFormat::Proto,
+        );
+        let first = p.encoded().unwrap();
+        let again = p.encoded().unwrap();
+        assert!(
+            std::ptr::eq(first.as_ptr(), again.as_ptr()),
+            "second encoded() must be a refcount bump, not a re-encode"
+        );
+        let clone = p.try_clone().unwrap();
+        assert!(
+            std::ptr::eq(clone.bytes().as_ptr(), first.as_ptr()),
+            "try_clone shares the memoized encode"
+        );
+        // Proto view reuses the memo too (its bytes borrow from it).
+        let v = p.view::<StringValueView>().unwrap();
+        let ptr = v.reborrow().value.as_ptr() as usize;
+        let range = first.as_ptr() as usize..first.as_ptr() as usize + first.len();
+        assert!(
+            range.contains(&ptr),
+            "view should borrow the memoized bytes"
+        );
+
+        p.set_message(StringValue {
+            value: "twice".into(),
+            ..Default::default()
+        });
+        let rt: StringValue = crate::codec::decode_proto(&p.encoded().unwrap()).unwrap();
+        assert_eq!(rt.value, "twice", "set_message must invalidate the memo");
+    }
+
+    /// `try_clone` keeps the decode options (the service's limits) rather
+    /// than resetting to buffa defaults. `DecodeOptions` has no `PartialEq`,
+    /// so compare a distinctive `Debug` rendering.
+    #[test]
+    fn try_clone_preserves_decode_options() {
+        let opts = buffa::DecodeOptions::new().with_recursion_limit(7);
+        let p = proto_payload("x").with_decode_options(opts.clone());
+        let c = p.try_clone().unwrap();
+        assert_eq!(format!("{:?}", c.decode_options()), format!("{:?}", opts));
+        assert_ne!(
+            format!("{:?}", c.decode_options()),
+            format!("{:?}", buffa::DecodeOptions::new()),
+            "fixture must differ from the default for this test to mean anything"
+        );
+    }
+
+    /// The typed-API divergence `try_clone` documents for JSON payloads:
+    /// the original (holding a replacement) can `view()`; the copy (holding
+    /// JSON bytes) cannot, but is identical on the wire.
+    #[cfg(feature = "json")]
+    #[test]
+    fn try_clone_json_replacement_is_wire_equal_not_api_equal() {
+        let mut p = Payload::new(
+            encode_json(&StringValue {
+                value: "before".into(),
+                ..Default::default()
+            })
+            .unwrap(),
+            CodecFormat::Json,
+        );
+        p.set_message(StringValue {
+            value: "after".into(),
+            ..Default::default()
+        });
+        assert!(
+            p.view::<StringValueView>().is_ok(),
+            "original: replacement can be viewed"
+        );
+        let c = p.try_clone().unwrap();
+        assert_eq!(c.encoded().unwrap(), p.encoded().unwrap(), "wire-equal");
+        assert_eq!(c.format(), CodecFormat::Json);
+        assert!(
+            c.view::<StringValueView>().is_err(),
+            "copy: JSON bytes cannot back a view"
+        );
+        assert_eq!(c.message::<StringValue>().unwrap().value, "after");
     }
 
     #[test]

--- a/connectrpc/src/payload.rs
+++ b/connectrpc/src/payload.rs
@@ -206,7 +206,9 @@ impl Payload {
     /// decode cache.
     ///
     /// The copy is equivalent **on the wire**, not through the typed API:
-    /// it carries bytes, not the replacement, so on the copy
+    /// it carries bytes, not the replacement (a replacement's bytes keep
+    /// buffa's default decode limits rather than this payload's wire
+    /// limits, as [`view`](Payload::view) already grants them), so on the copy
     /// [`message`](Payload::message) / [`take_message`](Payload::take_message)
     /// perform a real decode, a wrong-type read reports `InvalidArgument`
     /// rather than `Internal`, and [`view`](Payload::view) follows the
@@ -216,10 +218,16 @@ impl Payload {
     ///
     /// Returns an error if encoding a replacement fails.
     pub fn try_clone(&self) -> Result<Self, ConnectError> {
-        Ok(
-            Self::new(self.encoded()?, self.format)
-                .with_decode_options(self.decode_options.clone()),
-        )
+        let copy = Self::new(self.encoded()?, self.format);
+        Ok(if self.replaced.is_some() {
+            // The body was encoded from a message this process holds, so the
+            // wire-facing limits (an amplification defence against peer
+            // bytes) do not apply to it — the same exemption `view` gives
+            // the replacement before the copy is taken.
+            copy
+        } else {
+            copy.with_decode_options(self.decode_options.clone())
+        })
     }
 
     /// Attach the decode limits a typed accessor should honour.
@@ -251,7 +259,9 @@ impl Payload {
         &self.bytes
     }
 
-    /// The codec format the wire bytes are encoded in.
+    /// The codec format of the body: the format the wire bytes arrived in,
+    /// or, for a [`from_message`](Payload::from_message) payload, the format
+    /// it will be encoded in.
     pub fn format(&self) -> CodecFormat {
         self.format
     }
@@ -410,8 +420,8 @@ impl Payload {
     /// - [`internal`](ConnectError::internal) if a replacement set with
     ///   [`set_message`](Payload::set_message) fails to re-encode or
     ///   decode as `V` — server-supplied data, so the asymmetry with the
-    ///   wire-bytes case is intentional. A replacement is decoded without
-    ///   the limits for the same reason.
+    ///   wire-bytes case is intentional. A replacement is decoded under
+    ///   buffa's defaults rather than these limits for the same reason.
     pub fn view<V>(&self) -> Result<OwnedView<V>, ConnectError>
     where
         V: MessageView<'static>,
@@ -483,8 +493,36 @@ impl Payload {
             return Ok(cached.clone());
         }
         let bytes = replaced.message.encode(self.format)?;
-        let _ = replaced.encoded.set(bytes.clone());
-        Ok(bytes)
+        // A racing loser returns the winner's allocation, so later
+        // `try_clone` / `view` calls share one memo.
+        Ok(replaced.encoded.get_or_init(|| bytes).clone())
+    }
+
+    /// The body encoded in `format`, which the dispatch path negotiated with
+    /// the peer and which may differ from this payload's own
+    /// [`format`](Payload::format).
+    ///
+    /// A payload built from a message is simply encoded in the requested
+    /// format (memoized only when it matches the payload's own format). A
+    /// payload carrying wire bytes in another format cannot be transcoded
+    /// without knowing its message type, so that is an error rather than a
+    /// body the peer cannot parse.
+    ///
+    /// # Errors
+    ///
+    /// `internal` if a replacement fails to encode, or if the payload holds
+    /// wire bytes in a format other than `format`.
+    pub fn encoded_as(&self, format: CodecFormat) -> Result<Bytes, ConnectError> {
+        if format == self.format {
+            return self.encoded();
+        }
+        match &self.replaced {
+            Some(replaced) => replaced.message.encode(format),
+            None => Err(ConnectError::internal(format!(
+                "payload carries {:?} wire bytes but the call negotiated {format:?}",
+                self.format
+            ))),
+        }
     }
 }
 
@@ -668,6 +706,32 @@ mod tests {
         let p = Payload::from_message(StringValue::from("j"), CodecFormat::Json);
         let rt: StringValue = decode_json(&p.encoded().unwrap()).unwrap();
         assert_eq!(rt.value, "j");
+    }
+
+    /// The dispatch path answers in the format the call negotiated, not the
+    /// one the interceptor happened to build the payload with.
+    #[cfg(feature = "json")]
+    #[test]
+    fn encoded_as_transcodes_a_message_payload() {
+        let p = Payload::from_message(StringValue::from("x"), CodecFormat::Proto);
+        let json = p.encoded_as(CodecFormat::Json).unwrap();
+        let rt: StringValue = decode_json(&json).unwrap();
+        assert_eq!(rt.value, "x");
+        // Same-format requests still hit the memo.
+        let a = p.encoded_as(CodecFormat::Proto).unwrap();
+        let b = p.encoded().unwrap();
+        assert!(std::ptr::eq(a.as_ptr(), b.as_ptr()));
+    }
+
+    #[test]
+    fn encoded_as_rejects_wire_bytes_in_another_format() {
+        let p = proto_payload("x");
+        let err = p.encoded_as(CodecFormat::Json).unwrap_err();
+        assert_eq!(err.code, crate::ErrorCode::Internal, "{err:?}");
+        assert!(
+            err.message.as_deref().unwrap_or("").contains("negotiated"),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -160,14 +160,9 @@ impl RequestContext {
     /// negotiated compression) were resolved from the headers *before*
     /// interceptors ran; rewriting `connect-timeout-ms`, `grpc-timeout`,
     /// `content-type`, or `accept-encoding` here changes only what
-    /// downstream code reads, not dispatch behavior.
-    ///
-    /// # Note
-    ///
-    /// The same by-value caveat as [`extensions_mut`](Self::extensions_mut)
-    /// applies: a *handler* mutating its own `ctx` affects nothing
-    /// downstream. This accessor is for code that still holds the context
-    /// before dispatch continues.
+    /// downstream code reads, not dispatch behavior. As with
+    /// [`extensions_mut`](Self::extensions_mut), a *handler* mutating its
+    /// own by-value `ctx` affects nothing downstream.
     pub fn headers_mut(&mut self) -> &mut HeaderMap {
         &mut self.headers
     }

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -156,11 +156,13 @@ impl RequestContext {
     /// auth token, a propagated trace context, a tenant id. Inner
     /// interceptors and the handler see the mutated map.
     ///
-    /// Protocol-derived values (the [`deadline`](Self::deadline), codec,
-    /// negotiated compression) were resolved from the headers *before*
-    /// interceptors ran; rewriting `connect-timeout-ms`, `grpc-timeout`,
-    /// `content-type`, or `accept-encoding` here changes only what
-    /// downstream code reads, not dispatch behavior. As with
+    /// On the server, protocol-derived values (the
+    /// [`deadline`](Self::deadline), codec, negotiated compression) were
+    /// resolved from the headers *before* interceptors ran; rewriting
+    /// `connect-timeout-ms`, `grpc-timeout`, `content-type`, or
+    /// `accept-encoding` here changes only what downstream code reads, not
+    /// dispatch behavior. On a client-side chain the edited map is what goes
+    /// on the wire, so those headers are load-bearing there. As with
     /// [`extensions_mut`](Self::extensions_mut), a *handler* mutating its
     /// own by-value `ctx` affects nothing downstream.
     pub fn headers_mut(&mut self) -> &mut HeaderMap {

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -149,6 +149,29 @@ impl RequestContext {
         self.headers.get(key)
     }
 
+    /// Mutable access to the request headers.
+    ///
+    /// This is the hook an [`Interceptor`](crate::Interceptor) uses to add
+    /// or rewrite request metadata before calling `next.run(req)` — an
+    /// auth token, a propagated trace context, a tenant id. Inner
+    /// interceptors and the handler see the mutated map.
+    ///
+    /// Protocol-derived values (the [`deadline`](Self::deadline), codec,
+    /// negotiated compression) were resolved from the headers *before*
+    /// interceptors ran; rewriting `connect-timeout-ms`, `grpc-timeout`,
+    /// `content-type`, or `accept-encoding` here changes only what
+    /// downstream code reads, not dispatch behavior.
+    ///
+    /// # Note
+    ///
+    /// The same by-value caveat as [`extensions_mut`](Self::extensions_mut)
+    /// applies: a *handler* mutating its own `ctx` affects nothing
+    /// downstream. This accessor is for code that still holds the context
+    /// before dispatch continues.
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        &mut self.headers
+    }
+
     /// Absolute request deadline parsed from the protocol's timeout header
     /// (`Connect-Timeout-Ms` or `grpc-timeout`), if the client asserted one.
     ///
@@ -1568,6 +1591,23 @@ mod tests {
         let mut ctx = RequestContext::new(HeaderMap::new());
         ctx.extensions_mut().insert(Tag(1));
         assert_eq!(ctx.extensions().get::<Tag>(), Some(&Tag(1)));
+    }
+
+    #[test]
+    fn request_context_headers_mut() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-keep", HeaderValue::from_static("k"));
+        let mut ctx = RequestContext::new(headers);
+        ctx.headers_mut()
+            .insert("authorization", HeaderValue::from_static("Bearer t"));
+        assert_eq!(ctx.header("authorization").unwrap(), "Bearer t");
+        assert_eq!(
+            ctx.header("x-keep").unwrap(),
+            "k",
+            "existing entries survive"
+        );
+        ctx.headers_mut().remove("x-keep");
+        assert!(ctx.header("x-keep").is_none());
     }
 
     #[cfg(feature = "server")]

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -67,8 +67,8 @@ use crate::envelope::EnvelopeDecoder;
 use crate::error::ConnectError;
 use crate::handler::BoxStream;
 use crate::interceptor::{
-    Interceptor, call_bidi_streaming_intercepted, call_client_streaming_intercepted,
-    call_server_streaming_intercepted, call_unary_intercepted,
+    Interceptor, InterceptorChain, call_bidi_streaming_intercepted,
+    call_client_streaming_intercepted, call_server_streaming_intercepted, call_unary_intercepted,
 };
 use crate::protocol::Protocol;
 use crate::response::{EncodedResponse, RequestContext};
@@ -1321,9 +1321,9 @@ pub struct ConnectRpcService<D = Router> {
     compression: Arc<CompressionRegistry>,
     compression_policy: CompressionPolicy,
     deadline_policy: DeadlinePolicy,
-    /// Unary interceptor chain, outermost first. The `Arc<[..]>` is one
-    /// pointer to clone per request regardless of chain length.
-    interceptors: Arc<[Arc<dyn Interceptor>]>,
+    /// Interceptor chain, outermost first. One pointer to clone per
+    /// request regardless of chain length.
+    interceptors: InterceptorChain,
 }
 
 // Manual Clone impl because `#[derive(Clone)]` would add a `D: Clone` bound,
@@ -1336,7 +1336,7 @@ impl<D> Clone for ConnectRpcService<D> {
             compression: Arc::clone(&self.compression),
             compression_policy: self.compression_policy,
             deadline_policy: self.deadline_policy.clone(),
-            interceptors: Arc::clone(&self.interceptors),
+            interceptors: self.interceptors.clone(),
         }
     }
 }
@@ -1360,7 +1360,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
             compression: Arc::new(CompressionRegistry::default()),
             compression_policy: CompressionPolicy::default(),
             deadline_policy: DeadlinePolicy::new(),
-            interceptors: Arc::default(),
+            interceptors: InterceptorChain::default(),
         }
     }
 
@@ -1448,11 +1448,7 @@ impl<D: Dispatcher> ConnectRpcService<D> {
     /// which takes ownership and wraps for you.
     #[must_use]
     pub fn with_interceptor_arc(mut self, interceptor: Arc<dyn Interceptor>) -> Self {
-        // The Arc<[..]> is shared across cloned service handles; rebuild
-        // it on registration. Registration is a cold path.
-        let mut v: Vec<Arc<dyn Interceptor>> = self.interceptors.to_vec();
-        v.push(interceptor);
-        self.interceptors = Arc::from(v);
+        self.interceptors.push(interceptor);
         self
     }
 
@@ -1568,7 +1564,7 @@ where
         let compression = Arc::clone(&self.compression);
         let compression_policy = self.compression_policy;
         let deadline_policy = self.deadline_policy.clone();
-        let interceptors = Arc::clone(&self.interceptors);
+        let interceptors = self.interceptors.clone();
 
         // Only create and attach the tracing span when a subscriber would
         // actually observe it. For disabled-debug (the common production case),

--- a/connectrpc/src/spec.rs
+++ b/connectrpc/src/spec.rs
@@ -215,14 +215,28 @@ impl Spec {
         self
     }
 
-    /// Whether `self` and `other` describe the same RPC method, ignoring
-    /// which side ([`origin`](Spec::origin)) produced them.
+    /// Set which side this `Spec` describes. Returns `self` for chaining in
+    /// `const` position.
     ///
-    /// `Spec` derives `PartialEq` over *all* fields, so the generated
-    /// server constant `FOO_SERVICE_BAR_SPEC` and its client sibling
-    /// `FOO_SERVICE_BAR_CLIENT_SPEC` are **not** `==`. Use this (or compare
-    /// [`procedure`](Spec::procedure) directly) when an interceptor that
-    /// runs on both sides asks "is this the `Bar` method?".
+    /// Code generation emits one constant per method (`FOO_SERVICE_BAR_SPEC`,
+    /// [`SpecOrigin::Server`]); the generated client passes
+    /// `FOO_SERVICE_BAR_SPEC.with_origin(SpecOrigin::Client)` to the runtime,
+    /// so a client-side interceptor observes the same method facts with
+    /// [`origin`](Spec::origin) flipped.
+    #[must_use]
+    pub const fn with_origin(mut self, origin: SpecOrigin) -> Self {
+        self.origin = origin;
+        self
+    }
+
+    /// Whether `self` and `other` describe the same RPC method, ignoring
+    /// which side ([`origin`](Spec::origin)) they describe.
+    ///
+    /// `Spec` derives `PartialEq` over *all* fields, so the value a client
+    /// interceptor sees (origin `Client`) is **not** `==` to the generated
+    /// `FOO_SERVICE_BAR_SPEC` constant (origin `Server`). Use this (or
+    /// compare [`procedure`](Spec::procedure) directly) when asking "is this
+    /// the `Bar` method?" regardless of side.
     #[must_use]
     pub fn same_method(&self, other: &Spec) -> bool {
         self.procedure == other.procedure
@@ -331,15 +345,19 @@ mod tests {
         assert!(!procedure_is_well_formed("/"));
     }
 
-    /// The generated server/client siblings for one method are not `==`
-    /// (origin differs) but are `same_method`; different methods are not.
+    /// A constant and its `with_origin(Client)` form are not `==` (origin
+    /// differs) but are `same_method`; different methods are not.
     #[test]
     fn same_method_ignores_origin() {
         const SERVER: Spec = Spec::server("/pkg.Greet/Say", StreamType::Unary)
             .with_idempotency_level(IdempotencyLevel::NoSideEffects);
-        const CLIENT: Spec = Spec::client("/pkg.Greet/Say", StreamType::Unary)
-            .with_idempotency_level(IdempotencyLevel::NoSideEffects);
+        const CLIENT: Spec = SERVER.with_origin(SpecOrigin::Client);
         const OTHER: Spec = Spec::client("/pkg.Greet/Shout", StreamType::Unary);
+        assert_eq!(
+            CLIENT,
+            Spec::client("/pkg.Greet/Say", StreamType::Unary)
+                .with_idempotency_level(IdempotencyLevel::NoSideEffects)
+        );
         assert_ne!(SERVER, CLIENT, "PartialEq includes origin");
         assert!(SERVER.same_method(&CLIENT));
         assert!(CLIENT.same_method(&SERVER));

--- a/connectrpc/src/spec.rs
+++ b/connectrpc/src/spec.rs
@@ -115,8 +115,13 @@ pub enum SpecOrigin {
 /// proto-declared idempotency contract, and which generated artifact
 /// (server or client) produced it.
 ///
-/// `Spec` is `Copy` and contains only `'static` data, so it can be stored,
-/// captured in closures, and compared freely with no allocation.
+/// `Spec` is `Copy` and contains only `'static` data, so it can be stored
+/// and captured in closures with no allocation. `PartialEq` and `Hash`
+/// cover every field, including [`origin`](Spec::origin): the value a
+/// client-side interceptor sees is *not* `==` to the generated
+/// `FOO_SERVICE_BAR_SPEC` constant (origin `Server`), and a `HashMap` keyed
+/// by the constants misses it. Compare method identity across sides with
+/// [`same_method`](Spec::same_method).
 ///
 /// Construct one with [`Spec::server`] or [`Spec::client`]. The struct is
 /// `#[non_exhaustive]` so future fields can be added without a breaking
@@ -161,10 +166,12 @@ impl Spec {
     /// constructor in `const` position, so `Spec` constants live in
     /// `.rodata`.
     ///
-    /// In debug builds, asserts that `procedure` starts with `/` and
-    /// contains a `/Service/Method` separator so a malformed test fixture
-    /// fails loudly rather than producing misleading [`service`](Spec::service)
-    /// / [`method`](Spec::method) accessor results.
+    /// # Panics
+    ///
+    /// In debug builds, if `procedure` does not start with `/` or has no
+    /// `/Service/Method` separator (a `const` fails at compile time), so a
+    /// malformed fixture fails loudly rather than producing misleading
+    /// [`service`](Spec::service) / [`method`](Spec::method) results.
     pub const fn server(procedure: &'static str, stream_type: StreamType) -> Self {
         debug_assert_well_formed(procedure);
         Self {
@@ -183,10 +190,12 @@ impl Spec {
     /// constructor in `const` position, so `Spec` constants live in
     /// `.rodata`.
     ///
-    /// In debug builds, asserts that `procedure` starts with `/` and
-    /// contains a `/Service/Method` separator so a malformed test fixture
-    /// fails loudly rather than producing misleading [`service`](Spec::service)
-    /// / [`method`](Spec::method) accessor results.
+    /// # Panics
+    ///
+    /// In debug builds, if `procedure` does not start with `/` or has no
+    /// `/Service/Method` separator (a `const` fails at compile time). The
+    /// client entry points repeat that check in every build, plus a check
+    /// that the path is a valid URI path, and report `internal` instead.
     ///
     /// # Building one without generated code
     ///
@@ -229,16 +238,17 @@ impl Spec {
         self
     }
 
-    /// Whether `self` and `other` describe the same RPC method, ignoring
-    /// which side ([`origin`](Spec::origin)) they describe.
+    /// Whether `self` and `other` name the same RPC method: compares
+    /// [`procedure`](Spec::procedure) only, ignoring [`origin`](Spec::origin)
+    /// (and the other fields, which are derived from the method).
     ///
     /// `Spec` derives `PartialEq` over *all* fields, so the value a client
     /// interceptor sees (origin `Client`) is **not** `==` to the generated
-    /// `FOO_SERVICE_BAR_SPEC` constant (origin `Server`). Use this (or
-    /// compare [`procedure`](Spec::procedure) directly) when asking "is this
-    /// the `Bar` method?" regardless of side.
+    /// `FOO_SERVICE_BAR_SPEC` constant (origin `Server`). Use this when
+    /// asking "is this the `Bar` method?" regardless of side:
+    /// `spec.same_method(FOO_SERVICE_BAR_SPEC)`.
     #[must_use]
-    pub fn same_method(&self, other: &Spec) -> bool {
+    pub fn same_method(self, other: Spec) -> bool {
         self.procedure == other.procedure
     }
 
@@ -359,9 +369,9 @@ mod tests {
                 .with_idempotency_level(IdempotencyLevel::NoSideEffects)
         );
         assert_ne!(SERVER, CLIENT, "PartialEq includes origin");
-        assert!(SERVER.same_method(&CLIENT));
-        assert!(CLIENT.same_method(&SERVER));
-        assert!(!CLIENT.same_method(&OTHER));
+        assert!(SERVER.same_method(CLIENT));
+        assert!(CLIENT.same_method(SERVER));
+        assert!(!CLIENT.same_method(OTHER));
     }
 
     #[test]

--- a/connectrpc/src/spec.rs
+++ b/connectrpc/src/spec.rs
@@ -264,27 +264,30 @@ impl Spec {
 /// release builds.
 const fn debug_assert_well_formed(procedure: &str) {
     if cfg!(debug_assertions) {
-        let bytes = procedure.as_bytes();
-        // Must start with '/'.
         assert!(
-            !bytes.is_empty() && bytes[0] == b'/',
-            "Spec procedure must start with '/' (e.g. \"/pkg.Service/Method\")"
-        );
-        // Must have a second '/' separating Service from Method.
-        let mut has_inner_slash = false;
-        let mut i = 1;
-        while i < bytes.len() {
-            if bytes[i] == b'/' {
-                has_inner_slash = true;
-                break;
-            }
-            i += 1;
-        }
-        assert!(
-            has_inner_slash,
-            "Spec procedure must contain a '/Service/Method' separator (e.g. \"/pkg.Service/Method\")"
+            procedure_is_well_formed(procedure),
+            "Spec procedure must start with '/' and contain a '/Service/Method' separator (e.g. \"/pkg.Service/Method\")"
         );
     }
+}
+
+/// Whether `procedure` looks like `"/package.Service/Method"`: a leading
+/// slash and at least one interior slash. The one definition of
+/// "well-formed" shared by the constructors' debug assertion above and the
+/// client entry points' release-mode check.
+pub(crate) const fn procedure_is_well_formed(procedure: &str) -> bool {
+    let bytes = procedure.as_bytes();
+    if bytes.is_empty() || bytes[0] != b'/' {
+        return false;
+    }
+    let mut i = 1;
+    while i < bytes.len() {
+        if bytes[i] == b'/' {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -313,6 +316,19 @@ mod tests {
         assert_eq!(SPEC.stream_type, StreamType::Unary);
         assert_eq!(SPEC.idempotency_level, IdempotencyLevel::NoSideEffects);
         const { assert!(matches!(SPEC.origin, SpecOrigin::Server)) };
+    }
+
+    #[test]
+    fn procedure_well_formedness() {
+        assert!(procedure_is_well_formed("/pkg.Svc/M"));
+        assert!(procedure_is_well_formed("/Svc/M"));
+        assert!(!procedure_is_well_formed("pkg.Svc/M"), "no leading slash");
+        assert!(
+            !procedure_is_well_formed("/pkg.SvcM"),
+            "no method separator"
+        );
+        assert!(!procedure_is_well_formed(""));
+        assert!(!procedure_is_well_formed("/"));
     }
 
     /// The generated server/client siblings for one method are not `==`
@@ -347,7 +363,7 @@ mod tests {
     #[test]
     #[cfg_attr(
         debug_assertions,
-        should_panic(expected = "Spec procedure must contain a '/Service/Method' separator")
+        should_panic(expected = "contain a '/Service/Method' separator")
     )]
     fn spec_malformed_path_no_method_separator_debug_asserts() {
         let _ = Spec::server("/nopath", StreamType::Unary);

--- a/connectrpc/src/spec.rs
+++ b/connectrpc/src/spec.rs
@@ -187,6 +187,16 @@ impl Spec {
     /// contains a `/Service/Method` separator so a malformed test fixture
     /// fails loudly rather than producing misleading [`service`](Spec::service)
     /// / [`method`](Spec::method) accessor results.
+    ///
+    /// # Building one without generated code
+    ///
+    /// `procedure` is `&'static str` because a `Spec` is meant to be a
+    /// per-method constant. A hand-written client with a fixed set of
+    /// methods uses string literals. A truly dynamic caller (a proxy or CLI
+    /// that learns method names at runtime) should **intern** each distinct
+    /// procedure once — e.g. keep a `HashMap<String, Spec>` and `Box::leak`
+    /// the string only on first sight — rather than leaking per call, which
+    /// grows without bound.
     pub const fn client(procedure: &'static str, stream_type: StreamType) -> Self {
         debug_assert_well_formed(procedure);
         Self {
@@ -203,6 +213,19 @@ impl Spec {
     pub const fn with_idempotency_level(mut self, idempotency_level: IdempotencyLevel) -> Self {
         self.idempotency_level = idempotency_level;
         self
+    }
+
+    /// Whether `self` and `other` describe the same RPC method, ignoring
+    /// which side ([`origin`](Spec::origin)) produced them.
+    ///
+    /// `Spec` derives `PartialEq` over *all* fields, so the generated
+    /// server constant `FOO_SERVICE_BAR_SPEC` and its client sibling
+    /// `FOO_SERVICE_BAR_CLIENT_SPEC` are **not** `==`. Use this (or compare
+    /// [`procedure`](Spec::procedure) directly) when an interceptor that
+    /// runs on both sides asks "is this the `Bar` method?".
+    #[must_use]
+    pub fn same_method(&self, other: &Spec) -> bool {
+        self.procedure == other.procedure
     }
 
     /// The bare service name (`"package.Service"`) from
@@ -290,6 +313,21 @@ mod tests {
         assert_eq!(SPEC.stream_type, StreamType::Unary);
         assert_eq!(SPEC.idempotency_level, IdempotencyLevel::NoSideEffects);
         const { assert!(matches!(SPEC.origin, SpecOrigin::Server)) };
+    }
+
+    /// The generated server/client siblings for one method are not `==`
+    /// (origin differs) but are `same_method`; different methods are not.
+    #[test]
+    fn same_method_ignores_origin() {
+        const SERVER: Spec = Spec::server("/pkg.Greet/Say", StreamType::Unary)
+            .with_idempotency_level(IdempotencyLevel::NoSideEffects);
+        const CLIENT: Spec = Spec::client("/pkg.Greet/Say", StreamType::Unary)
+            .with_idempotency_level(IdempotencyLevel::NoSideEffects);
+        const OTHER: Spec = Spec::client("/pkg.Greet/Shout", StreamType::Unary);
+        assert_ne!(SERVER, CLIENT, "PartialEq includes origin");
+        assert!(SERVER.same_method(&CLIENT));
+        assert!(CLIENT.same_method(&SERVER));
+        assert!(!CLIENT.same_method(&OTHER));
     }
 
     #[test]

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -998,7 +998,7 @@ The generated client passes the same constant to the runtime with its
 so that is the value a client-side interceptor observes. Because `Spec`'s
 `PartialEq` covers every field, that value is **not** `==` to the constant;
 an interceptor that runs on both sides and asks "is this the `Greet`
-method?" should use `spec.same_method(&GREET_SERVICE_GREET_SPEC)` (or
+method?" should use `spec.same_method(GREET_SERVICE_GREET_SPEC)` (or
 compare `procedure`), which ignores `origin`. The low-level
 `connectrpc::client::call_*` entry points take a `Spec` for the same
 reason; see the `call_unary` and `Spec::client` rustdoc for hand-written

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -993,6 +993,26 @@ assert_eq!(GREET_SERVICE_GREET_SPEC.stream_type, StreamType::Unary);
 assert_eq!(GREET_SERVICE_GREET_SPEC.origin, SpecOrigin::Server);
 ```
 
+Each method also gets a client-side sibling,
+`<SERVICE>_<METHOD>_CLIENT_SPEC`, identical except that its `origin` is
+`SpecOrigin::Client` (and gated with the client feature when
+`gate_client_feature` is on). Generated client methods pass it to the
+runtime, so this is the value a client-side interceptor observes. Because
+`Spec`'s `PartialEq` covers every field, the two siblings are **not**
+`==`; an interceptor that runs on both sides and asks "is this the
+`Greet` method?" should use `spec.same_method(&GREET_SERVICE_GREET_SPEC)`
+(or compare `procedure`), which ignores `origin`.
+
+The low-level `connectrpc::client::call_unary` / `call_unary_get` /
+`call_server_stream` / `call_client_stream` / `call_bidi_stream` entry
+points take a `Spec` for the same reason. A hand-written caller builds
+one with `Spec::client("/pkg.Service/Method", StreamType::…)`; the
+procedure is `&'static str`, so a caller whose method names arrive at
+runtime should intern each distinct procedure once (see the `Spec::client`
+rustdoc) rather than leak per call. Passing a spec of the wrong stream
+shape or origin to an entry point returns an `Internal` error before
+anything is sent.
+
 > **Both dispatch paths populate `ctx.spec()`.** A code-generated
 > `FooServiceServer<T>` always supplies a `Spec`. The dynamic `Router`
 > (used by `FooServiceExt::register(Router)`) does too — the generated

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -993,14 +993,13 @@ assert_eq!(GREET_SERVICE_GREET_SPEC.stream_type, StreamType::Unary);
 assert_eq!(GREET_SERVICE_GREET_SPEC.origin, SpecOrigin::Server);
 ```
 
-Each method also gets a client-side sibling,
-`<SERVICE>_<METHOD>_CLIENT_SPEC`, identical except that its `origin` is
-`SpecOrigin::Client`. Generated client methods pass it to the runtime, so
-this is the value a client-side interceptor observes. Because `Spec`'s
-`PartialEq` covers every field, the two siblings are **not** `==`; an
-interceptor that runs on both sides and asks "is this the `Greet` method?"
-should use `spec.same_method(&GREET_SERVICE_GREET_SPEC)` (or compare
-`procedure`), which ignores `origin`. The low-level
+The generated client passes the same constant to the runtime with its
+`origin` flipped, `GREET_SERVICE_GREET_SPEC.with_origin(SpecOrigin::Client)`,
+so that is the value a client-side interceptor observes. Because `Spec`'s
+`PartialEq` covers every field, that value is **not** `==` to the constant;
+an interceptor that runs on both sides and asks "is this the `Greet`
+method?" should use `spec.same_method(&GREET_SERVICE_GREET_SPEC)` (or
+compare `procedure`), which ignores `origin`. The low-level
 `connectrpc::client::call_*` entry points take a `Spec` for the same
 reason; see the `call_unary` and `Spec::client` rustdoc for hand-written
 and dynamic callers.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1081,11 +1081,11 @@ process-wide), use `with_interceptor_arc(Arc<dyn Interceptor>)`.
 ### Reading and rewriting the request
 
 `UnaryRequest` is `{ ctx: RequestContext, payload: Payload }`. Mutating
-`ctx` (headers, extensions) before `next.run` propagates to the handler.
-The `payload` is the request body — wire bytes plus a lazy decode
-cache. Most interceptors never read it; ones that do call
-`payload.message::<M>()` to decode once and cache, so the handler's
-decode is free:
+`ctx` through `ctx.headers_mut()` or `ctx.extensions_mut()` before
+`next.run` propagates to the handler. The `payload` is the request body
+— wire bytes plus a lazy decode cache. Most interceptors never read it;
+ones that do call `payload.message::<M>()` to decode once and cache, so
+the handler's decode is free:
 
 ```rust,ignore
 async fn intercept_unary(
@@ -1106,12 +1106,12 @@ async fn intercept_unary(
 }
 ```
 
-### Short-circuiting
+### Short-circuiting and re-running
 
 Returning without calling `next.run()` short-circuits the chain —
 neither inner interceptors nor the handler run. Returning `Err`
-surfaces the error on the protocol's normal error path, including
-any `response_headers` the error carries:
+surfaces the error on the protocol's normal error path, including any
+`response_headers` the error carries:
 
 ```rust,ignore
 async fn intercept_unary(
@@ -1129,6 +1129,30 @@ async fn intercept_unary(
     };
     self.tokens.verify(token)?;
     next.run(req).await
+}
+```
+
+Returning `Ok` without calling `next` works too. Build the body from a
+typed message with `Payload::from_message`, which encodes lazily in the
+request's wire format:
+
+```rust,ignore
+if let Some(reply) = self.cache.get(req.payload.message::<LookupRequest>()?) {
+    return Ok(Response::new(Payload::from_message(reply.clone(), req.payload.format())));
+}
+next.run(req).await
+```
+
+The opposite of short-circuiting is running the chain more than once.
+`Next` is `Clone`, and `UnaryRequest::try_clone()` copies the context and
+body, so a retry looks like this (gate it on `Spec::idempotency_level`;
+on the server a re-run invokes the handler again):
+
+```rust,ignore
+let spare = req.try_clone()?;
+match next.clone().run(req).await {
+    Err(e) if e.code == ErrorCode::Unavailable => next.run(spare).await,
+    done => done,
 }
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1037,7 +1037,7 @@ boundary, span builder, validator, or rate limiter actually wants.
 
 ```rust,ignore
 use connectrpc::interceptor::{UnaryRequest, UnaryResponse};
-use connectrpc::{ConnectError, Interceptor, Next};
+use connectrpc::{ConnectError, Interceptor, Next, Payload, Response};
 
 struct Logging;
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -995,23 +995,15 @@ assert_eq!(GREET_SERVICE_GREET_SPEC.origin, SpecOrigin::Server);
 
 Each method also gets a client-side sibling,
 `<SERVICE>_<METHOD>_CLIENT_SPEC`, identical except that its `origin` is
-`SpecOrigin::Client` (and gated with the client feature when
-`gate_client_feature` is on). Generated client methods pass it to the
-runtime, so this is the value a client-side interceptor observes. Because
-`Spec`'s `PartialEq` covers every field, the two siblings are **not**
-`==`; an interceptor that runs on both sides and asks "is this the
-`Greet` method?" should use `spec.same_method(&GREET_SERVICE_GREET_SPEC)`
-(or compare `procedure`), which ignores `origin`.
-
-The low-level `connectrpc::client::call_unary` / `call_unary_get` /
-`call_server_stream` / `call_client_stream` / `call_bidi_stream` entry
-points take a `Spec` for the same reason. A hand-written caller builds
-one with `Spec::client("/pkg.Service/Method", StreamType::…)`; the
-procedure is `&'static str`, so a caller whose method names arrive at
-runtime should intern each distinct procedure once (see the `Spec::client`
-rustdoc) rather than leak per call. Passing a spec of the wrong stream
-shape or origin to an entry point returns an `Internal` error before
-anything is sent.
+`SpecOrigin::Client`. Generated client methods pass it to the runtime, so
+this is the value a client-side interceptor observes. Because `Spec`'s
+`PartialEq` covers every field, the two siblings are **not** `==`; an
+interceptor that runs on both sides and asks "is this the `Greet` method?"
+should use `spec.same_method(&GREET_SERVICE_GREET_SPEC)` (or compare
+`procedure`), which ignores `origin`. The low-level
+`connectrpc::client::call_*` entry points take a `Spec` for the same
+reason; see the `call_unary` and `Spec::client` rustdoc for hand-written
+and dynamic callers.
 
 > **Both dispatch paths populate `ctx.spec()`.** A code-generated
 > `FooServiceServer<T>` always supplies a `Spec`. The dynamic `Router`

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -126,37 +126,19 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const ELIZA_SERVICE_SERVICE_NAME: &str = "connectrpc.eliza.v1.ElizaService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Say` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Say` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const ELIZA_SERVICE_SAY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.eliza.v1.ElizaService/Say",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Static [`Spec`](::connectrpc::Spec) for the `Converse` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Converse` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const ELIZA_SERVICE_CONVERSE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.eliza.v1.ElizaService/Converse",
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `Introduce` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Introduce` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const ELIZA_SERVICE_INTRODUCE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.eliza.v1.ElizaService/Introduce",
         ::connectrpc::StreamType::ServerStream,

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -140,6 +140,15 @@ pub const ELIZA_SERVICE_SAY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::serve
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
+/// Client-side sibling of `ELIZA_SERVICE_SAY_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const ELIZA_SERVICE_SAY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.eliza.v1.ElizaService/Say",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `Converse` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -150,6 +159,15 @@ pub const ELIZA_SERVICE_SAY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::serve
 /// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
 /// `procedure` to match this method on either side.
 pub const ELIZA_SERVICE_CONVERSE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/connectrpc.eliza.v1.ElizaService/Converse",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `ELIZA_SERVICE_CONVERSE_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const ELIZA_SERVICE_CONVERSE_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.eliza.v1.ElizaService/Converse",
         ::connectrpc::StreamType::BidiStream,
     )
@@ -168,40 +186,10 @@ pub const ELIZA_SERVICE_INTRODUCE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec:
         ::connectrpc::StreamType::ServerStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Say` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `ELIZA_SERVICE_SAY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const ELIZA_SERVICE_SAY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.eliza.v1.ElizaService/Say",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Converse` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `ELIZA_SERVICE_CONVERSE_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const ELIZA_SERVICE_CONVERSE_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.eliza.v1.ElizaService/Converse",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Introduce` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `ELIZA_SERVICE_INTRODUCE_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `ELIZA_SERVICE_INTRODUCE_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const ELIZA_SERVICE_INTRODUCE_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.eliza.v1.ElizaService/Introduce",
         ::connectrpc::StreamType::ServerStream,

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -130,6 +130,11 @@ pub const ELIZA_SERVICE_SERVICE_NAME: &str = "connectrpc.eliza.v1.ElizaService";
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `ELIZA_SERVICE_SAY_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const ELIZA_SERVICE_SAY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.eliza.v1.ElizaService/Say",
         ::connectrpc::StreamType::Unary,
@@ -139,6 +144,11 @@ pub const ELIZA_SERVICE_SAY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::serve
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `ELIZA_SERVICE_CONVERSE_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const ELIZA_SERVICE_CONVERSE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.eliza.v1.ElizaService/Converse",
         ::connectrpc::StreamType::BidiStream,
@@ -148,7 +158,51 @@ pub const ELIZA_SERVICE_CONVERSE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `ELIZA_SERVICE_INTRODUCE_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const ELIZA_SERVICE_INTRODUCE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/connectrpc.eliza.v1.ElizaService/Introduce",
+        ::connectrpc::StreamType::ServerStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Say` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `ELIZA_SERVICE_SAY_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const ELIZA_SERVICE_SAY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.eliza.v1.ElizaService/Say",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Converse` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `ELIZA_SERVICE_CONVERSE_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const ELIZA_SERVICE_CONVERSE_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/connectrpc.eliza.v1.ElizaService/Converse",
+        ::connectrpc::StreamType::BidiStream,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Introduce` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `ELIZA_SERVICE_INTRODUCE_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const ELIZA_SERVICE_INTRODUCE_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.eliza.v1.ElizaService/Introduce",
         ::connectrpc::StreamType::ServerStream,
     )
@@ -704,8 +758,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                ELIZA_SERVICE_SERVICE_NAME,
-                "Say",
+                ELIZA_SERVICE_SAY_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -743,8 +796,7 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                ELIZA_SERVICE_SERVICE_NAME,
-                "Converse",
+                ELIZA_SERVICE_CONVERSE_CLIENT_SPEC,
                 options,
             )
             .await
@@ -785,8 +837,7 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                ELIZA_SERVICE_SERVICE_NAME,
-                "Introduce",
+                ELIZA_SERVICE_INTRODUCE_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
+++ b/examples/eliza/src/generated/connect/connectrpc.eliza.v1.eliza.__connect.rs
@@ -126,71 +126,38 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const ELIZA_SERVICE_SERVICE_NAME: &str = "connectrpc.eliza.v1.ElizaService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Say` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Say` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `ELIZA_SERVICE_SAY_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const ELIZA_SERVICE_SAY_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.eliza.v1.ElizaService/Say",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Client-side sibling of `ELIZA_SERVICE_SAY_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const ELIZA_SERVICE_SAY_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.eliza.v1.ElizaService/Say",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Converse` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Converse` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `ELIZA_SERVICE_CONVERSE_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const ELIZA_SERVICE_CONVERSE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/connectrpc.eliza.v1.ElizaService/Converse",
         ::connectrpc::StreamType::BidiStream,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `ELIZA_SERVICE_CONVERSE_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const ELIZA_SERVICE_CONVERSE_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/connectrpc.eliza.v1.ElizaService/Converse",
-        ::connectrpc::StreamType::BidiStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Introduce` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Introduce` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `ELIZA_SERVICE_INTRODUCE_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const ELIZA_SERVICE_INTRODUCE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/connectrpc.eliza.v1.ElizaService/Introduce",
-        ::connectrpc::StreamType::ServerStream,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `ELIZA_SERVICE_INTRODUCE_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const ELIZA_SERVICE_INTRODUCE_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/connectrpc.eliza.v1.ElizaService/Introduce",
         ::connectrpc::StreamType::ServerStream,
     )
@@ -746,7 +713,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                ELIZA_SERVICE_SAY_CLIENT_SPEC,
+                ELIZA_SERVICE_SAY_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -784,7 +751,8 @@ where
         ::connectrpc::client::call_bidi_stream(
                 &self.transport,
                 &self.config,
-                ELIZA_SERVICE_CONVERSE_CLIENT_SPEC,
+                ELIZA_SERVICE_CONVERSE_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 options,
             )
             .await
@@ -825,7 +793,8 @@ where
         ::connectrpc::client::call_server_stream(
                 &self.transport,
                 &self.config,
-                ELIZA_SERVICE_INTRODUCE_CLIENT_SPEC,
+                ELIZA_SERVICE_INTRODUCE_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -54,25 +54,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const GREET_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.greet.v1.GreetService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Greet` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Greet` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `GREET_SERVICE_GREET_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const GREET_SERVICE_GREET_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/anthropic.connectrpc.greet.v1.GreetService/Greet",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Client-side sibling of `GREET_SERVICE_GREET_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const GREET_SERVICE_GREET_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.greet.v1.GreetService/Greet",
         ::connectrpc::StreamType::Unary,
     )
@@ -477,7 +466,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                GREET_SERVICE_GREET_CLIENT_SPEC,
+                GREET_SERVICE_GREET_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -68,14 +68,10 @@ pub const GREET_SERVICE_GREET_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::ser
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Greet` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `GREET_SERVICE_GREET_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `GREET_SERVICE_GREET_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const GREET_SERVICE_GREET_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.greet.v1.GreetService/Greet",
         ::connectrpc::StreamType::Unary,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -54,13 +54,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const GREET_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.greet.v1.GreetService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Greet` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Greet` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const GREET_SERVICE_GREET_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.greet.v1.GreetService/Greet",
         ::connectrpc::StreamType::Unary,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.greet.v1.greet.__connect.rs
@@ -58,7 +58,25 @@ pub const GREET_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.greet.v1.Gree
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `GREET_SERVICE_GREET_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const GREET_SERVICE_GREET_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/anthropic.connectrpc.greet.v1.GreetService/Greet",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::NoSideEffects);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Greet` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `GREET_SERVICE_GREET_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const GREET_SERVICE_GREET_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.greet.v1.GreetService/Greet",
         ::connectrpc::StreamType::Unary,
     )
@@ -463,8 +481,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                GREET_SERVICE_SERVICE_NAME,
-                "Greet",
+                GREET_SERVICE_GREET_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -46,13 +46,7 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const MATH_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.math.v1.MathService";
-/// Static [`Spec`](::connectrpc::Spec) for the `Add` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Add` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const MATH_SERVICE_ADD_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.math.v1.MathService/Add",
         ::connectrpc::StreamType::Unary,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -46,25 +46,14 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const MATH_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.math.v1.MathService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Add` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Add` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `MATH_SERVICE_ADD_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const MATH_SERVICE_ADD_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/anthropic.connectrpc.math.v1.MathService/Add",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `MATH_SERVICE_ADD_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const MATH_SERVICE_ADD_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.math.v1.MathService/Add",
         ::connectrpc::StreamType::Unary,
     )
@@ -468,7 +457,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                MATH_SERVICE_ADD_CLIENT_SPEC,
+                MATH_SERVICE_ADD_SPEC.with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -50,7 +50,25 @@ pub const MATH_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.math.v1.MathSe
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `MATH_SERVICE_ADD_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const MATH_SERVICE_ADD_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/anthropic.connectrpc.math.v1.MathService/Add",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Add` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `MATH_SERVICE_ADD_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const MATH_SERVICE_ADD_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.math.v1.MathService/Add",
         ::connectrpc::StreamType::Unary,
     )
@@ -454,8 +472,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                MATH_SERVICE_SERVICE_NAME,
-                "Add",
+                MATH_SERVICE_ADD_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.math.v1.math.__connect.rs
@@ -60,14 +60,10 @@ pub const MATH_SERVICE_ADD_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Add` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `MATH_SERVICE_ADD_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `MATH_SERVICE_ADD_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const MATH_SERVICE_ADD_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.math.v1.MathService/Add",
         ::connectrpc::StreamType::Unary,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -184,6 +184,15 @@ pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC: ::connectrpc::Spec = ::con
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CreateEvent",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `CalculateDuration` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -194,6 +203,15 @@ pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC: ::connectrpc::Spec = ::con
 /// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
 /// `procedure` to match this method on either side.
 pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
         ::connectrpc::StreamType::Unary,
     )
@@ -212,6 +230,15 @@ pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC: ::connectrpc::Spec = :
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
+pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/ProcessMetadata",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `Heartbeat` RPC.
 ///
 /// The dispatcher surfaces this on
@@ -226,53 +253,10 @@ pub const WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC: ::connectrpc::Spec = ::connec
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `CreateEvent` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CreateEvent",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `CalculateDuration` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `ProcessMetadata` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
-pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/ProcessMetadata",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the client-side `Heartbeat` RPC.
-///
-/// The generated client passes this to the runtime, so it is the value a
-/// client-side interceptor observes. It differs from the server-side
-/// `WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC` only in [`origin`](::connectrpc::Spec::origin),
-/// so the two are **not** `==`; use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method regardless of side.
+/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC` (same method,
+/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
+/// what generated client methods pass to the runtime and what a
+/// client-side interceptor observes.
 pub const WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/Heartbeat",
         ::connectrpc::StreamType::Unary,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -170,49 +170,25 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.wkt.v1.WellKnownTypesService";
-/// Static [`Spec`](::connectrpc::Spec) for the `CreateEvent` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `CreateEvent` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CreateEvent",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `CalculateDuration` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `CalculateDuration` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `ProcessMetadata` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `ProcessMetadata` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/ProcessMetadata",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the `Heartbeat` RPC.
-///
-/// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
-/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
-/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
+/// Static [`Spec`](::connectrpc::Spec) for the `Heartbeat` RPC, as seen by the server; the generated client passes it with [`origin`](::connectrpc::Spec::origin) `Client` (compare across sides with [`Spec::same_method`](::connectrpc::Spec::same_method)).
 pub const WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/Heartbeat",
         ::connectrpc::StreamType::Unary,

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -174,6 +174,11 @@ pub const WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.wk
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CreateEvent",
         ::connectrpc::StreamType::Unary,
@@ -183,6 +188,11 @@ pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC: ::connectrpc::Spec = ::con
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
         ::connectrpc::StreamType::Unary,
@@ -192,6 +202,11 @@ pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC: ::connectrpc::Spec =
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/ProcessMetadata",
         ::connectrpc::StreamType::Unary,
@@ -201,7 +216,64 @@ pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC: ::connectrpc::Spec = :
 ///
 /// The dispatcher surfaces this on
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+///
+/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_CLIENT_SPEC`. The two are not `==` (their
+/// [`origin`](::connectrpc::Spec::origin) differs); use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method on either side.
 pub const WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/Heartbeat",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `CreateEvent` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CreateEvent",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `CalculateDuration` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `ProcessMetadata` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
+        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/ProcessMetadata",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the client-side `Heartbeat` RPC.
+///
+/// The generated client passes this to the runtime, so it is the value a
+/// client-side interceptor observes. It differs from the server-side
+/// `WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC` only in [`origin`](::connectrpc::Spec::origin),
+/// so the two are **not** `==`; use
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
+/// `procedure` to match this method regardless of side.
+pub const WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/Heartbeat",
         ::connectrpc::StreamType::Unary,
     )
@@ -848,8 +920,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME,
-                "CreateEvent",
+                WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -893,8 +964,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME,
-                "CalculateDuration",
+                WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -938,8 +1008,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME,
-                "ProcessMetadata",
+                WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC,
                 request,
                 options,
             )
@@ -979,8 +1048,7 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME,
-                "Heartbeat",
+                WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_CLIENT_SPEC,
                 request,
                 options,
             )

--- a/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
+++ b/examples/multiservice/src/generated/connect/anthropic.connectrpc.wkt.v1.wkt.__connect.rs
@@ -170,94 +170,50 @@ for ::buffa::view::OwnedView<
 }
 /// Full service name for this service.
 pub const WELL_KNOWN_TYPES_SERVICE_SERVICE_NAME: &str = "anthropic.connectrpc.wkt.v1.WellKnownTypesService";
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `CreateEvent` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `CreateEvent` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CreateEvent",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CreateEvent",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `CalculateDuration` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `CalculateDuration` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/CalculateDuration",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `ProcessMetadata` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `ProcessMetadata` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/ProcessMetadata",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
-        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/ProcessMetadata",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Static [`Spec`](::connectrpc::Spec) for the server-side `Heartbeat` RPC.
+/// Static [`Spec`](::connectrpc::Spec) for the `Heartbeat` RPC.
 ///
 /// The dispatcher surfaces this on
-/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
-///
-/// Client sibling: `WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_CLIENT_SPEC`. The two are not `==` (their
-/// [`origin`](::connectrpc::Spec::origin) differs); use
-/// [`Spec::same_method`](::connectrpc::Spec::same_method) or compare
-/// `procedure` to match this method on either side.
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec); the generated
+/// client passes it with [`origin`](::connectrpc::Spec::origin) set to
+/// [`Client`](::connectrpc::SpecOrigin::Client), so on that side compare with
+/// [`Spec::same_method`](::connectrpc::Spec::same_method) rather than `==`.
 pub const WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
-        "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/Heartbeat",
-        ::connectrpc::StreamType::Unary,
-    )
-    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
-/// Client-side sibling of `WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC` (same method,
-/// [`SpecOrigin::Client`](::connectrpc::SpecOrigin::Client), so not `==` to it):
-/// what generated client methods pass to the runtime and what a
-/// client-side interceptor observes.
-pub const WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_CLIENT_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::client(
         "/anthropic.connectrpc.wkt.v1.WellKnownTypesService/Heartbeat",
         ::connectrpc::StreamType::Unary,
     )
@@ -904,7 +860,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_CLIENT_SPEC,
+                WELL_KNOWN_TYPES_SERVICE_CREATE_EVENT_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -948,7 +905,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_CLIENT_SPEC,
+                WELL_KNOWN_TYPES_SERVICE_CALCULATE_DURATION_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -992,7 +950,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_CLIENT_SPEC,
+                WELL_KNOWN_TYPES_SERVICE_PROCESS_METADATA_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )
@@ -1032,7 +991,8 @@ where
         ::connectrpc::client::call_unary(
                 &self.transport,
                 &self.config,
-                WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_CLIENT_SPEC,
+                WELL_KNOWN_TYPES_SERVICE_HEARTBEAT_SPEC
+                    .with_origin(::connectrpc::SpecOrigin::Client),
                 request,
                 options,
             )


### PR DESCRIPTION
> Stacked on #269 (first two commits, already rebased onto current `main`); will rebase again when it lands.

Second step toward client-side interceptors: the client runtime now receives the method's `Spec` (procedure, stream type, idempotency, origin) instead of two strings, so a client interceptor can see what a server interceptor sees.

**Changes**

- **Breaking:** `connectrpc::client::call_unary` / `call_unary_get` / `call_server_stream` / `call_client_stream` / `call_bidi_stream` take `spec: Spec` in place of `service: &str, method: &str`. Generated clients pass `FOO_SERVICE_BAR_SPEC.with_origin(SpecOrigin::Client)`; hand-written callers do the same or use `Spec::client("/pkg.Svc/Method", StreamType::…)`. Wire paths are unchanged.
- New `Spec::with_origin(SpecOrigin)` and `Spec::same_method(&Spec)` (the client-side value is not `==` to the constant, since `origin` differs).
- A spec with the wrong stream shape or a server origin is rejected with `Internal` before anything is sent, with a message naming the fix.
- Request URIs are built structurally from the base URI's parsed parts, in one helper instead of five `format!` + re-parse copies.
- Conformance client updated; six checked-in generated dirs regenerated.

**Decisions**

- Replace the string pair rather than add parallel `_spec` entry points: generated code is the real caller and the crate is pre-1.0. A dynamic caller interns its `&'static` procedure (documented on `Spec::client`).
- One `Spec` constant per method plus `with_origin`, rather than a second `*_CLIENT_SPEC` constant per method: origin is a call-site property (as in connect-go), and this avoids doubling generated constants and docs.

Client conformance (Connect, gRPC, gRPC-Web) passes; wire behavior unchanged.
