### PR TITLE
bench: measure the segmented encode on compressed streams

### DIFF
--- a/benches/rpc/Cargo.toml
+++ b/benches/rpc/Cargo.toml
@@ -18,6 +18,7 @@ http-body-util = { workspace = true }
 bytes = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
+tower = { workspace = true }
 futures = { workspace = true }
 redis = { version = "1.0", default-features = false, features = ["tokio-comp"] }
 criterion = { version = "0.5", features = ["async_tokio"] }
@@ -74,6 +75,10 @@ harness = false
 
 [[bench]]
 name = "view_rope_encode"
+harness = false
+
+[[bench]]
+name = "stream_compressed_encode"
 harness = false
 
 [lints]

--- a/benches/rpc/README.md
+++ b/benches/rpc/README.md
@@ -10,6 +10,7 @@ Benchmark crate for `connectrpc`. `publish = false`; nothing here ships.
 | `cross_impl_bench` | Cross-implementation comparison vs tonic. | `cargo bench --bench cross_impl_bench` |
 | `echo_bloat` | Codec-layer (no HTTP) `{owned,view}×{decode,encode}` sweep across five payload shapes + a 1→N fanout sweep. Motivates the future view-response handler API. | `cargo bench --bench echo_bloat` |
 | `view_rope_encode` | Encode cost of a response view, contiguous vs a rope backed by the view's own buffer, swept either side of the segment threshold. Shows what the segmented response path buys and what it costs below the threshold. | `cargo bench --bench view_rope_encode` |
+| `stream_compressed_encode` | Per-item cost of a server-streaming view item through the real framing path, segmented vs contiguous encode, with and without gzip negotiated. Shows what the segmented encode costs once compression flattens it, and what it saves when nothing does. | `cargo bench --bench stream_compressed_encode` |
 
 Filter by criterion regex: `cargo bench --bench echo_bloat -- fanout` or `-- map_dominated`.
 

