### PR TITLE
server: stream response items as segments so large fields are not copied

### DIFF
--- a/.changes/unreleased/Changed-20260717-173621.yaml
+++ b/.changes/unreleased/Changed-20260717-173621.yaml
@@ -11,9 +11,9 @@ body: |-
   the framing threshold, owned-message responses (their `String` and `Vec<u8>`
   fields cannot be handed over by reference), a response much smaller than the
   request it borrows from (capturing would keep the whole request buffer alive
-  while the response flushes), Connect-protocol unary, streaming, and any call
-  passing through an interceptor, since an interceptor may replace the body and
-  so needs it whole.
+  while the response flushes), Connect-protocol unary, and any call passing
+  through an interceptor, since an interceptor may replace the body and so
+  needs it whole.
 
   **Breaking, for custom dispatch only.** `EncodedResponse` is now
   `Response<EncodedBody>` rather than `Response<Bytes>`. If you implement the

--- a/.changes/unreleased/Changed-20260819-175304.yaml
+++ b/.changes/unreleased/Changed-20260819-175304.yaml
@@ -1,0 +1,33 @@
+kind: Changed
+body: |-
+  **Streaming responses no longer copy large fields that the encoder can hand
+  over by reference count.** Each item of a server-streaming or bidi response,
+  each client-streaming response, and a unary response served over gRPC or
+  gRPC-Web is now encoded through `Encodable::encode_segments`, and the
+  framing layer emits every segment at or above the 16 KiB framing threshold
+  as its own body frame, unmoved, while the tag/length fragments between large
+  fields ride in the batch buffer with the envelope header. Wire bytes are
+  unchanged. In practice this reaches handlers that stream `OwnedView` items
+  (or `MaybeBorrowed::Borrowed` wrapping one) and any custom `Encodable` whose
+  `encode_segments` yields segments. Owned-message items, bare views,
+  `PreEncoded`, and `StreamMessage` items encode contiguously as before
+  (though the whole message is still framed by reference count past the
+  threshold), as do JSON responses, Connect-protocol unary, and calls passing
+  through an interceptor.
+
+  The segmented encode applies only to an *uncompressed* response. With the
+  default `CompressionPolicy` (compress from 1 KiB) and a client that
+  advertises an encoding, every item large enough to segment is compressed
+  instead, which needs the message contiguous. Opt out per response with
+  `Response::compress(false)`, or raise `CompressionPolicy::min_size`, when
+  the payload is already compressed or the copy matters more than the bytes.
+
+  **Breaking, for custom dispatch only.** `StreamingResult`'s body is now
+  `EncodedStream` (`ServiceStream<EncodedBody>`) rather than a stream of
+  `Bytes`, mirroring `EncodedResponse`, and `StreamResponse::from_encoded` /
+  `StreamResponse::into_encoded` follow. A hand-written `Dispatcher` or test
+  double converts with
+  `Box::pin(stream.map(|item| item.map(EncodedBody::from)))` and recovers a
+  single buffer per item with `EncodedBody::into_contiguous()`. Generated
+  dispatchers and handler traits are unaffected, so no regeneration is needed.
+time: 2026-08-19T17:53:04.066187220Z

--- a/.changes/unreleased/Changed-20260819-175304.yaml
+++ b/.changes/unreleased/Changed-20260819-175304.yaml
@@ -6,8 +6,9 @@ body: |-
   gRPC-Web is now encoded through `Encodable::encode_segments`, and the
   framing layer emits every segment at or above the 16 KiB framing threshold
   as its own body frame, unmoved, while the tag/length fragments between large
-  fields ride in the batch buffer with the envelope header. Wire bytes are
-  unchanged. In practice this reaches handlers that stream `OwnedView` items
+  fields ride in the batch buffer with the envelope header. The encoded message
+  bytes are unchanged; a segmented message is now split across more HTTP body
+  frames. In practice this reaches handlers that stream `OwnedView` items
   (or `MaybeBorrowed::Borrowed` wrapping one) and any custom `Encodable` whose
   `encode_segments` yields segments. Owned-message items, bare views,
   `PreEncoded`, and `StreamMessage` items encode contiguously as before
@@ -18,16 +19,20 @@ body: |-
   The segmented encode applies only to an *uncompressed* response. With the
   default `CompressionPolicy` (compress from 1 KiB) and a client that
   advertises an encoding, every item large enough to segment is compressed
-  instead, which needs the message contiguous. Opt out per response with
-  `Response::compress(false)`, or raise `CompressionPolicy::min_size`, when
-  the payload is already compressed or the copy matters more than the bytes.
+  instead, which needs the message contiguous — so on that path the segmented
+  encode is flattened again and costs more than the contiguous encode it
+  replaced. Opt out per response with `Response::compress(false)`, or raise
+  `CompressionPolicy::with_min_size`, when the payload is already compressed
+  or the copy matters more than the bytes.
 
   **Breaking, for custom dispatch only.** `StreamingResult`'s body is now
   `EncodedStream` (`ServiceStream<EncodedBody>`) rather than a stream of
   `Bytes`, mirroring `EncodedResponse`, and `StreamResponse::from_encoded` /
   `StreamResponse::into_encoded` follow. A hand-written `Dispatcher` or test
   double converts with
-  `Box::pin(stream.map(|item| item.map(EncodedBody::from)))` and recovers a
-  single buffer per item with `EncodedBody::into_contiguous()`. Generated
-  dispatchers and handler traits are unaffected, so no regeneration is needed.
+  `Response::stream(items.map(|r| r.map(EncodedBody::from)))` and recovers a
+  single buffer per item with `EncodedBody::into_contiguous()`; `EncodedBody`
+  is also now `#[non_exhaustive]`, so match through its accessors rather than
+  its variants. Generated dispatchers and handler traits are unaffected, so no
+  regeneration is needed.
 time: 2026-08-19T17:53:04.066187220Z

--- a/connectrpc/src/deadline.rs
+++ b/connectrpc/src/deadline.rs
@@ -20,7 +20,6 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use bytes::Bytes;
 use futures::Stream;
 use pin_project::pin_project;
 use tokio::time::Sleep;
