### PR TITLE
perf: trim per-request allocations on the unary paths

### DIFF
--- a/.changes/unreleased/Added-20260906-162100.yaml
+++ b/.changes/unreleased/Added-20260906-162100.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: |-
+    `Envelope::decode_from_bytes_with_limit` unframes an envelope from a
+    collected `Bytes` body without first copying it into a `BytesMut`, and
+    `CompressionRegistry::accept_encoding_value` exposes the registry's
+    supported-encodings list as a ready-made `HeaderValue`.
+time: 2026-09-06T16:21:00.000000000+00:00

--- a/.changes/unreleased/Changed-20260906-155000.yaml
+++ b/.changes/unreleased/Changed-20260906-155000.yaml
@@ -1,0 +1,11 @@
+kind: Changed
+body: |-
+    **Fewer allocations per request.** A unary gRPC request is unframed out of
+    the collected body by reference count instead of being copied first (one
+    fewer full copy of every request body), the request's header map is moved
+    into the handler's `RequestContext` rather than cloned, and the
+    `content-type`, encoding, `te` and protocol-version header values on server
+    responses and client requests are static values, with the accept-encoding
+    value built once per `CompressionRegistry` and shared. Together this is
+    nine fewer heap allocations per small unary gRPC call on the server.
+time: 2026-09-06T15:50:00.000000000+00:00

--- a/.changes/unreleased/Changed-20260906-162000.yaml
+++ b/.changes/unreleased/Changed-20260906-162000.yaml
@@ -1,0 +1,10 @@
+kind: Changed
+body: |-
+    `CompressionRegistry::register` now panics when the provider's `name()` is
+    not an RFC 9110 token (empty, or containing anything outside
+    ``A-Za-z0-9!#$%&'*+-.^_`|~``). Only custom `CompressionProvider`
+    implementations can be affected; the built-in providers are unchanged. Such
+    a name could never be carried in `content-encoding` / `accept-encoding`, so
+    it previously produced failed responses at request time instead. If a
+    provider name is computed, validate it before building the registry.
+time: 2026-09-06T16:20:00.000000000+00:00

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ use bytes::Bytes;
 struct MyCompression;
 
 impl CompressionProvider for MyCompression {
-    fn name(&self) -> &'static str { "my-algo" }
+    fn name(&self) -> &'static str { "my-algo" } // an HTTP token; `register` panics otherwise
     fn compress(&self, data: &[u8]) -> Result<Bytes, ConnectError> { /* ... */ }
     fn decompressor<'a>(&self, data: &'a [u8]) -> Result<Box<dyn std::io::Read + 'a>, ConnectError> {
         // Return a reader that yields decompressed bytes. The framework

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2050,9 +2050,8 @@ where
         );
     }
     // Accept-Encoding so the server can compress the response.
