### PR TITLE
health, reflection: generate wire types without unknown-field retention

### DIFF
--- a/.changes/unreleased/Changed-20260821-170000.yaml
+++ b/.changes/unreleased/Changed-20260821-170000.yaml
@@ -1,0 +1,25 @@
+kind: Changed
+body: |-
+    **`connectrpc-health` and `connectrpc-reflection` messages no longer
+    retain unknown fields.** Neither service reads or acts on a field its copy
+    of `health.proto` / `reflection.proto` does not define, so their wire types
+    are now generated with buffa's `unknown_fields=false`: an unrecognized
+    field is skipped during decode (still depth-limited) instead of being
+    recorded, and is absent from anything these types re-encode — including
+    reflection's `original_request` echo, which grpc-go re-emits verbatim.
+    This is scoped to the two crates' own `grpc.health.v1` and
+    `grpc.reflection.v1`/`v1alpha` messages; code generated for your own
+    services is unchanged. Reflection's descriptor payloads are opaque bytes
+    and unaffected.
+
+    **Breaking** for code that uses the re-exported `wire` types directly. The
+    hidden `__buffa_unknown_fields` field and the `buffa::ExtensionSet` impl are
+    gone from every message in both crates, so naming either is a rustc error
+    (`<T as buffa::MessageName>::FULL_NAME` replaces `ExtensionSet::PROTO_FQN`).
+    Struct literals such as `HealthCheckRequest { service, ..Default::default() }`
+    still compile, but every field is now named, so `clippy::needless_update`
+    fires — drop the `..Default::default()` tail. A message decoded and
+    re-encoded through these types no longer round-trips fields from a newer
+    revision of the protocol, and a body carrying more unknown fields than
+    buffa's per-decode allowance is now skipped through rather than rejected.
+time: 2026-08-21T17:00:00.000000000+00:00

--- a/connectrpc-health/buf.gen.yaml
+++ b/connectrpc-health/buf.gen.yaml
@@ -2,7 +2,12 @@ version: v2
 plugins:
   - local: ../../buffa/target/release/protoc-gen-buffa
     out: src/generated/buffa
-    opt: [views=true, json=true]
+    # `unknown_fields=false`: nothing in the health service reads or
+    # re-emits unknown fields, so the generated types skip them on decode
+    # instead of recording them — smaller structs (no
+    # `__buffa_unknown_fields`) and no per-field bookkeeping on the request
+    # path.
+    opt: [views=true, json=true, unknown_fields=false]
   - local: ../../buffa/target/release/protoc-gen-buffa-packaging
     out: src/generated/buffa
     strategy: all

