### PR TITLE
health, reflection: bound the echoed name and the decode budget on the bundled routes

### DIFF
--- a/.changes/unreleased/Changed-20260829-120000.yaml
+++ b/.changes/unreleased/Changed-20260829-120000.yaml
@@ -1,0 +1,18 @@
+kind: Changed
+body: |-
+    **`connectrpc-health` and `connectrpc-reflection` bound what an error
+    echoes and what a decode may allocate** ([#288]). `StaticChecker`'s
+    `not_found` error and reflection's in-band `ErrorResponse` now echo at
+    most 128 bytes of the peer-supplied service, file, symbol or type name
+    (longer names are cut with `... [name truncated, N bytes]`), so a
+    request-sized name no longer comes back several times over in the
+    `grpc-message` header or error body. Both crates' `request_limits()`
+    profile now also sets the element-memory decode budget to 64 KiB (four
+    times `MAX_REQUEST_BYTES`) instead of leaving it at the 32 MiB
+    `connectrpc` default; neither request type has a repeated or map field,
+    so legitimate requests never charge it. When tuning either profile with
+    `apply_request_limits`, start from `request_limits()` rather than
+    `Limits::default()` so the decode budget carries over.
+
+    [#288]: https://github.com/connectrpc/connect-rust/issues/288
+time: 2026-08-29T12:00:00.000000000+00:00

--- a/connectrpc-health/src/checker.rs
+++ b/connectrpc-health/src/checker.rs
@@ -25,7 +25,10 @@ use crate::Status;
 ///     async fn check(&self, service: &str) -> Result<Status, ConnectError> {
 ///         match service {
 ///             "" | "acme.user.v1.UserService" => Ok(Status::Serving),
-///             _ => Err(ConnectError::not_found(format!("unknown service {service}"))),
+///             // Echo the name only if you bound it first: the routes admit
+///             // names up to `MAX_REQUEST_BYTES`, and an error message is
+///             // sent back to the caller.
+///             _ => Err(ConnectError::not_found("unknown service")),
 ///         }
 ///     }
 /// }
@@ -37,7 +40,12 @@ pub trait Checker: Send + Sync + 'static {
     /// # Errors
     ///
     /// Return `Err(ConnectError::not_found(_))` for any service the
-    /// implementation doesn't recognize.
+    /// implementation doesn't recognize. `service` is peer-supplied and may
+    /// be up to [`MAX_REQUEST_BYTES`](crate::MAX_REQUEST_BYTES) long, so do
+    /// not echo it whole into the error message:
+    /// [`StaticChecker`](crate::StaticChecker) caps its
+    /// echo at 128 bytes, while a custom implementation's message is bounded
+    /// only by what it writes.
     fn check(&self, service: &str) -> impl Future<Output = Result<Status, ConnectError>> + Send;
 
     /// Subscribe to status changes for `service`. The returned

--- a/connectrpc-health/src/lib.rs
+++ b/connectrpc-health/src/lib.rs
@@ -71,7 +71,11 @@
 //! profile — and a larger request is refused with `resource_exhausted`
 //! before it reaches the [`Checker`]. The profile *replaces* the
 //! service-wide limits on these two routes, whether those are looser or
-//! tighter.
+//! tighter. Within that ceiling, [`StaticChecker`]'s `not_found` error for
+//! an unregistered service echoes at most 128 bytes of the name, so the
+//! error message is bounded by a constant rather than by the size of the
+//! request. A custom [`Checker`] is responsible for bounding its own error
+//! text.
 //!
 //! * [`install_static`] applies [`request_limits`] for you.
 //! * Registering a [`HealthService`] any other way — the generated
@@ -82,14 +86,15 @@
 //!   with your own `Limits` after either path; the later call wins.
 //!
 //! ```no_run
-//! use connectrpc::{Limits, Router};
-//! use connectrpc_health::{apply_request_limits, install_static};
+//! use connectrpc::Router;
+//! use connectrpc_health::{apply_request_limits, install_static, request_limits};
 //!
 //! let (router, health) = install_static(Router::new(), ["acme.user.v1.UserService"]);
 //! // Optional: hold the health routes to 1 KiB instead of the bundled 16 KiB.
+//! // Start from `request_limits()` so the rest of the profile carries over.
 //! let router = apply_request_limits(
 //!     router,
-//!     Limits::default()
+//!     request_limits()
 //!         .with_max_request_body_size(1024)
 //!         .with_max_message_size(1024),
 //! );

--- a/connectrpc-health/src/service.rs
+++ b/connectrpc-health/src/service.rs
@@ -144,12 +144,17 @@ pub const MAX_REQUEST_BYTES: usize = 16 * 1024;
 /// The per-route [`Limits`](connectrpc::Limits) this crate sets on its
 /// `Check` and `Watch` routes: message size capped at [`MAX_REQUEST_BYTES`]
 /// (the request body at that plus the 5-byte envelope framed protocols add),
-/// decode budget left at the `connectrpc` default.
+/// and the element-memory decode budget at four times that instead of the
+/// 32 MiB `connectrpc` default. A `HealthCheckRequest` has no repeated or
+/// map fields, so a decode that charges the budget at all is one this
+/// service was never going to answer; the bound keeps a future revision of
+/// the protocol from changing that quietly.
 #[must_use]
 pub fn request_limits() -> connectrpc::Limits {
     connectrpc::Limits::default()
         .with_max_request_body_size(MAX_REQUEST_BYTES + connectrpc::envelope::HEADER_SIZE)
         .with_max_message_size(MAX_REQUEST_BYTES)
+        .with_element_memory_limit(4 * MAX_REQUEST_BYTES)
 }
 
 /// Set the `Check` and `Watch` routes on `router` to `limits`, replacing
@@ -162,7 +167,10 @@ pub fn request_limits() -> connectrpc::Limits {
 /// [`Router::add_service`](connectrpc::Router::add_service) — since those
 /// generic registration paths cannot; or call it after either path with
 /// your own [`Limits`](connectrpc::Limits) to tune the health routes
-/// specifically. The later call wins.
+/// specifically. The later call wins. Build an override from
+/// [`request_limits`] rather than `Limits::default()`: the replacement is
+/// whole, so anything the profile sets and the override does not is reset
+/// to the `connectrpc` default.
 ///
 /// # Panics
 ///
@@ -518,6 +526,49 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
+    }
+
+    /// The largest name the bundled profile admits decodes under its decode
+    /// budget and misses with a `not_found` whose message is a small
+    /// fraction of the request, over both the header-borne (gRPC) and
+    /// body-borne (Connect) error paths.
+    #[tokio::test]
+    async fn largest_admitted_name_misses_with_a_bounded_error() {
+        use crate::install_static;
+        let (router, _health) = install_static(Router::new(), ["acme.A"]);
+        let app = router.into_axum_router();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        // 8 bytes of slack covers the field tag and length varint, so the
+        // encoded message sits just under MAX_REQUEST_BYTES.
+        let request = HealthCheckRequest {
+            service: "x".repeat(crate::MAX_REQUEST_BYTES - 8),
+            ..Default::default()
+        };
+        let config = || ClientConfig::new(format!("http://{addr}").parse().unwrap());
+        for (transport, config) in [
+            (
+                HttpClient::plaintext_http2_only(),
+                config().with_protocol(connectrpc::Protocol::Grpc),
+            ),
+            (HttpClient::plaintext(), config()),
+        ] {
+            let client = HealthClient::new(transport, config);
+            let err = client.check(request.clone()).await.unwrap_err();
+            assert_eq!(err.code, connectrpc::ErrorCode::NotFound, "{err}");
+            let message = err.message.unwrap();
+            assert!(message.len() < 512, "{}", message.len());
+            assert!(
+                message.ends_with(&format!(
+                    "[name truncated, {} bytes]",
+                    request.service.len()
+                )),
+                "{message}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/connectrpc-health/src/static_checker.rs
+++ b/connectrpc-health/src/static_checker.rs
@@ -260,7 +260,7 @@ impl Checker for StaticChecker {
             let services = self.lock();
             services.get(service).map(|sender| *sender.borrow())
         };
-        snapshot.ok_or_else(|| ConnectError::not_found(format!("unknown service {service}")))
+        snapshot.ok_or_else(|| unknown_service(service))
     }
 
     async fn watch(&self, service: &str) -> Result<StatusStream, ConnectError> {
@@ -270,8 +270,52 @@ impl Checker for StaticChecker {
         };
         receiver
             .map(StatusStream::from_watch)
-            .ok_or_else(|| ConnectError::not_found(format!("unknown service {service}")))
+            .ok_or_else(|| unknown_service(service))
     }
+}
+
+/// Longest prefix of a peer-supplied service name echoed into a `not_found`
+/// error, in bytes.
+///
+/// The error message travels back as a `grpc-message` header or a Connect
+/// error body, so echoing the whole name would let a request-sized name
+/// (up to [`MAX_REQUEST_BYTES`](crate::MAX_REQUEST_BYTES)) come back at
+/// several times its size once percent-encoded. Any legitimate
+/// fully-qualified service name fits well inside this bound.
+const MAX_ECHOED_NAME_BYTES: usize = 128;
+
+/// A peer-supplied service name as it appears in an error message: verbatim
+/// up to [`MAX_ECHOED_NAME_BYTES`], beyond that cut there with the original
+/// length noted.
+///
+/// Unquoted, unlike [`UnknownServiceError`]'s Display: this text is the wire
+/// error message clients have always received for a miss, and it stays
+/// byte-for-byte the same for every name inside the bound.
+struct Echoed<'a>(&'a str);
+
+impl std::fmt::Display for Echoed<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = self.0;
+        if name.len() <= MAX_ECHOED_NAME_BYTES {
+            return f.write_str(name);
+        }
+        // `str::floor_char_boundary` is not stable at the crate's MSRV.
+        let mut end = MAX_ECHOED_NAME_BYTES;
+        while !name.is_char_boundary(end) {
+            end -= 1;
+        }
+        write!(
+            f,
+            "{}... [name truncated, {} bytes]",
+            &name[..end],
+            name.len()
+        )
+    }
+}
+
+/// The `not_found` error for a service name the checker does not know.
+fn unknown_service(service: &str) -> ConnectError {
+    ConnectError::not_found(format!("unknown service {}", Echoed(service)))
 }
 
 #[cfg(test)]
@@ -721,6 +765,51 @@ mod tests {
         assert!(
             err.to_string().contains("acme."),
             "Display must include the prefix verbatim: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_service_echoes_short_names_whole() {
+        let err = unknown_service("acme.user.v1.UserService");
+        assert_eq!(err.code, connectrpc::ErrorCode::NotFound);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("unknown service acme.user.v1.UserService")
+        );
+
+        let at_the_bound = "s".repeat(MAX_ECHOED_NAME_BYTES);
+        assert_eq!(
+            unknown_service(&at_the_bound).message,
+            Some(format!("unknown service {at_the_bound}"))
+        );
+    }
+
+    #[test]
+    fn unknown_service_truncates_long_names_at_a_char_boundary() {
+        // A 4-byte char straddles the bound; slicing inside it would panic.
+        let name = format!("{}\u{1F600}tail", "s".repeat(126));
+        let err = unknown_service(&name);
+        assert_eq!(err.code, connectrpc::ErrorCode::NotFound);
+        assert_eq!(
+            err.message,
+            Some(format!(
+                "unknown service {}... [name truncated, {} bytes]",
+                "s".repeat(126),
+                name.len()
+            ))
+        );
+
+        // The largest name the routes admit still yields a short message.
+        let huge = "x".repeat(crate::MAX_REQUEST_BYTES);
+        let message = unknown_service(&huge).message.unwrap();
+        assert!(
+            message.len() < 2 * MAX_ECHOED_NAME_BYTES,
+            "{}",
+            message.len()
+        );
+        assert!(
+            message.ends_with("[name truncated, 16384 bytes]"),
+            "{message}"
         );
     }
 }

