### PR TITLE
Per-route request limits

### DIFF
--- a/.changes/unreleased/Added-20260821-180000.yaml
+++ b/.changes/unreleased/Added-20260821-180000.yaml
@@ -1,0 +1,16 @@
+kind: Added
+body: |-
+    **Per-route request limits.** `Router::with_route_limits(procedure, limits)`
+    gives one method its own `Limits`, replacing the service-wide ones from
+    `ConnectRpcService::with_limits` for requests to that route, so request
+    body size, message size and decode budget can be sized per RPC rather than
+    only globally — tighter for a method whose requests are always small,
+    looser for an upload-shaped one, without moving the ceiling for every other
+    route. The route's limits are surfaced on `MethodDescriptor::limits` (with
+    a `with_limits` builder for custom dispatchers) and apply on every dispatch
+    path, including the body drain of a request refused before dispatch.
+    `Router::has_method` now accepts the path with or without its leading
+    slash, matching `with_spec` and `with_route_limits`. `Limits` is now
+    `Copy`, `PartialEq` and `Eq`, so an existing `limits.clone()` trips
+    `clippy::clone_on_copy`; drop the `.clone()`.
+time: 2026-08-21T18:00:00.000000000+00:00

--- a/.changes/unreleased/Changed-20260821-180001.yaml
+++ b/.changes/unreleased/Changed-20260821-180001.yaml
@@ -1,0 +1,15 @@
+kind: Changed
+body: |-
+    **`connectrpc-health` and `connectrpc-reflection` bound their routes to 16
+    KiB per request message.** `install_static` and `install` now apply a
+    per-route `Limits` profile (`MAX_REQUEST_BYTES`, `request_limits()`) sized
+    to the small fixed shape of `HealthCheckRequest` and
+    `ServerReflectionRequest`; a larger message is refused with
+    `resource_exhausted` where 0.8 accepted anything up to the service-wide
+    limit. The profile replaces the service-wide limits on those routes in both
+    directions. Each crate's new `apply_request_limits(router, limits)` tunes
+    those routes specifically — pass `request_limits()` after another
+    registration path (`HealthExt::register`, `Router::add_service`, a single
+    reflection version), or your own `Limits` after any path, including a
+    service configured tighter than 16 KiB; the later call wins.
+time: 2026-08-21T18:00:01.000000000+00:00

--- a/connectrpc-health/src/lib.rs
+++ b/connectrpc-health/src/lib.rs
@@ -58,7 +58,43 @@
 //!
 //! For custom logic (probing a database, propagating dependency state),
 //! implement [`Checker`] directly and wrap it in [`HealthService::new`]
-//! / [`HealthService::from_arc`].
+//! / [`HealthService::from_arc`]; see the next section for the one extra
+//! call that path needs.
+//!
+//! # Request limits
+//!
+//! A `HealthCheckRequest` is one service name, so the health routes do not
+//! need the multi-megabyte request ceiling a `connectrpc` service allows by
+//! default. This crate sizes `Check` and `Watch` to [`MAX_REQUEST_BYTES`]
+//! (16 KiB) per request through per-route
+//! [`Limits`](connectrpc::Limits) — see [`request_limits`] for the exact
+//! profile — and a larger request is refused with `resource_exhausted`
+//! before it reaches the [`Checker`]. The profile *replaces* the
+//! service-wide limits on these two routes, whether those are looser or
+//! tighter.
+//!
+//! * [`install_static`] applies [`request_limits`] for you.
+//! * Registering a [`HealthService`] any other way — the generated
+//!   [`HealthExt::register`](HealthExt) or
+//!   [`Router::add_service`](connectrpc::Router::add_service) — does not, so
+//!   follow it with [`apply_request_limits`]`(router, `[`request_limits`]`())`.
+//! * To tune the health routes specifically, call [`apply_request_limits`]
+//!   with your own `Limits` after either path; the later call wins.
+//!
+//! ```no_run
+//! use connectrpc::{Limits, Router};
+//! use connectrpc_health::{apply_request_limits, install_static};
+//!
+//! let (router, health) = install_static(Router::new(), ["acme.user.v1.UserService"]);
+//! // Optional: hold the health routes to 1 KiB instead of the bundled 16 KiB.
+//! let router = apply_request_limits(
+//!     router,
+//!     Limits::default()
+//!         .with_max_request_body_size(1024)
+//!         .with_max_message_size(1024),
+//! );
+//! # drop((router, health));
+//! ```
 //!
 //! [`grpc.health.v1.Health`]: https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -74,7 +110,9 @@ mod connect;
 mod proto;
 
 pub use checker::{Checker, StatusStream};
-pub use service::{HealthService, install_static};
+pub use service::{
+    HealthService, MAX_REQUEST_BYTES, apply_request_limits, install_static, request_limits,
+};
 pub use static_checker::{StaticChecker, UnknownServiceError};
 pub use status::Status;
 

--- a/connectrpc-health/src/service.rs
+++ b/connectrpc-health/src/service.rs
@@ -8,7 +8,7 @@ use connectrpc::{
 };
 use futures::StreamExt;
 
-use crate::connect::grpc::health::v1::{Health, HealthExt};
+use crate::connect::grpc::health::v1::{HEALTH_CHECK_SPEC, HEALTH_WATCH_SPEC, Health, HealthExt};
 use crate::proto::grpc::health::v1::{
     HealthCheckRequest, HealthCheckResponse, health_check_response::ServingStatus,
 };
@@ -31,7 +31,10 @@ use crate::{Checker, StaticChecker};
 ///     "acme.user.v1.UserService",
 /// ]));
 /// let service = Arc::new(HealthService::from_arc(Arc::clone(&checker)));
+/// // Hold the health routes to a few KiB per request; `install_static`
+/// // does this itself, generic registration cannot.
 /// let router = service.register(Router::new());
+/// let router = connectrpc_health::apply_request_limits(router, connectrpc_health::request_limits());
 /// ```
 ///
 /// `HealthService::new(checker)` is the move-in shorthand; use