--- a/benches/rpc/benches/stream_compressed_encode.rs
+++ b/benches/rpc/benches/stream_compressed_encode.rs
@@ -1,0 +1,320 @@
+//! What the segmented encode costs per streamed view item once the response
+//! is compressed, and what it saves when it is not.
+//!
+//! A server-streaming handler that yields views has each item encoded
+//! through [`Encodable::encode_segments`], so a large borrowed field is
+//! captured by reference count instead of copied. That choice is made before
+//! the framing layer applies the negotiated compression, and a compressor
+//! needs one contiguous input, so a compressed item is flattened right back.
+//! With the default policy and a client that advertises gzip — connect-go's
+//! default — every item past the segment threshold pays the rope for
+//! nothing. The flatten itself is the one payload copy a contiguous encode
+//! makes anyway; what the rope adds around it — its tail buffer, the segment
+//! list, the fragments re-copied between captures — is the waste, and the
+//! gzip arms show how it compares to the compressor's own cost.
+//!
+//! Each arm drives a real [`ConnectRpcService`] in process: a streaming
+//! request whose handler yields `ITEMS` pre-decoded views, framed through the
+//! same batching body the server uses, and drained frame by frame. The arms
+//! differ only in whether the item encodes through `encode_segments`
+//! (`segmented`, the generated `OwnedView` impl) or `encode` (`contiguous`),
+//! and in whether the request negotiated gzip. The identity arms are the
+//! control that shows what segmenting buys when the framing layer can use it.
+//! Every arm carries the same fixed per-request cost — dispatch, the request
+//! decode, the response headers — so the arms compare directly but the
+//! per-byte figure reads a little low at the small sizes.
+//!
+//! Two field shapes: one large string field, which the rope captures whole,
+//! and 1 KiB strings summing to the same size, none of which it can capture.
+//! The sizes straddle the segment threshold, so the smallest is a control
+//! where both arms run the same code.
+
+use std::sync::{Arc, Mutex};
+
+use buffa::view::OwnedView;
+use bytes::Bytes;
+use connectrpc::handler::streaming_handler_fn;
+use connectrpc::{
+    CodecFormat, ConnectError, ConnectRpcService, Encodable, RequestContext, Response, Router,
+};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use http::{Request, header};
+use http_body_util::{BodyExt, Full};
+use rpc_bench::proto::bench::v1::__buffa::view::BloatEchoView;
+use rpc_bench::proto::bench::v1::BloatEcho;
+use tower::Service as _;
+
+/// Items per streamed response. Enough to amortise dispatch and the request
+/// parse, few enough that an uncompressed iteration stays in the tens of
+/// microseconds at the small sizes.
+const ITEMS: usize = 16;
+
+type Item = OwnedView<BloatEchoView<'static>>;
+
+/// Where the setup leaves the items for the handler to take. The bench
+/// decodes the views outside the timed region so the measurement is the
+/// encode and framing of an item, not its decode.
+type Slot = Arc<Mutex<Vec<Item>>>;
+
+/// A view that encodes through `Encodable::encode` only, so the default
+/// `encode_segments` hands the framing layer one contiguous buffer — the
+/// pre-0.9 path, and what the segmented arm is measured against.
+struct Contiguous(Item);
+
+impl Encodable<BloatEcho> for Contiguous {
+    fn encode(&self, codec: CodecFormat) -> Result<Bytes, ConnectError> {
+        self.0.encode(codec)
+    }
+}
+
+/// Text that compresses like a log line rather than like a run of one byte.
+/// Deterministic, so every item and every arm sees the same bytes; `seed`
+/// keeps the 1 KiB fields of one item from being copies of each other, which
+/// gzip would otherwise match whole.
+fn filler(len: usize, seed: u64) -> String {
+    const WORDS: [&str; 16] = [
+        "request", "tenant", "latency", "span", "error", "retry", "region", "cache", "upstream",
+        "timeout", "header", "route", "shard", "replica", "queue", "trace",
+    ];
+    let mut out = String::with_capacity(len + 16);
+    // Knuth's MMIX LCG; the seed is mixed with the xorshift* multiplier so
+    // seed 0 is not a degenerate start.
+    let mut state = 0x2545_F491_4F6C_DD1D_u64 ^ seed;
+    while out.len() < len {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        let word = WORDS[(state >> 60) as usize];
+        out.push_str(word);
+        out.push('=');
+        out.push_str(&((state >> 32) as u32 % 10_000).to_string());
+        out.push(' ');
+    }
+    out.truncate(len);
+    out
+}
+
+/// How an item's payload is divided between fields.
+#[derive(Clone, Copy)]
+enum Shape {
+    /// All of it in one `string` field, which the rope captures whole.
+    OneField,
+    /// 1 KiB `string` fields, none of which reaches the segment threshold.
+    ManyFields,
+}
+
+impl Shape {
+    fn name(self) -> &'static str {
+        match self {
+            Self::OneField => "one_field",
+            Self::ManyFields => "many_fields",
+        }
+    }
+
+    /// The wire bytes of one item carrying `size` bytes of payload.
+    fn encoded_item(self, size: usize) -> Bytes {
+        let msg = match self {
+            Self::OneField => BloatEcho {
+                user_agent: filler(size, 0),
+                ..Default::default()
+            },
+            Self::ManyFields => BloatEcho {
+                tags: (0..size / 1024).map(|i| filler(1024, i as u64)).collect(),
+                ..Default::default()
+            },
+        };
+        Bytes::from(buffa::Message::encode_to_vec(&msg))
+    }
+}
+
+/// Decode `ITEMS` views, each from its own copy of `wire` so the backing
+/// buffer an item captures from is that item's alone.
+fn decode_items(wire: &Bytes) -> Vec<Item> {
+    (0..ITEMS)
+        .map(|_| OwnedView::decode(Bytes::copy_from_slice(wire)).expect("decode view"))
+        .collect()
+}
+
+/// Two server-streaming routes over the same item slot; the handler takes
+/// whatever the setup left there and yields it either as-is (the generated
+/// `OwnedView` impl, which segments) or wrapped in [`Contiguous`].
+fn service(slot: &Slot) -> ConnectRpcService<Router> {
+    let segmented = Arc::clone(slot);
+    let contiguous = Arc::clone(slot);
+    let router = Router::new()
+        .route_server_stream(
+            "bench.v1.BloatEchoService",
+            "Segmented",
+            streaming_handler_fn(move |_ctx: RequestContext, _req: BloatEcho| {
+                let items = std::mem::take(&mut *segmented.lock().expect("slot"));
+                async move { Response::stream_ok(futures::stream::iter(items.into_iter().map(Ok))) }
+            }),
+        )
+        .route_server_stream(
+            "bench.v1.BloatEchoService",
+            "Contiguous",
+            streaming_handler_fn(move |_ctx: RequestContext, _req: BloatEcho| {
+                let items = std::mem::take(&mut *contiguous.lock().expect("slot"));
+                async move {
+                    Response::stream_ok(futures::stream::iter(
+                        items.into_iter().map(|v| Ok(Contiguous(v))),
+                    ))
+                }
+            }),
+        );
+    ConnectRpcService::new(router)
+}
+
+/// A Connect server-streaming request for `method`, advertising gzip when
+/// `gzip` so the response negotiates it. The request message is empty: the
+/// handler ignores it.
+fn request(method: &str, gzip: bool) -> Request<Full<Bytes>> {
+    let mut req = Request::builder()
+        .method(http::Method::POST)
+        .uri(format!("/bench.v1.BloatEchoService/{method}"))
+        .header(header::CONTENT_TYPE, "application/connect+proto");
+    if gzip {
+        req = req.header("connect-accept-encoding", "gzip");
+    }
+    // One empty data envelope: flags 0, length 0.
+    req.body(Full::new(Bytes::from_static(&[0, 0, 0, 0, 0])))
+        .expect("request")
+}
+
+/// Drive one request through the service and drain the response body frame
+/// by frame, the way a connection would. Returns the data frames emitted.
+async fn run(svc: &mut ConnectRpcService<Router>, method: &str, gzip: bool) -> Vec<Bytes> {
+    let resp = svc.call(request(method, gzip)).await.expect("infallible");
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let negotiated = resp.headers().contains_key("connect-content-encoding");
+    assert_eq!(
+        negotiated, gzip,
+        "gzip negotiation did not match the request"
+    );
+    let mut body = resp.into_body();
+    let mut frames = Vec::new();
+    while let Some(frame) = body.frame().await {
+        if let Ok(data) = frame.expect("frame").into_data() {
+            frames.push(data);
+        }
+    }
+    // Every item costs at least its 5-byte envelope header, so a response
+    // that framed nothing — an empty slot — cannot pass as a fast one.
+    let emitted: usize = frames.iter().map(Bytes::len).sum();
+    assert!(emitted > ITEMS * 5, "{method}: the handler framed no items");
+    frames
+}
+
+/// Whether any of `frames` lies inside one of the `backings` — a payload
+/// that reached the body by reference count rather than by copy.
+fn aliases_backing(frames: &[Bytes], backings: &[(usize, usize)]) -> bool {
+    frames.iter().any(|frame| {
+        let start = frame.as_ptr() as usize;
+        backings
+            .iter()
+            .any(|&(base, len)| start >= base && start + frame.len() <= base + len)
+    })
+}
+
+/// Put `items` where the handler will find them, after checking that the
+/// previous request took its own.
+fn fill(slot: &Slot, items: Vec<Item>) {
+    let stale = std::mem::replace(&mut *slot.lock().expect("slot"), items);
+    assert!(stale.is_empty(), "a request did not take its items");
+}
+
+fn bench_stream_compressed_encode(c: &mut Criterion) {
+    // Single-threaded: the whole path runs inline on the polling thread, and
+    // a pinned-core run must not have worker threads to contend with.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let slot: Slot = Arc::new(Mutex::new(Vec::new()));
+    let mut svc = service(&slot);
+
+    for shape in [Shape::OneField, Shape::ManyFields] {
+        let mut group = c.benchmark_group(format!("stream_compressed_encode/{}", shape.name()));
+
+        // 4 KiB sits under the 16 KiB segment threshold, so both arms encode
+        // contiguously there and the pair should match; 32 KiB and 256 KiB
+        // clear it.
+        for size in [4 * 1024usize, 32 * 1024, 256 * 1024] {
+            let wire = shape.encoded_item(size);
+            group.throughput(Throughput::Bytes((wire.len() * ITEMS) as u64));
+
+            for (encoding, gzip) in [("gzip", true), ("identity", false)] {
+                for method in ["Segmented", "Contiguous"] {
+                    // Every arm must produce a well-formed response before it
+                    // is timed; the identity body carries every payload byte.
+                    let items = decode_items(&wire);
+                    // Held for the duration so a freed backing cannot be
+                    // reused for a frame and alias by coincidence.
+                    let held: Vec<Bytes> = items.iter().map(|item| item.bytes().clone()).collect();
+                    let backings: Vec<(usize, usize)> = held
+                        .iter()
+                        .map(|bytes| (bytes.as_ptr() as usize, bytes.len()))
+                        .collect();
+                    fill(&slot, items);
+                    let frames = rt.block_on(run(&mut svc, method, gzip));
+                    let emitted: usize = frames.iter().map(Bytes::len).sum();
+                    if gzip {
+                        assert!(
+                            emitted < wire.len() * ITEMS,
+                            "{method}: gzip did not shrink the body"
+                        );
+                    } else {
+                        assert!(
+                            emitted > wire.len() * ITEMS,
+                            "{method}: identity body is short"
+                        );
+                    }
+                    // The segmented arm is only a different arm if its
+                    // captures reach the body untouched, which happens for
+                    // exactly one combination: uncompressed, past the
+                    // threshold, through the generated impl, with a field
+                    // large enough to capture. Anywhere else a frame aliasing
+                    // an item's buffer would mean a copy was skipped that the
+                    // arm claims to make.
+                    let captured = !gzip
+                        && method == "Segmented"
+                        && size >= 16 * 1024
+                        && matches!(shape, Shape::OneField);
+                    assert_eq!(
+                        aliases_backing(&frames, &backings),
+                        captured,
+                        "{encoding}/{method}/{size}: capture did not match the arm"
+                    );
+                    drop(held);
+
+                    let id = BenchmarkId::new(
+                        format!("{encoding}/{}", method.to_ascii_lowercase()),
+                        size,
+                    );
+                    group.bench_with_input(id, &wire, |b, wire| {
+                        // The service clone is a handful of `Arc` bumps; a
+                        // `Fn` setup cannot lend the one `&mut svc` out.
+                        // `LargeInput` keeps criterion from materialising
+                        // hundreds of decoded batches ahead of the timer.
+                        b.to_async(&rt).iter_batched(
+                            || (decode_items(wire), svc.clone()),
+                            |(items, mut svc)| {
+                                let slot = Arc::clone(&slot);
+                                async move {
+                                    fill(&slot, items);
+                                    std::hint::black_box(run(&mut svc, method, gzip).await)
+                                }
+                            },
+                            BatchSize::LargeInput,
+                        );
+                    });
+                }
+            }
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_stream_compressed_encode);
+criterion_main!(benches);

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -1254,8 +1254,10 @@ pub type EncodedResponse = Response<EncodedBody>;
 /// response: compression needs one contiguous input, so a response that
 /// negotiates an encoding (the default for messages of at least
 /// `CompressionPolicy`'s `min_size` when the client advertises one) flattens
-/// each item first, and the segmented encode was then wasted work. Opt out
-/// per response with [`Response::compress`].
+/// each item first, and the segmented encode was then wasted work — though
+/// no more than about one percent of the compressor's own, so not worth
+/// avoiding for its own sake. Opt out per response with
+/// [`Response::compress`].
 ///
 /// A hand-written [`Dispatcher`](crate::Dispatcher) or test double that
 /// produced `Bytes` items before 0.9 converts each item, and recovers a


### PR DESCRIPTION
#271 encodes every streaming view item through `Encodable::encode_segments` before the framing layer knows whether the item will be compressed, and `EnvelopeEncoder::encode_chained` flattens a segmented body back to one buffer for the compressor. With the default policy and a client that advertises gzip, every item past the 16 KiB segment threshold pays the rope for nothing. #277 asks how much that costs, and to stop taking the segmented path under compression if the answer is "enough".

This adds `stream_compressed_encode` to `benches/rpc`. Each arm drives a real in-process `ConnectRpcService` server-streaming call whose handler yields 16 pre-decoded `OwnedView<BloatEchoView>` items, framed through the same `BatchingEnvelopeStream` the server uses and drained frame by frame; the views are decoded in criterion's setup so the timed region is encode, framing and compression only. The arms differ in whether the item encodes through `encode_segments` (`segmented`) or `encode` (a newtype leaving `encode_segments` at its contiguous default, `contiguous`), and in whether the request negotiated gzip. Two shapes: one large `string` field the rope captures whole, and 1 KiB `string`s summing to the same size, none capturable (the #278 shape). 4 KiB sits under the segment threshold as a control. A pointer check asserts that a frame aliases an item's backing buffer in exactly the one combination where a capture should reach the body, so a silently flattened segmented arm cannot pass as "no difference".

Measured on a dedicated `c7i.metal-24xl` (turbo off, `performance` governor, pinned core, 10 s measurement). Median per item, segmented vs contiguous:

| shape | size | gzip: segmented | gzip: contiguous | delta | identity: segmented | identity: contiguous | delta |
|---|---:|---:|---:|---:|---:|---:|---:|
| one large field | 4 KiB | 20.00 µs | 20.10 µs | −0.5% | 0.78 µs | 0.79 µs | −0.4% |
| one large field | 32 KiB | 162.4 µs | 161.6 µs | +0.5% | 0.90 µs | 1.75 µs | −48.2% |
| one large field | 256 KiB | 1572.2 µs | 1571.7 µs | +0.03% | 1.26 µs | 14.48 µs | −91.3% |
| 1 KiB fields | 4 KiB | 20.41 µs | 20.41 µs | +0.03% | 0.94 µs | 0.93 µs | +1.1% |
| 1 KiB fields | 32 KiB | 164.2 µs | 163.5 µs | +0.5% | 3.56 µs | 2.40 µs | +48.3% |
| 1 KiB fields | 256 KiB | 1605.4 µs | 1589.6 µs | +1.0% | 27.83 µs | 18.88 µs | +47.4% |

The threshold for "costs more" was 5%, the run-to-run floor this setup resolves; the 4 KiB rows, where both arms take the identical path, agree within 1.1%. No compressed arm clears it: the segmented encode adds at most 1.0% (about 16 µs per 256 KiB item) to a compressor that costs 1.6 ms for the same item. For the shape whose field the rope captures, the flatten is one payload copy the contiguous encode paid anyway, and the rope's bookkeeping is below what the pair can resolve. The only visible cost is the 1 KiB-fields shape, and it appears without compression too (+47–48%): that is the rope's doubling tail capturing nothing — #278's gate problem, not a compression problem — and #278's fix takes it out of both columns.

So no change to the encode choice. Threading the negotiated encoding to the dispatcher's encode closure without touching the `Dispatcher` trait or generated code would need an ambient hint set around the framing layer's poll, and the measurement does not justify a hidden coupling for a sub-1% saving. The `EncodedStream` doc, which said the segmented encode under compression "was then wasted work", now bounds how much.

Fixes #277

No changelog fragment: a benchmark and a doc sentence are not user-visible.

## Deferred review findings

- Two casts in the bench's text generator would trip `clippy::cast_possible_truncation` under pedantic (not enabled); both are provably in range.

Gates: nightly fmt `--check`; clippy 1.95.0 `-D warnings` clean; `cargo test --workspace` 936 passed; `cargo test -p connectrpc --no-default-features` 513 passed; rustdoc `-Dwarnings` clean.