--- a/connectrpc-reflection/src/lib.rs
+++ b/connectrpc-reflection/src/lib.rs
@@ -61,7 +61,14 @@
 //! profile; `ServerReflectionInfo` is a bidirectional stream, so the bound
 //! is per message rather than per call. A larger message ends the stream
 //! with `resource_exhausted`. The profile *replaces* the service-wide limits
-//! on these routes, whether those are looser or tighter.
+//! on these routes, whether those are looser or tighter; its decode budget
+//! is likewise charged per message. Within that ceiling, a lookup miss
+//! echoes at most 128 bytes of the queried name in
+//! its `ErrorResponse`, so the error text is bounded by a constant rather
+//! than by the size of the request. What remains is the protocol's own
+//! echo: every response carries `original_request` whole and repeats its
+//! `host` as `valid_host`, as grpc-go's does, so a response is at most about
+//! twice the request that produced it.
 //!
 //! * [`install`] applies [`request_limits`] for you, to both versions.
 //! * Registering a [`ReflectionService`] any other way — one version through
@@ -74,14 +81,15 @@
 //!   later call wins.
 //!
 //! ```no_run
-//! use connectrpc::{Limits, Router};
-//! use connectrpc_reflection::{Reflector, apply_request_limits, install};
+//! use connectrpc::Router;
+//! use connectrpc_reflection::{Reflector, apply_request_limits, install, request_limits};
 //!
 //! # fn descriptor_set_bytes() -> &'static [u8] { &[] }
 //! let reflector = Reflector::from_descriptor_set_bytes(descriptor_set_bytes()).unwrap();
 //! let router = install(Router::new(), reflector);
 //! // Optional: hold reflection messages to 1 KiB instead of the bundled 16 KiB.
