### PR TITLE
docs: say where interceptors run relative to the body, and where authentication belongs

### DIFF
--- a/.changes/unreleased/Security-20260824-180000.yaml
+++ b/.changes/unreleased/Security-20260824-180000.yaml
@@ -1,0 +1,15 @@
+kind: Security
+body: |-
+  **Documented where server interceptors run relative to the request body,
+  and where authentication belongs.** An `Interceptor` runs after the
+  request body has been read and decompressed under `Limits` but *before* the
+  message is decoded, so an interceptor that rejects a call never pays for
+  the decode — the step whose memory cost can exceed the wire size by orders
+  of magnitude. The guide's interceptor section and comparison table, its
+  examples, the `Interceptor` trait doc, and
+  `ConnectRpcService::with_interceptor` now state this ordering, give the
+  bounds an unauthenticated request can cost under the default limits, and
+  direct *authentication* to Tower middleware (which runs before any body
+  byte is read) and *authorization* to interceptors. No runtime behavior
+  changed.
+time: 2026-08-24T18:00:00.000000000Z

--- a/connectrpc/src/interceptor.rs
+++ b/connectrpc/src/interceptor.rs
@@ -1,8 +1,9 @@
 //! RPC-level interceptors.
 //!
 //! Interceptors are the typed equivalent of `tower` middleware: they wrap
-//! a single RPC *after* envelope decoding, decompression, and header
-//! parsing, and *before* the handler runs. Two surfaces:
+//! a single RPC *after* the request head is parsed and the body read and
+//! decompressed, and *before* the message is decoded or the handler runs.
+//! Two surfaces:
 //!
 //! - **Unary** ([`Interceptor::intercept_unary`]): sees a [`UnaryRequest`]
 //!   (the [`Spec`](crate::Spec), headers, deadline, extensions, and a
@@ -78,6 +79,21 @@ pub use async_trait::async_trait;
 /// `Interceptor` is an async trait. Annotate the impl with the
 /// [`connectrpc::async_trait`](crate::async_trait) re-export — there is
 /// no separate `async-trait` dependency to add.
+///
+/// # When it runs
+///
+/// After the request head is parsed and — for unary and server-streaming
+/// calls — after the body has been read and decompressed under the
+/// service's [`Limits`](crate::Limits), but before the message is decoded:
+/// the [`Payload`] an interceptor receives decodes only when something reads
+/// it. Returning `Err` from an interceptor therefore never pays for a decode,
+/// the step whose memory cost can exceed the wire size by orders of
+/// magnitude. It does pay for the bounded body read, which Tower middleware
+/// wrapping the service does not, so a pure credential check (authentication)
+/// belongs in middleware and an interceptor is the place for checks that need
+/// the resolved [`Spec`](crate::Spec) or the parsed headers (authorization,
+/// tracing, validation). The user guide gives the exact bounds:
+/// <https://github.com/connectrpc/connect-rust/blob/main/docs/guide.md#authentication-and-the-cost-of-an-unauthenticated-request>.
 ///
 /// # Example
 ///
@@ -160,14 +176,14 @@ pub trait Interceptor: Send + Sync + 'static {
     ///
     /// ```rust,ignore
     /// #[connectrpc::async_trait]
-    /// impl Interceptor for AuthInterceptor {
+    /// impl Interceptor for AuthzInterceptor {
     ///     async fn intercept_streaming(
     ///         &self,
     ///         req: StreamRequest,
     ///         inbound: PayloadStream,
     ///         next: NextStream<'_>,
     ///     ) -> Result<StreamResponse, ConnectError> {
-    ///         // Auth runs once at establishment, not per message.
+    ///         // Authorization runs once at establishment, not per message.
     ///         let path = req.ctx.path().expect("dispatch sets path");
     ///         self.authorize(path, req.ctx.headers()).await?;
     ///         next.run(req, inbound).await