@@ -287,11 +286,11 @@ impl DeadlinePolicy {
     /// policy adds no overhead.
     ///
     /// Requires a tokio runtime; constructs `tokio::time::Sleep` internally.
-    pub(crate) fn enforce_on_response_stream(
+    pub(crate) fn enforce_on_response_stream<T: Send + 'static>(
         &self,
-        stream: BoxStream<Result<Bytes, ConnectError>>,
+        stream: BoxStream<Result<T, ConnectError>>,
         remaining: Option<Duration>,
-    ) -> BoxStream<Result<Bytes, ConnectError>> {
+    ) -> BoxStream<Result<T, ConnectError>> {
         let absolute = if self.enforce_on_streams {
             remaining
         } else {
@@ -344,11 +343,11 @@ impl<S> DeadlineStream<S> {
     }
 }
 
-impl<S> Stream for DeadlineStream<S>
+impl<S, T> Stream for DeadlineStream<S>
 where
-    S: Stream<Item = Result<Bytes, ConnectError>>,
+    S: Stream<Item = Result<T, ConnectError>>,
 {
-    type Item = Result<Bytes, ConnectError>;
+    type Item = Result<T, ConnectError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
@@ -414,6 +413,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
     use futures::StreamExt;
 
     fn ms(n: u64) -> Duration {

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -24,7 +24,7 @@ use crate::error::ConnectError;
 use crate::handler::BoxFuture;
 use crate::handler::BoxStream;
 use crate::payload::Payload;
-use crate::response::{EncodedResponse, RequestContext};
+use crate::response::{EncodedResponse, EncodedStream, RequestContext};
 use crate::router::MethodKind;
 use crate::spec::Spec;
 
@@ -118,11 +118,10 @@ pub type UnaryResult = BoxFuture<'static, Result<EncodedResponse, ConnectError>>
 
 /// Result type for server-streaming and bidi-streaming handler calls.
 ///
-/// The body is a stream of pre-encoded message bytes.
-pub type StreamingResult = BoxFuture<
-    'static,
-    Result<crate::response::Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError>,
->;
+/// The body is an [`EncodedStream`]: one already-encoded
+/// [`EncodedBody`](crate::EncodedBody) per response message.
+pub type StreamingResult =
+    BoxFuture<'static, Result<crate::response::Response<EncodedStream>, ConnectError>>;
 
 /// A stream of raw request message bytes (client-streaming / bidi input).
 pub type RequestStream = BoxStream<Result<Bytes, ConnectError>>;
@@ -357,22 +356,24 @@ pub mod codegen {
     pub use super::unimplemented_streaming;
     pub use super::unimplemented_unary;
 
-    /// Map a stream of typed responses through [`Encodable::encode`].
+    /// Map a stream of typed responses through
+    /// [`Encodable::encode_segments`].
     ///
     /// Used by generated `call_server_streaming` and `call_bidi_streaming`
     /// arms to convert the handler's `Stream<Item = Result<B, _>>` into
-    /// the `Stream<Item = Result<Bytes, _>>` that the dispatcher protocol
-    /// requires. `B` is any [`Encodable<Res>`](crate::Encodable) — typically `Res` itself,
-    /// but may be [`PreEncoded`](crate::PreEncoded) or
-    /// [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
-    /// borrowing views per item.
+    /// the [`EncodedStream`](crate::EncodedStream) that the dispatcher
+    /// protocol requires. `B` is any [`Encodable<Res>`](crate::Encodable),
+    /// typically `Res` itself, but may be [`PreEncoded`](crate::PreEncoded)
+    /// or [`MaybeBorrowed`](crate::MaybeBorrowed) for handlers that encode
+    /// borrowing views per item. An item that can hand a large payload over
+    /// by reference count arrives segmented and, on an uncompressed
+    /// response, is framed without copying that payload. Every other item
+    /// takes the contiguous default. See [`EncodedStream`](crate::EncodedStream)
+    /// for when compression flattens it instead.
     ///
     /// [`Encodable`]: crate::Encodable
-    /// [`Encodable::encode`]: crate::Encodable::encode
-    pub fn encode_response_stream<Res, B, S>(
-        stream: S,
-        format: CodecFormat,
-    ) -> BoxStream<Result<Bytes, ConnectError>>
+    /// [`Encodable::encode_segments`]: crate::Encodable::encode_segments
+    pub fn encode_response_stream<Res, B, S>(stream: S, format: CodecFormat) -> crate::EncodedStream
     where
         Res: Message + Send + 'static,
         B: crate::Encodable<Res> + Send + 'static,
@@ -386,7 +387,7 @@ pub mod codegen {
                     format,
                 ),
                 async |(mut s, fmt)| match s.next().await {
-                    Some(Ok(res)) => Some((Encodable::<Res>::encode(&res, fmt), (s, fmt))),
+                    Some(Ok(res)) => Some((Encodable::<Res>::encode_segments(&res, fmt), (s, fmt))),
                     Some(Err(e)) => Some((Err(e), (s, fmt))),
                     None => None,
                 },

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -121,24 +121,10 @@ impl Envelope {
         body: crate::response::EncodedBody,
         min_chain: usize,
     ) -> (Bytes, Vec<Bytes>) {
-        let total = body.len();
-        if total < min_chain {
-            let mut buf = BytesMut::with_capacity(HEADER_SIZE + total);
-            write_envelope_header(flags, total, &mut buf)
-                .expect("envelope payload exceeds u32::MAX");
-            for segment in body.segments() {
-                buf.extend_from_slice(segment);
-            }
-            return (buf.freeze(), Vec::new());
-        }
-
-        let mut head = BytesMut::with_capacity(HEADER_SIZE);
-        write_envelope_header(flags, total, &mut head).expect("envelope payload exceeds u32::MAX");
-
-        let segments = match body {
-            crate::response::EncodedBody::Contiguous(bytes) => vec![bytes],
-            crate::response::EncodedBody::Segmented(segments) => segments,
-        };
+        let mut head = BytesMut::new();
+        let mut segments = Vec::new();
+        write_envelope_chained(flags, body, &mut head, &mut segments, min_chain)
+            .expect("envelope payload exceeds u32::MAX");
         (head.freeze(), segments)
     }
 
@@ -357,11 +343,18 @@ impl EnvelopeEncoder {
     /// Encode a data envelope, avoiding the payload copy for large messages.
     ///
     /// When the on-wire payload (post-compression, if negotiated) is at
-    /// least `min_chain` bytes, only the 5-byte envelope header is written
-    /// into `dst` and the payload is returned for the caller to emit as its
-    /// own body frame — a refcount move instead of a payload-sized memcpy.
-    /// Smaller payloads are written contiguously into `dst` and `None` is
-    /// returned.
+    /// least `min_chain` bytes in total, only the 5-byte envelope header is
+    /// written into `dst` and the payload's segments are appended to
+    /// `chained`, in wire order, for the caller to emit after `dst`: a
+    /// refcount move instead of a payload-sized memcpy. A body the encoder
+    /// already split keeps its segments, so a large field handed over by
+    /// reference count reaches the socket without being flattened here.
+    /// Smaller payloads are written contiguously into `dst` and nothing is
+    /// appended.
+    ///
+    /// Compression needs one contiguous input, so a segmented body is
+    /// flattened before compressing and the compressed output chains as a
+    /// single segment on its post-compression size.
     ///
     /// The [`Encoder`](tokio_util::codec::Encoder) impl delegates here with
     /// `min_chain = usize::MAX` (never chain), so the compression decision and
@@ -374,23 +367,20 @@ impl EnvelopeEncoder {
     /// does not change the wire protocol.
     pub(crate) fn encode_chained(
         &mut self,
-        data: Bytes,
+        body: crate::response::EncodedBody,
         dst: &mut BytesMut,
+        chained: &mut impl Extend<Bytes>,
         min_chain: usize,
-    ) -> Result<Option<Bytes>, ConnectError> {
-        let (flag, payload) = if let Some((ref comp, ref encoding)) = self.compression
-            && self.policy.should_compress(data.len())
+    ) -> Result<(), ConnectError> {
+        let (flag, body) = if let Some((ref comp, ref encoding)) = self.compression
+            && self.policy.should_compress(body.len())
         {
-            (flags::COMPRESSED, comp.compress(encoding, &data)?)
+            let compressed = comp.compress(encoding, &body.into_contiguous())?;
+            (flags::COMPRESSED, compressed.into())
         } else {
-            (flags::DATA, data)
+            (flags::DATA, body)
         };
-        if payload.len() < min_chain {
-            write_envelope(flag, &payload, dst)?;
-            return Ok(None);
-        }
-        write_envelope_header(flag, payload.len(), dst)?;
-        Ok(Some(payload))
+        write_envelope_chained(flag, body, dst, chained, min_chain)
     }
 }
 
@@ -399,33 +389,65 @@ impl tokio_util::codec::Encoder<Bytes> for EnvelopeEncoder {
 
     fn encode(&mut self, data: Bytes, dst: &mut BytesMut) -> Result<(), ConnectError> {
         // `usize::MAX` threshold: the contiguous entry point never chains.
-        let chained = self.encode_chained(data, dst, usize::MAX)?;
-        debug_assert!(chained.is_none(), "usize::MAX threshold cannot chain");
+        let mut chained = Vec::new();
+        self.encode_chained(data.into(), dst, &mut chained, usize::MAX)?;
+        debug_assert!(chained.is_empty(), "usize::MAX threshold cannot chain");
         Ok(())
     }
 }
 
 /// Write a single envelope (header + payload) into a `BytesMut` buffer.
-/// The length is validated (via [`write_envelope_header`]) before any
-/// buffer growth, so an oversized payload errors without allocating.
+/// The length is validated (via [`envelope_length`]) before any buffer
+/// growth, so an oversized payload errors without allocating.
 fn write_envelope(flag: u8, data: &[u8], dst: &mut BytesMut) -> Result<(), ConnectError> {
-    write_envelope_header(flag, data.len(), dst)?;
+    put_envelope_header(flag, envelope_length(data.len())?, dst);
     dst.put_slice(data);
     Ok(())
 }
 
-/// Write only the 5-byte envelope header (flag + big-endian length) into
-/// `dst`, for callers that emit the payload as its own body frame.
-fn write_envelope_header(flag: u8, len: usize, dst: &mut BytesMut) -> Result<(), ConnectError> {
-    if len > u32::MAX as usize {
-        return Err(ConnectError::resource_exhausted(format!(
-            "envelope payload {len} bytes exceeds u32::MAX"
-        )));
+/// Write the envelope header for `body` into `dst`, then either copy the
+/// body in after it (below `min_chain` bytes in total) or append the body's
+/// segments to `chained` in wire order for the caller to emit after `dst`.
+/// The header always declares the total across every segment, and the
+/// length is validated before any buffer growth.
+fn write_envelope_chained(
+    flag: u8,
+    body: crate::response::EncodedBody,
+    dst: &mut BytesMut,
+    chained: &mut impl Extend<Bytes>,
+    min_chain: usize,
+) -> Result<(), ConnectError> {
+    let total = body.len();
+    let declared = envelope_length(total)?;
+    if total < min_chain {
+        dst.reserve(HEADER_SIZE + total);
+        put_envelope_header(flag, declared, dst);
+        for segment in body.segments() {
+            dst.put_slice(segment);
+        }
+        return Ok(());
     }
+    put_envelope_header(flag, declared, dst);
+    match body {
+        crate::response::EncodedBody::Contiguous(bytes) => chained.extend([bytes]),
+        crate::response::EncodedBody::Segmented(segments) => chained.extend(segments),
+    }
+    Ok(())
+}
+
+/// The envelope length field for a payload of `len` bytes, or
+/// `ResourceExhausted` when it does not fit the 32-bit field.
+fn envelope_length(len: usize) -> Result<u32, ConnectError> {
+    u32::try_from(len).map_err(|_| {
+        ConnectError::resource_exhausted(format!("envelope payload {len} bytes exceeds u32::MAX"))
+    })
+}
+
+/// Write only the 5-byte envelope header (flag + big-endian length).
+fn put_envelope_header(flag: u8, len: u32, dst: &mut BytesMut) {
     dst.reserve(HEADER_SIZE);
     dst.put_u8(flag);
-    dst.put_u32(len as u32);
-    Ok(())
+    dst.put_u32(len);
 }
 
 #[cfg(test)]
@@ -482,10 +504,12 @@ mod tests {
             .map(|i| (i.wrapping_mul(2654435761) >> 13) as u8)
             .collect();
         let mut dst = BytesMut::new();
-        let chained = enc
-            .encode_chained(Bytes::from(data), &mut dst, 1024)
-            .unwrap()
-            .expect("large compressed payload must chain");
+        let mut chained = Vec::new();
+        enc.encode_chained(Bytes::from(data).into(), &mut dst, &mut chained, 1024)
+            .unwrap();
+        let [chained] = &chained[..] else {
+            panic!("large compressed payload must chain as one segment");
+        };
 
         assert_eq!(dst.len(), HEADER_SIZE);
         assert_eq!(dst[0], flags::COMPRESSED);
@@ -496,10 +520,95 @@ mod tests {
 
         // Reassembled envelope decodes back to the original payload.
         let mut wire = dst;
-        wire.put_slice(&chained);
+        wire.put_slice(chained);
         let mut dec = EnvelopeDecoder::new(1024 * 1024, Some("gzip".to_owned()), registry);
         let decoded = Decoder::decode(&mut dec, &mut wire).unwrap().unwrap();
         assert_eq!(decoded.len(), 64 * 1024);
+    }
+
+    /// A body the encoder already split keeps its segments through
+    /// `encode_chained`: only the header lands in `dst`, and every segment,
+    /// large or small, comes back as the same allocation in wire order. The
+    /// framing stream decides which of them to copy.
+    #[test]
+    fn encode_chained_keeps_segments_of_a_large_body() {
+        use crate::response::EncodedBody;
+
+        let lead = Bytes::from_static(b"tag");
+        let big = Bytes::from(vec![3u8; 64]);
+        let tail = Bytes::from_static(b"end");
+        let body = EncodedBody::Segmented(vec![lead.clone(), big.clone(), tail.clone()]);
+        let total = body.len();
+
+        let mut enc = EnvelopeEncoder::uncompressed();
+        let mut dst = BytesMut::new();
+        let mut segments = Vec::new();
+        enc.encode_chained(body, &mut dst, &mut segments, 32)
+            .unwrap();
+
+        assert_eq!(dst.len(), HEADER_SIZE, "only the header is copied");
+        assert_eq!(
+            u32::from_be_bytes([dst[1], dst[2], dst[3], dst[4]]) as usize,
+            total,
+            "header declares the total across segments"
+        );
+        let [s0, s1, s2] = &segments[..] else {
+            panic!("expected three segments, got {}", segments.len());
+        };
+        assert!(std::ptr::eq(s0.as_ptr(), lead.as_ptr()));
+        assert!(std::ptr::eq(s1.as_ptr(), big.as_ptr()));
+        assert!(std::ptr::eq(s2.as_ptr(), tail.as_ptr()));
+    }
+
+    /// Below the threshold a segmented body is copied in after the header,
+    /// exactly as a contiguous one would be.
+    #[test]
+    fn encode_chained_copies_a_small_segmented_body() {
+        use crate::response::EncodedBody;
+
+        let body =
+            EncodedBody::Segmented(vec![Bytes::from_static(b"ab"), Bytes::from_static(b"cd")]);
+        let mut enc = EnvelopeEncoder::uncompressed();
+        let mut dst = BytesMut::new();
+        let mut segments = Vec::new();
+        enc.encode_chained(body, &mut dst, &mut segments, 32)
+            .unwrap();
+
+        assert!(segments.is_empty());
+        assert_eq!(
+            dst.freeze(),
+            Envelope::data(Bytes::from_static(b"abcd")).encode()
+        );
+    }
+
+    /// Compression flattens a segmented body first, so the compressed
+    /// envelope decodes to the concatenation of the segments.
+    #[test]
+    #[cfg(feature = "gzip")]
+    fn encode_chained_compresses_a_segmented_body_as_one() {
+        use crate::response::EncodedBody;
+
+        let registry = Arc::new(CompressionRegistry::default());
+        let mut enc = EnvelopeEncoder::new(
+            Some((Arc::clone(&registry), "gzip")),
+            CompressionPolicy::default().min_size(0),
+        );
+        let body = EncodedBody::Segmented(vec![
+            Bytes::from(vec![b'a'; 4096]),
+            Bytes::from(vec![b'b'; 4096]),
+        ]);
+        let expected = body.clone().into_contiguous();
+
+        let mut wire = BytesMut::new();
+        let mut segments = Vec::new();
+        enc.encode_chained(body, &mut wire, &mut segments, usize::MAX)
+            .unwrap();
+        assert!(segments.is_empty());
+        assert_eq!(wire[0], flags::COMPRESSED);
+
+        let mut dec = EnvelopeDecoder::new(1024 * 1024, Some("gzip".to_owned()), registry);
+        let decoded = Decoder::decode(&mut dec, &mut wire).unwrap().unwrap();
+        assert_eq!(decoded, expected);
     }
 
     #[test]

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -591,7 +591,7 @@ mod tests {
         let registry = Arc::new(CompressionRegistry::default());
         let mut enc = EnvelopeEncoder::new(
             Some((Arc::clone(&registry), "gzip")),
-            CompressionPolicy::default().min_size(0),
+            CompressionPolicy::default().with_min_size(0),
         );
         let body = EncodedBody::Segmented(vec![
             Bytes::from(vec![b'a'; 4096]),

--- a/connectrpc/src/handler.rs
+++ b/connectrpc/src/handler.rs
@@ -90,10 +90,7 @@ pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 /// `dispatcher::codegen` path; the implementation is shared with the
 /// codegen-emitted dispatcher arms (see
 /// [`encode_response_stream`](crate::dispatcher::codegen::encode_response_stream)).
-fn encode_body_stream<Res, B, S>(
-    stream: S,
-    format: CodecFormat,
-) -> BoxStream<Result<Bytes, ConnectError>>
+fn encode_body_stream<Res, B, S>(stream: S, format: CodecFormat) -> crate::EncodedStream
 where
     Res: Message + Send + 'static,
     B: Encodable<Res> + Send + 'static,
@@ -126,7 +123,7 @@ pub(crate) trait ErasedHandler: Send + Sync {
 
 /// Result type for erased streaming handlers.
 pub(crate) type StreamingHandlerResult =
-    BoxFuture<'static, Result<Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError>>;
+    BoxFuture<'static, Result<Response<crate::EncodedStream>, ConnectError>>;
 
 /// Type-erased server-streaming handler for use in the router.
 pub(crate) trait ErasedStreamingHandler: Send + Sync {
@@ -1362,11 +1359,41 @@ mod tests {
             Err(ConnectError::internal("boom")),
         ]);
         let mut out = encode_body_stream::<StringValue, _, _>(s, CodecFormat::Proto);
-        let a = out.next().await.unwrap().unwrap();
-        let b = out.next().await.unwrap().unwrap();
+        let a = out.next().await.unwrap().unwrap().into_contiguous();
+        let b = out.next().await.unwrap().unwrap().into_contiguous();
         assert_eq!(StringValue::decode_from_slice(&a).unwrap().value, "a");
         assert_eq!(StringValue::decode_from_slice(&b).unwrap().value, "b");
         assert!(out.next().await.unwrap().is_err());
+        assert!(out.next().await.is_none());
+    }
+
+    /// A body that hands its payload over in segments reaches the stream as
+    /// those segments, not flattened: the per-item encode goes through
+    /// `Encodable::encode_segments`.
+    #[tokio::test]
+    async fn encode_body_stream_forwards_segments() {
+        use crate::EncodedBody;
+        use futures::StreamExt as _;
+
+        struct Split(Bytes, Bytes);
+        impl Encodable<StringValue> for Split {
+            fn encode(&self, _: CodecFormat) -> Result<Bytes, ConnectError> {
+                unreachable!("the streaming path takes encode_segments")
+            }
+            fn encode_segments(&self, _: CodecFormat) -> Result<EncodedBody, ConnectError> {
+                Ok(EncodedBody::Segmented(vec![self.0.clone(), self.1.clone()]))
+            }
+        }
+
+        let (a, b) = (Bytes::from_static(b"\x0a\x03"), Bytes::from_static(b"abc"));
+        let s = futures::stream::iter([Ok(Split(a.clone(), b.clone()))]);
+        let mut out = encode_body_stream::<StringValue, _, _>(s, CodecFormat::Proto);
+        let item = out.next().await.unwrap().unwrap();
+        let [s0, s1] = item.segments() else {
+            panic!("expected two segments");
+        };
+        assert!(std::ptr::eq(s0.as_ptr(), a.as_ptr()));
+        assert!(std::ptr::eq(s1.as_ptr(), b.as_ptr()));
         assert!(out.next().await.is_none());
     }
 
@@ -1389,8 +1416,14 @@ mod tests {
         ]);
         let mut out =
             encode_body_stream::<StringValue, PreEncoded<StringValue>, _>(s, CodecFormat::Proto);
-        assert_eq!(out.next().await.unwrap().unwrap(), bytes_a);
-        assert_eq!(out.next().await.unwrap().unwrap(), bytes_b);
+        assert_eq!(
+            out.next().await.unwrap().unwrap().into_contiguous(),
+            bytes_a
+        );
+        assert_eq!(
+            out.next().await.unwrap().unwrap().into_contiguous(),
+            bytes_b
+        );
         assert!(out.next().await.is_none());
     }
 
@@ -1415,11 +1448,11 @@ mod tests {
         let mut out =
             encode_body_stream::<StringValue, PreEncoded<StringValue>, _>(s, CodecFormat::Json);
         assert_eq!(
-            out.next().await.unwrap().unwrap(),
+            out.next().await.unwrap().unwrap().into_contiguous(),
             Bytes::from(serde_json::to_vec(&m_a).unwrap())
         );
         assert_eq!(
-            out.next().await.unwrap().unwrap(),
+            out.next().await.unwrap().unwrap().into_contiguous(),
             Bytes::from(serde_json::to_vec(&m_b).unwrap())
         );
         assert!(out.next().await.is_none());

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -51,7 +51,7 @@ use crate::dispatcher::RequestStream;
 use crate::error::ConnectError;
 use crate::handler::BoxStream;
 use crate::payload::Payload;
-use crate::response::{EncodedResponse, RequestContext, Response};
+use crate::response::{EncodedResponse, EncodedStream, RequestContext, Response};
 
 /// Re-export of [`async_trait::async_trait`] so interceptor authors don't
 /// need a direct `async-trait` dependency.
@@ -424,12 +424,19 @@ pub type StreamResponse = Response<PayloadStream>;
 impl StreamResponse {
     /// Build a `StreamResponse` from a dispatcher's encoded streaming
     /// response by wrapping each body item in a [`Payload`].
-    pub fn from_encoded(
-        resp: Response<BoxStream<Result<Bytes, ConnectError>>>,
-        format: CodecFormat,
-    ) -> Self {
+    ///
+    /// A [`Payload`] carries one contiguous buffer, so an item the encoder
+    /// split into segments is flattened here: a call with an interceptor
+    /// configured gives up the per-field segmented encode, because the
+    /// interceptor may read or replace the whole message. The flattened item
+    /// is still framed by reference count on the way out, so the batch-buffer
+    /// copy stays avoided.
+    pub fn from_encoded(resp: Response<EncodedStream>, format: CodecFormat) -> Self {
         resp.map_body(move |stream| -> PayloadStream {
-            Box::pin(stream.map(move |item| item.map(|bytes| Payload::new(bytes, format))))
+            Box::pin(
+                stream
+                    .map(move |item| item.map(|body| Payload::new(body.into_contiguous(), format))),
+            )
         })
     }
 
@@ -441,9 +448,9 @@ impl StreamResponse {
     /// dispatch path renders as a streaming error and then ends the
     /// stream. There is no fallible up-front conversion: stream items
     /// haven't been produced yet.
-    pub fn into_encoded(self) -> Response<BoxStream<Result<Bytes, ConnectError>>> {
-        self.map_body(|stream| -> BoxStream<Result<Bytes, ConnectError>> {
-            Box::pin(stream.map(|item| item.and_then(|payload| payload.encoded())))
+    pub fn into_encoded(self) -> Response<EncodedStream> {
+        self.map_body(|stream| -> EncodedStream {
+            Box::pin(stream.map(|item| item.and_then(|payload| payload.encoded().map(Into::into))))
         })
     }
 }
@@ -663,7 +670,7 @@ pub(crate) async fn call_server_streaming_intercepted<D: crate::Dispatcher>(
     ctx: RequestContext,
     body: Bytes,
     format: CodecFormat,
-) -> Result<Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError> {
+) -> Result<Response<EncodedStream>, ConnectError> {
     if interceptors.is_empty() {
         return dispatcher
             .call_server_streaming(path, ctx, body, format)
@@ -749,7 +756,7 @@ pub(crate) async fn call_bidi_streaming_intercepted<D: crate::Dispatcher>(
     ctx: RequestContext,
     requests: RequestStream,
     format: CodecFormat,
-) -> Result<Response<BoxStream<Result<Bytes, ConnectError>>>, ConnectError> {
+) -> Result<Response<EncodedStream>, ConnectError> {
     if interceptors.is_empty() {
         return dispatcher
             .call_bidi_streaming(path, ctx, requests, format)
@@ -1754,8 +1761,8 @@ mod tests {
             _: CodecFormat,
         ) -> crate::dispatcher::StreamingResult {
             Box::pin(async move {
-                let body: BoxStream<Result<Bytes, ConnectError>> =
-                    Box::pin(futures::stream::once(async move { Ok(request) }));
+                let body: crate::EncodedStream =
+                    Box::pin(futures::stream::once(async move { Ok(request.into()) }));
                 Ok(Response {
                     body,
                     headers: http::HeaderMap::new(),
@@ -1788,14 +1795,34 @@ mod tests {
             _: CodecFormat,
         ) -> crate::dispatcher::StreamingResult {
             Box::pin(async move {
+                let body: crate::EncodedStream = Box::pin(requests.map(|r| r.map(Into::into)));
                 Ok(Response {
-                    body: requests,
+                    body,
                     headers: http::HeaderMap::new(),
                     trailers: http::HeaderMap::new(),
                     compress: None,
                 })
             })
         }
+    }
+
+    /// An interceptor sees one contiguous `Payload` per item, so a segmented
+    /// item is flattened on the way in and comes back out contiguous.
+    #[tokio::test]
+    async fn stream_response_from_encoded_flattens_segments() {
+        let segmented = crate::EncodedBody::Segmented(vec![
+            Bytes::from_static(b"ab"),
+            Bytes::from_static(b"cd"),
+        ]);
+        let body: EncodedStream = Box::pin(futures::stream::iter([Ok(segmented)]));
+        let resp = StreamResponse::from_encoded(Response::new(body), CodecFormat::Proto);
+        let out: Vec<_> = resp
+            .into_encoded()
+            .body
+            .map(|b| b.unwrap().into_contiguous())
+            .collect()
+            .await;
+        assert_eq!(out, [Bytes::from_static(b"abcd")]);
     }
 
     /// All three `call_*_streaming_intercepted` empty-chain fast paths
@@ -1816,12 +1843,13 @@ mod tests {
         )
         .await
         .unwrap();
-        let out: Vec<_> = resp.body.collect().await;
+        let out: Vec<_> = resp
+            .body
+            .map(|b| b.unwrap().into_contiguous())
+            .collect()
+            .await;
         assert_eq!(out.len(), 1);
-        assert!(std::ptr::eq(
-            out[0].as_ref().unwrap().as_ptr(),
-            body.as_ptr()
-        ));
+        assert!(std::ptr::eq(out[0].as_ptr(), body.as_ptr()));
 
         // Client-streaming.
         let inbound: RequestStream = Box::pin(futures::stream::iter(vec![
@@ -1856,12 +1884,13 @@ mod tests {
         )
         .await
         .unwrap();
-        let out: Vec<_> = resp.body.collect().await;
+        let out: Vec<_> = resp
+            .body
+            .map(|b| b.unwrap().into_contiguous())
+            .collect()
+            .await;
         assert_eq!(out.len(), 1);
-        assert!(std::ptr::eq(
-            out[0].as_ref().unwrap().as_ptr(),
-            body.as_ptr()
-        ));
+        assert!(std::ptr::eq(out[0].as_ptr(), body.as_ptr()));
     }
 
     /// `call_*_streaming_intercepted` propagates a short-circuit error
@@ -1994,9 +2023,13 @@ mod tests {
         )
         .await
         .unwrap();
-        let out: Vec<_> = resp.body.collect().await;
+        let out: Vec<_> = resp
+            .body
+            .map(|b| b.unwrap().into_contiguous())
+            .collect()
+            .await;
         assert_eq!(out.len(), 1);
-        assert_eq!(out[0].as_ref().unwrap(), &body);
+        assert_eq!(out[0], body);
 
         // Client-streaming: 2-item inbound stream → terminal hands stream
         // to dispatcher → dispatcher's single response collapses to body.
@@ -2031,10 +2064,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let out: Vec<_> = resp.body.collect().await;
+        let out: Vec<_> = resp
+            .body
+            .map(|b| b.unwrap().into_contiguous())
+            .collect()
+            .await;
         assert_eq!(out.len(), 2);
-        assert_eq!(out[0].as_ref().unwrap(), &Bytes::from_static(b"1"));
-        assert_eq!(out[1].as_ref().unwrap(), &Bytes::from_static(b"2"));
+        assert_eq!(out[0], Bytes::from_static(b"1"));
+        assert_eq!(out[1], Bytes::from_static(b"2"));
     }
 
     // ========================================================================

--- a/connectrpc/src/lib.rs
+++ b/connectrpc/src/lib.rs
@@ -275,6 +275,7 @@ pub use request::ServiceRequest;
 pub use response::Encodable;
 pub use response::EncodedBody;
 pub use response::EncodedResponse;
+pub use response::EncodedStream;
 pub use response::InboundStream;
 pub use response::MaybeBorrowed;
 pub use response::PreEncoded;

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -805,7 +805,7 @@ fn checked_response_size(size: u32) -> Result<usize, ConnectError> {
 /// smaller is copied into the framing buffer downstream regardless, and a
 /// message can clear a smaller gate while none of its individual fields do,
 /// which spends the rope's cost and captures nothing. Matching the framing
-/// threshold also makes every segment map to exactly one body frame.
+/// threshold also makes every large segment map to exactly one body frame.
 ///
 /// # Errors
 ///
@@ -1211,6 +1211,19 @@ impl<M: Message + JsonSerialize> Encodable<M> for PreEncoded<M> {
 /// protocol layer — encoding happens inside the dispatcher so the body
 /// type stays generic across the trait boundary.
 pub type EncodedResponse = Response<EncodedBody>;
+
+/// The body of a streaming [`Response`] once each item is encoded: the
+/// streaming counterpart of [`EncodedResponse`]'s body.
+///
+/// Items are [`EncodedBody`] rather than `Bytes` so a message the encoder
+/// split into reference-counted segments stays split through the framing
+/// layer, which emits each large segment as its own body frame instead of
+/// copying it into the batch buffer. That only holds for an uncompressed
+/// response: compression needs one contiguous input, so a response that
+/// negotiates an encoding (the default for messages of at least
+/// `CompressionPolicy`'s `min_size` when the client advertises one) flattens
+/// each item first. Opt out per response with [`Response::compress`].
+pub type EncodedStream = ServiceStream<EncodedBody>;
 
 impl<B> Response<B> {
     /// Encode the body to bytes via [`Encodable<M>`], preserving

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -460,6 +460,12 @@ impl<B> Response<B> {
     ///
     /// `true` forces compression, `false` disables it, `None` (or
     /// never calling this) defers to the server's policy.
+    ///
+    /// Compression needs one contiguous input, so a compressed response
+    /// gives up the segmented encode that lets a view body's large fields
+    /// reach the transport without a copy (see [`EncodedStream`]). For a
+    /// response dominated by large, already-compressed or incompressible
+    /// `bytes` fields, `compress(false)` is usually the faster choice.
     #[must_use]
     pub fn compress(mut self, enabled: impl Into<Option<bool>>) -> Self {
         self.compress = enabled.into();
@@ -536,7 +542,13 @@ pub type InboundStream<M> = ServiceStream<crate::StreamMessage<M>>;
 ///
 /// The single-buffer case is kept unboxed: a small message that was never
 /// worth segmenting costs no allocation to carry.
+///
+/// Prefer [`segments`](Self::segments) / [`into_contiguous`](Self::into_contiguous)
+/// over matching on the variants: the split is not canonical (compare two
+/// bodies in tests via `into_contiguous()`), and further representations may
+/// be added.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum EncodedBody {
     /// One contiguous buffer — what a non-segmenting encode produces.
     Contiguous(Bytes),
@@ -1222,7 +1234,22 @@ pub type EncodedResponse = Response<EncodedBody>;
 /// response: compression needs one contiguous input, so a response that
 /// negotiates an encoding (the default for messages of at least
 /// `CompressionPolicy`'s `min_size` when the client advertises one) flattens
-/// each item first. Opt out per response with [`Response::compress`].
+/// each item first, and the segmented encode was then wasted work. Opt out
+/// per response with [`Response::compress`].
+///
+/// A hand-written [`Dispatcher`](crate::Dispatcher) or test double that
+/// produced `Bytes` items before 0.9 converts each item, and recovers a
+/// single buffer on the way out with [`EncodedBody::into_contiguous`]:
+///
+/// ```rust
+/// use connectrpc::{ConnectError, EncodedBody, EncodedStream, Response};
+/// use bytes::Bytes;
+/// use futures::{stream, StreamExt};
+///
+/// let items = stream::iter([Ok::<_, ConnectError>(Bytes::from_static(b"encoded"))]);
+/// let response: Response<EncodedStream> = Response::stream(items.map(|r| r.map(EncodedBody::from)));
+/// # let _ = response;
+/// ```
 pub type EncodedStream = ServiceStream<EncodedBody>;
 
 impl<B> Response<B> {

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -30,6 +30,7 @@
 //!     .merge(connect_router.into_axum_router());
 //! ```
 
+use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::future::Future;
 use std::ops::ControlFlow;
@@ -945,7 +946,7 @@ impl StreamingResponseBody {
     /// in the final envelope. For gRPC, trailers are sent as HTTP/2 trailing
     /// HEADERS frames.
     fn new(
-        response_stream: BoxStream<Result<Bytes, ConnectError>>,
+        response_stream: crate::EncodedStream,
         trailers: http::HeaderMap,
         protocol: Protocol,
         compression: Option<(Arc<CompressionRegistry>, &'static str)>,
@@ -1077,14 +1078,20 @@ impl StreamFinalizer {
 /// The 16 KiB threshold bounds memory for the pathological case (fast
 /// synchronous producer with large items).
 ///
+/// A message at or above `MIN_CHAIN_SIZE` is not batched: its envelope header
+/// is flushed with whatever precedes it and each of its large segments becomes
+/// a data frame of its own, by reference count. The small fragments between
+/// or after those segments ride in `buf`, so such a message can add a short
+/// data frame per large field rather than one per poll cycle.
+///
 /// # Terminal state machine
 ///
 /// At stream end (source returns `None` or `Err`), if `buf` is non-empty,
 /// the data frame is emitted FIRST, and the finalizer frame is staged for
 /// the next poll. This ensures partial batches aren't dropped.
 struct BatchingEnvelopeStream {
-    /// Source of encoded message bytes (already proto/JSON encoded).
-    source: futures::stream::Fuse<BoxStream<Result<Bytes, ConnectError>>>,
+    /// Source of encoded messages (already proto/JSON encoded).
+    source: futures::stream::Fuse<crate::EncodedStream>,
     /// Accumulation buffer — envelopes are appended here until flush.
     buf: bytes::BytesMut,
     /// Envelope encoder — writes 5-byte header + optional compression.
@@ -1095,20 +1102,20 @@ struct BatchingEnvelopeStream {
     finalizer: StreamFinalizer,
     /// Finalizer frame staged for the next poll (when buf was non-empty at end).
     pending_final: Option<Frame<Bytes>>,
-    /// Large payload (post-compression, when negotiated) staged for the next
-    /// poll: emitted as its
-    /// own data frame (refcount clone) right after the header flush, instead
-    /// of being copied into `buf`. See [`EnvelopeEncoder::encode_chained`].
+    /// Segments of the current envelope not yet emitted, in wire order. Its
+    /// header (and everything before it) is already in `buf` or flushed, so
+    /// these precede anything else the stream produces. See
+    /// [`EnvelopeEncoder::encode_chained`] and [`Self::drain_segments`].
     ///
     /// [`EnvelopeEncoder::encode_chained`]: crate::envelope::EnvelopeEncoder::encode_chained
-    pending_payload: Option<Bytes>,
+    pending_segments: VecDeque<Bytes>,
     /// Fused-done flag.
     done: bool,
 }
 
 impl BatchingEnvelopeStream {
     fn new(
-        source: BoxStream<Result<Bytes, ConnectError>>,
+        source: crate::EncodedStream,
         trailers: http::HeaderMap,
         compression: Option<(Arc<CompressionRegistry>, &'static str)>,
         compression_policy: CompressionPolicy,
@@ -1121,7 +1128,7 @@ impl BatchingEnvelopeStream {
             trailers,
             finalizer,
             pending_final: None,
-            pending_payload: None,
+            pending_segments: VecDeque::new(),
             done: false,
         }
     }
@@ -1130,6 +1137,36 @@ impl BatchingEnvelopeStream {
     #[inline]
     fn flush_buf(&mut self) -> Frame<Bytes> {
         Frame::data(self.buf.split().freeze())
+    }
+
+    /// Advance through `pending_segments`, returning the next data frame to
+    /// emit if one is due.
+    ///
+    /// A segment of at least `MIN_CHAIN_SIZE` becomes its own data frame by
+    /// reference count, after flushing `buf` so the envelope header and any
+    /// earlier bytes go out ahead of it. A smaller segment (the tag/length
+    /// fragment between two large fields, or a short tail) is copied into
+    /// `buf` and rides with whatever is batched next, since a frame of its own
+    /// would cost a 9-byte HTTP/2 frame header to save a copy of a few bytes.
+    /// `None` means every pending segment has been consumed and `buf` may be
+    /// extended with the next envelope.
+    fn drain_segments(&mut self) -> Option<Frame<Bytes>> {
+        while let Some(segment) = self.pending_segments.pop_front() {
+            if segment.len() < crate::envelope::MIN_CHAIN_SIZE {
+                self.buf.extend_from_slice(&segment);
+                // A body made only of small segments must not grow `buf`
+                // past the batch bound the source loop enforces.
+                if self.buf.len() >= STREAM_BATCH_THRESHOLD {
+                    return Some(self.flush_buf());
+                }
+            } else if self.buf.is_empty() {
+                return Some(Frame::data(segment));
+            } else {
+                self.pending_segments.push_front(segment);
+                return Some(self.flush_buf());
+            }
+        }
+        None
     }
 }
 
@@ -1141,15 +1178,19 @@ impl Stream for BatchingEnvelopeStream {
             return Poll::Ready(None);
         }
 
-        // Staged large payload from a prior poll — its envelope header was
-        // already flushed, so this must precede everything else (including
-        // a staged finalizer).
-        if let Some(payload) = self.pending_payload.take() {
-            return Poll::Ready(Some(Ok(Frame::data(payload))));
+        // Segments staged by a prior poll: their envelope header was already
+        // flushed, so they precede everything else (including a staged
+        // finalizer).
+        if let Some(frame) = self.drain_segments() {
+            return Poll::Ready(Some(Ok(frame)));
         }
 
         // Staged finalizer from a prior poll (buf was non-empty at stream end).
+        // Only ever staged once the source has ended, which cannot happen
+        // while segments are pending: the source is not polled until they
+        // drain.
         if let Some(frame) = self.pending_final.take() {
+            debug_assert!(self.pending_segments.is_empty());
             self.done = true;
             return Poll::Ready(Some(Ok(frame)));
         }
@@ -1194,11 +1235,13 @@ impl Stream for BatchingEnvelopeStream {
                         return Poll::Ready(Some(Ok(self.flush_buf())));
                     }
                 }
-                Poll::Ready(Some(Ok(data))) => {
+                Poll::Ready(Some(Ok(body))) => {
                     let me = &mut *self;
+                    debug_assert!(me.pending_segments.is_empty());
                     match me.encoder.encode_chained(
-                        data,
+                        body,
                         &mut me.buf,
+                        &mut me.pending_segments,
                         crate::envelope::MIN_CHAIN_SIZE,
                     ) {
                         Err(err) => {
@@ -1218,14 +1261,14 @@ impl Stream for BatchingEnvelopeStream {
                                 return Poll::Ready(Some(Ok(self.flush_buf())));
                             }
                         }
-                        Ok(Some(payload)) => {
-                            // Large payload: `buf` now ends with
-                            // its 5-byte envelope header. Flush the buffer and
-                            // stage the payload as the next frame, unmoved.
-                            self.pending_payload = Some(payload);
-                            return Poll::Ready(Some(Ok(self.flush_buf())));
+                        Ok(()) => {
+                            // Segments are pending only for a large payload:
+                            // `buf` now ends with its envelope header and the
+                            // segments follow, the large ones unmoved.
+                            if let Some(frame) = self.drain_segments() {
+                                return Poll::Ready(Some(Ok(frame)));
+                            }
                         }
-                        Ok(None) => {}
                     }
                     if self.buf.len() >= STREAM_BATCH_THRESHOLD {
                         return Poll::Ready(Some(Ok(self.flush_buf())));
@@ -1240,7 +1283,7 @@ impl Stream for BatchingEnvelopeStream {
 
 /// Create a Connect-protocol envelope stream (ends with END_STREAM envelope).
 fn create_envelope_stream(
-    response_stream: BoxStream<Result<Bytes, ConnectError>>,
+    response_stream: crate::EncodedStream,
     trailers: http::HeaderMap,
     compression: Option<(Arc<CompressionRegistry>, &'static str)>,
     compression_policy: CompressionPolicy,
@@ -1256,7 +1299,7 @@ fn create_envelope_stream(
 
 /// Create a gRPC envelope stream that sends HTTP/2 trailers.
 fn create_grpc_envelope_stream(
-    response_stream: BoxStream<Result<Bytes, ConnectError>>,
+    response_stream: crate::EncodedStream,
     trailers: http::HeaderMap,
     compression: Option<(Arc<CompressionRegistry>, &'static str)>,
     compression_policy: CompressionPolicy,
@@ -1272,7 +1315,7 @@ fn create_grpc_envelope_stream(
 
 /// Create a gRPC-Web envelope stream that encodes trailers as a body frame.
 fn create_grpc_web_envelope_stream(
-    response_stream: BoxStream<Result<Bytes, ConnectError>>,
+    response_stream: crate::EncodedStream,
     trailers: http::HeaderMap,
     compression: Option<(Arc<CompressionRegistry>, &'static str)>,
     compression_policy: CompressionPolicy,
@@ -2611,14 +2654,10 @@ where
                 codec_format,
             );
             match with_request_deadline(deadline, fut).await {
-                // Wrap single response in a one-item stream
-                // The streaming machinery carries contiguous message bytes,
-                // and re-enveloping happens per item downstream, so a
-                // client-streaming response flattens here.
-                Ok(r) => r.map_body(|body| -> BoxStream<Result<Bytes, ConnectError>> {
-                    Box::pin(futures::stream::once(
-                        async move { Ok(body.into_contiguous()) },
-                    ))
+                // Wrap the single response in a one-item stream. Its
+                // segments, if any, ride through to the framing layer.
+                Ok(r) => r.map_body(|body| -> crate::EncodedStream {
+                    Box::pin(futures::stream::once(async move { Ok(body) }))
                 }),
                 Err(e) => return streaming_error_response(&e, protocol, codec_format),
             }
@@ -2800,10 +2839,8 @@ where
     }
 
     let stream_compression = response_encoding.map(|encoding| (compression, encoding));
-    let response_stream: BoxStream<Result<Bytes, ConnectError>> =
-        Box::pin(futures::stream::once(async {
-            Ok(resp.body.into_contiguous())
-        }));
+    let response_stream: crate::EncodedStream =
+        Box::pin(futures::stream::once(async { Ok(resp.body) }));
     let effective_policy = compression_policy.with_override(resp.compress);
     let body = StreamingResponseBody::new(
         response_stream,
@@ -3540,7 +3577,7 @@ mod tests {
 
         let payload = Bytes::from(vec![0x42u8; crate::envelope::MIN_CHAIN_SIZE]);
         let original_ptr = payload.as_ptr();
-        let source = futures::stream::iter([Ok::<_, ConnectError>(payload.clone())]).boxed();
+        let source = futures::stream::iter([Ok::<_, ConnectError>(payload.clone().into())]).boxed();
         let mut stream = std::pin::pin!(create_grpc_envelope_stream(
             source,
             http::HeaderMap::new(),
@@ -3578,7 +3615,7 @@ mod tests {
         use futures::StreamExt as _;
 
         let payload = Bytes::from_static(b"small");
-        let source = futures::stream::iter([Ok::<_, ConnectError>(payload.clone())]).boxed();
+        let source = futures::stream::iter([Ok::<_, ConnectError>(payload.clone().into())]).boxed();
         let mut stream = std::pin::pin!(create_grpc_envelope_stream(
             source,
             http::HeaderMap::new(),
@@ -3608,7 +3645,9 @@ mod tests {
             Ok(large.clone()),
             Ok(small.clone()),
         ];
-        let source = futures::stream::iter(items).boxed();
+        let source = futures::stream::iter(items)
+            .map(|r| r.map(Into::into))
+            .boxed();
         let mut stream = std::pin::pin!(create_envelope_stream(
             source,
             http::HeaderMap::new(),
@@ -3648,7 +3687,9 @@ mod tests {
             Ok::<_, ConnectError>(large.clone()),
             Err(ConnectError::internal("boom")),
         ];
-        let source = futures::stream::iter(items).boxed();
+        let source = futures::stream::iter(items)
+            .map(|r| r.map(Into::into))
+            .boxed();
         let mut stream = std::pin::pin!(create_grpc_envelope_stream(
             source,
             http::HeaderMap::new(),
@@ -3663,6 +3704,163 @@ mod tests {
         let trailers = stream.next().await.unwrap().unwrap();
         let map = trailers.into_trailers().unwrap();
         assert_eq!(map.get("grpc-status").unwrap(), "13", "internal = 13");
+        assert!(stream.next().await.is_none());
+    }
+
+    /// An item the encoder split into segments keeps its large segments as
+    /// their own frames, by refcount, while the tag/length fragments between
+    /// them ride in the batch buffer: header+lead, large A, fragment,
+    /// large B, then the next (small) envelope with the trailing fragment
+    /// ahead of it, then trailers. Reassembled, the bytes decode to the same
+    /// envelopes a contiguous encode would have produced.
+    #[tokio::test]
+    async fn streaming_segmented_item_chains_each_large_segment() {
+        use crate::response::EncodedBody;
+        use futures::StreamExt as _;
+
+        let min = crate::envelope::MIN_CHAIN_SIZE;
+        let lead = Bytes::from_static(b"tag");
+        let a = Bytes::from(vec![0xA1u8; min]);
+        let mid = Bytes::from_static(b"ln");
+        let b = Bytes::from(vec![0xB2u8; min + 1]);
+        let tail = Bytes::from_static(b"t");
+        let segmented = EncodedBody::Segmented(vec![
+            lead.clone(),
+            a.clone(),
+            mid.clone(),
+            b.clone(),
+            tail.clone(),
+        ]);
+        let first_message = segmented.clone().into_contiguous();
+        let small = Bytes::from_static(b"next");
+        let items = [
+            Ok::<_, ConnectError>(segmented),
+            Ok(EncodedBody::Contiguous(small.clone())),
+        ];
+        let mut stream = std::pin::pin!(create_grpc_envelope_stream(
+            futures::stream::iter(items).boxed(),
+            http::HeaderMap::new(),
+            None,
+            CompressionPolicy::disabled(),
+        ));
+
+        let mut frames = Vec::new();
+        let mut terminal = None;
+        while let Some(frame) = stream.next().await {
+            match frame.unwrap().into_data() {
+                Ok(data) => frames.push(data),
+                Err(frame) => terminal = Some(frame),
+            }
+        }
+
+        let hdr = crate::envelope::HEADER_SIZE;
+        let lens: Vec<usize> = frames.iter().map(Bytes::len).collect();
+        assert_eq!(
+            lens,
+            [
+                hdr + lead.len(),
+                a.len(),
+                mid.len(),
+                b.len(),
+                tail.len() + hdr + small.len()
+            ]
+        );
+        assert!(
+            std::ptr::eq(frames[1].as_ptr(), a.as_ptr()),
+            "A by refcount"
+        );
+        assert!(
+            std::ptr::eq(frames[3].as_ptr(), b.as_ptr()),
+            "B by refcount"
+        );
+        assert!(terminal.expect("trailers frame").is_trailers());
+
+        let mut wire = bytes::BytesMut::new();
+        for frame in &frames {
+            wire.extend_from_slice(frame);
+        }
+        let first = Envelope::decode(&mut wire).unwrap().unwrap();
+        let second = Envelope::decode(&mut wire).unwrap().unwrap();
+        assert_eq!(first.data, first_message);
+        assert_eq!(second.data, small);
+        assert!(wire.is_empty());
+    }
+
+    /// With an async producer the trailing fragment of a segmented item must
+    /// be flushed when the source goes `Pending`, so the peer can decode the
+    /// message before the next item exists: header+lead, large, tail, then
+    /// `Pending`.
+    #[tokio::test]
+    async fn streaming_segmented_tail_flushes_before_pending() {
+        use crate::response::EncodedBody;
+        use futures::StreamExt as _;
+
+        let min = crate::envelope::MIN_CHAIN_SIZE;
+        let lead = Bytes::from_static(b"tag");
+        let big = Bytes::from(vec![9u8; min]);
+        let tail = Bytes::from_static(b"end");
+        let item = EncodedBody::Segmented(vec![lead.clone(), big.clone(), tail.clone()]);
+        let source = futures::stream::iter([Ok::<_, ConnectError>(item)])
+            .chain(futures::stream::pending())
+            .boxed();
+        let mut stream = Box::pin(create_envelope_stream(
+            source,
+            http::HeaderMap::new(),
+            None,
+            CompressionPolicy::disabled(),
+        ));
+
+        let hdr = crate::envelope::HEADER_SIZE;
+        let f1 = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(f1.len(), hdr + lead.len());
+        let f2 = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert!(std::ptr::eq(f2.as_ptr(), big.as_ptr()));
+        let f3 = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(f3, tail, "tail must not wait for the next item");
+        let waker = futures::task::noop_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+        assert!(stream.as_mut().poll_next(&mut cx).is_pending());
+    }
+
+    /// A source error right after a segmented item still emits every staged
+    /// segment, in order, before the error finalizer.
+    #[tokio::test]
+    async fn streaming_error_after_segmented_item_preserves_order() {
+        use crate::response::EncodedBody;
+        use futures::StreamExt as _;
+
+        let min = crate::envelope::MIN_CHAIN_SIZE;
+        let a = Bytes::from(vec![1u8; min]);
+        let b = Bytes::from(vec![2u8; min]);
+        let items = [
+            Ok::<_, ConnectError>(EncodedBody::Segmented(vec![a.clone(), b.clone()])),
+            Err(ConnectError::internal("boom")),
+        ];
+        let mut stream = std::pin::pin!(create_grpc_envelope_stream(
+            futures::stream::iter(items).boxed(),
+            http::HeaderMap::new(),
+            None,
+            CompressionPolicy::disabled(),
+        ));
+
+        let head = stream.next().await.unwrap().unwrap().into_data().unwrap();
+        assert_eq!(head.len(), crate::envelope::HEADER_SIZE);
+        assert_eq!(
+            stream.next().await.unwrap().unwrap().into_data().unwrap(),
+            a
+        );
+        assert_eq!(
+            stream.next().await.unwrap().unwrap().into_data().unwrap(),
+            b
+        );
+        let trailers = stream
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_trailers()
+            .unwrap();
+        assert_eq!(trailers.get("grpc-status").unwrap(), "13", "internal = 13");
         assert!(stream.next().await.is_none());
     }
 
@@ -4218,7 +4416,8 @@ mod tests {
         // then one trailers frame.
         let items: Vec<Result<Bytes, ConnectError>> =
             (0..10).map(|_| Ok(Bytes::from_static(b"msg"))).collect();
-        let source: BoxStream<_> = Box::pin(futures::stream::iter(items));
+        let source: crate::EncodedStream =
+            Box::pin(futures::stream::iter(items).map(|r| r.map(Into::into)));
 
         let stream = BatchingEnvelopeStream::new(
             source,
@@ -4247,7 +4446,8 @@ mod tests {
         // 9KB items: first fills buf to 9K < 16K → loop, second fills to 18K ≥ 16K → flush.
         let big = Bytes::from(vec![b'x'; 9 * 1024]);
         let items: Vec<Result<Bytes, ConnectError>> = (0..4).map(|_| Ok(big.clone())).collect();
-        let source: BoxStream<_> = Box::pin(futures::stream::iter(items));
+        let source: crate::EncodedStream =
+            Box::pin(futures::stream::iter(items).map(|r| r.map(Into::into)));
 
         let stream = BatchingEnvelopeStream::new(
             source,
@@ -4285,8 +4485,8 @@ mod tests {
     fn batching_connect_finalizer_is_data_frame() {
         // Connect protocol finalizer is an END_STREAM envelope (data frame),
         // not an HTTP/2 trailers frame.
-        let source: BoxStream<_> = Box::pin(futures::stream::once(async {
-            Ok(Bytes::from_static(b"x"))
+        let source: crate::EncodedStream = Box::pin(futures::stream::once(async {
+            Ok(Bytes::from_static(b"x").into())
         }));
         let stream = BatchingEnvelopeStream::new(
             source,
@@ -4315,7 +4515,8 @@ mod tests {
             Ok(Bytes::from_static(b"c")),
             Err(ConnectError::internal("boom")),
         ];
-        let source: BoxStream<_> = Box::pin(futures::stream::iter(items));
+        let source: crate::EncodedStream =
+            Box::pin(futures::stream::iter(items).map(|r| r.map(Into::into)));
         let stream = BatchingEnvelopeStream::new(
             source,
             http::HeaderMap::new(),

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -571,6 +571,16 @@ async fn redact(
 }
 ```
 
+A view body's large `bytes` and `string` fields reach the transport by
+reference count rather than being copied into one buffer, on unary and
+streaming responses alike (each stream item is encoded the same way).
+Two things restore the copy: an owned-message body, whose fields the
+encoder cannot borrow, and compression, which needs one contiguous
+input. Under the default `CompressionPolicy` any response over 1 KiB to
+a client advertising `gzip` is compressed, so a handler streaming large,
+poorly-compressible view items should return
+`Response::stream(..).compress(false)` to keep the copy-free path.
+
 The `'a` on the trait method also lets the body borrow from `&self`
 (e.g. cached server state). View bodies only encode for the proto
 codec - JSON clients receive `unimplemented`; see

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1007,6 +1007,63 @@ mod tests {
         );
     }
 
+    /// A server stream of `OwnedView` items whose `data` field clears the
+    /// framing threshold: each item is encoded in segments, the large field
+    /// travels to the socket as its own body chunk by reference count, and
+    /// the client still reads back exactly the messages the handler produced.
+    /// A small item in the middle takes the contiguous path in the same
+    /// stream, so both shapes interleave on one HTTP/1.1 chunked body.
+    #[tokio::test]
+    async fn server_stream_segmented_view_items_round_trip() {
+        use buffa::Message as _;
+        use buffa::view::OwnedView;
+
+        fn item(sequence: i32, len: usize) -> OwnedView<EchoResponseView<'static>> {
+            let owned = EchoResponse {
+                sequence,
+                data: "x".repeat(len),
+                ..Default::default()
+            };
+            OwnedView::decode(owned.encode_to_bytes()).unwrap()
+        }
+        const SIZES: [usize; 4] = [20 * 1024, 7, 48 * 1024, 16 * 1024];
+
+        let handler = connectrpc::streaming_handler_fn(|_ctx, _req: EchoRequest| async {
+            let items = SIZES
+                .iter()
+                .enumerate()
+                .map(|(i, len)| Ok(item(i as i32, *len)));
+            // Compression would flatten each item to feed the compressor;
+            // the segmented path is the uncompressed one.
+            Ok(Response::stream(futures::stream::iter(items)).compress(false))
+        });
+        let router =
+            Router::new().route_server_stream(ECHO_SERVICE_SERVICE_NAME, "ServerStream", handler);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            axum::serve(listener, router.into_axum_router())
+                .await
+                .unwrap();
+        });
+
+        let mut stream = make_client(addr)
+            .server_stream(EchoRequest::default())
+            .await
+            .unwrap();
+        let mut got = Vec::new();
+        while let Some(msg) = stream.message().await.unwrap() {
+            assert!(msg.view().data.bytes().all(|b| b == b'x'));
+            got.push((msg.view().sequence, msg.view().data.len()));
+        }
+        let expected: Vec<(i32, usize)> = SIZES
+            .iter()
+            .enumerate()
+            .map(|(i, l)| (i as i32, *l))
+            .collect();
+        assert_eq!(got, expected);
+    }
+
     /// Same as [`server_stream_pre_encoded_round_trip`] but for bidi —
     /// covers the `BidiStreamingViewHandlerWrapper` → `EchoServiceServer`
     /// → `ConnectRpcService` chain with `type Item = PreEncoded<…>`. Uses


### PR DESCRIPTION
## Summary

Extends #232's segmented encode to streaming responses. Today every stream item is encoded to one contiguous `Bytes` before framing, so `Encodable::encode_segments` is never consulted on the streaming path and a large field the encoder could hand over by reference count is memcpy'd once per item. #219 already removed the second (framing) copy; this removes the first for any body that yields segments.

With this change each item of a server-streaming or bidi response (and a client-streaming or unary response served over gRPC, which rides the same framing) goes through `encode_segments`. `BatchingEnvelopeStream` writes the 5-byte envelope header into its batch buffer as before, then walks the item's segments in wire order: a segment at or above `MIN_CHAIN_SIZE` becomes its own body frame, unmoved; a smaller one (the tag/length fragment between two large fields, or a short tail) is copied into the batch buffer and rides with whatever is batched next. Wire bytes are unchanged; only HTTP frame boundaries move, as in #219.

Measured on a dev machine, one `OwnedView` item with a single dominant field through the Connect framing stream (encode + frame, release build):

| payload | contiguous (main) | segmented |
|---|---|---|
| 16 KiB | 374 ns | 425 ns |
| 512 KiB | 11.3 µs | 0.41 µs |
| 2 MiB | 130 µs | 0.42 µs |

Above the threshold the per-item cost is flat, since only the framing is still being written.

## Where this deliberately does nothing

- Owned-message items keep the contiguous default from #232 (their `encode_segments` is not overridden), so a handler streaming plain owned messages sees no change. See the question below.
- Compressed streams flatten the item to feed the compressor and chain the compressed output as one segment, as before.
- A call through an interceptor flattens each item into a `Payload`, matching the unary path.
- Connect unary still hardcodes `Full<Bytes>`; not touched here.

## Design notes

- `EncodedStream` (`Pin<Box<dyn Stream<Item = Result<EncodedBody, ConnectError>> + Send>>`) is the streaming counterpart of `EncodedResponse`'s body and is what `StreamingResult` now carries.
- `EnvelopeEncoder::encode_chained` takes an `EncodedBody` and returns the segments to chain (empty when the body was copied in below the threshold). The header-then-segments policy is one private helper, `write_envelope_chained`, shared with `Envelope::encode_body_parts`, so the unary and streaming paths cannot drift.
- `DeadlineStream` is generic over the item type rather than naming `EncodedBody`, since it never inspects items.
- The two sites that flattened a unary `EncodedBody` into the streaming machinery (`into_contiguous()` for unary-over-gRPC and client-streaming responses) now pass it through, so those responses keep their segments too.

## Breaking change, confined to custom dispatch

`StreamingResult`'s body is `EncodedStream` rather than `BoxStream<Result<Bytes, ConnectError>>`, and `StreamResponse::{from_encoded, into_encoded}` follow. Hand-written `Dispatcher` impls and test doubles map items with `Bytes::into()` / `.map(|r| r.map(Into::into))` and recover a buffer with `EncodedBody::into_contiguous()`. Generated dispatchers only name the alias and `encode_response_stream`, so no regeneration is needed; handler traits are unchanged.

## Question for review: owned messages with `bytes::Bytes` fields

buffa's `bytes_type(BytesRepr::Bytes)` gives an owned message `bytes::Bytes` fields whose `ProtoBytes::as_shared` lets a `Rope` capture them, but the blanket `impl Encodable<M> for M` cannot tell such a message from one with `Vec<u8>` fields, so it stays contiguous. A downstream crate can opt in today with a small `Encodable` wrapper that encodes through `buffa::Rope`. Would you prefer that as a provided wrapper here (e.g. `Segmented<M>`, alongside `PreEncoded`/`MaybeBorrowed`), or a type-level signal from buffa codegen that the blanket impl can branch on? Happy to send either as a follow-up.

## Testing

- New unit tests: `encode_chained` keeps segments of a large body by pointer and declares the total; copies a small segmented body; compresses a segmented body as one (gzip). `BatchingEnvelopeStream`: a segmented item interleaved with a small item yields header+lead / large A / fragment / large B / tail+next envelope, large frames by pointer, reassembly decodes to the contiguous envelopes; error after a segmented item preserves order. `encode_response_stream` forwards `encode_segments`; `StreamResponse::from_encoded` flattens.
- New e2e test in `tests/streaming`: a server stream of `OwnedView` items with 20 KiB / 7 B / 48 KiB / 16 KiB fields round-trips over HTTP/1.1 (compression disabled so the segmented path is the one exercised).
- `cargo test --workspace --all-features`, `cargo test -p connectrpc --no-default-features`, clippy `-D warnings`, `cargo +nightly-2026-02-27 fmt --check`, `cargo doc` with `-Dwarnings`: clean.
- Server conformance suite: 3600 passed, 0 failed.