-//! let router = apply_request_limits(router, Limits::default().with_max_message_size(1024));
+//! // Start from `request_limits()` so the rest of the profile carries over.
+//! let router = apply_request_limits(router, request_limits().with_max_message_size(1024));
 //! # drop(router);
 //! ```
 //!

--- a/connectrpc-reflection/src/reflector.rs
+++ b/connectrpc-reflection/src/reflector.rs
@@ -106,6 +106,41 @@ impl From<buffa::DecodeError> for ReflectionError {
     }
 }
 
+/// Longest prefix of a peer-supplied name echoed into a `not_found`
+/// `ErrorResponse`, in bytes.
+///
+/// The reflection protocol already echoes the whole request back in
+/// `original_request`; repeating a request-sized name (up to
+/// [`MAX_REQUEST_BYTES`](crate::MAX_REQUEST_BYTES)) a second time in the
+/// error message, Debug-escaped, would let a single request pull back a
+/// response several times its size. Any legitimate file name, symbol or
+/// type name fits well inside this bound.
+const MAX_ECHOED_NAME_BYTES: usize = 128;
+
+/// A peer-supplied name as it appears in an error message: Debug-quoted, and
+/// cut to [`MAX_ECHOED_NAME_BYTES`] with the original length noted.
+struct Echoed<'a>(&'a str);
+
+impl std::fmt::Display for Echoed<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = self.0;
+        if name.len() <= MAX_ECHOED_NAME_BYTES {
+            return write!(f, "{name:?}");
+        }
+        // `str::floor_char_boundary` is not stable at the crate's MSRV.
+        let mut end = MAX_ECHOED_NAME_BYTES;
+        while !name.is_char_boundary(end) {
+            end -= 1;
+        }
+        write!(
+            f,
+            "{:?}... [name truncated, {} bytes]",
+            &name[..end],
+            name.len()
+        )
+    }
+}
+
 /// The answer to a single reflection query, protocol-version agnostic.
 ///
 /// `service.rs` maps this onto the generated `v1` / `v1alpha` response