-    let accept = config.compression.accept_encoding_header();
-    if !accept.is_empty() {
-        builder = builder.header(http::header::ACCEPT_ENCODING, accept);
+    if let Some(accept) = config.compression.accept_encoding_value() {
+        builder = builder.header(http::header::ACCEPT_ENCODING, accept.clone());
     }
 
     // Merge user-provided headers
@@ -4739,39 +4738,39 @@ fn add_unary_request_headers(
 ) -> http::request::Builder {
     builder = builder.header(
         http::header::CONTENT_TYPE,
-        unary_request_content_type(config),
+        http::HeaderValue::from_static(unary_request_content_type(config)),
     );
 
     match config.protocol {
         Protocol::Connect => {
-            builder = builder.header(connect_header::PROTOCOL_VERSION, "1");
+            builder = builder.header(
+                connect_header::PROTOCOL_VERSION,
+                http::HeaderValue::from_static("1"),
+            );
             // Connect unary uses standard content-encoding / accept-encoding.
             // Only set Content-Encoding if compression was actually applied.
             if let Some(encoding) = applied_content_encoding {
                 builder = builder.header(http::header::CONTENT_ENCODING, encoding);
             }
-            let accept = config.compression.accept_encoding_header();
-            if !accept.is_empty() {
-                builder = builder.header(http::header::ACCEPT_ENCODING, accept);
+            if let Some(accept) = config.compression.accept_encoding_value() {
+                builder = builder.header(http::header::ACCEPT_ENCODING, accept.clone());
             }
         }
         Protocol::Grpc => {
-            builder = builder.header("te", "trailers");
+            builder = builder.header("te", http::HeaderValue::from_static("trailers"));
             if let Some(ref encoding) = config.request_compression {
                 builder = builder.header("grpc-encoding", encoding.as_str());
             }
-            let accept = config.compression.accept_encoding_header();
-            if !accept.is_empty() {
-                builder = builder.header("grpc-accept-encoding", accept);
+            if let Some(accept) = config.compression.accept_encoding_value() {
+                builder = builder.header("grpc-accept-encoding", accept.clone());
             }
         }
         Protocol::GrpcWeb => {
             if let Some(ref encoding) = config.request_compression {
                 builder = builder.header("grpc-encoding", encoding.as_str());
             }
-            let accept = config.compression.accept_encoding_header();
-            if !accept.is_empty() {
-                builder = builder.header("grpc-accept-encoding", accept);
+            if let Some(accept) = config.compression.accept_encoding_value() {
+                builder = builder.header("grpc-accept-encoding", accept.clone());
             }
         }
     }
@@ -4794,15 +4793,18 @@ fn add_streaming_request_headers(
 ) -> http::request::Builder {
     builder = builder.header(
         http::header::CONTENT_TYPE,
-        streaming_request_content_type(config),
+        http::HeaderValue::from_static(streaming_request_content_type(config)),
     );
 
     match config.protocol {
         Protocol::Connect => {
-            builder = builder.header(connect_header::PROTOCOL_VERSION, "1");
+            builder = builder.header(
+                connect_header::PROTOCOL_VERSION,
+                http::HeaderValue::from_static("1"),
+            );
         }
         Protocol::Grpc => {
-            builder = builder.header("te", "trailers");
+            builder = builder.header("te", http::HeaderValue::from_static("trailers"));
         }
         Protocol::GrpcWeb => {}
     }
@@ -4813,9 +4815,8 @@ fn add_streaming_request_headers(
     if let Some(ref encoding) = config.request_compression {
         builder = builder.header(encoding_header, encoding.as_str());
     }
-    let accept = config.compression.accept_encoding_header();
-    if !accept.is_empty() {
-        builder = builder.header(accept_header, accept);
+    if let Some(accept) = config.compression.accept_encoding_value() {
+        builder = builder.header(accept_header, accept.clone());
     }
 
     if let Some(timeout) = timeout {

--- a/connectrpc/src/compression.rs
+++ b/connectrpc/src/compression.rs
@@ -67,6 +67,15 @@ fn malformed_compressed_payload(message: impl Into<String>) -> ConnectError {
     ConnectError::invalid_argument(message)
 }
 
+/// Whether `s` is an RFC 9110 `token`: one or more `tchar`s. Encoding names
+/// have to be tokens to appear in `content-encoding` / `accept-encoding`
+/// headers, and a token is always a valid `HeaderValue`.
+fn is_http_token(s: &str) -> bool {
+    !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&b))
+}
+
 /// Trait for compression algorithm implementations.
 ///
 /// Implement this trait to provide custom compression support. The only
@@ -82,8 +91,10 @@ fn malformed_compressed_payload(message: impl Into<String>) -> ConnectError {
 pub trait CompressionProvider: Send + Sync + 'static {
     /// The encoding name for this algorithm.
     ///
-    /// This should match the value used in Content-Encoding headers
-    /// (e.g., "gzip", "zstd", "br").
+    /// This is the value used in Content-Encoding headers (e.g., "gzip",
+    /// "zstd", "br") and must be an HTTP token: non-empty ASCII without
+    /// whitespace, quotes or separators. [`CompressionRegistry::register`]
+    /// panics on a name that is not one.
     fn name(&self) -> &'static str;
 
     /// Compress the given data.
@@ -146,10 +157,10 @@ pub trait CompressionProvider: Send + Sync + 'static {
 #[derive(Clone)]
 pub struct CompressionRegistry {
     providers: Arc<HashMap<&'static str, Arc<dyn CompressionProvider>>>,
-    /// Cached, sorted, comma-joined list of supported encodings for
-    /// Accept-Encoding headers. Recomputed when providers are registered
-    /// (rather than on every request).
-    accept_encoding: Arc<str>,
+    /// Sorted, comma-joined list of supported encodings as an
+    /// `accept-encoding` header value, rebuilt when providers are registered
+    /// rather than on every request; `None` while no providers are registered.
+    accept_encoding: Option<http::HeaderValue>,
 }
 
 impl std::fmt::Debug for CompressionRegistry {
@@ -168,20 +179,46 @@ impl CompressionRegistry {
     pub fn new() -> Self {
         Self {
             providers: Arc::new(HashMap::new()),
-            accept_encoding: Arc::from(""),
+            accept_encoding: None,
         }
     }
 
-    /// Recompute the cached accept-encoding string from the current provider set.
+    /// Recompute the cached accept-encoding value from the current provider set.
     fn rebuild_accept_encoding(&mut self) {
         let mut encodings: Vec<_> = self.providers.keys().copied().collect();
         encodings.sort_unstable();
-        self.accept_encoding = Arc::from(encodings.join(", "));
+        self.accept_encoding = if encodings.is_empty() {
+            None
+        } else {
+            // `register` only admits token names, so the joined list is always
+            // a valid header value.
+            http::HeaderValue::from_str(&encodings.join(", ")).ok()
+        };
+    }
+
+    /// The supported encodings as a ready-made `accept-encoding` /
+    /// `grpc-accept-encoding` header value (sorted, comma-separated), or
+    /// `None` when no providers are registered. Built once when providers
+    /// are registered, so attaching it to a request costs no allocation.
+    #[must_use]
+    pub fn accept_encoding_value(&self) -> Option<&http::HeaderValue> {
+        self.accept_encoding.as_ref()
     }
 
     /// Register a compression provider.
     ///
-    /// Returns self for method chaining.
+    /// Returns self for method chaining. Registering a provider whose
+    /// `name()` matches an existing entry replaces it, so
+    /// `CompressionRegistry::default().register(MyGzip)` overrides the
+    /// built-in gzip.
+    ///
+    /// # Panics
+    ///
+    /// If [`provider.name()`](CompressionProvider::name) is empty or contains
+    /// any byte outside the RFC 9110 `tchar` set (ASCII alphanumerics and
+    /// ``!#$%&'*+-.^_`|~``). Such a name could never be negotiated or carried
+    /// in an encoding header, so it is rejected when the registry is built
+    /// rather than on each request.
     ///
     /// # Example
     ///
@@ -197,8 +234,16 @@ impl CompressionRegistry {
     /// ```
     #[must_use]
     pub fn register<P: CompressionProvider>(mut self, provider: P) -> Self {
+        let name = provider.name();
+        assert!(
+            is_http_token(name),
+            "CompressionProvider::name() returned {name:?} for {}: an encoding name must be a \
+             non-empty HTTP token (ASCII alphanumerics and !#$%&'*+-.^_`|~), because it is sent \
+             in content-encoding and accept-encoding headers",
+            std::any::type_name::<P>()
+        );
         let providers = Arc::make_mut(&mut self.providers);
-        providers.insert(provider.name(), Arc::new(provider));
+        providers.insert(name, Arc::new(provider));
         self.rebuild_accept_encoding();
         self
     }
@@ -223,10 +268,15 @@ impl CompressionRegistry {
 
     /// Get a comma-separated string of supported encodings.
     ///
-    /// Useful for Accept-Encoding headers. The string is computed once when
-    /// providers are registered and cached, so this is a cheap lookup.
+    /// The string form of [`accept_encoding_value`](Self::accept_encoding_value):
+    /// computed once when providers are registered, so this is a cheap
+    /// lookup; empty when no providers are registered. To set a header, use
+    /// `accept_encoding_value`, which needs no re-parse.
     pub fn accept_encoding_header(&self) -> &str {
-        &self.accept_encoding
+        self.accept_encoding
+            .as_ref()
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("")
     }
 
     /// Negotiate a response encoding based on the client's accept-encoding header.
@@ -1652,6 +1702,69 @@ mod tests {
             let registry = CompressionRegistry::new().register(GzipProvider::default());
             assert_eq!(registry.accept_encoding_header(), "gzip");
         }
+    }
+
+    #[test]
+    fn accept_encoding_value_is_none_for_an_empty_registry() {
+        assert!(CompressionRegistry::new().accept_encoding_value().is_none());
+    }
+
+    /// A provider whose only interesting property is its name.
+    struct Named(&'static str);
+
+    impl CompressionProvider for Named {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+        fn compress(&self, data: &[u8]) -> Result<Bytes, ConnectError> {
+            Ok(Bytes::copy_from_slice(data))
+        }
+        fn decompressor<'a>(
+            &self,
+            data: &'a [u8],
+        ) -> Result<Box<dyn std::io::Read + 'a>, ConnectError> {
+            Ok(Box::new(data))
+        }
+    }
+
+    #[test]
+    fn register_accepts_token_names_and_advertises_them_sorted() {
+        let registry = CompressionRegistry::new()
+            .register(Named("x-snappy"))
+            .register(Named("br"));
+        assert_eq!(registry.accept_encoding_header(), "br, x-snappy");
+        assert_eq!(registry.accept_encoding_value().unwrap(), "br, x-snappy");
+    }
+
+    #[test]
+    fn http_token_rule_matches_rfc9110_tchar() {
+        for good in ["gzip", "br", "x-snappy", "zstd", "A1!#$%&'*+-.^_`|~"] {
+            assert!(is_http_token(good), "{good:?} is a token");
+        }
+        for bad in [
+            "", "my algo", "gzip\n", "gzíp", "a,b", "\"q\"", "a/b", "gzip;q=1",
+        ] {
+            assert!(!is_http_token(bad), "{bad:?} is not a token");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a non-empty HTTP token")]
+    fn register_rejects_a_name_that_is_not_an_http_token() {
+        let _ = CompressionRegistry::new().register(Named("my algo"));
+    }
+
+    #[cfg(all(feature = "gzip", feature = "zstd"))]
+    #[test]
+    fn accept_encoding_value_tracks_the_header_string() {
+        let registry = CompressionRegistry::new()
+            .register(GzipProvider::default())
+            .register(ZstdProvider::default());
+        assert_eq!(
+            registry.accept_encoding_value().unwrap(),
+            registry.accept_encoding_header()
+        );
+        assert_eq!(registry.accept_encoding_value().unwrap(), "gzip, zstd");
     }
 
     #[cfg(all(feature = "gzip", feature = "zstd"))]

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -148,10 +148,50 @@ impl Envelope {
     ///
     /// This protects against malicious clients declaring very large message
     /// sizes in the envelope header.
+    ///
+    /// Use this on a read buffer that is still being filled; for a body
+    /// already collected into a [`Bytes`], see
+    /// [`decode_from_bytes_with_limit`](Self::decode_from_bytes_with_limit).
     pub fn decode_with_limit(
         buf: &mut BytesMut,
         max_size: usize,
     ) -> Result<Option<Self>, ConnectError> {
+        let Some((flags, length)) = Self::complete_header(buf, max_size)? else {
+            return Ok(None);
+        };
+        buf.advance(HEADER_SIZE);
+        let data = buf.split_to(length).freeze();
+        Ok(Some(Self { flags, data }))
+    }
+
+    /// [`decode_with_limit`](Self::decode_with_limit) for a body that is
+    /// already an immutable [`Bytes`] (for example the result of collecting
+    /// an HTTP body): the payload is split off by reference count rather than
+    /// copied, and whatever follows the envelope is left in `buf`.
+    ///
+    /// # Errors
+    ///
+    /// `ResourceExhausted` when the declared message size exceeds `max_size`.
+    pub fn decode_from_bytes_with_limit(
+        buf: &mut Bytes,
+        max_size: usize,
+    ) -> Result<Option<Self>, ConnectError> {
+        let Some((flags, length)) = Self::complete_header(buf, max_size)? else {
+            return Ok(None);
+        };
+        buf.advance(HEADER_SIZE);
+        let data = buf.split_to(length);
+        Ok(Some(Self { flags, data }))
+    }
+
+    /// The `(flags, length)` of the envelope at the front of `buf` when the
+    /// whole envelope is present, `None` when more bytes are needed.
+    ///
+    /// # Errors
+    ///
+    /// `ResourceExhausted` when the declared length exceeds `max_size`; this
+    /// is checked before waiting for the payload to arrive.
+    fn complete_header(buf: &[u8], max_size: usize) -> Result<Option<(u8, usize)>, ConnectError> {
         if buf.len() < HEADER_SIZE {
             return Ok(None);
         }
@@ -174,11 +214,7 @@ impl Envelope {
         if buf.len() < HEADER_SIZE.saturating_add(length) {
             return Ok(None);
         }
-
-        buf.advance(HEADER_SIZE);
-        let data = buf.split_to(length).freeze();
-
-        Ok(Some(Self { flags, data }))
+        Ok(Some((flags, length)))
     }
 }
 
@@ -727,6 +763,92 @@ mod tests {
         let result = Envelope::decode_with_limit(&mut buf, 1024 * 1024);
         assert!(result.is_ok());
         assert!(result.unwrap().is_some());
+    }
+
+    #[test]
+    fn decode_from_bytes_with_limit_splits_payload_without_copying() {
+        let mut payload = Envelope::data(Bytes::from_static(b"small"))
+            .encode()
+            .to_vec();
+        payload.extend_from_slice(b"trailing");
+        let mut buf = Bytes::from(payload);
+        let base = buf.as_ptr();
+
+        let env = Envelope::decode_from_bytes_with_limit(&mut buf, 1024)
+            .unwrap()
+            .unwrap();
+        assert_eq!(&env.data[..], b"small");
+        assert!(!env.is_compressed());
+        // The payload is a view into the original buffer, not a copy.
+        assert_eq!(env.data.as_ptr(), base.wrapping_add(HEADER_SIZE));
+        // What follows the envelope stays in the buffer for the caller to reject.
+        assert_eq!(&buf[..], b"trailing");
+    }
+
+    #[test]
+    fn decode_from_bytes_with_limit_waits_and_bounds_like_decode_with_limit() {
+        let mut short = Bytes::from_static(&[0, 0, 0, 0]);
+        assert!(
+            Envelope::decode_from_bytes_with_limit(&mut short, 1024)
+                .unwrap()
+                .is_none()
+        );
+
+        let mut truncated = Bytes::from_static(&[0, 0, 0, 0, 9, b'x']);
+        assert!(
+            Envelope::decode_from_bytes_with_limit(&mut truncated, 1024)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(truncated.len(), 6, "an incomplete envelope is left intact");
+
+        let mut too_big = Bytes::from_static(&[0, 0, 0x10, 0, 0]);
+        let err = Envelope::decode_from_bytes_with_limit(&mut too_big, 512 * 1024).unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::ResourceExhausted);
+    }
+
+    /// The `Bytes` and `BytesMut` decoders agree on every input: same
+    /// outcome, same envelope, same remainder left in the buffer.
+    #[test]
+    fn decode_bytes_and_decode_with_limit_agree() {
+        fn frame(flags: u8, payload: &[u8], trailing: &[u8]) -> Vec<u8> {
+            let mut v = vec![flags];
+            v.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+            v.extend_from_slice(payload);
+            v.extend_from_slice(trailing);
+            v
+        }
+        const LIMIT: usize = 8;
+        let cases: Vec<(&str, Vec<u8>)> = vec![
+            ("exact fit", frame(0, b"12345", b"")),
+            ("zero-length payload", frame(0, b"", b"")),
+            ("end-stream flag", frame(flags::END_STREAM, b"{}", b"")),
+            ("compressed flag", frame(flags::COMPRESSED, b"zz", b"")),
+            ("trailing bytes", frame(0, b"abc", b"next")),
+            ("length == limit", frame(0, &[7; LIMIT], b"")),
+            ("length == limit + 1", frame(0, &[7; LIMIT + 1], b"")),
+            ("short header", vec![0, 0, 0]),
+            ("truncated payload", vec![0, 0, 0, 0, 4, 1, 2]),
+            ("empty", vec![]),
+        ];
+        for (name, input) in cases {
+            let mut as_mut = BytesMut::from(&input[..]);
+            let mut as_bytes = Bytes::from(input.clone());
+            let from_mut = Envelope::decode_with_limit(&mut as_mut, LIMIT);
+            let from_bytes = Envelope::decode_from_bytes_with_limit(&mut as_bytes, LIMIT);
+            match (from_mut, from_bytes) {
+                (Ok(a), Ok(b)) => {
+                    assert_eq!(
+                        a.as_ref().map(|e| (e.flags, e.data.clone())),
+                        b.as_ref().map(|e| (e.flags, e.data.clone())),
+                        "{name}: envelope"
+                    );
+                }
+                (Err(a), Err(b)) => assert_eq!(a.code, b.code, "{name}: error code"),
+                (a, b) => panic!("{name}: {a:?} vs {b:?}"),
+            }
+            assert_eq!(&as_mut[..], &as_bytes[..], "{name}: remainder");
+        }
     }
 
     #[test]

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -148,9 +148,6 @@ fn parse_get_query_params(query: Option<&str>) -> Result<GetQueryParams, Connect
 struct RequestMetadata {
     /// The Content-Type header value.
     content_type: Option<String>,
-    /// The detected protocol. Used for protocol-specific behavior in handlers.
-    #[allow(dead_code)]
-    protocol: Protocol,
     /// The timeout parsed from the protocol's timeout header.
     timeout: Option<Duration>,
     /// Compression encoding for unary requests (from Content-Encoding header).
@@ -164,23 +161,22 @@ struct RequestMetadata {
     /// The Connect protocol version from connect-protocol-version header.
     /// Only meaningful for the Connect protocol.
     protocol_version: Option<String>,
-    /// The original request headers (for passing to handlers).
+    /// The original request headers, handed on to the handler's
+    /// `RequestContext`.
     headers: http::HeaderMap,
 }
 
 impl RequestMetadata {
-    /// Extract metadata from request headers, using the detected protocol to
-    /// determine which header names to read.
-    fn from_headers(headers: &http::HeaderMap, protocol: Protocol) -> Self {
+    /// Extract metadata from the request's headers, using the detected
+    /// protocol to determine which header names to read, and keep the map for
+    /// the handler.
+    fn from_headers(headers: http::HeaderMap, protocol: Protocol) -> Self {
         let content_type = headers
             .get(header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_owned());
 
-        let timeout = headers
-            .get(protocol.timeout_header())
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| parse_timeout(s, protocol));
+        let timeout = timeout_from_headers(&headers, protocol);
 
         let unary_encoding = headers
             .get(header::CONTENT_ENCODING)
@@ -209,14 +205,13 @@ impl RequestMetadata {
 
         Self {
             content_type,
-            protocol,
             timeout,
             unary_encoding,
             streaming_encoding,
             unary_accept_encoding,
             streaming_accept_encoding,
             protocol_version,
-            headers: headers.clone(),
+            headers,
         }
     }
 }
@@ -329,13 +324,25 @@ fn absolute_deadline(timeout: Option<Duration>) -> Option<std::time::Instant> {
     timeout.and_then(|t| std::time::Instant::now().checked_add(t))
 }
 
+/// The client-requested timeout from the protocol's timeout header, if
+/// present and well-formed.
+fn timeout_from_headers(headers: &http::HeaderMap, protocol: Protocol) -> Option<Duration> {
+    headers
+        .get(protocol.timeout_header())
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| parse_timeout(s, protocol))
+}
+
+/// The request deadline for paths that never build a [`RequestMetadata`]
+/// (early rejections that still drain the body under the client's timeout):
+/// the same timeout `RequestMetadata` would parse, moderated by the policy.
 fn deadline_from_headers(
     headers: &http::HeaderMap,
     protocol: Protocol,
     path: &str,
     deadline_policy: &DeadlinePolicy,
 ) -> Option<std::time::Instant> {
-    let timeout = RequestMetadata::from_headers(headers, protocol).timeout;
+    let timeout = timeout_from_headers(headers, protocol);
     absolute_deadline(deadline_policy.moderate(timeout, path))
 }
 
@@ -827,7 +834,7 @@ fn connect_streaming_error_response(
 
     let response = Response::builder().status(StatusCode::OK).header(
         header::CONTENT_TYPE,
-        Protocol::Connect.response_content_type(codec_format, true),
+        http::HeaderValue::from_static(Protocol::Connect.response_content_type(codec_format, true)),
     );
 
     let response = echo_error_headers(response, err);
@@ -877,7 +884,7 @@ fn grpc_error_response(
 
     let mut response = Response::builder().status(StatusCode::OK).header(
         header::CONTENT_TYPE,
-        protocol.response_content_type(codec_format, true),
+        http::HeaderValue::from_static(protocol.response_content_type(codec_format, true)),
     );
 
     // For trailers-only gRPC responses, also include grpc-status in headers
@@ -1967,17 +1974,14 @@ where
     B: Body<Data = Bytes> + Send + 'static,
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    let query_string = req.uri().query().map(|s| s.to_owned());
-    let method = req.method().clone();
+    let (parts, body) = req.into_parts();
+    let method = parts.method;
+    let extensions = parts.extensions;
 
     // Extract metadata from headers using the Connect protocol (unary is always Connect)
-    let mut metadata = RequestMetadata::from_headers(req.headers(), Protocol::Connect);
+    let mut metadata = RequestMetadata::from_headers(parts.headers, Protocol::Connect);
     metadata.timeout = deadline_policy.moderate(metadata.timeout, path);
     let deadline = absolute_deadline(metadata.timeout);
-
-    // Split request to consume the body
-    let (parts, body) = req.into_parts();
-    let extensions = parts.extensions;
 
     // IMPORTANT: Read the full request body BEFORE returning any errors.
     // For HTTP/1.1, returning an error without reading the body causes
@@ -2008,7 +2012,7 @@ where
         }
 
         // Parse query parameters for GET request
-        let params = parse_get_query_params(query_string.as_deref())?;
+        let params = parse_get_query_params(parts.uri.query())?;
 
         // Validate connect version from query param
         if let Some(ref version) = params.connect_version
@@ -2088,7 +2092,7 @@ where
         // The leading slash was stripped for the Dispatcher::lookup key;
         // restore it so RequestContext::path() matches http::Uri::path()
         // and Spec::procedure.
-        .with_path(format!("/{path}"))
+        .with_path(["/", path].concat())
         .with_decode_options(limits.decode_options());
 
     // Call the handler with the appropriate codec format.
@@ -2128,19 +2132,13 @@ where
     };
 
     // Build response with the same content type as the request
-    let mut response = Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, codec_format.content_type());
-
-    if let Some(encoding) = content_encoding {
-        response = response.header(header::CONTENT_ENCODING, encoding);
-    }
-
-    // Advertise what encodings we accept (optional per spec, informational)
-    let accept = compression.accept_encoding_header();
-    if !accept.is_empty() {
-        response = response.header(header::ACCEPT_ENCODING, accept);
-    }
+    let mut response = response_head(
+        codec_format.content_type(),
+        &header::CONTENT_ENCODING,
+        content_encoding,
+        &header::ACCEPT_ENCODING,
+        &compression,
+    );
 
     // Add response headers set by the handler
     for (key, value) in resp.headers.iter() {
@@ -2153,6 +2151,32 @@ where
     response
         .body(Full::new(final_body))
         .map_err(|e| ConnectError::internal(format!("failed to build response: {e}")))
+}
+
+/// Start a `200 OK` response carrying the negotiated content type, the
+/// response encoding when one was applied, and the accept-encoding
+/// advertisement (optional per spec, informational). Every value is a static
+/// or registry-cached `HeaderValue`, so none is allocated per response.
+fn response_head(
+    content_type: &'static str,
+    encoding_header: &header::HeaderName,
+    encoding: Option<&'static str>,
+    accept_encoding_header: &header::HeaderName,
+    compression: &CompressionRegistry,
+) -> http::response::Builder {
+    let mut response = Response::builder().status(StatusCode::OK).header(
+        header::CONTENT_TYPE,
+        http::HeaderValue::from_static(content_type),
+    );
+    if let Some(encoding) = encoding {
+        // Encoding names are validated as HTTP tokens by
+        // `CompressionRegistry::register`, which is what `from_static` needs.
+        response = response.header(encoding_header, http::HeaderValue::from_static(encoding));
+    }
+    if let Some(accept) = compression.accept_encoding_value() {
+        response = response.header(accept_encoding_header, accept.clone());
+    }
+    response
 }
 
 /// Handle a gRPC/gRPC-Web unary request via the fast path.
@@ -2179,8 +2203,11 @@ where
     B: Body<Data = Bytes> + Send + 'static,
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    // Extract metadata before any body reads, including error-path drains.
-    let mut metadata = RequestMetadata::from_headers(req.headers(), protocol);
+    // Take the request apart first: the headers move into the metadata (and
+    // from there into the handler context), the body is read below.
+    let (parts, body) = req.into_parts();
+    let extensions = parts.extensions;
+    let mut metadata = RequestMetadata::from_headers(parts.headers, protocol);
     metadata.timeout = deadline_policy.moderate(metadata.timeout, path);
     let deadline = absolute_deadline(metadata.timeout);
 
@@ -2196,7 +2223,7 @@ where
         };
         let mut response = Response::builder().status(StatusCode::OK).header(
             header::CONTENT_TYPE,
-            protocol.response_content_type(codec_format, true),
+            http::HeaderValue::from_static(protocol.response_content_type(codec_format, true)),
         );
         // For trailers-only gRPC responses, include grpc-status in headers
         if protocol == Protocol::Grpc {
@@ -2226,10 +2253,9 @@ where
 
     // gRPC requires POST. Backstop: `handle_request` already rejects non-GET/
     // POST verbs upstream, and GET never routes here, so this is defensive.
-    if req.method() != Method::POST {
-        let err = ConnectError::internal(format!("invalid method for gRPC: {}", req.method()));
+    if parts.method != Method::POST {
+        let err = ConnectError::internal(format!("invalid method for gRPC: {}", parts.method));
         // Drain the request body to avoid broken pipe on HTTP/1.1.
-        let (_parts, body) = req.into_parts();
         let _ = with_request_deadline(
             deadline,
             collect_body_limited(body, limits.max_request_body_size),
@@ -2245,7 +2271,6 @@ where
     {
         let err = ConnectError::unimplemented(format!("unsupported compression: {encoding}"));
         // Drain the request body to avoid broken pipe on HTTP/1.1.
-        let (_parts, body) = req.into_parts();
         let _ = with_request_deadline(
             deadline,
             collect_body_limited(body, limits.max_request_body_size),
@@ -2256,8 +2281,6 @@ where
 
     // Read the full body. collect_body_limited bounds allocation during the
     // read, so an oversized body is rejected before it is fully buffered.
-    let (parts, body) = req.into_parts();
-    let extensions = parts.extensions;
     let post_body = match with_request_deadline(
         deadline,
         collect_body_limited(body, limits.max_request_body_size),
@@ -2274,18 +2297,19 @@ where
         let err = ConnectError::unimplemented("request body is empty: expected a message");
         return grpc_unary_error(&err);
     } else {
-        let mut buf = bytes::BytesMut::from(&post_body[..]);
-        let envelope = match Envelope::decode_with_limit(&mut buf, limits.max_message_size) {
-            Ok(Some(env)) => env,
-            Ok(None) => {
-                let err = ConnectError::invalid_argument("incomplete request envelope");
-                return grpc_unary_error(&err);
-            }
-            Err(e) => return grpc_unary_error(&e),
-        };
+        let mut post_body = post_body;
+        let envelope =
+            match Envelope::decode_from_bytes_with_limit(&mut post_body, limits.max_message_size) {
+                Ok(Some(env)) => env,
+                Ok(None) => {
+                    let err = ConnectError::invalid_argument("incomplete request envelope");
+                    return grpc_unary_error(&err);
+                }
+                Err(e) => return grpc_unary_error(&e),
+            };
 
-        // Reject multiple envelopes in a unary request
-        if !buf.is_empty() {
+        // Reject anything after the one envelope of a unary request
+        if !post_body.is_empty() {
             let err = ConnectError::unimplemented("unary request must have exactly one message");
             return grpc_unary_error(&err);
         }
@@ -2321,7 +2345,7 @@ where
         .with_extensions(extensions)
         .with_spec(spec)
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"))
+        .with_path(["/", path].concat())
         .with_decode_options(limits.decode_options());
 
     // Call the handler with the same deadline used while receiving the body.
@@ -2385,19 +2409,13 @@ where
     };
 
     // Build response headers
-    let mut response = Response::builder().status(StatusCode::OK).header(
-        header::CONTENT_TYPE,
+    let mut response = response_head(
         protocol.response_content_type(codec_format, true),
+        protocol.content_encoding_header(),
+        response_encoding,
+        protocol.accept_encoding_header(),
+        &compression,
     );
-
-    if let Some(encoding) = response_encoding {
-        response = response.header(protocol.content_encoding_header(), encoding);
-    }
-
-    let accept = compression.accept_encoding_header();
-    if !accept.is_empty() {
-        response = response.header(protocol.accept_encoding_header(), accept);
-    }
 
     // Add response headers set by the handler
     for (key, value) in resp.headers.iter() {
@@ -2453,16 +2471,18 @@ where
     B: Body<Data = Bytes> + Send + 'static,
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    // Extract metadata before any body reads, including error-path drains.
-    let mut metadata = RequestMetadata::from_headers(req.headers(), protocol);
+    // Take the request apart first: the headers move into the metadata (and
+    // from there into the handler context), the body is read or streamed below.
+    let (parts, body) = req.into_parts();
+    let extensions = parts.extensions;
+    let mut metadata = RequestMetadata::from_headers(parts.headers, protocol);
     metadata.timeout = deadline_policy.moderate(metadata.timeout, path);
 
     // gRPC and gRPC-Web require POST method. Backstop: non-GET/POST verbs are
     // already rejected upstream in `handle_request`, and GET never routes here.
-    if matches!(protocol, Protocol::Grpc | Protocol::GrpcWeb) && req.method() != Method::POST {
-        let err = ConnectError::internal(format!("invalid method for gRPC: {}", req.method()));
+    if matches!(protocol, Protocol::Grpc | Protocol::GrpcWeb) && parts.method != Method::POST {
+        let err = ConnectError::internal(format!("invalid method for gRPC: {}", parts.method));
         // Drain the request body to avoid broken pipe on HTTP/1.1.
-        let (_parts, body) = req.into_parts();
         let deadline = absolute_deadline(metadata.timeout);
         let _ = with_request_deadline(
             deadline,
@@ -2479,7 +2499,6 @@ where
     {
         let err = ConnectError::unimplemented(format!("unsupported compression: {encoding}"));
         // Drain the request body to avoid broken pipe on HTTP/1.1.
-        let (_parts, body) = req.into_parts();
         let deadline = absolute_deadline(metadata.timeout);
         let _ = with_request_deadline(
             deadline,
@@ -2488,10 +2507,6 @@ where
         .await;
         return streaming_error_response(&err, protocol, codec_format);
     }
-
-    // Split request to consume the body
-    let (parts, body) = req.into_parts();
-    let extensions = parts.extensions;
 
     // For bidi streaming, pass the raw body stream directly (no buffering)
     if matches!(method_desc, Some(d) if d.kind == MethodKind::BidiStreaming) {
@@ -2578,20 +2593,21 @@ where
         let err = ConnectError::unimplemented("server streaming request requires a message");
         return streaming_error_response(&err, protocol, codec_format);
     } else {
-        let mut buf = bytes::BytesMut::from(&post_body[..]);
-        let envelope = match Envelope::decode_with_limit(&mut buf, limits.max_message_size) {
-            Ok(Some(env)) => env,
-            Ok(None) => {
-                let err = ConnectError::invalid_argument("incomplete request envelope");
-                return streaming_error_response(&err, protocol, codec_format);
-            }
-            Err(e) => {
-                return streaming_error_response(&e, protocol, codec_format);
-            }
-        };
+        let mut post_body = post_body;
+        let envelope =
+            match Envelope::decode_from_bytes_with_limit(&mut post_body, limits.max_message_size) {
+                Ok(Some(env)) => env,
+                Ok(None) => {
+                    let err = ConnectError::invalid_argument("incomplete request envelope");
+                    return streaming_error_response(&err, protocol, codec_format);
+                }
+                Err(e) => {
+                    return streaming_error_response(&e, protocol, codec_format);
+                }
+            };
 
         // Check for multiple request envelopes (server streaming only allows one)
-        if !buf.is_empty() {
+        if !post_body.is_empty() {
             let err = ConnectError::unimplemented(
                 "server streaming request must have exactly one message",
             );
@@ -2632,7 +2648,7 @@ where
         .with_extensions(extensions)
         .with_spec(method_desc.and_then(|d| d.spec))
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"))
+        .with_path(["/", path].concat())
         .with_decode_options(limits.decode_options());
 
     // Call the handler with the appropriate codec format.
@@ -2679,20 +2695,13 @@ where
     );
 
     // Build streaming response
-    let mut response = Response::builder().status(StatusCode::OK).header(
-        header::CONTENT_TYPE,
+    let mut response = response_head(
         protocol.response_content_type(codec_format, true),
+        protocol.content_encoding_header(),
+        response_encoding,
+        protocol.accept_encoding_header(),
+        &compression,
     );
-
-    if let Some(encoding) = response_encoding {
-        response = response.header(protocol.content_encoding_header(), encoding);
-    }
-
-    // Advertise what encodings we accept (optional per spec, informational)
-    let accept = compression.accept_encoding_header();
-    if !accept.is_empty() {
-        response = response.header(protocol.accept_encoding_header(), accept);
-    }
 
     // Add response headers set by the handler
     for (key, value) in resp.headers.iter() {
@@ -2772,7 +2781,7 @@ where
         .with_extensions(extensions)
         .with_spec(spec)
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"))
+        .with_path(["/", path].concat())
         .with_decode_options(limits.decode_options());
 
     // Call the handler. On error paths, the reader task is left running
@@ -2827,19 +2836,13 @@ where
     );
 
     // Build streaming response with a single data envelope + END_STREAM
-    let mut response = Response::builder().status(StatusCode::OK).header(
-        header::CONTENT_TYPE,
+    let mut response = response_head(
         protocol.response_content_type(codec_format, true),
+        protocol.content_encoding_header(),
+        response_encoding,
+        protocol.accept_encoding_header(),
+        &compression,
     );
-
-    if let Some(encoding) = response_encoding {
-        response = response.header(protocol.content_encoding_header(), encoding);
-    }
-
-    let accept = compression.accept_encoding_header();
-    if !accept.is_empty() {
-        response = response.header(protocol.accept_encoding_header(), accept);
-    }
 
     // Add response headers set by the handler
     for (key, value) in resp.headers.iter() {
@@ -3177,7 +3180,7 @@ where
         .with_extensions(extensions)
         .with_spec(spec)
         .with_protocol(Some(protocol))
-        .with_path(format!("/{path}"))
+        .with_path(["/", path].concat())
         .with_decode_options(limits.decode_options());
 
     // Call the handler with timeout if configured
@@ -3229,20 +3232,13 @@ where
     );
 
     // Build streaming response
-    let mut response = Response::builder().status(StatusCode::OK).header(
-        header::CONTENT_TYPE,
+    let mut response = response_head(
         protocol.response_content_type(codec_format, true),
+        protocol.content_encoding_header(),
+        response_encoding,
+        protocol.accept_encoding_header(),
+        &compression,
     );
-
-    if let Some(encoding) = response_encoding {
-        response = response.header(protocol.content_encoding_header(), encoding);
-    }
-
-    // Advertise what encodings we accept (optional per spec, informational)
-    let accept = compression.accept_encoding_header();
-    if !accept.is_empty() {
-        response = response.header(protocol.accept_encoding_header(), accept);
-    }
 
     // Add response headers set by the handler
     for (key, value) in resp.headers.iter() {
@@ -6277,6 +6273,193 @@ mod tests {
             .err()
             .expect("miss");
             assert_eq!(err.code, crate::ErrorCode::Unimplemented);
+        }
+    }
+
+    /// The request's header map is moved into the handler's `RequestContext`
+    /// on every dispatch path. Each path takes the request apart at a
+    /// different point, so each is driven separately; client- and
+    /// bidi-streaming receive the parsed metadata from
+    /// `handle_streaming_request` rather than the request itself.
+    mod request_headers_reach_handler {
+        use super::*;
+        use buffa_types::google::protobuf::StringValue;
+        use std::sync::Mutex;
+
+        const PROBE: &str = "x-probe";
+
+        type Seen = Arc<Mutex<Vec<Option<String>>>>;
+
+        fn record(seen: &Seen, ctx: &RequestContext) {
+            seen.lock().unwrap().push(
+                ctx.header(PROBE)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned),
+            );
+        }
+
+        fn router(seen: &Seen) -> Arc<Router> {
+            let unary = {
+                let seen = Arc::clone(seen);
+                crate::handler_fn(move |ctx: RequestContext, req: StringValue| {
+                    record(&seen, &ctx);
+                    async move { crate::Response::ok(req) }
+                })
+            };
+            let unary_get = {
+                let seen = Arc::clone(seen);
+                crate::handler_fn(move |ctx: RequestContext, req: StringValue| {
+                    record(&seen, &ctx);
+                    async move { crate::Response::ok(req) }
+                })
+            };
+            let server_stream = {
+                let seen = Arc::clone(seen);
+                crate::handler::streaming_handler_fn(
+                    move |ctx: RequestContext, req: StringValue| {
+                        record(&seen, &ctx);
+                        async move { crate::Response::stream_ok(futures::stream::iter([Ok(req)])) }
+                    },
+                )
+            };
+            let client_stream = {
+                let seen = Arc::clone(seen);
+                crate::handler::client_streaming_handler_fn(
+                    move |ctx: RequestContext, _reqs: crate::ServiceStream<StringValue>| {
+                        record(&seen, &ctx);
+                        async move { crate::Response::ok(StringValue::default()) }
+                    },
+                )
+            };
+            let bidi = {
+                let seen = Arc::clone(seen);
+                crate::handler::bidi_streaming_handler_fn(
+                    move |ctx: RequestContext, reqs: crate::ServiceStream<StringValue>| {
+                        record(&seen, &ctx);
+                        async move { crate::Response::stream_ok(reqs) }
+                    },
+                )
+            };
+            Arc::new(
+                Router::new()
+                    .route("svc", "Unary", unary)
+                    .route_idempotent("svc", "Get", unary_get)
+                    .route_server_stream("svc", "ServerStream", server_stream)
+                    .route_client_stream("svc", "ClientStream", client_stream)
+                    .route_bidi_stream("svc", "Bidi", bidi),
+            )
+        }
+
+        fn message() -> Bytes {
+            crate::codec::encode_proto(&StringValue {
+                value: "v".into(),
+                ..Default::default()
+            })
+            .unwrap()
+        }
+
+        fn post(path: &str, content_type: &str, body: Bytes, probe: &str) -> Request<Full<Bytes>> {
+            Request::builder()
+                .method(Method::POST)
+                .uri(path)
+                .header(header::CONTENT_TYPE, content_type)
+                .header(PROBE, probe)
+                .body(Full::new(body))
+                .unwrap()
+        }
+
+        async fn call(router: &Arc<Router>, req: Request<Full<Bytes>>) {
+            let resp = handle_request(
+                Arc::clone(router),
+                req,
+                Limits::default(),
+                Arc::new(CompressionRegistry::new()),
+                &CompressionPolicy::default(),
+                &DeadlinePolicy::new(),
+                &[],
+            )
+            .await
+            .expect("dispatch succeeds");
+            assert_eq!(resp.status(), StatusCode::OK);
+            // Drive the body so streaming handlers run to completion.
+            let _ = resp.into_body().collect().await;
+        }
+
+        #[tokio::test]
+        async fn on_every_dispatch_path() {
+            use base64::Engine as _;
+            let seen: Seen = Arc::default();
+            let router = router(&seen);
+            let enveloped = Envelope::data(message()).encode();
+
+            call(
+                &router,
+                post(
+                    "/svc/Unary",
+                    "application/proto",
+                    message(),
+                    "connect-unary",
+                ),
+            )
+            .await;
+            let get = Request::builder()
+                .method(Method::GET)
+                .uri(format!(
+                    "/svc/Get?encoding=proto&base64=1&connect=v1&message={}",
+                    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(message())
+                ))
+                .header(PROBE, "connect-get")
+                .body(Full::new(Bytes::new()))
+                .unwrap();
+            call(&router, get).await;
+            call(
+                &router,
+                post(
+                    "/svc/Unary",
+                    "application/grpc",
+                    enveloped.clone(),
+                    "grpc-unary",
+                ),
+            )
+            .await;
+            call(
+                &router,
+                post(
+                    "/svc/ServerStream",
+                    "application/grpc",
+                    enveloped.clone(),
+                    "server-stream",
+                ),
+            )
+            .await;
+            call(
+                &router,
+                post(
+                    "/svc/ClientStream",
+                    "application/grpc",
+                    enveloped.clone(),
+                    "client-stream",
+                ),
+            )
+            .await;
+            call(
+                &router,
+                post("/svc/Bidi", "application/grpc", enveloped, "bidi"),
+            )
+            .await;
+
+            assert_eq!(
+                *seen.lock().unwrap(),
+                [
+                    "connect-unary",
+                    "connect-get",
+                    "grpc-unary",
+                    "server-stream",
+                    "client-stream",
+                    "bidi"
+                ]
+                .map(|s| Some(s.to_owned())),
+            );
         }
     }
 }

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1983,6 +1983,8 @@ use bytes::Bytes;
 struct MyCompression;
 
 impl CompressionProvider for MyCompression {
+    // Sent in content-encoding / accept-encoding, so it must be an HTTP
+    // token; `register` panics on anything else.
     fn name(&self) -> &'static str { "my-algo" }
 
     fn compress(&self, data: &[u8]) -> Result<Bytes, ConnectError> {


### PR DESCRIPTION
Profiling the small-unary gRPC benchmark (`cross/unary_small_grpc`, the ~300-byte `small_request()` payload) showed the server making 63 heap allocations per request, about 26 of them in connect-rust's own request path rather than in decode or the handler. This removes nine of them and one full copy of every request body:

- `handle_grpc_unary_request` (and the server-streaming path) copied the collected body into a `BytesMut` to parse the 5-byte envelope. `Envelope::decode_from_bytes_with_limit` splits the payload out of the `Bytes` by reference count.
- `RequestMetadata::from_headers` cloned the request `HeaderMap` for the handler context although the request is consumed a few lines later. The three entry points now take the request apart first and move the map.
- Constant header values (content-type, encodings, `te`, `connect-protocol-version`) on server responses and client requests use `HeaderValue::from_static`, and the accept-encoding value is built once per `CompressionRegistry` (now exposed as `accept_encoding_value()`), instead of each going through `HeaderValue::from_str`.

`from_static` on a negotiated encoding name is only safe if provider names are valid header values, so `CompressionRegistry::register` now panics when `CompressionProvider::name()` is not an RFC 9110 token. The alternative was caching a `HeaderValue` per provider and keeping `register` infallible.

Measured locally with a counting allocator and `perf stat`, single worker, closed loop: 63 → 54 allocations and 87k → 84k instructions per request on the server. Latency at c=1 is loopback-bound and does not move.