--- a/connectrpc-health/src/generated/buffa/grpc.health.v1.health.__view.rs
+++ b/connectrpc-health/src/generated/buffa/grpc.health.v1.health.__view.rs
@@ -5,7 +5,6 @@
 pub struct HealthCheckRequestView<'a> {
     /// Field 1: `service`
     pub service: &'a str,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for HealthCheckRequestView<'a> {
     type Owned = super::super::HealthCheckRequest;
@@ -29,7 +28,7 @@ impl<'a> ::buffa::MessageView<'a> for HealthCheckRequestView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -46,8 +45,6 @@ impl<'a> ::buffa::MessageView<'a> for HealthCheckRequestView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -67,7 +64,6 @@ impl<'a> ::buffa::MessageView<'a> for HealthCheckRequestView<'a> {
         let _ = __buffa_src;
         ::core::result::Result::Ok(super::super::HealthCheckRequest {
             service: self.service.to_string(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -81,7 +77,6 @@ impl<'a> ::buffa::ViewEncode<'a> for HealthCheckRequestView<'a> {
         if !self.service.is_empty() {
             size += 1u64 + ::buffa::types::string_encoded_len(&self.service) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -95,7 +90,6 @@ impl<'a> ::buffa::ViewEncode<'a> for HealthCheckRequestView<'a> {
         if !self.service.is_empty() {
             ::buffa::types::put_string_field(1u32, &self.service, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -254,7 +248,8 @@ impl ::serde::Serialize for HealthCheckRequestOwnedView {
 pub struct HealthCheckResponseView<'a> {
     /// Field 1: `status`
     pub status: ::buffa::EnumValue<super::super::health_check_response::ServingStatus>,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+    #[doc(hidden)]
+    pub __buffa_phantom: ::core::marker::PhantomData<&'a ()>,
 }
 impl<'a> ::buffa::MessageView<'a> for HealthCheckResponseView<'a> {
     type Owned = super::super::HealthCheckResponse;
@@ -278,7 +273,7 @@ impl<'a> ::buffa::MessageView<'a> for HealthCheckResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -297,8 +292,6 @@ impl<'a> ::buffa::MessageView<'a> for HealthCheckResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -324,7 +317,6 @@ impl<'a> ::buffa::MessageView<'a> for HealthCheckResponseView<'a> {
         let _ = __buffa_src;
         ::core::result::Result::Ok(super::super::HealthCheckResponse {
             status: self.status,
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -341,7 +333,6 @@ impl<'a> ::buffa::ViewEncode<'a> for HealthCheckResponseView<'a> {
                 size += 1u64 + ::buffa::types::int32_encoded_len(val) as u64;
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -358,7 +349,6 @@ impl<'a> ::buffa::ViewEncode<'a> for HealthCheckResponseView<'a> {
                 ::buffa::types::put_int32_field(1u32, val, buf);
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.

--- a/connectrpc-health/src/generated/buffa/grpc.health.v1.health.rs
+++ b/connectrpc-health/src/generated/buffa/grpc.health.v1.health.rs
@@ -12,9 +12,6 @@ pub struct HealthCheckRequest {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_empty_str"
     )]
     pub service: ::buffa::alloc::string::String,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for HealthCheckRequest {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -51,7 +48,6 @@ impl ::buffa::Message for HealthCheckRequest {
         if !self.service.is_empty() {
             size += 1u64 + ::buffa::types::string_encoded_len(&self.service) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -64,7 +60,6 @@ impl ::buffa::Message for HealthCheckRequest {
         if !self.service.is_empty() {
             ::buffa::types::put_string_field(1u32, &self.service, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -85,24 +80,13 @@ impl ::buffa::Message for HealthCheckRequest {
                 ::buffa::types::merge_string(&mut self.service, buf)?;
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.service.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for HealthCheckRequest {
-    const PROTO_FQN: &'static str = "grpc.health.v1.HealthCheckRequest";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for HealthCheckRequest {
@@ -136,9 +120,6 @@ pub struct HealthCheckResponse {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_default_enum_value"
     )]
     pub status: ::buffa::EnumValue<health_check_response::ServingStatus>,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for HealthCheckResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -178,7 +159,6 @@ impl ::buffa::Message for HealthCheckResponse {
                 size += 1u64 + ::buffa::types::int32_encoded_len(val) as u64;
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -194,7 +174,6 @@ impl ::buffa::Message for HealthCheckResponse {
                 ::buffa::types::put_int32_field(1u32, val, buf);
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -217,24 +196,13 @@ impl ::buffa::Message for HealthCheckResponse {
                 );
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.status = ::buffa::EnumValue::from(0);
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for HealthCheckResponse {
-    const PROTO_FQN: &'static str = "grpc.health.v1.HealthCheckResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for HealthCheckResponse {

--- a/connectrpc-health/src/lib.rs
+++ b/connectrpc-health/src/lib.rs
@@ -135,6 +135,13 @@ pub use connect::grpc::health::v1::HEALTH_SERVICE_NAME;
 /// Re-exports of the generated `grpc.health.v1` wire types — request and
 /// response messages, `ServingStatus`, the `*_SPEC` constants. Downstream
 /// crates can build probe loops without regenerating the proto.
+///
+/// These messages do **not** retain unknown fields: anything on the wire
+/// that this crate's copy of `health.proto` does not define is skipped on
+/// decode and absent on re-encode, so they are not a lossless relay for a
+/// newer revision of the protocol. The health service itself never reads
+/// or re-emits unknown fields, so its generated types omit the bookkeeping
+/// for them.
 pub mod wire {
     pub use crate::connect::grpc::health::v1::{HEALTH_CHECK_SPEC, HEALTH_WATCH_SPEC};
     pub use crate::proto::grpc::health::v1::health_check_response::ServingStatus;

--- a/connectrpc-health/src/service.rs
+++ b/connectrpc-health/src/service.rs
@@ -197,7 +197,6 @@ impl<C: Checker> Health for HealthService<C> {
         let status = self.checker.check(request.service).await?;
         Response::ok(HealthCheckResponse {
             status: ServingStatus::from(status).into(),
-            ..Default::default()
         })
     }
 
@@ -210,7 +209,6 @@ impl<C: Checker> Health for HealthService<C> {
         Response::stream_ok(stream.map(|status| {
             Ok::<_, ConnectError>(HealthCheckResponse {
                 status: ServingStatus::from(status).into(),
-                ..Default::default()
             })
         }))
     }
@@ -251,6 +249,34 @@ mod tests {
         (client, addr)
     }
 
+    /// The wire types are generated with `unknown_fields=false`: an
+    /// unrecognized field is accepted and skipped on both decode paths, and
+    /// is absent when the message is re-encoded. Guards against a
+    /// regeneration silently dropping the option.
+    #[test]
+    fn unknown_fields_are_skipped_not_retained() {
+        use buffa::Message;
+        use buffa::view::MessageView;
+
+        use crate::proto::grpc::health::v1::HealthCheckRequestView;
+
+        let known = HealthCheckRequest {
+            service: "acme.A".into(),
+        }
+        .encode_to_vec();
+        let mut with_unknown = known.clone();
+        // Field 15, varint 0 — not defined by `HealthCheckRequest`.
+        with_unknown.extend_from_slice(&[0x78, 0x00]);
+
+        let owned = HealthCheckRequest::decode_from_slice(&with_unknown).unwrap();
+        assert_eq!(owned.service, "acme.A");
+        assert_eq!(owned.encode_to_vec(), known);
+
+        let view = HealthCheckRequestView::decode_view(&with_unknown).unwrap();
+        assert_eq!(view.service, "acme.A");
+        assert_eq!(view.to_owned_message().unwrap().encode_to_vec(), known);
+    }
+
     #[tokio::test]
     async fn check_serving_service() {
         let checker = Arc::new(StaticChecker::with_services(["acme.A"]));
@@ -259,7 +285,6 @@ mod tests {
         let resp = client
             .check(HealthCheckRequest {
                 service: "acme.A".into(),
-                ..Default::default()
             })
             .await
             .unwrap();
@@ -283,7 +308,6 @@ mod tests {
         let err = client
             .check(HealthCheckRequest {
                 service: "acme.NoSuch".into(),
-                ..Default::default()
             })
             .await
             .unwrap_err();
@@ -300,7 +324,6 @@ mod tests {
         let resp = client
             .check(HealthCheckRequest {
                 service: "acme.A".into(),
-                ..Default::default()
             })
             .await
             .unwrap();
@@ -337,7 +360,6 @@ mod tests {
         let mut stream = client
             .watch(HealthCheckRequest {
                 service: "acme.A".into(),
-                ..Default::default()
             })
             .await
             .unwrap();
@@ -395,7 +417,6 @@ mod tests {
         let mut stream = client
             .watch(HealthCheckRequest {
                 service: "acme.A".into(),
-                ..Default::default()
             })
             .await
             .unwrap();
@@ -429,7 +450,6 @@ mod tests {
         let resp = client
             .check(HealthCheckRequest {
                 service: "acme.A".into(),
-                ..Default::default()
             })
             .await
             .unwrap();
@@ -453,7 +473,6 @@ mod tests {
         let resp = client
             .check(HealthCheckRequest {
                 service: "acme.A".into(),
-                ..Default::default()
             })
             .await
             .unwrap();
@@ -464,7 +483,6 @@ mod tests {
         let resp = client
             .check(HealthCheckRequest {
                 service: "acme.A".into(),
-                ..Default::default()
             })
             .await
             .unwrap();
@@ -480,7 +498,6 @@ mod tests {
         );
         let oversized = HealthCheckRequest {
             service: "x".repeat(2 * crate::MAX_REQUEST_BYTES),
-            ..Default::default()
         };
         let err = client.check(oversized.clone()).await.unwrap_err();
         assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
@@ -513,7 +530,6 @@ mod tests {
         let err = client
             .check(HealthCheckRequest {
                 service: "x".repeat(2048),
-                ..Default::default()
             })
             .await
             .unwrap_err();

--- a/connectrpc-reflection/buf.gen.yaml
+++ b/connectrpc-reflection/buf.gen.yaml
@@ -14,7 +14,13 @@ inputs:
 plugins:
   - local: ../../buffa/target/release/protoc-gen-buffa
     out: src/generated/buffa
-    opt: [views=true, json=true]
+    # `unknown_fields=false`: the reflection service never reads unknown
+    # fields, so the generated types skip them on decode instead of recording
+    # them and re-encoding them into the `original_request` echo — smaller
+    # structs (no `__buffa_unknown_fields`) and no per-field bookkeeping on
+    # the request path. The echo therefore omits unknown fields, where
+    # grpc-go's re-emits them.
+    opt: [views=true, json=true, unknown_fields=false]
   - local: ../../buffa/target/release/protoc-gen-buffa-packaging
     out: src/generated/buffa
     strategy: all

--- a/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1.reflection.__view.rs
+++ b/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1.reflection.__view.rs
@@ -9,7 +9,6 @@ pub struct ServerReflectionRequestView<'a> {
     pub message_request: ::core::option::Option<
         super::super::__buffa::view::oneof::server_reflection_request::MessageRequest<'a>,
     >,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
     type Owned = super::super::ServerReflectionRequest;
@@ -33,7 +32,7 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -125,8 +124,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -198,7 +195,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
                 }
                 ::core::option::Option::None => ::core::option::Option::None,
             },
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -246,7 +242,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionRequestView<'a> {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -294,7 +289,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionRequestView<'a> {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -499,7 +493,6 @@ pub struct ExtensionRequestView<'a> {
     pub containing_type: &'a str,
     /// Field 2: `extension_number`
     pub extension_number: i32,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
     type Owned = super::super::ExtensionRequest;
@@ -523,7 +516,7 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -547,8 +540,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -569,7 +560,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
         ::core::result::Result::Ok(super::super::ExtensionRequest {
             containing_type: self.containing_type.to_string(),
             extension_number: self.extension_number,
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -590,7 +580,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionRequestView<'a> {
                 += 1u64
                     + ::buffa::types::int32_encoded_len(self.extension_number) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -607,7 +596,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionRequestView<'a> {
         if self.extension_number != 0i32 {
             ::buffa::types::put_int32_field(2u32, self.extension_number, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -788,7 +776,6 @@ pub struct ServerReflectionResponseView<'a> {
             'a,
         >,
     >,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
     type Owned = super::super::ServerReflectionResponse;
@@ -812,7 +799,7 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -974,8 +961,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -1055,7 +1040,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
                 }
                 ::core::option::Option::None => ::core::option::Option::None,
             },
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -1121,7 +1105,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionResponseView<'a> {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -1187,7 +1170,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionResponseView<'a> {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -1403,7 +1385,6 @@ pub struct FileDescriptorResponseView<'a> {
     ///
     /// Field 1: `file_descriptor_proto`
     pub file_descriptor_proto: ::buffa::RepeatedView<'a, &'a [u8]>,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
     type Owned = super::super::FileDescriptorResponse;
@@ -1427,7 +1408,7 @@ impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -1448,8 +1429,6 @@ impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -1479,7 +1458,6 @@ impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
                 .iter()
                 .map(|b| (b).to_vec())
                 .collect(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -1493,7 +1471,6 @@ impl<'a> ::buffa::ViewEncode<'a> for FileDescriptorResponseView<'a> {
         for v in &self.file_descriptor_proto {
             size += 1u64 + ::buffa::types::bytes_encoded_len(v) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -1507,7 +1484,6 @@ impl<'a> ::buffa::ViewEncode<'a> for FileDescriptorResponseView<'a> {
         for v in &self.file_descriptor_proto {
             ::buffa::types::put_shared_bytes_field(1u32, v, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -1681,7 +1657,6 @@ pub struct ExtensionNumberResponseView<'a> {
     pub base_type_name: &'a str,
     /// Field 2: `extension_number`
     pub extension_number: ::buffa::RepeatedView<'a, i32>,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
     type Owned = super::super::ExtensionNumberResponse;
@@ -1705,7 +1680,7 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -1741,8 +1716,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -1769,7 +1742,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
         ::core::result::Result::Ok(super::super::ExtensionNumberResponse {
             base_type_name: self.base_type_name.to_string(),
             extension_number: self.extension_number.to_vec(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -1793,7 +1765,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionNumberResponseView<'a> {
                 .sum::<u64>();
             size += 1u64 + ::buffa::encoding::varint_len(payload) as u64 + payload;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -1818,7 +1789,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionNumberResponseView<'a> {
                 ::buffa::types::encode_int32(v, buf);
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -1999,7 +1969,6 @@ pub struct ListServiceResponseView<'a> {
         'a,
         super::super::__buffa::view::ServiceResponseView<'a>,
     >,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
     type Owned = super::super::ListServiceResponse;
@@ -2023,7 +1992,7 @@ impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -2053,8 +2022,6 @@ impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -2084,7 +2051,6 @@ impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
                 .iter()
                 .map(|v| v.to_owned_from_source(__buffa_src))
                 .collect::<::core::result::Result<_, ::buffa::DecodeError>>()?,
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -2103,7 +2069,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ListServiceResponseView<'a> {
                 += 1u64 + ::buffa::encoding::varint_len(inner_size as u64) as u64
                     + inner_size as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -2122,7 +2087,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ListServiceResponseView<'a> {
             );
             v.write_to(__cache, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -2294,7 +2258,6 @@ pub struct ServiceResponseView<'a> {
     ///
     /// Field 1: `name`
     pub name: &'a str,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
     type Owned = super::super::ServiceResponse;
@@ -2318,7 +2281,7 @@ impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -2335,8 +2298,6 @@ impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -2356,7 +2317,6 @@ impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
         let _ = __buffa_src;
         ::core::result::Result::Ok(super::super::ServiceResponse {
             name: self.name.to_string(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -2370,7 +2330,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServiceResponseView<'a> {
         if !self.name.is_empty() {
             size += 1u64 + ::buffa::types::string_encoded_len(&self.name) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -2384,7 +2343,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServiceResponseView<'a> {
         if !self.name.is_empty() {
             ::buffa::types::put_string_field(1u32, &self.name, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -2549,7 +2507,6 @@ pub struct ErrorResponseView<'a> {
     pub error_code: i32,
     /// Field 2: `error_message`
     pub error_message: &'a str,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
     type Owned = super::super::ErrorResponse;
@@ -2573,7 +2530,7 @@ impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -2597,8 +2554,6 @@ impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -2619,7 +2574,6 @@ impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
         ::core::result::Result::Ok(super::super::ErrorResponse {
             error_code: self.error_code,
             error_message: self.error_message.to_string(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -2637,7 +2591,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ErrorResponseView<'a> {
             size
                 += 1u64 + ::buffa::types::string_encoded_len(&self.error_message) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -2654,7 +2607,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ErrorResponseView<'a> {
         if !self.error_message.is_empty() {
             ::buffa::types::put_string_field(2u32, &self.error_message, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.

--- a/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1.reflection.rs
+++ b/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1.reflection.rs
@@ -17,9 +17,6 @@ pub struct ServerReflectionRequest {
     pub message_request: ::core::option::Option<
         __buffa::oneof::server_reflection_request::MessageRequest,
     >,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ServerReflectionRequest {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -93,7 +90,6 @@ impl ::buffa::Message for ServerReflectionRequest {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -140,7 +136,6 @@ impl ::buffa::Message for ServerReflectionRequest {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -227,8 +222,7 @@ impl ::buffa::Message for ServerReflectionRequest {
                 );
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -236,16 +230,6 @@ impl ::buffa::Message for ServerReflectionRequest {
     fn clear(&mut self) {
         self.host.clear();
         self.message_request = ::core::option::Option::None;
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ServerReflectionRequest {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.ServerReflectionRequest";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl<'de> ::serde::Deserialize<'de> for ServerReflectionRequest {
@@ -489,9 +473,6 @@ pub struct ExtensionRequest {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_zero_i32"
     )]
     pub extension_number: i32,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ExtensionRequest {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -538,7 +519,6 @@ impl ::buffa::Message for ExtensionRequest {
                 += 1u64
                     + ::buffa::types::int32_encoded_len(self.extension_number) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -554,7 +534,6 @@ impl ::buffa::Message for ExtensionRequest {
         if self.extension_number != 0i32 {
             ::buffa::types::put_int32_field(2u32, self.extension_number, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -582,8 +561,7 @@ impl ::buffa::Message for ExtensionRequest {
                 self.extension_number = ::buffa::types::decode_int32(buf)?;
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -591,16 +569,6 @@ impl ::buffa::Message for ExtensionRequest {
     fn clear(&mut self) {
         self.containing_type.clear();
         self.extension_number = 0i32;
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ExtensionRequest {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.ExtensionRequest";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ExtensionRequest {
@@ -650,9 +618,6 @@ pub struct ServerReflectionResponse {
     pub message_response: ::core::option::Option<
         __buffa::oneof::server_reflection_response::MessageResponse,
     >,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ServerReflectionResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -745,7 +710,6 @@ impl ::buffa::Message for ServerReflectionResponse {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -810,7 +774,6 @@ impl ::buffa::Message for ServerReflectionResponse {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -930,8 +893,7 @@ impl ::buffa::Message for ServerReflectionResponse {
                 }
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -940,16 +902,6 @@ impl ::buffa::Message for ServerReflectionResponse {
         self.valid_host.clear();
         self.original_request = ::buffa::MessageField::none();
         self.message_response = ::core::option::Option::None;
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ServerReflectionResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.ServerReflectionResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl<'de> ::serde::Deserialize<'de> for ServerReflectionResponse {
@@ -1176,9 +1128,6 @@ pub struct FileDescriptorResponse {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_empty_vec"
     )]
     pub file_descriptor_proto: ::buffa::alloc::vec::Vec<::buffa::alloc::vec::Vec<u8>>,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for FileDescriptorResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1217,7 +1166,6 @@ impl ::buffa::Message for FileDescriptorResponse {
         for v in &self.file_descriptor_proto {
             size += 1u64 + ::buffa::types::bytes_encoded_len(v) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1230,7 +1178,6 @@ impl ::buffa::Message for FileDescriptorResponse {
         for v in &self.file_descriptor_proto {
             ::buffa::types::put_shared_bytes_field(1u32, v, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1255,24 +1202,13 @@ impl ::buffa::Message for FileDescriptorResponse {
                 self.file_descriptor_proto.push(__elem);
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.file_descriptor_proto.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for FileDescriptorResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.FileDescriptorResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for FileDescriptorResponse {
@@ -1320,9 +1256,6 @@ pub struct ExtensionNumberResponse {
         deserialize_with = "::buffa::json_helpers::null_as_default"
     )]
     pub extension_number: ::buffa::alloc::vec::Vec<i32>,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ExtensionNumberResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1372,7 +1305,6 @@ impl ::buffa::Message for ExtensionNumberResponse {
                 .sum::<u64>();
             size += 1u64 + ::buffa::encoding::varint_len(payload) as u64 + payload;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1396,7 +1328,6 @@ impl ::buffa::Message for ExtensionNumberResponse {
                 ::buffa::types::encode_int32(v, buf);
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1457,8 +1388,7 @@ impl ::buffa::Message for ExtensionNumberResponse {
                 }
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -1466,16 +1396,6 @@ impl ::buffa::Message for ExtensionNumberResponse {
     fn clear(&mut self) {
         self.base_type_name.clear();
         self.extension_number.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ExtensionNumberResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.ExtensionNumberResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ExtensionNumberResponse {
@@ -1513,9 +1433,6 @@ pub struct ListServiceResponse {
         deserialize_with = "::buffa::json_helpers::null_as_default"
     )]
     pub service: ::buffa::alloc::vec::Vec<ServiceResponse>,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ListServiceResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1557,7 +1474,6 @@ impl ::buffa::Message for ListServiceResponse {
                 += 1u64 + ::buffa::encoding::varint_len(inner_size as u64) as u64
                     + inner_size as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1575,7 +1491,6 @@ impl ::buffa::Message for ListServiceResponse {
             );
             v.write_to(__cache, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1601,24 +1516,13 @@ impl ::buffa::Message for ListServiceResponse {
                 self.service.push(elem);
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.service.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ListServiceResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.ListServiceResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ListServiceResponse {
@@ -1657,9 +1561,6 @@ pub struct ServiceResponse {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_empty_str"
     )]
     pub name: ::buffa::alloc::string::String,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ServiceResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1696,7 +1597,6 @@ impl ::buffa::Message for ServiceResponse {
         if !self.name.is_empty() {
             size += 1u64 + ::buffa::types::string_encoded_len(&self.name) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1709,7 +1609,6 @@ impl ::buffa::Message for ServiceResponse {
         if !self.name.is_empty() {
             ::buffa::types::put_string_field(1u32, &self.name, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1730,24 +1629,13 @@ impl ::buffa::Message for ServiceResponse {
                 ::buffa::types::merge_string(&mut self.name, buf)?;
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.name.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ServiceResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.ServiceResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ServiceResponse {
@@ -1793,9 +1681,6 @@ pub struct ErrorResponse {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_empty_str"
     )]
     pub error_message: ::buffa::alloc::string::String,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ErrorResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1839,7 +1724,6 @@ impl ::buffa::Message for ErrorResponse {
             size
                 += 1u64 + ::buffa::types::string_encoded_len(&self.error_message) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1855,7 +1739,6 @@ impl ::buffa::Message for ErrorResponse {
         if !self.error_message.is_empty() {
             ::buffa::types::put_string_field(2u32, &self.error_message, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1883,8 +1766,7 @@ impl ::buffa::Message for ErrorResponse {
                 ::buffa::types::merge_string(&mut self.error_message, buf)?;
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -1892,16 +1774,6 @@ impl ::buffa::Message for ErrorResponse {
     fn clear(&mut self) {
         self.error_code = 0i32;
         self.error_message.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ErrorResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1.ErrorResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ErrorResponse {

--- a/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1alpha.reflection.__view.rs
+++ b/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1alpha.reflection.__view.rs
@@ -9,7 +9,6 @@ pub struct ServerReflectionRequestView<'a> {
     pub message_request: ::core::option::Option<
         super::super::__buffa::view::oneof::server_reflection_request::MessageRequest<'a>,
     >,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
     type Owned = super::super::ServerReflectionRequest;
@@ -33,7 +32,7 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -125,8 +124,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -198,7 +195,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionRequestView<'a> {
                 }
                 ::core::option::Option::None => ::core::option::Option::None,
             },
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -246,7 +242,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionRequestView<'a> {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -294,7 +289,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionRequestView<'a> {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -499,7 +493,6 @@ pub struct ExtensionRequestView<'a> {
     pub containing_type: &'a str,
     /// Field 2: `extension_number`
     pub extension_number: i32,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
     type Owned = super::super::ExtensionRequest;
@@ -523,7 +516,7 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -547,8 +540,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -569,7 +560,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionRequestView<'a> {
         ::core::result::Result::Ok(super::super::ExtensionRequest {
             containing_type: self.containing_type.to_string(),
             extension_number: self.extension_number,
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -590,7 +580,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionRequestView<'a> {
                 += 1u64
                     + ::buffa::types::int32_encoded_len(self.extension_number) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -607,7 +596,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionRequestView<'a> {
         if self.extension_number != 0i32 {
             ::buffa::types::put_int32_field(2u32, self.extension_number, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -788,7 +776,6 @@ pub struct ServerReflectionResponseView<'a> {
             'a,
         >,
     >,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
     type Owned = super::super::ServerReflectionResponse;
@@ -812,7 +799,7 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -974,8 +961,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -1055,7 +1040,6 @@ impl<'a> ::buffa::MessageView<'a> for ServerReflectionResponseView<'a> {
                 }
                 ::core::option::Option::None => ::core::option::Option::None,
             },
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -1121,7 +1105,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionResponseView<'a> {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -1187,7 +1170,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServerReflectionResponseView<'a> {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -1403,7 +1385,6 @@ pub struct FileDescriptorResponseView<'a> {
     ///
     /// Field 1: `file_descriptor_proto`
     pub file_descriptor_proto: ::buffa::RepeatedView<'a, &'a [u8]>,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
     type Owned = super::super::FileDescriptorResponse;
@@ -1427,7 +1408,7 @@ impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -1448,8 +1429,6 @@ impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -1479,7 +1458,6 @@ impl<'a> ::buffa::MessageView<'a> for FileDescriptorResponseView<'a> {
                 .iter()
                 .map(|b| (b).to_vec())
                 .collect(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -1493,7 +1471,6 @@ impl<'a> ::buffa::ViewEncode<'a> for FileDescriptorResponseView<'a> {
         for v in &self.file_descriptor_proto {
             size += 1u64 + ::buffa::types::bytes_encoded_len(v) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -1507,7 +1484,6 @@ impl<'a> ::buffa::ViewEncode<'a> for FileDescriptorResponseView<'a> {
         for v in &self.file_descriptor_proto {
             ::buffa::types::put_shared_bytes_field(1u32, v, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -1681,7 +1657,6 @@ pub struct ExtensionNumberResponseView<'a> {
     pub base_type_name: &'a str,
     /// Field 2: `extension_number`
     pub extension_number: ::buffa::RepeatedView<'a, i32>,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
     type Owned = super::super::ExtensionNumberResponse;
@@ -1705,7 +1680,7 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -1741,8 +1716,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -1769,7 +1742,6 @@ impl<'a> ::buffa::MessageView<'a> for ExtensionNumberResponseView<'a> {
         ::core::result::Result::Ok(super::super::ExtensionNumberResponse {
             base_type_name: self.base_type_name.to_string(),
             extension_number: self.extension_number.to_vec(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -1793,7 +1765,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionNumberResponseView<'a> {
                 .sum::<u64>();
             size += 1u64 + ::buffa::encoding::varint_len(payload) as u64 + payload;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -1818,7 +1789,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ExtensionNumberResponseView<'a> {
                 ::buffa::types::encode_int32(v, buf);
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -1999,7 +1969,6 @@ pub struct ListServiceResponseView<'a> {
         'a,
         super::super::__buffa::view::ServiceResponseView<'a>,
     >,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
     type Owned = super::super::ListServiceResponse;
@@ -2023,7 +1992,7 @@ impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -2053,8 +2022,6 @@ impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -2084,7 +2051,6 @@ impl<'a> ::buffa::MessageView<'a> for ListServiceResponseView<'a> {
                 .iter()
                 .map(|v| v.to_owned_from_source(__buffa_src))
                 .collect::<::core::result::Result<_, ::buffa::DecodeError>>()?,
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -2103,7 +2069,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ListServiceResponseView<'a> {
                 += 1u64 + ::buffa::encoding::varint_len(inner_size as u64) as u64
                     + inner_size as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -2122,7 +2087,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ListServiceResponseView<'a> {
             );
             v.write_to(__cache, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -2294,7 +2258,6 @@ pub struct ServiceResponseView<'a> {
     ///
     /// Field 1: `name`
     pub name: &'a str,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
     type Owned = super::super::ServiceResponse;
@@ -2318,7 +2281,7 @@ impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -2335,8 +2298,6 @@ impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -2356,7 +2317,6 @@ impl<'a> ::buffa::MessageView<'a> for ServiceResponseView<'a> {
         let _ = __buffa_src;
         ::core::result::Result::Ok(super::super::ServiceResponse {
             name: self.name.to_string(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -2370,7 +2330,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServiceResponseView<'a> {
         if !self.name.is_empty() {
             size += 1u64 + ::buffa::types::string_encoded_len(&self.name) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -2384,7 +2343,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ServiceResponseView<'a> {
         if !self.name.is_empty() {
             ::buffa::types::put_string_field(1u32, &self.name, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.
@@ -2549,7 +2507,6 @@ pub struct ErrorResponseView<'a> {
     pub error_code: i32,
     /// Field 2: `error_message`
     pub error_message: &'a str,
-    pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
 }
 impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
     type Owned = super::super::ErrorResponse;
@@ -2573,7 +2530,7 @@ impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
         &mut self,
         tag: ::buffa::encoding::Tag,
         cur: &'a [u8],
-        before_tag: &'a [u8],
+        _before_tag: &'a [u8],
         ctx: ::buffa::DecodeContext<'_>,
     ) -> ::core::result::Result<&'a [u8], ::buffa::DecodeError> {
         let _ = ctx;
@@ -2597,8 +2554,6 @@ impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
             }
             _ => {
                 ::buffa::encoding::skip_field_depth(tag, &mut cur, ctx.depth())?;
-                let span_len = before_tag.len() - cur.len();
-                view.__buffa_unknown_fields.push_record(before_tag, span_len, ctx)?;
             }
         }
         ::core::result::Result::Ok(cur)
@@ -2619,7 +2574,6 @@ impl<'a> ::buffa::MessageView<'a> for ErrorResponseView<'a> {
         ::core::result::Result::Ok(super::super::ErrorResponse {
             error_code: self.error_code,
             error_message: self.error_message.to_string(),
-            __buffa_unknown_fields: self.__buffa_unknown_fields.to_owned()?.into(),
             ..::core::default::Default::default()
         })
     }
@@ -2637,7 +2591,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ErrorResponseView<'a> {
             size
                 += 1u64 + ::buffa::types::string_encoded_len(&self.error_message) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     #[allow(clippy::needless_borrow)]
@@ -2654,7 +2607,6 @@ impl<'a> ::buffa::ViewEncode<'a> for ErrorResponseView<'a> {
         if !self.error_message.is_empty() {
             ::buffa::types::put_string_field(2u32, &self.error_message, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
 }
 /// Serializes this view as protobuf JSON.

--- a/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1alpha.reflection.rs
+++ b/connectrpc-reflection/src/generated/buffa/grpc.reflection.v1alpha.reflection.rs
@@ -17,9 +17,6 @@ pub struct ServerReflectionRequest {
     pub message_request: ::core::option::Option<
         __buffa::oneof::server_reflection_request::MessageRequest,
     >,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ServerReflectionRequest {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -93,7 +90,6 @@ impl ::buffa::Message for ServerReflectionRequest {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -140,7 +136,6 @@ impl ::buffa::Message for ServerReflectionRequest {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -227,8 +222,7 @@ impl ::buffa::Message for ServerReflectionRequest {
                 );
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -236,16 +230,6 @@ impl ::buffa::Message for ServerReflectionRequest {
     fn clear(&mut self) {
         self.host.clear();
         self.message_request = ::core::option::Option::None;
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ServerReflectionRequest {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.ServerReflectionRequest";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl<'de> ::serde::Deserialize<'de> for ServerReflectionRequest {
@@ -489,9 +473,6 @@ pub struct ExtensionRequest {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_zero_i32"
     )]
     pub extension_number: i32,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ExtensionRequest {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -538,7 +519,6 @@ impl ::buffa::Message for ExtensionRequest {
                 += 1u64
                     + ::buffa::types::int32_encoded_len(self.extension_number) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -554,7 +534,6 @@ impl ::buffa::Message for ExtensionRequest {
         if self.extension_number != 0i32 {
             ::buffa::types::put_int32_field(2u32, self.extension_number, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -582,8 +561,7 @@ impl ::buffa::Message for ExtensionRequest {
                 self.extension_number = ::buffa::types::decode_int32(buf)?;
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -591,16 +569,6 @@ impl ::buffa::Message for ExtensionRequest {
     fn clear(&mut self) {
         self.containing_type.clear();
         self.extension_number = 0i32;
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ExtensionRequest {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.ExtensionRequest";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ExtensionRequest {
@@ -650,9 +618,6 @@ pub struct ServerReflectionResponse {
     pub message_response: ::core::option::Option<
         __buffa::oneof::server_reflection_response::MessageResponse,
     >,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ServerReflectionResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -745,7 +710,6 @@ impl ::buffa::Message for ServerReflectionResponse {
                 }
             }
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -810,7 +774,6 @@ impl ::buffa::Message for ServerReflectionResponse {
                 }
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -930,8 +893,7 @@ impl ::buffa::Message for ServerReflectionResponse {
                 }
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -940,16 +902,6 @@ impl ::buffa::Message for ServerReflectionResponse {
         self.valid_host.clear();
         self.original_request = ::buffa::MessageField::none();
         self.message_response = ::core::option::Option::None;
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ServerReflectionResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.ServerReflectionResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl<'de> ::serde::Deserialize<'de> for ServerReflectionResponse {
@@ -1176,9 +1128,6 @@ pub struct FileDescriptorResponse {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_empty_vec"
     )]
     pub file_descriptor_proto: ::buffa::alloc::vec::Vec<::buffa::alloc::vec::Vec<u8>>,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for FileDescriptorResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1217,7 +1166,6 @@ impl ::buffa::Message for FileDescriptorResponse {
         for v in &self.file_descriptor_proto {
             size += 1u64 + ::buffa::types::bytes_encoded_len(v) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1230,7 +1178,6 @@ impl ::buffa::Message for FileDescriptorResponse {
         for v in &self.file_descriptor_proto {
             ::buffa::types::put_shared_bytes_field(1u32, v, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1255,24 +1202,13 @@ impl ::buffa::Message for FileDescriptorResponse {
                 self.file_descriptor_proto.push(__elem);
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.file_descriptor_proto.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for FileDescriptorResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.FileDescriptorResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for FileDescriptorResponse {
@@ -1320,9 +1256,6 @@ pub struct ExtensionNumberResponse {
         deserialize_with = "::buffa::json_helpers::null_as_default"
     )]
     pub extension_number: ::buffa::alloc::vec::Vec<i32>,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ExtensionNumberResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1372,7 +1305,6 @@ impl ::buffa::Message for ExtensionNumberResponse {
                 .sum::<u64>();
             size += 1u64 + ::buffa::encoding::varint_len(payload) as u64 + payload;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1396,7 +1328,6 @@ impl ::buffa::Message for ExtensionNumberResponse {
                 ::buffa::types::encode_int32(v, buf);
             }
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1457,8 +1388,7 @@ impl ::buffa::Message for ExtensionNumberResponse {
                 }
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -1466,16 +1396,6 @@ impl ::buffa::Message for ExtensionNumberResponse {
     fn clear(&mut self) {
         self.base_type_name.clear();
         self.extension_number.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ExtensionNumberResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.ExtensionNumberResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ExtensionNumberResponse {
@@ -1513,9 +1433,6 @@ pub struct ListServiceResponse {
         deserialize_with = "::buffa::json_helpers::null_as_default"
     )]
     pub service: ::buffa::alloc::vec::Vec<ServiceResponse>,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ListServiceResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1557,7 +1474,6 @@ impl ::buffa::Message for ListServiceResponse {
                 += 1u64 + ::buffa::encoding::varint_len(inner_size as u64) as u64
                     + inner_size as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1575,7 +1491,6 @@ impl ::buffa::Message for ListServiceResponse {
             );
             v.write_to(__cache, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1601,24 +1516,13 @@ impl ::buffa::Message for ListServiceResponse {
                 self.service.push(elem);
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.service.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ListServiceResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.ListServiceResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ListServiceResponse {
@@ -1657,9 +1561,6 @@ pub struct ServiceResponse {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_empty_str"
     )]
     pub name: ::buffa::alloc::string::String,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ServiceResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1696,7 +1597,6 @@ impl ::buffa::Message for ServiceResponse {
         if !self.name.is_empty() {
             size += 1u64 + ::buffa::types::string_encoded_len(&self.name) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1709,7 +1609,6 @@ impl ::buffa::Message for ServiceResponse {
         if !self.name.is_empty() {
             ::buffa::types::put_string_field(1u32, &self.name, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1730,24 +1629,13 @@ impl ::buffa::Message for ServiceResponse {
                 ::buffa::types::merge_string(&mut self.name, buf)?;
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
         self.name.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ServiceResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.ServiceResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ServiceResponse {
@@ -1793,9 +1681,6 @@ pub struct ErrorResponse {
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_empty_str"
     )]
     pub error_message: ::buffa::alloc::string::String,
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
 }
 impl ::core::fmt::Debug for ErrorResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1839,7 +1724,6 @@ impl ::buffa::Message for ErrorResponse {
             size
                 += 1u64 + ::buffa::types::string_encoded_len(&self.error_message) as u64;
         }
-        size += self.__buffa_unknown_fields.encoded_len() as u64;
         ::buffa::saturate_size(size)
     }
     fn write_to(
@@ -1855,7 +1739,6 @@ impl ::buffa::Message for ErrorResponse {
         if !self.error_message.is_empty() {
             ::buffa::types::put_string_field(2u32, &self.error_message, buf);
         }
-        self.__buffa_unknown_fields.write_to(buf);
     }
     fn merge_field(
         &mut self,
@@ -1883,8 +1766,7 @@ impl ::buffa::Message for ErrorResponse {
                 ::buffa::types::merge_string(&mut self.error_message, buf)?;
             }
             _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, ctx)?);
+                ::buffa::encoding::skip_field_depth(tag, buf, ctx.depth())?;
             }
         }
         ::core::result::Result::Ok(())
@@ -1892,16 +1774,6 @@ impl ::buffa::Message for ErrorResponse {
     fn clear(&mut self) {
         self.error_code = 0i32;
         self.error_message.clear();
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for ErrorResponse {
-    const PROTO_FQN: &'static str = "grpc.reflection.v1alpha.ErrorResponse";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for ErrorResponse {

--- a/connectrpc-reflection/src/lib.rs
+++ b/connectrpc-reflection/src/lib.rs
@@ -48,7 +48,7 @@
 //! The bytes path needs only `emit_descriptor_set` — reflection codegen
 //! is **not** required — and answers with the compiler's original
 //! per-file descriptor bytes; the pool path re-encodes (semantically
-//! faithful, unknown fields preserved). See [`Reflector`] for the
+//! faithful — buffa's descriptor types preserve unknown fields). See [`Reflector`] for the
 //! trade-off.
 //!
 //! # Request limits
@@ -187,6 +187,14 @@ pub use connect::grpc::reflection::v1::ServerReflectionClient;
 /// constants. Everything a downstream crate needs to drive
 /// `ServerReflectionClient` (gated on the `client` feature) or inspect
 /// responses without regenerating the protos.
+///
+/// These messages do **not** retain unknown fields: anything on the wire
+/// that this crate's copy of `reflection.proto` does not define is skipped
+/// on decode and absent on re-encode — including from the `original_request`
+/// the service echoes back. The reflection service itself never reads
+/// unknown fields, so its generated types omit the bookkeeping for them.
+/// Descriptor payloads (`FileDescriptorResponse.file_descriptor_proto`) are
+/// opaque bytes and are unaffected.
 pub mod wire {
     /// `grpc.reflection.v1` wire types.
     pub mod v1 {

--- a/connectrpc-reflection/src/reflector.rs
+++ b/connectrpc-reflection/src/reflector.rs
@@ -17,9 +17,9 @@
 //!   ([`from_descriptor_pool`](Reflector::from_descriptor_pool)), e.g. the
 //!   `descriptor_pool()` a buffa-generated package exposes when reflection
 //!   is enabled. Responses re-encode the pool's parsed
-//!   `FileDescriptorProto`s; buffa retains unknown fields, so the bytes
-//!   are semantically faithful but not guaranteed byte-identical to the
-//!   compiler's output.
+//!   `FileDescriptorProto`s; buffa's descriptor types retain unknown
+//!   fields, so the bytes are semantically faithful but not guaranteed
+//!   byte-identical to the compiler's output.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -205,9 +205,10 @@ impl Reflector {
     /// spans the whole codegen run.
     ///
     /// Response payloads are re-encoded from the pool's parsed
-    /// `FileDescriptorProto`s. buffa preserves unknown fields, so the
-    /// bytes are semantically faithful to the compiler's output but not
-    /// guaranteed byte-identical (field ordering is canonicalized). For
+    /// `FileDescriptorProto`s. buffa's descriptor types preserve unknown
+    /// fields, so the bytes are semantically faithful to the compiler's
+    /// output but not guaranteed byte-identical (field ordering is
+    /// canonicalized). For
     /// byte-exact responses, build from
     /// [`from_descriptor_set_bytes`](Self::from_descriptor_set_bytes).
     ///

--- a/connectrpc-reflection/src/service.rs
+++ b/connectrpc-reflection/src/service.rs
@@ -191,32 +191,25 @@ macro_rules! impl_server_reflection {
                 Answer::Files(file_descriptor_proto) => {
                     MessageResponse::from(pb::FileDescriptorResponse {
                         file_descriptor_proto,
-                        ..Default::default()
                     })
                 }
                 Answer::ExtensionNumbers { base_type, numbers } => {
                     MessageResponse::from(pb::ExtensionNumberResponse {
                         base_type_name: base_type,
                         extension_number: numbers,
-                        ..Default::default()
                     })
                 }
                 Answer::Services(names) => MessageResponse::from(pb::ListServiceResponse {
                     service: names
                         .into_iter()
-                        .map(|name| pb::ServiceResponse {
-                            name,
-                            ..Default::default()
-                        })
+                        .map(|name| pb::ServiceResponse { name })
                         .collect(),
-                    ..Default::default()
                 }),
                 Answer::NotFound(message) => MessageResponse::from(pb::ErrorResponse {
                     // tonic and grpc-go use the gRPC status code numbering
                     // here; 5 is NOT_FOUND.
                     error_code: 5,
                     error_message: message,
-                    ..Default::default()
                 }),
             };
 
@@ -224,7 +217,6 @@ macro_rules! impl_server_reflection {
                 valid_host: request.host.clone(),
                 original_request: ::buffa::MessageField::some(request),
                 message_response: Some(message_response),
-                ..Default::default()
             })
         }
     };
@@ -300,7 +292,6 @@ mod tests {
         ServerReflectionRequest {
             host: "test-host".into(),
             message_request: Some(message_request),
-            ..Default::default()
         }
     }
 
@@ -342,6 +333,31 @@ mod tests {
         stream.close_send();
         let err = stream.message().await.unwrap_err();
         assert_eq!(err.code, connectrpc::ErrorCode::ResourceExhausted);
+    }
+
+    /// The wire types are generated with `unknown_fields=false`: an
+    /// unrecognized field is accepted and skipped on both decode paths, so
+    /// the request the service echoes as `original_request` re-encodes
+    /// without it. Guards against a regeneration silently dropping the
+    /// option.
+    #[test]
+    fn unknown_fields_are_skipped_not_echoed() {
+        use buffa::view::MessageView;
+
+        use crate::proto::grpc::reflection::v1::ServerReflectionRequestView;
+
+        let known = request(MessageRequest::ListServices(String::new())).encode_to_vec();
+        let mut with_unknown = known.clone();
+        // Field 15, varint 0 — not defined by `ServerReflectionRequest`.
+        with_unknown.extend_from_slice(&[0x78, 0x00]);
+
+        let owned = ServerReflectionRequest::decode_from_slice(&with_unknown).unwrap();
+        assert_eq!(owned.host, "test-host");
+        assert_eq!(owned.encode_to_vec(), known);
+
+        // The server decodes a view and echoes `to_owned_message()`.
+        let view = ServerReflectionRequestView::decode_view(&with_unknown).unwrap();
+        assert_eq!(view.to_owned_message().unwrap().encode_to_vec(), known);
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Breaking for the two crates' re-exported `wire` types; 0.10 only.**

Neither the health service nor the reflection service reads or acts on a field its copy of `health.proto` / `reflection.proto` does not define, yet both crates' generated messages retained unknown fields: every unrecognised field on the wire was recorded (a bounded but per-field allocation), carried through `to_owned_message()`, and in reflection's case re-encoded into the `original_request` echo. This regenerates both crates with buffa's `unknown_fields=false`, so an unrecognised field is skipped during decode (still depth-limited, no allocation) and is absent from anything these types re-encode. Code generated for user services is unchanged; reflection's descriptor payloads are opaque bytes and unaffected.

What breaks: the `__buffa_unknown_fields` field and the `buffa::ExtensionSet` impl are gone from every message in both crates, so naming either is a compile error. Struct literals such as `HealthCheckRequest { service, ..Default::default() }` still compile, but every field is now named, so `clippy::needless_update` fires on the tail. A message decoded and re-encoded through these types no longer round-trips fields from a newer revision of the protocol; grpc-go's `original_request` echo does round-trip them, which the reflection docs now note.

Regeneration against the v0.9.1 buffa plugins is a no-op on this branch. Keep as draft until the 0.10 window opens.