@@ -354,7 +389,7 @@ impl Reflector {
                 return Answer::Files(source.closure(fd));
             }
         }
-        Answer::NotFound(format!("file {name:?} not found"))
+        Answer::NotFound(format!("file {} not found", Echoed(name)))
     }
 
     pub(crate) fn file_containing_symbol(&self, symbol: &str) -> Answer {
@@ -363,13 +398,14 @@ impl Reflector {
                 return Answer::Files(source.closure(fd));
             }
         }
-        Answer::NotFound(format!("symbol {symbol:?} not found"))
+        Answer::NotFound(format!("symbol {} not found", Echoed(symbol)))
     }
 
     pub(crate) fn file_containing_extension(&self, containing_type: &str, number: i32) -> Answer {
         let not_found = || {
             Answer::NotFound(format!(
-                "extension {number} of type {containing_type:?} not found"
+                "extension {number} of type {} not found",
+                Echoed(containing_type)
             ))
         };
         let Ok(number) = u32::try_from(number) else {
@@ -408,7 +444,7 @@ impl Reflector {
                 numbers,
             };
         }
-        Answer::NotFound(format!("message {normalized:?} not found"))
+        Answer::NotFound(format!("message {} not found", Echoed(name)))
     }
 
     pub(crate) fn list_services(&self) -> Answer {
@@ -568,6 +604,79 @@ mod tests {
 
     const SELF_V1: &str = "grpc.reflection.v1.ServerReflection";
     const SELF_V1ALPHA: &str = "grpc.reflection.v1alpha.ServerReflection";
+
+    #[test]
+    fn echoed_quotes_short_names_whole() {
+        assert_eq!(Echoed("acme.api.Search").to_string(), "\"acme.api.Search\"");
+        let at_the_bound = "s".repeat(MAX_ECHOED_NAME_BYTES);
+        assert_eq!(
+            Echoed(&at_the_bound).to_string(),
+            format!("{at_the_bound:?}")
+        );
+    }
+
+    #[test]
+    fn echoed_truncates_long_names_at_a_char_boundary() {
+        // 126 ASCII bytes then a 4-byte char straddling the 128-byte bound:
+        // the cut must land before it, never inside it.
+        let name = format!("{}\u{1F600}tail", "s".repeat(126));
+        assert_eq!(
+            Echoed(&name).to_string(),
+            format!(
+                "\"{}\"... [name truncated, {} bytes]",
+                "s".repeat(126),
+                name.len()
+            )
+        );
+
+        // The largest name the routes admit still yields a short message.
+        let huge = "x".repeat(crate::MAX_REQUEST_BYTES);
+        let echoed = Echoed(&huge).to_string();
+        assert!(echoed.len() < 2 * MAX_ECHOED_NAME_BYTES, "{}", echoed.len());
+        assert!(
+            echoed.ends_with("[name truncated, 16384 bytes]"),
+            "{echoed}"
+        );
+    }
+
+    #[test]
+    fn echoed_bound_is_on_name_bytes_not_escaped_output() {
+        // Debug escaping expands a control character to `\u{1}` (5 chars),
+        // so the rendered message runs past the byte bound on the name; it
+        // stays a constant multiple of that bound, never of the input.
+        let control = "\u{1}".repeat(crate::MAX_REQUEST_BYTES);
+        let echoed = Echoed(&control).to_string();
+        assert!(echoed.len() < 6 * MAX_ECHOED_NAME_BYTES, "{}", echoed.len());
+        assert!(
+            echoed.ends_with("[name truncated, 16384 bytes]"),
+            "{echoed}"
+        );
+    }
+
+    #[test]
+    fn lookup_misses_echo_a_bounded_name() {
+        let reflector = Reflector::from_descriptor_set_bytes(&test_set().encode_to_vec()).unwrap();
+        let huge = "x".repeat(crate::MAX_REQUEST_BYTES);
+        for answer in [
+            reflector.file_by_filename(&huge),
+            reflector.file_containing_symbol(&huge),
+            reflector.file_containing_extension(&huge, 1),
+            reflector.all_extension_numbers_of_type(&huge),
+        ] {
+            let Answer::NotFound(message) = answer else {
+                panic!("expected NotFound");
+            };
+            assert!(
+                message.len() < 3 * MAX_ECHOED_NAME_BYTES,
+                "{}",
+                message.len()
+            );
+            assert!(
+                message.contains("[name truncated, 16384 bytes]"),
+                "{message}"
+            );
+        }
+    }
 
     /// A two-file set: `acme/base.proto` (imported) and `acme/api.proto`
     /// exercising every symbol kind the index covers.

--- a/connectrpc-reflection/src/service.rs
+++ b/connectrpc-reflection/src/service.rs
@@ -85,12 +85,17 @@ pub const MAX_REQUEST_BYTES: usize = 16 * 1024;
 /// The per-route [`Limits`](connectrpc::Limits) this crate sets on its
 /// routes: message size capped at [`MAX_REQUEST_BYTES`] (and the request
 /// body, which only governs non-streaming calls, at that plus the 5-byte
-/// envelope), decode budget left at the `connectrpc` default.
+/// envelope), and the element-memory decode budget at four times that
+/// instead of the 32 MiB `connectrpc` default. A `ServerReflectionRequest`
+/// has no repeated or map fields, so a decode that charges the budget at all
+/// is one this service was never going to answer; the bound keeps a future
+/// revision of the protocol from changing that quietly.
 #[must_use]
 pub fn request_limits() -> connectrpc::Limits {
     connectrpc::Limits::default()
         .with_max_request_body_size(MAX_REQUEST_BYTES + connectrpc::envelope::HEADER_SIZE)
         .with_max_message_size(MAX_REQUEST_BYTES)
+        .with_element_memory_limit(4 * MAX_REQUEST_BYTES)
 }
 
 /// Set whichever of the `v1` and `v1alpha` reflection routes are registered
@@ -103,7 +108,10 @@ pub fn request_limits() -> connectrpc::Limits {
 /// [`Router::add_service`](connectrpc::Router::add_service), since those
 /// generic registration paths cannot; or call it after either path with your
 /// own [`Limits`](connectrpc::Limits) to tune the reflection routes
-/// specifically. The later call wins.
+/// specifically. The later call wins. Build an override from
+/// [`request_limits`] rather than `Limits::default()`: the replacement is
+/// whole, so anything the profile sets and the override does not is reset
+/// to the `connectrpc` default.
 ///
 /// # Panics
 ///
@@ -342,6 +350,41 @@ mod tests {
         stream.close_send();
         let err = stream.message().await.unwrap_err();
         assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
+    }
+
+    /// The largest symbol the bundled profile admits decodes under its decode
+    /// budget and misses in-band with an `ErrorResponse` whose message is a
+    /// small fraction of the request.
+    #[tokio::test]
+    async fn largest_admitted_symbol_misses_with_a_bounded_error() {
+        let client = spawn_reflection_server().await;
+        let mut stream = client.server_reflection_info().await.unwrap();
+        // 64 bytes of slack covers the `host` field, the oneof tag and the
+        // length varints, so the encoded message sits just under
+        // MAX_REQUEST_BYTES.
+        let symbol = "x".repeat(crate::MAX_REQUEST_BYTES - 64);
+        stream
+            .send(request(MessageRequest::FileContainingSymbol(
+                symbol.clone(),
+            )))
+            .await
+            .unwrap();
+        stream.close_send();
+        let resp = stream.message().await.unwrap().unwrap().to_owned_message();
+        match resp.message_response.unwrap() {
+            MessageResponse::ErrorResponse(err) => {
+                assert_eq!(err.error_code, 5);
+                assert!(err.error_message.len() < 512, "{}", err.error_message.len());
+                assert!(
+                    err.error_message
+                        .contains(&format!("[name truncated, {} bytes]", symbol.len())),
+                    "{}",
+                    err.error_message
+                );
+            }
+            other => panic!("expected error_response, got {other:?}"),
+        }
+        assert!(stream.message().await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1488,7 +1488,12 @@ Check-only probes; override it if your probes call Watch.
 per-route `Limits` profile (see [Request limits](#request-limits)) that
 replaces the service-wide limits on those two routes, whether those are
 looser or tighter — and a larger request is refused with
-`resource_exhausted` before it reaches the checker. Registering a
+`resource_exhausted` before it reaches the checker. The profile also
+holds the decode budget to four times the 16 KiB message bound (64
+KiB), and `StaticChecker`'s `not_found` error echoes at most 128 bytes
+of an unregistered name, so the error message is bounded by a constant
+rather than by the size of the request (a custom `Checker` bounds its
+own error text). Registering a
 `HealthService` any other way (`HealthExt::register`,
 `Router::add_service`) does not apply it, so follow that with
 `apply_request_limits(router, request_limits())`. To tune the health
@@ -1496,13 +1501,13 @@ routes specifically, call `apply_request_limits` with your own `Limits`
 after either path; the later call wins:
 
 ```rust,ignore
-use connectrpc::Limits;
-use connectrpc_health::{apply_request_limits, install_static};
+use connectrpc_health::{apply_request_limits, install_static, request_limits};
 
 let (router, health) = install_static(Router::new(), [/* ... */]);
+// Start from `request_limits()` so the rest of the profile carries over.
 let router = apply_request_limits(
     router,
-    Limits::default()
+    request_limits()
         .with_max_request_body_size(1024)
         .with_max_message_size(1024),
 );
@@ -1568,7 +1573,13 @@ let router = install(router, reflector); // mounts v1 + v1alpha
 (see [Request limits](#request-limits)) that replaces the service-wide
 limits on those routes, whether those are looser or tighter; the RPC is
 a bidirectional stream, so the bound is per message rather than per
-call. Mounting a single version through the generated
+call. The profile also holds the per-message decode budget to four
+times the 16 KiB bound (64 KiB), and a lookup miss echoes at most 128
+bytes of the queried name in its
+`ErrorResponse`, so the error text is bounded by a constant rather than
+by the size of the request; the protocol's own `original_request` and
+`valid_host` echoes remain, so a response is at most about twice the
+request that produced it. Mounting a single version through the generated
 `ServerReflectionExt::register` (or using `Router::add_service`) does
 not apply it, so follow that with
 `apply_request_limits(router, request_limits())`. To tune the
@@ -1576,11 +1587,11 @@ reflection routes specifically, call `apply_request_limits` with your
 own `Limits` after either path; the later call wins:
 
 ```rust,ignore
-use connectrpc::Limits;
-use connectrpc_reflection::{apply_request_limits, install};
+use connectrpc_reflection::{apply_request_limits, install, request_limits};
 
 let router = install(router, reflector);
-let router = apply_request_limits(router, Limits::default().with_max_message_size(1024));
+// Start from `request_limits()` so the rest of the profile carries over.
+let router = apply_request_limits(router, request_limits().with_max_message_size(1024));
 ```
 
 Alternatively, when your buffa codegen has reflection enabled, serve


### PR DESCRIPTION
Fixes #288.

Since #272 the bundled health and reflection routes admit 16 KiB request messages, but two things in the services themselves still scaled with that input.

**Error messages echoed the whole peer-supplied name.** `StaticChecker` copied an unregistered name into `not_found("unknown service {name}")`, which travels back as the `grpc-message` header (percent-encoded) or a Connect error body; reflection's lookup misses Debug-echoed the queried name into the in-band `ErrorResponse`, on top of the protocol's own `original_request` echo. Both now echo at most 128 bytes of the name, cut at a char boundary and suffixed with `... [name truncated, N bytes]`, so the error text is bounded by a constant rather than by the request. Names inside the bound produce exactly the messages they did before.

**`request_limits()` left the decode budget at the 32 MiB default.** Neither `HealthCheckRequest` nor `ServerReflectionRequest` has a repeated or map field, so nothing legitimate charges buffa's element-memory budget on these routes; both profiles now set it to four times `MAX_REQUEST_BYTES` (64 KiB) to record that rather than inherit the general-purpose value.

Because `apply_request_limits` replaces a route's limits whole, an override built from `Limits::default()` would now silently drop the budget; the rustdoc and guide examples for tuning the routes start from `request_limits()` instead, and `apply_request_limits` says so. The `Checker` trait's example and `# Errors` section no longer teach an unbounded echo and say a custom implementation bounds its own error text.

Driven over a real socket: a 16 KiB unknown service name now comes back as a 386-byte `grpc-message` header over gRPC h2c and a 210-byte Connect error body; a reflection miss for a 16 KiB symbol returns a 16.6 KB response (the protocol's `original_request` echo) with the truncated text.