@@ -91,7 +94,11 @@ impl<C: Checker> HealthService<C> {
 /// reporting [`Status::Serving`](crate::Status::Serving)), wraps it in
 /// a [`HealthService`], registers that service on `router`, and hands
 /// back both the updated router and a shared `Arc<StaticChecker>` for
-/// status mutation.
+/// status mutation. The two health routes are set to
+/// [`request_limits`] (16 KiB per request) via [`apply_request_limits`],
+/// which replaces the service-wide limits on those routes even when they
+/// are tighter; to tune them, call `apply_request_limits(router, yours)`
+/// on the returned router — the later call wins.
 ///
 /// Pass the generated `*_SERVICE_NAME` constants from your service
 /// stubs to avoid drifting from the wire name a probe will ask about.
@@ -121,8 +128,50 @@ where
 {
     let checker = Arc::new(StaticChecker::with_services(services));
     let service = Arc::new(HealthService::from_arc(Arc::clone(&checker)));
-    let router = service.register(router);
+    let router = apply_request_limits(service.register(router), request_limits());
     (router, checker)
+}
+
+/// The largest request message, in bytes on the wire and after
+/// decompression, the health routes accept under [`request_limits`]: 16 KiB.
+///
+/// A `HealthCheckRequest` carries one fully-qualified service name, so a
+/// legitimate request is a few hundred bytes; 16 KiB leaves two orders of
+/// magnitude of headroom while sizing the routes to their actual request
+/// profile rather than the general-purpose service-wide default.
+pub const MAX_REQUEST_BYTES: usize = 16 * 1024;
+
+/// The per-route [`Limits`](connectrpc::Limits) this crate sets on its
+/// `Check` and `Watch` routes: message size capped at [`MAX_REQUEST_BYTES`]
+/// (the request body at that plus the 5-byte envelope framed protocols add),
+/// decode budget left at the `connectrpc` default.
+#[must_use]
+pub fn request_limits() -> connectrpc::Limits {
+    connectrpc::Limits::default()
+        .with_max_request_body_size(MAX_REQUEST_BYTES + connectrpc::envelope::HEADER_SIZE)
+        .with_max_message_size(MAX_REQUEST_BYTES)
+}
+
+/// Set the `Check` and `Watch` routes on `router` to `limits`, replacing
+/// the service-wide limits for them (whether looser or tighter).
+///
+/// [`install_static`] already applies [`request_limits`]. Call this
+/// yourself, usually with [`request_limits`], after registering a
+/// [`HealthService`] built around a custom [`Checker`] — via
+/// [`HealthExt::register`](crate::HealthExt) or
+/// [`Router::add_service`](connectrpc::Router::add_service) — since those
+/// generic registration paths cannot; or call it after either path with
+/// your own [`Limits`](connectrpc::Limits) to tune the health routes
+/// specifically. The later call wins.
+///
+/// # Panics
+///
+/// Panics if the health routes are not registered on `router`.
+#[must_use]
+pub fn apply_request_limits(router: Router, limits: connectrpc::Limits) -> Router {
+    router
+        .with_route_limits(HEALTH_CHECK_SPEC.procedure, limits)
+        .with_route_limits(HEALTH_WATCH_SPEC.procedure, limits)
 }
 
 impl<C> Clone for HealthService<C> {
@@ -420,6 +469,55 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.view().status, ServingStatus::NOT_SERVING);
+
+        // `install_static` holds both routes to MAX_REQUEST_BYTES: an
+        // oversized request is refused before it reaches the checker. Over
+        // HTTP/2, so the refused request's stream is reset on its own rather
+        // than closing an HTTP/1.1 connection the next call might reuse.
+        let client = HealthClient::new(
+            HttpClient::plaintext_http2_only(),
+            ClientConfig::new(format!("http://{addr}").parse().unwrap()),
+        );
+        let oversized = HealthCheckRequest {
+            service: "x".repeat(2 * crate::MAX_REQUEST_BYTES),
+            ..Default::default()
+        };
+        let err = client.check(oversized.clone()).await.unwrap_err();
+        assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
+        let mut stream = client.watch(oversized).await.unwrap();
+        let err = stream.message().await.unwrap_err();
+        assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
+    }
+
+    /// An integrator's own `apply_request_limits` after `install_static`
+    /// replaces the bundled profile: tightened to 1 KiB, a 2 KiB request the
+    /// default 16 KiB would serve is refused.
+    #[tokio::test]
+    async fn integrator_limits_replace_the_bundled_profile() {
+        use crate::{apply_request_limits, install_static};
+        let (router, _health) = install_static(Router::new(), ["acme.A"]);
+        let router = apply_request_limits(
+            router,
+            connectrpc::Limits::default().with_max_message_size(1024),
+        );
+        let app = router.into_axum_router();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let client = HealthClient::new(
+            HttpClient::plaintext_http2_only(),
+            ClientConfig::new(format!("http://{addr}").parse().unwrap()),
+        );
+        let err = client
+            .check(HealthCheckRequest {
+                service: "x".repeat(2048),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
     }
 
     #[tokio::test]

--- a/connectrpc-reflection/src/lib.rs
+++ b/connectrpc-reflection/src/lib.rs
@@ -33,7 +33,8 @@
 //! ```
 //!
 //! [`install`] registers both protocol versions; use the generated
-//! extension traits directly if you want only one.
+//! extension traits directly if you want only one (and see
+//! [Request limits](#request-limits) below for the extra call that needs).
 //!
 //! Alternatively, when your buffa codegen has reflection enabled, skip
 //! the build-script step and serve straight from the generated package's
@@ -49,6 +50,40 @@
 //! per-file descriptor bytes; the pool path re-encodes (semantically
 //! faithful, unknown fields preserved). See [`Reflector`] for the
 //! trade-off.
+//!
+//! # Request limits
+//!
+//! A `ServerReflectionRequest` is a host plus one symbol, file name or type
+//! name, so the reflection routes do not need the multi-megabyte request
+//! ceiling a `connectrpc` service allows by default. This crate sizes them
+//! to [`MAX_REQUEST_BYTES`] (16 KiB) per request *message* through per-route
+//! [`Limits`](connectrpc::Limits) — see [`request_limits`] for the exact
+//! profile; `ServerReflectionInfo` is a bidirectional stream, so the bound
+//! is per message rather than per call. A larger message ends the stream
+//! with `resource_exhausted`. The profile *replaces* the service-wide limits
+//! on these routes, whether those are looser or tighter.
+//!
+//! * [`install`] applies [`request_limits`] for you, to both versions.
+//! * Registering a [`ReflectionService`] any other way — one version through
+//!   the generated [`ServerReflectionExt::register`](ServerReflectionExt), or
+//!   [`Router::add_service`](connectrpc::Router::add_service) — does not, so
+//!   follow it with [`apply_request_limits`]`(router, `[`request_limits`]`())`;
+//!   it covers whichever versions are mounted.
+//! * To tune the reflection routes specifically, call
+//!   [`apply_request_limits`] with your own `Limits` after either path; the
+//!   later call wins.
+//!
+//! ```no_run
+//! use connectrpc::{Limits, Router};
+//! use connectrpc_reflection::{Reflector, apply_request_limits, install};
+//!
+//! # fn descriptor_set_bytes() -> &'static [u8] { &[] }
+//! let reflector = Reflector::from_descriptor_set_bytes(descriptor_set_bytes()).unwrap();
+//! let router = install(Router::new(), reflector);
+//! // Optional: hold reflection messages to 1 KiB instead of the bundled 16 KiB.
+//! let router = apply_request_limits(router, Limits::default().with_max_message_size(1024));
+//! # drop(router);
+//! ```
 //!
 //! # What gets exposed
 //!
@@ -95,7 +130,9 @@ mod connect;
 mod proto;
 
 pub use reflector::{ReflectionError, Reflector};
-pub use service::{ReflectionService, install};
+pub use service::{
+    MAX_REQUEST_BYTES, ReflectionService, apply_request_limits, install, request_limits,
+};
 
 /// The wire-format `FileDescriptorSet` for this crate's protos
 /// (`grpc.reflection.v1` and `v1alpha`, from the public Buf Schema
@@ -121,7 +158,12 @@ pub use connect::grpc::reflection::v1::SERVER_REFLECTION_SERVICE_NAME;
 /// # fn descriptor_set_bytes() -> &'static [u8] { &[] }
 /// let reflector = Reflector::from_descriptor_set_bytes(descriptor_set_bytes()).unwrap();
 /// let service = Arc::new(ReflectionService::new(reflector));
-/// let router = service.register(Router::new()); // v1 only
+/// // v1 only; `apply_request_limits` bounds whichever versions are mounted.
+/// let router = service.register(Router::new());
+/// let router = connectrpc_reflection::apply_request_limits(
+///     router,
+///     connectrpc_reflection::request_limits(),
+/// );
 /// ```
 pub use connect::grpc::reflection::v1::{ServerReflection, ServerReflectionExt};
 

--- a/connectrpc-reflection/src/service.rs
+++ b/connectrpc-reflection/src/service.rs
@@ -54,7 +54,11 @@ impl ReflectionService {
 ///
 /// Unlike `connectrpc_health::install_static`, no handle is returned:
 /// a [`Reflector`] is immutable once built, so there is nothing to flip
-/// at runtime.
+/// at runtime. Both routes are set to [`request_limits`] (16 KiB per
+/// request message) via [`apply_request_limits`], which replaces the
+/// service-wide limits on those routes even when they are tighter; to tune
+/// them, call `apply_request_limits(router, yours)` on the returned router —
+/// the later call wins.
 #[must_use]
 pub fn install(router: Router, reflector: Reflector) -> Router {
     let service = Arc::new(ReflectionService::new(reflector));
@@ -62,7 +66,66 @@ pub fn install(router: Router, reflector: Reflector) -> Router {
         Arc::clone(&service),
         router,
     );
-    crate::connect::grpc::reflection::v1alpha::ServerReflectionExt::register(service, router)
+    let router =
+        crate::connect::grpc::reflection::v1alpha::ServerReflectionExt::register(service, router);
+    apply_request_limits(router, request_limits())
+}
+
+/// The largest request message, after decompression, the reflection routes
+/// accept under [`request_limits`]: 16 KiB.
+///
+/// A `ServerReflectionRequest` carries a host plus one file name, symbol or
+/// type name, so a legitimate request is well under a kilobyte; 16 KiB leaves
+/// generous headroom while sizing the routes to their actual request profile
+/// rather than the general-purpose service-wide default. Reflection is a
+/// bidirectional stream, so this bounds each message, not how many a client
+/// may send.
+pub const MAX_REQUEST_BYTES: usize = 16 * 1024;
+
+/// The per-route [`Limits`](connectrpc::Limits) this crate sets on its
+/// routes: message size capped at [`MAX_REQUEST_BYTES`] (and the request
+/// body, which only governs non-streaming calls, at that plus the 5-byte
+/// envelope), decode budget left at the `connectrpc` default.
+#[must_use]
+pub fn request_limits() -> connectrpc::Limits {
+    connectrpc::Limits::default()
+        .with_max_request_body_size(MAX_REQUEST_BYTES + connectrpc::envelope::HEADER_SIZE)
+        .with_max_message_size(MAX_REQUEST_BYTES)
+}
+
+/// Set whichever of the `v1` and `v1alpha` reflection routes are registered
+/// on `router` to `limits`, replacing the service-wide limits for them
+/// (whether looser or tighter).
+///
+/// [`install`] already applies [`request_limits`]. Call this yourself,
+/// usually with [`request_limits`], after registering a [`ReflectionService`]
+/// through the generated `ServerReflectionExt::register` or
+/// [`Router::add_service`](connectrpc::Router::add_service), since those
+/// generic registration paths cannot; or call it after either path with your
+/// own [`Limits`](connectrpc::Limits) to tune the reflection routes
+/// specifically. The later call wins.
+///
+/// # Panics
+///
+/// Panics if neither reflection route is registered on `router`.
+#[must_use]
+pub fn apply_request_limits(mut router: Router, limits: connectrpc::Limits) -> Router {
+    let mut applied = false;
+    for spec in [
+        crate::connect::grpc::reflection::v1::SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC,
+        crate::connect::grpc::reflection::v1alpha::SERVER_REFLECTION_SERVER_REFLECTION_INFO_SPEC,
+    ] {
+        if router.has_method(spec.procedure) {
+            router = router.with_route_limits(spec.procedure, limits);
+            applied = true;
+        }
+    }
+    assert!(
+        applied,
+        "connectrpc_reflection::apply_request_limits: no reflection route is registered \
+         on this router — register `ReflectionService` before applying its limits"
+    );
+    router
 }
 
 /// Implements the generated `ServerReflection` trait for one protocol
@@ -219,7 +282,10 @@ mod tests {
     /// client targeting it. The server runs until the test exits.
     async fn spawn_reflection_server() -> ServerReflectionClient<HttpClient> {
         let reflector = Reflector::from_descriptor_set_bytes(&test_set_bytes()).unwrap();
-        let router = install(Router::new(), reflector);
+        spawn_router(install(Router::new(), reflector)).await
+    }
+
+    async fn spawn_router(router: Router) -> ServerReflectionClient<HttpClient> {
         let app = router.into_axum_router();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -236,6 +302,46 @@ mod tests {
             message_request: Some(message_request),
             ..Default::default()
         }
+    }
+
+    /// `install` holds both routes to MAX_REQUEST_BYTES per message: an
+    /// oversized request ends the stream with `resource_exhausted`.
+    #[tokio::test]
+    async fn oversized_request_is_refused() {
+        let client = spawn_reflection_server().await;
+        let mut stream = client.server_reflection_info().await.unwrap();
+        stream
+            .send(request(MessageRequest::FileContainingSymbol(
+                "x".repeat(2 * crate::MAX_REQUEST_BYTES),
+            )))
+            .await
+            .unwrap();
+        stream.close_send();
+        let err = stream.message().await.unwrap_err();
+        assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
+    }
+
+    /// An integrator's own `apply_request_limits` after `install` replaces
+    /// the bundled profile: tightened to 1 KiB, a 2 KiB request the default
+    /// 16 KiB would serve is refused.
+    #[tokio::test]
+    async fn integrator_limits_replace_the_bundled_profile() {
+        let reflector = Reflector::from_descriptor_set_bytes(&test_set_bytes()).unwrap();
+        let router = apply_request_limits(
+            install(Router::new(), reflector),
+            connectrpc::Limits::default().with_max_message_size(1024),
+        );
+        let client = spawn_router(router).await;
+        let mut stream = client.server_reflection_info().await.unwrap();
+        stream
+            .send(request(MessageRequest::FileContainingSymbol(
+                "x".repeat(2048),
+            )))
+            .await
+            .unwrap();
+        stream.close_send();
+        let err = stream.message().await.unwrap_err();
+        assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
     }
 
     #[tokio::test]

--- a/connectrpc/src/dispatcher.rs
+++ b/connectrpc/src/dispatcher.rs
@@ -50,9 +50,22 @@ pub struct MethodDescriptor {
     /// Static method metadata, when known.
     ///
     /// Code-generated dispatchers always supply a [`Spec`]; the dynamic
-    /// [`Router`](crate::Router) returns `None` because its method paths
-    /// are owned `String`s and `Spec::procedure` requires `&'static str`.
+    /// [`Router`](crate::Router) supplies one when
+    /// [`Router::with_spec`](crate::Router::with_spec) was chained for the
+    /// route, which generated `register()` always does.
     pub spec: Option<Spec>,
+    /// Per-route [`Limits`](crate::Limits), when the route declares its own.
+    ///
+    /// `Some` replaces the service-wide limits configured with
+    /// [`ConnectRpcService::with_limits`](crate::ConnectRpcService::with_limits)
+    /// for requests to this method — body size, message size and decode
+    /// budget alike — so a route can be tighter (a health check that never
+    /// legitimately exceeds a few KiB) or looser (an upload RPC) than the
+    /// rest of the service. `None` uses the service-wide limits. Set on a
+    /// [`Router`](crate::Router) route with
+    /// [`Router::with_route_limits`](crate::Router::with_route_limits);
+    /// generated `FooServiceServer<T>` dispatchers always report `None`.
+    pub limits: Option<crate::Limits>,
 }
 
 impl MethodDescriptor {
@@ -81,13 +94,14 @@ impl MethodDescriptor {
     }
 
     /// Construct a descriptor for the given [`MethodKind`] with default
-    /// `idempotent` (`false`) and no [`Spec`].
+    /// `idempotent` (`false`), no [`Spec`] and no per-route limits.
     #[inline]
     pub const fn from_kind(kind: MethodKind) -> Self {
         Self {
             kind,
             idempotent: false,
             spec: None,
+            limits: None,
         }
     }
 
@@ -109,6 +123,15 @@ impl MethodDescriptor {
     #[must_use]
     pub const fn with_spec(mut self, spec: Spec) -> Self {
         self.spec = Some(spec);
+        self
+    }
+
+    /// Attach per-route [`Limits`](crate::Limits) that replace the
+    /// service-wide limits for this method. Returns `self` for chaining.
+    #[inline]
+    #[must_use]
+    pub fn with_limits(mut self, limits: crate::Limits) -> Self {
+        self.limits = Some(limits);
         self
     }
 }
@@ -482,7 +505,14 @@ mod tests {
             assert_eq!(d.kind, kind);
             assert!(!d.idempotent);
             assert_eq!(d.spec, None);
+            assert_eq!(d.limits, None);
         }
+
+        // `with_limits` attaches route limits and preserves the rest.
+        let route = crate::Limits::default().with_max_message_size(7);
+        let d = MethodDescriptor::unary(true).with_limits(route);
+        assert_eq!(d.limits, Some(route));
+        assert!(d.idempotent);
         assert_eq!(
             MethodDescriptor::from_kind(MethodKind::Unary).with_idempotent(true),
             MethodDescriptor::unary(true)

--- a/connectrpc/src/router.rs
+++ b/connectrpc/src/router.rs
@@ -78,7 +78,7 @@ enum Method {
     BidiStreaming(BidiStreamingMethod),
 }
 
-/// A registered method plus its optional static [`Spec`].
+/// A registered method plus its optional static [`Spec`] and per-route [`Limits`](crate::Limits).
 ///
 /// `spec` is `None` until [`Router::with_spec`] runs for the route. The
 /// generated `FooServiceExt::register` always chains `.with_spec(...)`
@@ -88,11 +88,16 @@ enum Method {
 struct RegisteredMethod {
     method: Method,
     spec: Option<Spec>,
+    limits: Option<crate::Limits>,
 }
 
 impl From<Method> for RegisteredMethod {
     fn from(method: Method) -> Self {
-        Self { method, spec: None }
+        Self {
+            method,
+            spec: None,
+            limits: None,
+        }
     }
 }
 
@@ -672,14 +677,65 @@ impl Router {
         self
     }
 
+    /// Give the route registered at `procedure` its own [`Limits`](crate::Limits), replacing
+    /// the service-wide limits from
+    /// [`ConnectRpcService::with_limits`](crate::ConnectRpcService::with_limits)
+    /// for requests to that one method.
+    ///
+    /// Use it to size a method to the request profile it actually has: a
+    /// health check or reflection lookup never legitimately carries more than
+    /// a few KiB, while an upload-shaped method may need more than the
+    /// service-wide default — and neither should set the ceiling for every
+    /// other route. The route's limits apply in full (body size, message size
+    /// and decode budget); they are not combined field-by-field with the
+    /// service-wide ones. Calling it again for the same route replaces the
+    /// earlier value; re-registering the route afterwards (under
+    /// [`allow_overrides`](Self::allow_overrides)) discards it. Per-route
+    /// limits are a `Router` feature: the generated monomorphic
+    /// `FooServiceServer<T>` dispatchers always use the service-wide limits.
+    ///
+    /// `procedure` is the method path, with or without its leading slash —
+    /// `Spec::procedure` and the generated `*_SPEC` constants fit directly:
+    ///
+    /// ```rust,ignore
+    /// let router = service
+    ///     .register(Router::new())
+    ///     .with_route_limits(
+    ///         PING_SERVICE_PING_SPEC.procedure,
+    ///         Limits::default().with_max_message_size(16 * 1024),
+    ///     );
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if no route is registered at `procedure` — a mistyped path or a
+    /// call made before the handler was registered. This is a limit that
+    /// exists to be relied on, so a call that could not attach it fails at
+    /// configuration time, in release builds too, rather than leaving the
+    /// route silently on the service-wide limits.
+    #[must_use]
+    pub fn with_route_limits(mut self, procedure: &str, limits: crate::Limits) -> Self {
+        let key = procedure.strip_prefix('/').unwrap_or(procedure);
+        match self.methods.get_mut(key) {
+            Some(m) => m.limits = Some(limits),
+            None => panic!(
+                "Router::with_route_limits: no route registered at {key:?} — \
+                 register the handler before attaching limits to it"
+            ),
+        }
+        self
+    }
+
     /// Get all registered method paths.
     pub fn methods(&self) -> impl Iterator<Item = &str> {
         self.methods.keys().map(String::as_str)
     }
 
-    /// Check if a path is registered.
+    /// Check if a path is registered. `path` may carry its leading slash, so
+    /// `Spec::procedure` and the generated `*_SPEC` constants fit directly.
     pub fn has_method(&self, path: &str) -> bool {
-        self.methods.contains_key(path)
+        self.methods
+            .contains_key(path.strip_prefix('/').unwrap_or(path))
     }
 }
 
@@ -697,9 +753,8 @@ impl crate::dispatcher::Dispatcher for Router {
             Method::ClientStreaming(_) => MethodDescriptor::client_streaming(),
             Method::BidiStreaming(_) => MethodDescriptor::bidi_streaming(),
         };
-        if let Some(spec) = m.spec {
-            desc = desc.with_spec(spec);
-        }
+        desc.spec = m.spec;
+        desc.limits = m.limits;
         Some(desc)
     }
 
@@ -1016,5 +1071,37 @@ mod tests {
         let _ = Router::new()
             .route("test.Svc", "Method", unary_handler())
             .with_spec(SPEC);
+    }
+
+    /// `with_route_limits` attaches per-route limits that `lookup` surfaces,
+    /// accepts the procedure with or without its leading slash, and leaves
+    /// other routes on the service-wide limits (`None`).
+    #[test]
+    fn with_route_limits_round_trips_through_lookup() {
+        let tight = crate::Limits::default().with_max_message_size(1024);
+        let router = Router::new()
+            .route("test.Svc", "Tight", unary_handler())
+            .route("test.Svc", "Slash", unary_handler())
+            .route("test.Svc", "Default", unary_handler())
+            .with_route_limits("test.Svc/Tight", tight)
+            .with_route_limits("/test.Svc/Slash", tight);
+
+        assert_eq!(router.lookup("test.Svc/Tight").unwrap().limits, Some(tight));
+        assert_eq!(router.lookup("test.Svc/Slash").unwrap().limits, Some(tight));
+        assert_eq!(router.lookup("test.Svc/Default").unwrap().limits, None);
+
+        let looser = crate::Limits::unlimited();
+        let router = router.with_route_limits("test.Svc/Tight", looser);
+        assert_eq!(
+            router.lookup("test.Svc/Tight").unwrap().limits,
+            Some(looser),
+            "a second call replaces the earlier limits"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Router::with_route_limits: no route registered")]
+    fn with_route_limits_without_route_panics() {
+        let _ = Router::new().with_route_limits("/test.Svc/Missing", crate::Limits::default());
     }
 }

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -2180,7 +2180,7 @@ mod tests {
             .with_max_request_body_size(1024)
             .with_max_message_size(512);
         let server = Server::new(Router::new())
-            .with_limits(limits.clone())
+            .with_limits(limits)
             .with_compression(CompressionRegistry::default())
             .with_compression_policy(CompressionPolicy::default().with_min_size(8192))
             .with_http1_keep_alive(false);

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -61,7 +61,7 @@ use crate::codec::header as connect_header;
 use crate::compression::CompressionPolicy;
 use crate::compression::CompressionRegistry;
 use crate::deadline::DeadlinePolicy;
-use crate::dispatcher::Dispatcher;
+use crate::dispatcher::{Dispatcher, MethodDescriptor};
 use crate::envelope::Envelope;
 use crate::envelope::EnvelopeDecoder;
 use crate::error::ConnectError;
@@ -465,6 +465,18 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 /// `max_message_size` can still expand by orders of magnitude. Raising one
 /// does not raise the other.
 ///
+/// # Where limits are set
+///
+/// Service-wide, on [`ConnectRpcService::with_limits`] (or the `Server`
+/// builder's `with_limits`), applying to every route. A single route on a
+/// [`Router`] can carry its own `Limits` via [`Router::with_route_limits`],
+/// which replace the service-wide ones for that method in full — so a
+/// method whose requests are always small can be sized to that, and an
+/// upload-shaped method can exceed the default without raising it for the
+/// rest. The bundled `connectrpc-health` and `connectrpc-reflection`
+/// services set a 16 KiB profile on their own routes this way and expose
+/// `apply_request_limits(router, limits)` for tuning it.
+///
 /// These are **server** limits, applied to received requests. The client
 /// side has its own equivalents for received *responses*:
 /// [`ClientConfig::with_default_element_memory_limit`](crate::client::ClientConfig::with_default_element_memory_limit)
@@ -484,9 +496,11 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 /// ```
 ///
 /// `Limits` is `#[non_exhaustive]`: new limits may be added in minor
-/// releases. Struct-literal and functional-update construction are not
-/// available outside the crate; use the builder methods.
-#[derive(Debug, Clone)]
+/// releases (it is and will stay `Copy` — a small bundle of plain numeric
+/// bounds, carried by value on [`MethodDescriptor`]).
+/// Struct-literal and functional-update construction are not available
+/// outside the crate; use the builder methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Limits {
     max_request_body_size: usize,
@@ -1332,7 +1346,7 @@ impl<D> Clone for ConnectRpcService<D> {
     fn clone(&self) -> Self {
         Self {
             dispatcher: Arc::clone(&self.dispatcher),
-            limits: self.limits.clone(),
+            limits: self.limits,
             compression: Arc::clone(&self.compression),
             compression_policy: self.compression_policy,
             deadline_policy: self.deadline_policy.clone(),
@@ -1364,9 +1378,15 @@ impl<D: Dispatcher> ConnectRpcService<D> {
         }
     }
 
-    /// Configure request limits.
+    /// Configure the service-wide request limits.
     ///
-    /// See [`Limits`] for available options.
+    /// See [`Limits`] for available options. A route registered on a
+    /// [`Router`] can carry its own limits via
+    /// [`Router::with_route_limits`], and those replace these entirely for
+    /// that method — including upward; [`MethodDescriptor::limits`] reports
+    /// which routes do.
+    ///
+    /// [`MethodDescriptor::limits`]: crate::dispatcher::MethodDescriptor::limits
     #[must_use]
     pub fn with_limits(mut self, limits: Limits) -> Self {
         self.limits = limits;
@@ -1564,7 +1584,7 @@ where
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
         let dispatcher = Arc::clone(&self.dispatcher);
-        let limits = self.limits.clone();
+        let limits = self.limits;
         let compression = Arc::clone(&self.compression);
         let compression_policy = self.compression_policy;
         let deadline_policy = self.deadline_policy.clone();
@@ -1639,6 +1659,14 @@ where
         span.record("codec", tracing::field::display(rp.codec_format));
     }
 
+    // Resolve the route once. When it declares its own limits they govern
+    // every body read below, the error-path drains included; the path and
+    // descriptor are handed on so no later stage derives them again.
+    let path = req.uri().path();
+    let path = path.strip_prefix('/').unwrap_or(path).to_owned();
+    let desc = dispatcher.lookup(&path);
+    let limits = desc.and_then(|d| d.limits).unwrap_or(limits);
+
     // Only GET and POST carry RPCs. Reject every other verb uniformly with
     // 405 Method Not Allowed plus an `Allow` header (connect-go parity),
     // regardless of whether a Content-Type is present. Without this, a bodyless
@@ -1646,7 +1674,7 @@ where
     // None) would fall through to the unsupported-media-type path and be
     // misreported as 415. An unknown path still maps to 404.
     if req.method() != Method::GET && req.method() != Method::POST {
-        return reject_unsupported_method(&*dispatcher, req, limits, deadline_policy).await;
+        return reject_unsupported_method(&path, desc, req, limits, deadline_policy).await;
     }
 
     // Connect GET requests don't have a Content-Type header, so protocol
@@ -1655,6 +1683,8 @@ where
     if req.method() == Method::GET {
         return handle_unary_request(
             &*dispatcher,
+            &path,
+            desc,
             req,
             limits,
             compression,
@@ -1688,12 +1718,8 @@ where
         } else {
             Protocol::Connect
         };
-        let deadline = deadline_from_headers(
-            req.headers(),
-            timeout_protocol,
-            req.uri().path(),
-            deadline_policy,
-        );
+        let deadline =
+            deadline_from_headers(req.headers(), timeout_protocol, &path, deadline_policy);
 
         // Drain the request body to avoid broken pipe on HTTP/1.1.
         let (_parts, body) = req.into_parts();
@@ -1739,12 +1765,8 @@ where
                     "gRPC-Web text mode (application/grpc-web-text) is not supported",
                 );
                 // Drain the body to preserve HTTP/1.1 keep-alive for the error response.
-                let deadline = deadline_from_headers(
-                    req.headers(),
-                    rp.protocol,
-                    req.uri().path(),
-                    deadline_policy,
-                );
+                let deadline =
+                    deadline_from_headers(req.headers(), rp.protocol, &path, deadline_policy);
                 let (_parts, body) = req.into_parts();
                 let _ = with_request_deadline(
                     deadline,
@@ -1756,34 +1778,32 @@ where
             }
 
             // If so, take the fast path that avoids stream wrapping overhead.
-            if matches!(rp.protocol, Protocol::Grpc | Protocol::GrpcWeb) {
-                let path = req.uri().path();
-                let path = path.strip_prefix('/').unwrap_or(path);
-                if let Some(desc) = dispatcher.lookup(path)
-                    && desc.kind == MethodKind::Unary
-                {
-                    let path = path.to_owned();
-                    let response = handle_grpc_unary_request(
-                        &*dispatcher,
-                        &path,
-                        desc.spec,
-                        req,
-                        rp.protocol,
-                        rp.codec_format,
-                        limits,
-                        compression,
-                        compression_policy,
-                        deadline_policy,
-                        interceptors,
-                    )
-                    .await;
-                    return Ok(response.map(ConnectRpcBody::GrpcUnary));
-                }
+            if matches!(rp.protocol, Protocol::Grpc | Protocol::GrpcWeb)
+                && let Some(desc) = desc
+                && desc.kind == MethodKind::Unary
+            {
+                let response = handle_grpc_unary_request(
+                    &*dispatcher,
+                    &path,
+                    desc.spec,
+                    req,
+                    rp.protocol,
+                    rp.codec_format,
+                    limits,
+                    compression,
+                    compression_policy,
+                    deadline_policy,
+                    interceptors,
+                )
+                .await;
+                return Ok(response.map(ConnectRpcBody::GrpcUnary));
             }
 
             // Streaming request (Connect streaming, gRPC, or gRPC-Web)
             let response = handle_streaming_request(
                 &*dispatcher,
+                &path,
+                desc,
                 req,
                 rp.protocol,
                 rp.codec_format,
@@ -1800,6 +1820,8 @@ where
             // Unary request (Connect unary) or unknown content type (for error reporting)
             handle_unary_request(
                 &*dispatcher,
+                &path,
+                desc,
                 req,
                 limits,
                 compression,
@@ -1838,20 +1860,18 @@ application/proto";
 /// `GET` for idempotent unary methods). An unknown path returns the same
 /// `unimplemented` (HTTP 404) as any other route miss. The request body is
 /// drained first so HTTP/1.1 connections stay reusable.
-async fn reject_unsupported_method<D, B>(
-    dispatcher: &D,
+async fn reject_unsupported_method<B>(
+    path: &str,
+    desc: Option<MethodDescriptor>,
     req: Request<B>,
     limits: Limits,
     deadline_policy: &DeadlinePolicy,
 ) -> Result<Response<ConnectRpcBody>, ConnectError>
 where
-    D: Dispatcher,
     B: Body<Data = Bytes> + Send + 'static,
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    let raw_path = req.uri().path();
-    let path = raw_path.strip_prefix('/').unwrap_or(raw_path).to_owned();
-    let allow = dispatcher.lookup(&path).map(|desc| {
+    let allow = desc.map(|desc| {
         if desc.kind == MethodKind::Unary && desc.idempotent {
             "GET, POST"
         } else {
@@ -1861,12 +1881,7 @@ where
 
     // Drain the request body so an early response doesn't break HTTP/1.1
     // keep-alive (see the streaming body-drop race notes).
-    let deadline = deadline_from_headers(
-        req.headers(),
-        Protocol::Connect,
-        req.uri().path(),
-        deadline_policy,
-    );
+    let deadline = deadline_from_headers(req.headers(), Protocol::Connect, path, deadline_policy);
     let (_parts, body) = req.into_parts();
     let _ = with_request_deadline(
         deadline,
@@ -1896,6 +1911,8 @@ where
 #[allow(clippy::too_many_arguments)]
 async fn handle_unary_request<D, B>(
     dispatcher: &D,
+    path: &str,
+    desc: Option<MethodDescriptor>,
     req: Request<B>,
     limits: Limits,
     compression: Arc<CompressionRegistry>,
@@ -1908,15 +1925,12 @@ where
     B: Body<Data = Bytes> + Send + 'static,
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    // Parse the path to extract service/method (owned to avoid borrowing req)
-    let path = req.uri().path();
-    let path = path.strip_prefix('/').unwrap_or(path).to_owned();
     let query_string = req.uri().query().map(|s| s.to_owned());
     let method = req.method().clone();
 
     // Extract metadata from headers using the Connect protocol (unary is always Connect)
     let mut metadata = RequestMetadata::from_headers(req.headers(), Protocol::Connect);
-    metadata.timeout = deadline_policy.moderate(metadata.timeout, &path);
+    metadata.timeout = deadline_policy.moderate(metadata.timeout, path);
     let deadline = absolute_deadline(metadata.timeout);
 
     // Split request to consume the body
@@ -1934,9 +1948,9 @@ where
     )
     .await?;
 
-    // Look up the method descriptor to check idempotency.
+    // A miss is reported only now that the body has been drained.
     // (Non-unary kinds are allowed through — they'll error at the dispatch call.)
-    let desc = dispatcher.lookup(&path).ok_or_else(|| {
+    let desc = desc.ok_or_else(|| {
         ConnectError::unimplemented(format!("method not found: {path}"))
             .with_http_status(StatusCode::NOT_FOUND)
     })?;
@@ -2038,7 +2052,7 @@ where
     // Call the handler with the appropriate codec format.
     let resp: EncodedResponse = with_request_deadline(
         deadline,
-        call_unary_intercepted(dispatcher, interceptors, &path, ctx, body, codec_format),
+        call_unary_intercepted(dispatcher, interceptors, path, ctx, body, codec_format),
     )
     .await?;
 
@@ -2381,6 +2395,8 @@ enum StreamingDispatchKind {
 #[allow(clippy::too_many_arguments)]
 async fn handle_streaming_request<D, B>(
     dispatcher: &D,
+    path: &str,
+    method_desc: Option<MethodDescriptor>,
     req: Request<B>,
     protocol: Protocol,
     codec_format: CodecFormat,
@@ -2395,13 +2411,9 @@ where
     B: Body<Data = Bytes> + Send + 'static,
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    // Parse the path to extract service/method
-    let path = req.uri().path();
-    let path = path.strip_prefix('/').unwrap_or(path).to_owned();
-
     // Extract metadata before any body reads, including error-path drains.
     let mut metadata = RequestMetadata::from_headers(req.headers(), protocol);
-    metadata.timeout = deadline_policy.moderate(metadata.timeout, &path);
+    metadata.timeout = deadline_policy.moderate(metadata.timeout, path);
 
     // gRPC and gRPC-Web require POST method. Backstop: non-GET/POST verbs are
     // already rejected upstream in `handle_request`, and GET never routes here.
@@ -2435,9 +2447,6 @@ where
         return streaming_error_response(&err, protocol, codec_format);
     }
 
-    // Single lookup to determine method kind.
-    let method_desc = dispatcher.lookup(&path);
-
     // Split request to consume the body
     let (parts, body) = req.into_parts();
     let extensions = parts.extensions;
@@ -2446,7 +2455,7 @@ where
     if matches!(method_desc, Some(d) if d.kind == MethodKind::BidiStreaming) {
         return handle_bidi_streaming_request(
             dispatcher,
-            &path,
+            path,
             method_desc.and_then(|d| d.spec),
             metadata,
             body,
@@ -2466,7 +2475,7 @@ where
     if matches!(method_desc, Some(d) if d.kind == MethodKind::ClientStreaming) {
         return handle_client_streaming_request(
             dispatcher,
-            &path,
+            path,
             method_desc.and_then(|d| d.spec),
             metadata,
             body,
@@ -2591,7 +2600,7 @@ where
             let fut = call_server_streaming_intercepted(
                 dispatcher,
                 interceptors,
-                &path,
+                path,
                 ctx,
                 request_body,
                 codec_format,
@@ -2605,7 +2614,7 @@ where
             let fut = call_unary_intercepted(
                 dispatcher,
                 interceptors,
-                &path,
+                path,
                 ctx,
                 request_body,
                 codec_format,
@@ -3752,6 +3761,8 @@ mod tests {
 
         let err = handle_unary_request(
             &router,
+            "svc/Method",
+            router.lookup("svc/Method"),
             req,
             Limits::default(),
             Arc::new(CompressionRegistry::new()),
@@ -3779,6 +3790,8 @@ mod tests {
 
         let resp = handle_streaming_request(
             &router,
+            "svc/Method",
+            router.lookup("svc/Method"),
             req,
             Protocol::Grpc,
             CodecFormat::Proto,
@@ -4441,6 +4454,8 @@ mod tests {
 
         handle_unary_request(
             &router,
+            "svc/Method",
+            router.lookup("svc/Method"),
             req,
             Limits::default(),
             Arc::new(CompressionRegistry::new()),
@@ -4491,6 +4506,8 @@ mod tests {
 
         handle_unary_request(
             &router,
+            "svc/Method",
+            router.lookup("svc/Method"),
             req,
             Limits::default(),
             Arc::new(CompressionRegistry::new()),
@@ -4605,6 +4622,8 @@ mod tests {
 
         handle_unary_request(
             &router,
+            "svc/Get",
+            router.lookup("svc/Get"),
             req,
             Limits::default(),
             Arc::new(CompressionRegistry::new()),
@@ -5651,5 +5670,413 @@ mod tests {
         );
         // The trailers-only status headers are the server's own and stay.
         assert_eq!(response.headers().get(&GRPC_STATUS).unwrap(), "14");
+    }
+
+    /// Per-route limits: a route carrying its own `Limits` is held to them on
+    /// every dispatch path, other routes keep the service-wide limits, and a
+    /// route may be looser than the service as well as tighter.
+    mod route_limits {
+        use super::*;
+        use buffa_types::google::protobuf::StringValue;
+
+        const TIGHT: usize = 64;
+        /// gRPC status text for `resource_exhausted`.
+        fn exhausted() -> String {
+            crate::ErrorCode::ResourceExhausted.grpc_code().to_string()
+        }
+
+        fn echo() -> impl crate::Handler<StringValue, StringValue> {
+            crate::handler_fn(|_ctx: RequestContext, req: StringValue| async move {
+                crate::Response::ok(req)
+            })
+        }
+
+        fn echo_stream() -> impl crate::handler::StreamingHandler<StringValue, StringValue> {
+            crate::handler::streaming_handler_fn(
+                |_ctx: RequestContext, req: StringValue| async move {
+                    crate::Response::stream_ok(futures::stream::iter([Ok(req)]))
+                },
+            )
+        }
+
+        /// `svc/Tight` and `svc/TightStream` are limited to `TIGHT` bytes;
+        /// `svc/Default` uses whatever the service is configured with.
+        fn router() -> Arc<Router> {
+            let tight = Limits::default()
+                .with_max_message_size(TIGHT)
+                .with_max_request_body_size(TIGHT);
+            Arc::new(
+                Router::new()
+                    .route("svc", "Tight", echo())
+                    .route("svc", "Default", echo())
+                    .route_server_stream("svc", "TightStream", echo_stream())
+                    .with_route_limits("/svc/Tight", tight)
+                    .with_route_limits("svc/TightStream", tight),
+            )
+        }
+
+        fn message(len: usize) -> Bytes {
+            crate::codec::encode_proto(&StringValue {
+                value: "x".repeat(len),
+                ..Default::default()
+            })
+            .unwrap()
+        }
+
+        fn enveloped(msg: Bytes) -> Bytes {
+            Envelope::data(msg).encode()
+        }
+
+        fn post(path: &str, content_type: &str, body: Bytes) -> Request<Full<Bytes>> {
+            Request::builder()
+                .method(Method::POST)
+                .uri(path)
+                .header(header::CONTENT_TYPE, content_type)
+                .body(Full::new(body))
+                .unwrap()
+        }
+
+        async fn call<B>(
+            router: &Arc<Router>,
+            service_limits: Limits,
+            req: Request<B>,
+        ) -> Result<Response<ConnectRpcBody>, ConnectError>
+        where
+            B: Body<Data = Bytes> + Send + 'static,
+            B::Error: std::error::Error + Send + Sync + 'static,
+        {
+            handle_request(
+                Arc::clone(router),
+                req,
+                service_limits,
+                Arc::new(CompressionRegistry::new()),
+                &CompressionPolicy::default(),
+                &DeadlinePolicy::new(),
+                &[],
+            )
+            .await
+        }
+
+        /// `grpc-status` from the response headers (a trailers-only error) —
+        /// `None` for a response that carries messages.
+        fn grpc_status_header(resp: &Response<ConnectRpcBody>) -> Option<String> {
+            resp.headers()
+                .get("grpc-status")
+                .map(|v| v.to_str().unwrap().to_owned())
+        }
+
+        /// `grpc-status` from the body trailers of a response that started
+        /// streaming.
+        async fn grpc_status_trailer(resp: Response<ConnectRpcBody>) -> Option<String> {
+            let body = resp.into_body().collect().await.unwrap();
+            body.trailers()
+                .and_then(|t| t.get("grpc-status"))
+                .map(|v| v.to_str().unwrap().to_owned())
+        }
+
+        #[tokio::test]
+        async fn connect_unary_route_limit_rejects_oversized_and_spares_other_routes() {
+            let router = router();
+            let big = message(2 * TIGHT);
+            let default = Limits::default();
+
+            let err = call(
+                &router,
+                default,
+                post("/svc/Tight", "application/proto", big.clone()),
+            )
+            .await
+            .err()
+            .expect("route limit must reject the oversized body");
+            assert_eq!(err.code, crate::ErrorCode::ResourceExhausted);
+
+            let ok = call(
+                &router,
+                default,
+                post("/svc/Default", "application/proto", big),
+            )
+            .await
+            .expect("service-wide limits admit it on another route");
+            assert_eq!(ok.status(), StatusCode::OK);
+
+            let ok = call(
+                &router,
+                default,
+                post("/svc/Tight", "application/proto", message(8)),
+            )
+            .await
+            .expect("a request within the route limit is served");
+            assert_eq!(ok.status(), StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn grpc_unary_fast_path_honours_route_limit() {
+            let router = router();
+            let big = enveloped(message(2 * TIGHT));
+            let default = Limits::default();
+
+            let resp = call(
+                &router,
+                default,
+                post("/svc/Tight", "application/grpc", big.clone()),
+            )
+            .await
+            .expect("gRPC errors are trailers-only responses");
+            assert_eq!(grpc_status_header(&resp), Some(exhausted()));
+
+            let resp = call(
+                &router,
+                default,
+                post("/svc/Default", "application/grpc", big),
+            )
+            .await
+            .unwrap();
+            assert_eq!(grpc_status_header(&resp), None);
+            assert_eq!(grpc_status_trailer(resp).await.as_deref(), Some("0"));
+        }
+
+        #[tokio::test]
+        async fn streaming_path_honours_route_limit() {
+            let router = router();
+            let default = Limits::default();
+
+            let big = enveloped(message(2 * TIGHT));
+            let resp = call(
+                &router,
+                default,
+                post("/svc/TightStream", "application/grpc", big),
+            )
+            .await
+            .expect("gRPC errors are trailers-only responses");
+            assert_eq!(grpc_status_header(&resp), Some(exhausted()));
+
+            let small = enveloped(message(8));
+            let resp = call(
+                &router,
+                default,
+                post("/svc/TightStream", "application/grpc", small),
+            )
+            .await
+            .unwrap();
+            assert_eq!(grpc_status_header(&resp), None);
+            assert_eq!(grpc_status_trailer(resp).await.as_deref(), Some("0"));
+        }
+
+        /// The route's limits replace the service-wide ones outright, so a
+        /// route can admit what the rest of the service refuses.
+        #[tokio::test]
+        async fn route_limit_can_loosen_service_limit() {
+            let service_tight = Limits::default()
+                .with_max_message_size(TIGHT)
+                .with_max_request_body_size(TIGHT);
+            let router = Arc::new(
+                Router::new()
+                    .route("svc", "Upload", echo())
+                    .route("svc", "Default", echo())
+                    .with_route_limits("/svc/Upload", Limits::default()),
+            );
+            let big = message(2 * TIGHT);
+
+            let ok = call(
+                &router,
+                service_tight,
+                post("/svc/Upload", "application/proto", big.clone()),
+            )
+            .await
+            .expect("the route's own (default) limits admit it");
+            assert_eq!(ok.status(), StatusCode::OK);
+
+            let err = call(
+                &router,
+                service_tight,
+                post("/svc/Default", "application/proto", big),
+            )
+            .await
+            .err()
+            .expect("the service-wide limit still governs other routes");
+            assert_eq!(err.code, crate::ErrorCode::ResourceExhausted);
+        }
+
+        /// Bytes the server read from a 64 × 1 KiB body before answering `req`.
+        async fn bytes_polled(router: &Arc<Router>, req: http::request::Builder) -> usize {
+            let pulled = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let body = CountingBody {
+                frames: std::iter::repeat_n(Bytes::from(vec![0u8; 1024]), 64).collect(),
+                pulled: Arc::clone(&pulled),
+            };
+            let _ = call(router, Limits::default(), req.body(body).unwrap()).await;
+            pulled.load(std::sync::atomic::Ordering::Relaxed)
+        }
+
+        /// Requests refused before dispatch — wrong verb, unknown content
+        /// type, unsupported encoding — still drain the body for keep-alive,
+        /// and on a route with its own limits that drain stops at the route's
+        /// limit (after the first 1 KiB frame here) rather than the
+        /// service-wide one (all 64 KiB).
+        #[tokio::test]
+        async fn pre_dispatch_error_drains_honour_route_limit() {
+            let router = router();
+            let put = || Request::builder().method(Method::PUT);
+            let post = || Request::builder().method(Method::POST);
+
+            // 405: verb not allowed.
+            assert_eq!(bytes_polled(&router, put().uri("/svc/Tight")).await, 1024);
+            assert_eq!(
+                bytes_polled(&router, put().uri("/svc/Default")).await,
+                64 * 1024
+            );
+            // 415: unknown content type.
+            let unknown_ct =
+                |b: http::request::Builder| b.header(header::CONTENT_TYPE, "application/foo");
+            assert_eq!(
+                bytes_polled(&router, unknown_ct(post().uri("/svc/Tight"))).await,
+                1024
+            );
+            assert_eq!(
+                bytes_polled(&router, unknown_ct(post().uri("/svc/Default"))).await,
+                64 * 1024
+            );
+            // Unsupported request compression on a streaming route.
+            let bogus_encoding = |b: http::request::Builder| {
+                b.header(header::CONTENT_TYPE, "application/grpc")
+                    .header("grpc-encoding", "bogus")
+            };
+            assert_eq!(
+                bytes_polled(&router, bogus_encoding(post().uri("/svc/TightStream"))).await,
+                1024
+            );
+            assert_eq!(
+                bytes_polled(&router, bogus_encoding(post().uri("/svc/Default"))).await,
+                64 * 1024
+            );
+        }
+
+        #[tokio::test]
+        async fn connect_get_honours_route_limit() {
+            use base64::Engine as _;
+            let tight = Limits::default().with_max_message_size(TIGHT);
+            let router = Arc::new(
+                Router::new()
+                    .route_idempotent("svc", "TightGet", echo())
+                    .route_idempotent("svc", "DefaultGet", echo())
+                    .with_route_limits("svc/TightGet", tight),
+            );
+            let msg = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(message(2 * TIGHT));
+            let get = |path: &str| {
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!(
+                        "{path}?encoding=proto&base64=1&connect=v1&message={msg}"
+                    ))
+                    .body(Full::new(Bytes::new()))
+                    .unwrap()
+            };
+            let err = call(&router, Limits::default(), get("/svc/TightGet"))
+                .await
+                .err()
+                .expect("over the route limit");
+            assert_eq!(err.code, crate::ErrorCode::ResourceExhausted);
+            let ok = call(&router, Limits::default(), get("/svc/DefaultGet"))
+                .await
+                .unwrap();
+            assert_eq!(ok.status(), StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn client_streaming_path_honours_route_limit() {
+            let tight = Limits::default().with_max_message_size(TIGHT);
+            let concat = crate::handler::client_streaming_handler_fn(
+                |_ctx: RequestContext, mut reqs: crate::ServiceStream<StringValue>| async move {
+                    use futures::StreamExt as _;
+                    let mut out = String::new();
+                    while let Some(r) = reqs.next().await {
+                        out.push_str(&r?.value);
+                    }
+                    crate::Response::ok(StringValue {
+                        value: out,
+                        ..Default::default()
+                    })
+                },
+            );
+            let router = Arc::new(
+                Router::new()
+                    .route_client_stream("svc", "Concat", concat)
+                    .with_route_limits("svc/Concat", tight),
+            );
+            let mut two = enveloped(message(8)).to_vec();
+            two.extend_from_slice(&enveloped(message(2 * TIGHT)));
+            let resp = call(
+                &router,
+                Limits::default(),
+                post("/svc/Concat", "application/grpc", Bytes::from(two)),
+            )
+            .await
+            .unwrap();
+            // The first message is within the limit; the second is not, and
+            // the error arrives in the trailers of an already-started stream.
+            assert_eq!(grpc_status_trailer(resp).await, Some(exhausted()));
+        }
+
+        /// The third `Limits` field, the decode budget, follows the route too:
+        /// a message that is tiny on the wire but allocates 64 elements is
+        /// refused on a route whose budget is one byte and served elsewhere.
+        #[tokio::test]
+        async fn route_limit_carries_the_element_budget() {
+            use buffa_types::google::protobuf::{ListValue, Value};
+            let count = || {
+                crate::handler_fn(|_ctx: RequestContext, req: ListValue| async move {
+                    crate::Response::ok(StringValue {
+                        value: req.values.len().to_string(),
+                        ..Default::default()
+                    })
+                })
+            };
+            let router = Arc::new(
+                Router::new()
+                    .route("svc", "TightCount", count())
+                    .route("svc", "Count", count())
+                    .with_route_limits(
+                        "svc/TightCount",
+                        Limits::default().with_element_memory_limit(1),
+                    ),
+            );
+            let list = Bytes::from(buffa::Message::encode_to_vec(&ListValue {
+                values: (0..64).map(|_| Value::default()).collect(),
+                ..Default::default()
+            }));
+            let err = call(
+                &router,
+                Limits::default(),
+                post("/svc/TightCount", "application/proto", list.clone()),
+            )
+            .await
+            .err()
+            .expect("over the route's element budget");
+            assert_eq!(err.code, crate::ErrorCode::InvalidArgument);
+            let ok = call(
+                &router,
+                Limits::default(),
+                post("/svc/Count", "application/proto", list),
+            )
+            .await
+            .unwrap();
+            assert_eq!(ok.status(), StatusCode::OK);
+        }
+
+        /// The lookup runs before the body read, but a miss must still surface
+        /// as `unimplemented` after the drain, not as a limits error.
+        #[tokio::test]
+        async fn unknown_route_still_reports_not_found() {
+            let router = router();
+            let err = call(
+                &router,
+                Limits::default(),
+                post("/svc/Missing", "application/proto", message(8)),
+            )
+            .await
+            .err()
+            .expect("miss");
+            assert_eq!(err.code, crate::ErrorCode::Unimplemented);
+        }
     }
 }

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1383,9 +1383,35 @@ health.shutdown();
 
 For custom logic (e.g. report `NotServing` while a database connection
 is down), implement the `Checker` trait directly and wrap it in
-`HealthService::new(...)` or `HealthService::from_arc(...)`. The default
-`Checker::watch` body returns `Unimplemented`, which is fine for
+`HealthService::new(...)` or `HealthService::from_arc(...)`. The
+default `Checker::watch` body returns `Unimplemented`, which is fine for
 Check-only probes; override it if your probes call Watch.
+
+**The health routes accept at most 16 KiB per request.** A
+`HealthCheckRequest` is one service name, so `install_static` sizes
+`Check` and `Watch` to `connectrpc_health::request_limits()` — a
+per-route `Limits` profile (see [Request limits](#request-limits)) that
+replaces the service-wide limits on those two routes, whether those are
+looser or tighter — and a larger request is refused with
+`resource_exhausted` before it reaches the checker. Registering a
+`HealthService` any other way (`HealthExt::register`,
+`Router::add_service`) does not apply it, so follow that with
+`apply_request_limits(router, request_limits())`. To tune the health
+routes specifically, call `apply_request_limits` with your own `Limits`
+after either path; the later call wins:
+
+```rust,ignore
+use connectrpc::Limits;
+use connectrpc_health::{apply_request_limits, install_static};
+
+let (router, health) = install_static(Router::new(), [/* ... */]);
+let router = apply_request_limits(
+    router,
+    Limits::default()
+        .with_max_request_body_size(1024)
+        .with_max_message_size(1024),
+);
+```
 
 The `HealthClient` (for in-process probes, integration tests, sidecar
 tooling) is gated on a `client` Cargo feature that is **on by default**.
@@ -1438,6 +1464,28 @@ let bytes: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/app.fds.bin"));
 let reflector = Reflector::from_descriptor_set_bytes(bytes)?;
 // `router` is your service router from `register()`.
 let router = install(router, reflector); // mounts v1 + v1alpha
+```
+
+**The reflection routes accept at most 16 KiB per request message.** A
+`ServerReflectionRequest` is a host plus one symbol or file name, so
+`install` sizes both versions' routes to
+`connectrpc_reflection::request_limits()` — a per-route `Limits` profile
+(see [Request limits](#request-limits)) that replaces the service-wide
+limits on those routes, whether those are looser or tighter; the RPC is
+a bidirectional stream, so the bound is per message rather than per
+call. Mounting a single version through the generated
+`ServerReflectionExt::register` (or using `Router::add_service`) does
+not apply it, so follow that with
+`apply_request_limits(router, request_limits())`. To tune the
+reflection routes specifically, call `apply_request_limits` with your
+own `Limits` after either path; the later call wins:
+
+```rust,ignore
+use connectrpc::Limits;
+use connectrpc_reflection::{apply_request_limits, install};
+
+let router = install(router, reflector);
+let router = apply_request_limits(router, Limits::default().with_max_message_size(1024));
 ```
 
 Alternatively, when your buffa codegen has reflection enabled, serve
@@ -1545,6 +1593,51 @@ if let Some(remaining) = ctx.time_remaining() {
     options = options.with_timeout(remaining.saturating_sub(margin));
 }
 ```
+
+### Request limits
+
+`Limits` bounds what a request may cost before a handler sees it: the
+body as read from the socket (`with_max_request_body_size`, 4 MB), each
+message after decompression (`with_max_message_size`, 4 MB), and the
+memory a decode may commit to repeated and string elements
+(`with_element_memory_limit`, 32 MiB). The body and message limits are
+enforced while reading and inflating, so an oversized or highly
+compressed request is refused with `resource_exhausted` without ever
+being fully buffered. Set them service-wide on `ConnectRpcService`:
+
+```rust,ignore
+let service = ConnectRpcService::new(router)
+    .with_limits(Limits::default().with_max_message_size(1024 * 1024));
+```
+
+A single route can carry its own `Limits` with
+`Router::with_route_limits`, and those replace the service-wide ones for
+that method — every field, not a field-by-field minimum. Use it to
+size a method to its actual request profile: one whose legitimate
+requests are a few hundred bytes need not accept the service default,
+and one upload-shaped method can exceed the default without raising it
+for everything else.
+
+```rust,ignore
+let router = service
+    .register(Router::new())
+    .with_route_limits(
+        PING_SERVICE_PING_SPEC.procedure,
+        Limits::default()
+            .with_max_request_body_size(16 * 1024)
+            .with_max_message_size(16 * 1024),
+    );
+```
+
+Per-route limits are a `Router` feature; the generated monomorphic
+`FooServiceServer<T>` dispatchers use the service-wide limits.
+
+The bundled `connectrpc-health` and `connectrpc-reflection` services
+use this mechanism on their own routes: `install_static` and `install`
+apply a 16 KiB-per-message profile (`request_limits()`), and each
+crate's `apply_request_limits(router, limits)` re-applies or tunes it —
+see [Health checking](#health-checking) and
+[Server reflection](#server-reflection).
 
 ## Clients
 


### PR DESCRIPTION
`Limits` — request body size, message size and decode budget — could only be set service-wide on `ConnectRpcService`, so every RPC on a server shared one ceiling sized for the largest request any of them accepts. This adds a per-route override so payload limits can be sized per RPC rather than only globally.

`Router::with_route_limits(procedure, limits)` gives one registered method its own `Limits`, which replace the service-wide ones wholesale for requests to that route (every field, not a field-by-field minimum) — so a method whose requests are always small can be held to that, and an upload-shaped method can exceed the default without raising it for everything else. `procedure` accepts the path with or without its leading slash, so the generated `*_SPEC.procedure` constants fit directly; an unregistered path panics at configuration time rather than silently leaving the route on the service-wide limits.

Implementation: `handle_request` now resolves the route once up front and threads the `MethodDescriptor` (which gains `limits` / `with_limits`) into the per-shape handlers, so the effective limits apply uniformly — Connect unary and GET, the gRPC unary fast path, server/client/bidi streaming, and the keep-alive body drain of requests answered before dispatch (405/415/unsupported encoding) — and the previous second lookup inside the unary and streaming handlers goes away. `Limits` becomes `Copy + PartialEq + Eq` (`MethodDescriptor` already derives those); a downstream `limits.clone()` will now trip `clippy::clone_on_copy`.

`connectrpc-health` and `connectrpc-reflection` use it to size their own routes to 16 KiB per request message, matching the small fixed shape of `HealthCheckRequest` / `ServerReflectionRequest`: `install_static` / `install` apply the profile (`request_limits()`) automatically, replacing the service-wide limits on those routes in either direction. Each crate exposes `apply_request_limits(router, limits)` — pass `request_limits()` after a by-hand registration path (`HealthExt::register`, `Router::add_service`, single-version reflection), or your own `Limits` after any path to tune those routes specifically; the later call wins. This is a behaviour change for existing `install_static` / `install` callers (requests over 16 KiB are now refused), so it is filed under Changed as well as Added. Per-route limits are a `Router` feature; the generated monomorphic `FooServiceServer<T>` dispatchers continue to use the service-wide limits.

Tests cover each dispatch path (including a byte-counting body for the pre-dispatch drains, Connect GET, client streaming, and the element budget), the loosening direction, the unknown-route 404 ordering, end-to-end oversized requests against both bundled services, and an integrator-supplied `Limits` overriding the bundled profile. The guide gains a "Request limits" subsection under Production hardening and per-crate paragraphs in Health checking / Server reflection; both crates' rustdoc gains a `# Request limits` section. `Router::has_method` now accepts a leading slash like `with_spec` / `with_route_limits`.