--- a/connectrpc/src/server.rs
+++ b/connectrpc/src/server.rs
@@ -481,9 +481,10 @@ impl Server {
     /// underlying service.
     ///
     /// Delegates to [`ConnectRpcService::with_interceptor`]. Interceptors
-    /// run after envelope decoding, decompression, and protocol header
-    /// parsing, and before the handler — they see the parsed request, not
-    /// the wire bytes. The first interceptor registered runs **outermost**:
+    /// run after the request body has been read and decompressed and before
+    /// it is decoded — they see the parsed request head and a lazily decoded
+    /// body, not the wire bytes; a credential check belongs in Tower
+    /// middleware, before the body is read. The first interceptor registered runs **outermost**:
     /// first on the way in, last on the way out. To share one interceptor
     /// instance across several `Server`s, use
     /// [`with_interceptor_arc`](Self::with_interceptor_arc).

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -1418,8 +1418,11 @@ impl<D: Dispatcher> ConnectRpcService<D> {
     ///
     /// The first interceptor registered runs **outermost**: first on the
     /// way in, last on the way out (matching `connect-go`'s
-    /// `WithInterceptors`). Interceptors run after envelope decoding,
-    /// decompression, and header parsing, and before the handler.
+    /// `WithInterceptors`). Interceptors run after the request body has
+    /// been read and decompressed under this service's [`Limits`] and
+    /// before it is decoded; a credential check that should run before any
+    /// body byte is read belongs in Tower middleware around the service
+    /// instead. See [`Interceptor`]'s "When it runs".
     ///
     /// When no interceptors are registered the dispatch path is identical
     /// to a build without this call — there is no per-request allocation

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1017,12 +1017,17 @@ Tower middleware (above) operates on `http::Request` / `http::Response`
 — it's the right level for cross-cutting concerns that don't need to
 know they're wrapping an RPC: connection-scoped tracing, gzip, raw
 header manipulation. **Interceptors** are the typed RPC layer on top: a
-single async hook per call that runs after envelope decoding,
-decompression, and protocol header parsing, and before the handler.
-Interceptors see the resolved [`Spec`](#static-method-metadata-spec),
-the parsed headers, the deadline, the negotiated protocol, the request
-extensions, and a lazily decoded message body — everything an auth
-boundary, span builder, validator, or rate limiter actually wants.
+single async hook per call that runs after the request head is parsed
+and the request body has been read and decompressed (under the
+service's `Limits`), but *before* the message is decoded, and before
+the handler. Interceptors see the resolved
+[`Spec`](#static-method-metadata-spec), the parsed headers, the deadline,
+the negotiated protocol, the request extensions, and a lazily decoded
+message body — what a span builder, validator, rate limiter, or
+authorization check wants. For *authentication* — rejecting a caller
+that has presented no credential — read
+[what an unauthenticated request costs](#authentication-and-the-cost-of-an-unauthenticated-request)
+before choosing between an interceptor and Tower middleware.
 
 ```rust,ignore
 use connectrpc::interceptor::{UnaryRequest, UnaryResponse};
@@ -1073,8 +1078,8 @@ on the dispatch path — no per-request allocation, no `Payload`
 construction, no `Box`ing.
 
 To share one interceptor instance across several `ConnectRpcService`s
-(an auth interceptor whose token cache or rate-limit counter is
-process-wide), use `with_interceptor_arc(Arc<dyn Interceptor>)`.
+(an authorization interceptor whose policy cache or rate-limit counter
+is process-wide), use `with_interceptor_arc(Arc<dyn Interceptor>)`.
 `with_interceptor` allocates a fresh `Arc` per registration;
 `with_interceptor_arc` accepts the one you already hold.
 
@@ -1119,15 +1124,20 @@ async fn intercept_unary(
     req: UnaryRequest,
     next: Next<'_>,
 ) -> Result<UnaryResponse, ConnectError> {
-    let Some(token) = req.ctx.header("authorization") else {
-        let mut err = ConnectError::unauthenticated("missing bearer token");
+    // Authentication already happened in Tower middleware, which stamped
+    // the caller's identity into the request extensions before any body
+    // byte was read. This interceptor decides whether that identity may
+    // call this method.
+    let user = req.ctx.extensions().get::<UserId>().cloned();
+    let procedure = req.ctx.spec().map_or("", |s| s.procedure);
+    if !self.policy.allows(user.as_ref(), procedure) {
+        let mut err = ConnectError::permission_denied("not allowed");
         err.response_headers_mut().insert(
-            http::header::WWW_AUTHENTICATE,
-            http::HeaderValue::from_static("Bearer"),
+            "x-denied-by",
+            http::HeaderValue::from_static("policy"),
         );
         return Err(err);
-    };
-    self.tokens.verify(token)?;
+    }
     next.run(req).await
 }
 ```
@@ -1146,14 +1156,14 @@ use connectrpc::interceptor::{StreamRequest, StreamResponse};
 use connectrpc::{Interceptor, NextStream, PayloadStream};
 
 #[connectrpc::async_trait]
-impl Interceptor for AuthInterceptor {
+impl Interceptor for AuthzInterceptor {
     async fn intercept_streaming(
         &self,
         req: StreamRequest,
         inbound: PayloadStream,
         next: NextStream<'_>,
     ) -> Result<StreamResponse, ConnectError> {
-        // Auth runs once at establishment, not per message.
+        // Authorization runs once at establishment, not per message.
         self.check(&req.ctx)?;
         let resp = next.run(req, inbound).await?;
         Ok(resp.with_header("x-served-by", &self.node_id))
@@ -1180,16 +1190,56 @@ client-streaming the outbound stream yields exactly one item. Read
 | | Tower middleware | Interceptor |
 |---|---|---|
 | Operates on | `http::Request` / `http::Response` | Decoded RPC: `Spec`, headers, deadline, `Payload` |
-| Runs | Before envelope decode + protocol parse | After envelope decode + protocol parse |
+| Runs | Before the body is read | After the body is read, before it is decoded ([details](#authentication-and-the-cost-of-an-unauthenticated-request)) |
 | Sees the RPC method | No (must re-parse the URI) | Yes (`ctx.path()`, `ctx.spec()`) |
 | Sees the message body | Compressed/enveloped wire bytes | Lazily decoded, codec-aware `Payload` |
 | Short-circuits | By returning an `http::Response` | By returning `Err` or a `UnaryResponse` |
-| Best for | gzip, raw header rewriting, generic HTTP concerns | Auth, RPC-aware tracing, validation, rate limiting |
+| Best for | Authentication, gzip, raw header rewriting, generic HTTP concerns | Authorization on the `Spec`, RPC-aware tracing, validation, rate limiting |
 
 Both compose: a Tower layer wraps the whole `ConnectRpcService`
 (including its interceptor chain). An interceptor that needs an
 HTTP-level fact (e.g. the remote socket address) reads it from
 `ctx.extensions()` after a Tower layer inserts it.
+
+### Authentication and the cost of an unauthenticated request
+
+A credential check should run as early as the server allows, because
+everything the server does before rejecting a request is work an
+unauthenticated peer can make it do for free. The two hooks sit at
+different points, and the difference is what has been spent by the time
+each one can say no:
+
+| Before the hook runs | Tower middleware | Interceptor |
+|---|---|---|
+| Request head parsed | yes | yes |
+| Request body read | no | unary and server-streaming: yes, up to `max_request_body_size` (4 MB by default); client- and bidi-streaming: at most a message or two are read ahead |
+| Body decompressed | no | yes, up to `max_message_size` (4 MB) per message |
+| Message decoded | no | **no** — `Payload` decodes lazily, only if something reads it |
+
+The message decode is the step that multiplies memory: a few bytes of
+`repeated` empty messages on the wire become a heap allocation per
+element, so a 4 MB body can decode into hundreds of MB. In this crate
+that step happens after the interceptor chain, and is bounded by
+`Limits::element_memory_limit` (32 MiB by default) when it does. An
+interceptor that returns `unauthenticated` therefore costs at most the
+bounded body read and inflate; a Tower layer that does the same costs
+only the head. Under the default limits, the worst an unauthenticated
+caller can hold open against an interceptor-based check is
+`max_request_body_size + max_message_size` per in-flight request (the
+compressed body is held while it inflates), multiplied by the HTTP/2
+concurrent-stream limit per connection.
+
+Put *authentication* — "does this caller hold any credential at all" —
+in Tower middleware, where it runs before a single body byte is read. The [middleware example](../examples/middleware)
+does this with `axum::middleware::from_fn` for a bearer token. Put
+*authorization* — "may this identity call this method" — in an
+interceptor, where the resolved `Spec` and the parsed headers are
+available and the body is still undecoded; an `Err` from it still
+costs the peer nothing past the limits above. If the same component
+must do both, it can still be an interceptor: keep `max_message_size`
+and `max_request_body_size` at values the deployment can absorb across
+its concurrent-stream budget, and reject before touching
+`req.payload`.
 
 ## Hosting
 


### PR DESCRIPTION
Docs only; no runtime change.

A server `Interceptor` runs after the request body has been read and decompressed under `Limits`, but *before* the message is decoded — `Payload` is lazy. So an interceptor that rejects a call never pays for the decode, which is the step whose memory cost can exceed the wire size by orders of magnitude (a few bytes of `repeated` empty messages becomes a heap allocation per element). What it does pay for is the bounded body read and inflate (`max_request_body_size` + `max_message_size`, 4 MB each by default), which Tower middleware wrapping the service does not, since that runs before any body byte.

The guide said the opposite of what a reader needs: the interceptor intro promised "everything an auth boundary wants", the comparison table listed **Best for: Auth** under Interceptor with a "Runs" row that was wrong in both columns, and the short-circuit and streaming examples — plus the trait's own streaming example — showed bearer-token authentication inside an interceptor with no mention of what had already been spent by then.

This states the ordering where people look for it, with the numbers:

- `docs/guide.md`: interceptor intro and comparison table corrected; new subsection *Authentication and the cost of an unauthenticated request* with a table of what each hook has consumed before it can say no, the worst-case bound under default limits, and the rule — *authentication* (is there a credential at all) in Tower middleware, *authorization* (may this identity call this method) in an interceptor. The short-circuit example is now an authorization check reading a `UserId` the middleware stamped into extensions; the streaming example is `AuthzInterceptor`.
- `Interceptor` trait: a "When it runs" section; module doc and streaming example aligned.
- `ConnectRpcService::with_interceptor` / `Server::with_interceptor`: the same sentence, replacing the old "after envelope decoding" wording rather than adding to it.
- A `Security` changelog fragment.
