### PR TITLE
client: share an Http2Connection without a buffer worker task

### DIFF
--- a/.changes/unreleased/Changed-20260906-170500.yaml
+++ b/.changes/unreleased/Changed-20260906-170500.yaml
@@ -1,0 +1,13 @@
+kind: Changed
+body: |-
+    **`SharedHttp2Connection` sends directly on the hyper connection handle;
+    `bound` now caps in-flight requests.** Each request clones the live hyper
+    request handle and sends on it, taking the reconnect state machine's lock
+    only when there is no open connection, which removes the `tower::buffer`
+    worker task and its per-call hop and wakeups. `Http2Connection::shared(bound)`
+    keeps its signature: `bound` is now the number of requests that may be in
+    flight (sent and awaiting response headers) rather than the depth of the
+    worker's queue. It must still be non-zero. `shared` no longer has to be
+    called inside a Tokio runtime, and the workspace no longer enables tower's
+    `buffer` feature.
+time: 2026-09-06T17:05:00.000000000+00:00

--- a/.changes/unreleased/Changed-20260906-170500.yaml
+++ b/.changes/unreleased/Changed-20260906-170500.yaml
@@ -1,13 +1,18 @@
 kind: Changed
 body: |-
-    **`SharedHttp2Connection` sends directly on the hyper connection handle;
-    `bound` now caps in-flight requests.** Each request clones the live hyper
-    request handle and sends on it, taking the reconnect state machine's lock
-    only when there is no open connection, which removes the `tower::buffer`
-    worker task and its per-call hop and wakeups. `Http2Connection::shared(bound)`
-    keeps its signature: `bound` is now the number of requests that may be in
-    flight (sent and awaiting response headers) rather than the depth of the
-    worker's queue. It must still be non-zero. `shared` no longer has to be
-    called inside a Tokio runtime, and the workspace no longer enables tower's
-    `buffer` feature.
+    **`SharedHttp2Connection` sends directly on the hyper connection handle
+    instead of through a `tower::buffer` worker.** Each request clones the live
+    hyper request handle and sends on it, taking the reconnect state machine's
+    lock only when there is no open connection, which removes the worker task
+    and its per-call hop and wakeups. `Http2Connection::shared(bound)` keeps its
+    signature and `bound` keeps its role: it is the number of requests that may
+    wait for the connection to be (re-)established at once (previously the
+    worker's queue depth), never a cap on concurrent streams. It must still be
+    non-zero. As a `tower::Service` the handle keeps `Http2Connection`'s
+    readiness contract (`poll_ready` drives re-establishment and is pending
+    meanwhile; a failed attempt is ready with the error returned by the next
+    `call`), and `call` without a successful `poll_ready` returns an `internal`
+    error where the buffer used to panic. `shared` no longer has to be called
+    inside a Tokio runtime, and `Debug` output now includes the endpoint URI.
+    No downstream action is needed.
 time: 2026-09-06T17:05:00.000000000+00:00

--- a/.changes/unreleased/Changed-20260908-160000.yaml
+++ b/.changes/unreleased/Changed-20260908-160000.yaml
@@ -1,0 +1,9 @@
+kind: Changed
+body: |-
+    **Connect failures through `SharedHttp2Connection` keep their own error
+    code.** Failures the transport classified itself (such as the
+    `invalid_argument` scheme check or the establishment timeout) used to reach
+    the caller re-wrapped as `unavailable: h2 send failed: …`; they now arrive
+    with their original code and message. Unclassified connect failures read
+    `h2 connect failed: …` rather than `h2 send failed: …`.
+time: 2026-09-08T16:00:00.000000000+00:00

--- a/.changes/unreleased/Fixed-20260906-172500.yaml
+++ b/.changes/unreleased/Fixed-20260906-172500.yaml
@@ -1,0 +1,14 @@
+kind: Fixed
+body: |-
+    `SharedHttp2Connection`: the first request after a graceful GOAWAY arrived
+    while another stream was still open failed with `h2 send failed: operation
+    was canceled` without reaching the wire (#285). Readiness is now checked
+    when the request is made rather than ahead of time by a worker, so that
+    request goes out on a new connection, and a request that races a closing
+    connection is resent. Two related fixes: a request abandoned while it
+    was establishing the connection (for example at its deadline) no longer
+    leaves a half-finished attempt and its establishment timeout to the next
+    request (the attempt now runs to completion on its own task), and connect failures that the transport classified
+    itself (such as the `invalid_argument` scheme check) keep their code
+    instead of being re-wrapped as `unavailable`.
+time: 2026-09-06T17:25:00.000000000+00:00

--- a/.changes/unreleased/Fixed-20260906-172500.yaml
+++ b/.changes/unreleased/Fixed-20260906-172500.yaml
@@ -1,14 +1,15 @@
 kind: Fixed
 body: |-
-    `SharedHttp2Connection`: the first request after a graceful GOAWAY arrived
-    while another stream was still open failed with `h2 send failed: operation
-    was canceled` without reaching the wire (#285). Readiness is now checked
-    when the request is made rather than ahead of time by a worker, so that
-    request goes out on a new connection, and a request that races a closing
-    connection is resent. Two related fixes: a request abandoned while it
-    was establishing the connection (for example at its deadline) no longer
-    leaves a half-finished attempt and its establishment timeout to the next
-    request (the attempt now runs to completion on its own task), and connect failures that the transport classified
-    itself (such as the `invalid_argument` scheme check) keep their code
-    instead of being re-wrapped as `unavailable`.
+    **`SharedHttp2Connection` no longer fails the first request after a graceful
+    GOAWAY** ([#285]). A request made while another stream was still open on
+    the retiring connection failed with `h2 send failed: operation was
+    canceled` without reaching the wire. Readiness is now checked when the
+    request is made rather than ahead of time by a worker, so that request goes
+    out on a new connection, and a request that a closing connection hands back
+    before it reached the wire is resent on a fresh one. Relatedly, a request
+    abandoned while it was establishing the connection (for example at its
+    deadline) no longer leaves a half-finished attempt and its establishment
+    timeout to the next request: the attempt runs to completion on its own task.
+
+    [#285]: https://github.com/connectrpc/connect-rust/issues/285
 time: 2026-09-06T17:25:00.000000000+00:00

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ http-body-util = "0.1"
 bytes = { version = "1.6", features = ["serde"] }
 
 # Tower service abstraction
-tower = { version = "0.5", features = ["util", "buffer"] }
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["catch-panic"] }
 
 # Async runtime

--- a/connectrpc/Cargo.toml
+++ b/connectrpc/Cargo.toml
@@ -61,7 +61,8 @@ serde_json = { workspace = true }
 flate2 = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 
-# Envelope framing (`Encoder`/`Decoder` for the 5-byte message header)
+# Envelope framing (`Encoder`/`Decoder` for the 5-byte message header) and
+# `PollSemaphore` for the shared h2 client handle
 tokio-util = { workspace = true, features = ["codec"] }
 
 # Error handling

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -50,7 +50,6 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 // TLS support types and helpers
 // ============================================================================
 
-#[cfg(feature = "client-tls")]
 use std::sync::Arc;
 
 /// A boxed bidirectional IO stream. Used to unify the concrete types
@@ -965,51 +964,271 @@ impl tower::Service<Request<ClientBody>> for Http2Connection {
     }
 }
 
-// Http2Connection needs Clone to satisfy ClientTransport, but the inner
-// Reconnect state machine is !Clone by design (each instance tracks one
-// connection). For ClientTransport's shared-access semantics we use an
-// Arc<tokio::Mutex> — but that would serialize requests and defeat the
-// purpose. Instead, we only implement ClientTransport for the wrapped
-// ServiceTransport version, and let users who want to share wrap in
-// Buffer or Balance themselves.
-//
-// For the direct "single connection" use case, the generated FooServiceClient
-// takes `T: ClientTransport` which requires Clone — so direct Http2Connection
-// can't be used without a Buffer layer. This is intentional: a raw h2
-// connection IS !Clone; sharing it requires coordination.
-//
-// Workaround for the common case: provide `Http2Connection::shared()` that
-// returns a Buffer-wrapped, Clone-able handle.
+// Http2Connection is a tower `Service` taking `&mut self`, and its Reconnect
+// state machine is !Clone by design (each instance tracks one connection),
+// while generated clients need `T: ClientTransport`, which is `Clone` and
+// sends through `&self`. `SharedHttp2Connection` bridges the two without a
+// queue or worker task of its own: hyper's h2 `SendRequest` is already a
+// cloneable handle that passes each request to the connection task over a
+// channel, so every request clones the current handle and sends on it
+// directly. A request that finds no live handle (never connected, or the
+// connection dropped), or has its request handed back unsent, takes the
+// reconnect state machine's lock, has it driven to a new connection, and
+// publishes the new handle for everyone else.
+
+type H2SendRequest = hyper::client::conn::http2::SendRequest<ClientBody>;
+
+/// State shared by every clone of a [`SharedHttp2Connection`].
+struct SharedState {
+    /// The live connection's request handle; cloned per request. `None`
+    /// before the first connect and while a replacement is being
+    /// established. A handle whose connection has gone away reports
+    /// `is_closed()` and sends callers to `conn` to replace it.
+    sender: std::sync::RwLock<Option<H2SendRequest>>,
+    /// The reconnect state machine, locked only to (re)establish the
+    /// connection. `Arc` so that an attempt can own the guard in its own
+    /// task and finish even if the request that started it goes away.
+    conn: Arc<tokio::sync::Mutex<Http2Connection>>,
+    /// Number of completed (re)connect attempts, successful or not. A caller
+    /// that queued for `conn` behind someone else's attempt shares its
+    /// outcome instead of dialling again, so a burst of requests during an
+    /// outage costs one dial, not one per request.
+    attempts: std::sync::atomic::AtomicU64,
+    /// The failure of the most recent attempt, for those callers to share.
+    /// Cleared by the next successful connect.
+    last_failure: std::sync::Mutex<Option<ConnectError>>,
+}
+
+impl SharedState {
+    /// The current request handle if its connection is still open.
+    fn live_sender(&self) -> Option<H2SendRequest> {
+        self.sender
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .filter(|s| !s.is_closed())
+            .cloned()
+    }
+
+    fn set_sender(&self, sender: Option<H2SendRequest>) {
+        *self
+            .sender
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = sender;
+    }
+
+    fn last_failure(&self) -> std::sync::MutexGuard<'_, Option<ConnectError>> {
+        self.last_failure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Get a request handle onto a live connection, establishing one if
+    /// needed, and publish it.
+    ///
+    /// The attempt itself runs in its own task holding the state machine's
+    /// lock, so it completes (and its result is published) even when the
+    /// request that started it is dropped at its deadline; requests queued
+    /// behind it then find either the new handle or the recorded failure
+    /// rather than a half-finished handshake to resume.
+    async fn reconnect(shared: &Arc<Self>) -> Result<H2SendRequest, ConnectError> {
+        use std::sync::atomic::Ordering;
+
+        let seen = shared.attempts.load(Ordering::Acquire);
+        let mut conn = Arc::clone(&shared.conn).lock_owned().await;
+        // Another caller may have reconnected while this one waited for the
+        // lock...
+        if let Some(sender) = shared.live_sender() {
+            return Ok(sender);
+        }
+        // ...or tried to and failed, in which case this caller takes that
+        // answer rather than dialling again straight away.
+        if shared.attempts.load(Ordering::Acquire) != seen
+            && let Some(failure) = shared.last_failure().clone()
+        {
+            return Err(failure);
+        }
+
+        shared.set_sender(None);
+        let owner = Arc::clone(shared);
+        let attempt = tokio::spawn(async move {
+            let ready = std::future::poll_fn(|cx| conn.inner.poll_ready(cx)).await;
+            // `Reconnect` reports a failed (re)connect as Ready plus a deferred
+            // error, so that a balancer can route around it; surface it here.
+            let result = match (ready, conn.inner.deferred_error.take()) {
+                (Err(e), _) | (Ok(()), Some(e)) => Err(e),
+                (Ok(()), None) => match &conn.inner.state {
+                    ReconnectState::Connected(svc) => Ok(svc.inner.clone()),
+                    ReconnectState::Idle | ReconnectState::Connecting(_) => {
+                        Err("Http2Connection ready but not connected".into())
+                    }
+                },
+            };
+            owner.attempts.fetch_add(1, Ordering::Release);
+            let mut last_failure = owner.last_failure();
+            let result = match result {
+                Ok(sender) => {
+                    *last_failure = None;
+                    owner.set_sender(Some(sender.clone()));
+                    Ok(sender)
+                }
+                Err(e) => {
+                    let failure = h2_transport_error(e, "h2 connect failed");
+                    *last_failure = Some(failure.clone());
+                    Err(failure)
+                }
+            };
+            // Published; only now let the next waiter in.
+            drop(conn);
+            result
+        });
+        match attempt.await {
+            Ok(result) => result,
+            Err(e) => Err(ConnectError::internal(format!(
+                "h2 connect task failed: {e}"
+            ))),
+        }
+    }
+
+    /// Send `req` on the shared connection, connecting first if needed, and
+    /// await the response head.
+    ///
+    /// A handle can pass the `is_closed()` check and still lose the race with
+    /// a connection that is going away. hyper hands the request back unsent in
+    /// that case, so it is resent on a fresh handle (a bounded number of
+    /// times) instead of failing a request that never reached the wire.
+    async fn send(
+        shared: &Arc<Self>,
+        mut req: Request<ClientBody>,
+    ) -> Result<Response<hyper::body::Incoming>, BoxError> {
+        /// Resends of a request hyper handed back unsent. The window is the
+        /// gap between a connection starting to close and its handle
+        /// reporting `is_closed()`, so one is nearly always enough.
+        const RESENDS: usize = 2;
+
+        let mut sender = match shared.live_sender() {
+            Some(sender) => sender,
+            None => Self::reconnect(shared).await?,
+        };
+        for _ in 0..RESENDS {
+            match sender.try_send_request(req).await {
+                Ok(response) => return Ok(response),
+                Err(mut unsent) => match unsent.take_message() {
+                    Some(returned) => {
+                        req = returned;
+                        // Do not let the fast path hand the same handle back.
+                        shared.set_sender(None);
+                        sender = Self::reconnect(shared).await?;
+                    }
+                    None => return Err(unsent.into_error().into()),
+                },
+            }
+        }
+        Ok(sender.send_request(req).await?)
+    }
+}
+
+/// Classify a failure from the h2 transport for the caller: a
+/// [`ConnectError`] anywhere in the chain (scheme and ALPN checks, the
+/// establishment timeout, a shared connect failure) is returned as is, and
+/// anything else (socket, TLS, h2 protocol errors) becomes `unavailable` with
+/// `context` and the original error as its source.
+fn h2_transport_error(err: BoxError, context: &str) -> ConnectError {
+    super::find_connect_error_in_chain(&*err)
+        .unwrap_or_else(|| ConnectError::unavailable_from_transport(context, err))
+}
 
 /// A `Clone + ClientTransport` handle to a shared [`Http2Connection`].
 ///
-/// Created via [`Http2Connection::shared`]. The underlying connection is
-/// driven by a background worker task; callers get a cheap-to-clone channel
-/// handle. Unlike [`HttpClient`](super::HttpClient), the underlying readiness
-/// still backpressures correctly through the buffer.
-#[derive(Clone)]
-#[allow(clippy::type_complexity)] // Buffer's type param is what it is
+/// Created via [`Http2Connection::shared`]. Clones are cheap and all use the
+/// one underlying connection (and its reconnect state machine); requests from
+/// different clones are multiplexed as concurrent HTTP/2 streams. At most
+/// `bound` requests may be waiting for their response headers at once;
+/// beyond that,
+/// [`poll_ready`](tower::Service::poll_ready) and
+/// [`send`](ClientTransport::send) wait for one to finish, so unlike
+/// [`HttpClient`](super::HttpClient) readiness reflects real capacity.
 pub struct SharedHttp2Connection {
-    inner: tower::buffer::Buffer<
-        Request<ClientBody>,
-        BoxFuture<'static, Result<Response<hyper::body::Incoming>, BoxError>>,
-    >,
+    shared: Arc<SharedState>,
+    in_flight: tokio_util::sync::PollSemaphore,
+    /// Taken in `poll_ready`, consumed by the following `call`. Never cloned:
+    /// a clone starts without readiness of its own.
+    permit: Option<tokio::sync::OwnedSemaphorePermit>,
+}
+
+impl Clone for SharedHttp2Connection {
+    fn clone(&self) -> Self {
+        Self {
+            shared: Arc::clone(&self.shared),
+            in_flight: self.in_flight.clone(),
+            permit: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for SharedHttp2Connection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedHttp2Connection")
+            .field("connected", &self.shared.live_sender().is_some())
+            .field("available_permits", &self.in_flight.available_permits())
+            .finish_non_exhaustive()
+    }
 }
 
 impl Http2Connection {
-    /// Wrap this connection in a [`tower::buffer::Buffer`] for `Clone +
-    /// ClientTransport` use.
+    /// Turn this connection into a `Clone + ClientTransport` handle that any
+    /// number of clients and tasks can share.
     ///
-    /// `bound` is the channel capacity — requests beyond this backpressure
-    /// through `poll_ready`. For a single-connection gRPC client, 1024 is
-    /// a reasonable default (covers typical `max_concurrent_streams`).
+    /// `bound` caps how many requests may be in flight (sent and still
+    /// waiting for response headers) at once; further requests wait in
+    /// `poll_ready` / `send` until one completes. A stream whose headers have
+    /// arrived no longer counts, so the number of open streams is limited
+    /// only by the peer's `max_concurrent_streams`, beyond which the
+    /// transport queues new streams itself. For a single-connection gRPC
+    /// client, 1024 is a reasonable default. Values above tokio's semaphore
+    /// limit are clamped to it, which is unbounded in practice.
     ///
-    /// Requires being called from within a tokio runtime (to spawn the
-    /// buffer's worker task).
+    /// Creating the handle needs no runtime; (re)connecting happens on a
+    /// spawned Tokio task when a request finds no live connection, so
+    /// requests must be made from within one (as with every transport here).
+    ///
+    /// # Panics
+    ///
+    /// If `bound` is 0.
+    #[must_use]
     pub fn shared(self, bound: usize) -> SharedHttp2Connection {
-        let (buffer, worker) = tower::buffer::Buffer::pair(self, bound);
-        tokio::spawn(worker);
-        SharedHttp2Connection { inner: buffer }
+        assert!(bound > 0, "SharedHttp2Connection bound must be positive");
+        let bound = bound.min(tokio::sync::Semaphore::MAX_PERMITS);
+        let sender = match &self.inner.state {
+            ReconnectState::Connected(svc) => Some(svc.inner.clone()),
+            ReconnectState::Idle | ReconnectState::Connecting(_) => None,
+        };
+        SharedHttp2Connection {
+            shared: Arc::new(SharedState {
+                sender: std::sync::RwLock::new(sender),
+                conn: Arc::new(tokio::sync::Mutex::new(self)),
+                attempts: std::sync::atomic::AtomicU64::new(0),
+                last_failure: std::sync::Mutex::new(None),
+            }),
+            in_flight: tokio_util::sync::PollSemaphore::new(Arc::new(tokio::sync::Semaphore::new(
+                bound,
+            ))),
+            permit: None,
+        }
+    }
+}
+
+impl SharedHttp2Connection {
+    /// Send `req` holding `permit`, which is released when this future
+    /// finishes or is dropped.
+    async fn start(
+        shared: Arc<SharedState>,
+        permit: tokio::sync::OwnedSemaphorePermit,
+        req: Request<ClientBody>,
+    ) -> Result<Response<hyper::body::Incoming>, BoxError> {
+        let result = SharedState::send(&shared, req).await;
+        drop(permit);
+        result
     }
 }
 
@@ -1019,12 +1238,23 @@ impl tower::Service<Request<ClientBody>> for SharedHttp2Connection {
     type Future = BoxFuture<'static, Result<Response<hyper::body::Incoming>, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        <_ as tower::Service<Request<ClientBody>>>::poll_ready(&mut self.inner, cx)
+        if self.permit.is_none() {
+            match futures::ready!(self.in_flight.poll_acquire(cx)) {
+                Some(permit) => self.permit = Some(permit),
+                // The semaphore is never closed.
+                None => return Poll::Ready(Err("h2 send failed: semaphore closed".into())),
+            }
+        }
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: Request<ClientBody>) -> Self::Future {
-        let fut = <_ as tower::Service<Request<ClientBody>>>::call(&mut self.inner, req);
-        Box::pin(fut)
+        let Some(permit) = self.permit.take() else {
+            return Box::pin(async {
+                Err("SharedHttp2Connection::call before poll_ready returned Ready".into())
+            });
+        };
+        Box::pin(Self::start(Arc::clone(&self.shared), permit, req))
     }
 }
 
@@ -1036,12 +1266,17 @@ impl ClientTransport for SharedHttp2Connection {
         &self,
         request: Request<ClientBody>,
     ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
-        use tower::ServiceExt;
-        let svc = self.clone();
+        let shared = Arc::clone(&self.shared);
+        let semaphore = self.in_flight.clone_inner();
         Box::pin(async move {
-            svc.oneshot(request)
+            // The semaphore is never closed, so this only waits.
+            let permit = semaphore
+                .acquire_owned()
                 .await
-                .map_err(|e| ConnectError::unavailable_from_transport("h2 send failed", e))
+                .map_err(|e| ConnectError::unavailable_from_transport("h2 send failed", e))?;
+            Self::start(shared, permit, request)
+                .await
+                .map_err(|e| h2_transport_error(e, "h2 send failed"))
         })
     }
 }
@@ -1555,7 +1790,7 @@ mod tests {
 
     #[tokio::test]
     async fn shared_send_after_deferred_connect_failure_preserves_source() {
-        // A lazy connection defers its first connect failure to call() (see
+        // A lazy connection defers its first connect failure (see
         // Reconnect::poll_ready) — that deferred-error path is exactly what
         // SharedHttp2Connection::send goes through for a shared connection
         // that never manages to connect.
@@ -1571,14 +1806,218 @@ mod tests {
         let err = ClientTransport::send(&shared, request)
             .await
             .expect_err("send over a connection that can never connect must fail");
+        assert_eq!(err.code, crate::error::ErrorCode::Unavailable, "{err:?}");
         assert!(
-            err.message.as_deref().unwrap().contains("h2 send failed"),
+            err.message
+                .as_deref()
+                .unwrap()
+                .contains("h2 connect failed"),
             "unexpected message: {err:?}"
         );
         assert!(
             std::error::Error::source(&err).is_some(),
-            "h2-send failure must retain its cause as source(): {err:?}"
+            "connect failure must retain its cause as source(): {err:?}"
         );
+    }
+
+    /// A connect failure that the transport classified itself (here the
+    /// plaintext/TLS scheme check, `invalid_argument`) reaches the caller
+    /// with its own code rather than re-wrapped as `unavailable`.
+    #[cfg(feature = "client-tls")]
+    #[tokio::test]
+    async fn shared_send_surfaces_classified_connect_errors_verbatim() {
+        let tls = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let shared =
+            Http2Connection::lazy_tls("http://127.0.0.1:1".parse().unwrap(), tls).shared(1);
+        let request = Request::builder()
+            .uri("http://127.0.0.1:1/")
+            .body(crate::client::full_body(bytes::Bytes::new()))
+            .unwrap();
+        let err = ClientTransport::send(&shared, request).await.unwrap_err();
+        assert_eq!(
+            err.code,
+            crate::error::ErrorCode::InvalidArgument,
+            "{err:?}"
+        );
+    }
+
+    /// `bound` is a real in-flight limit shared by every clone: readiness
+    /// taken by one clone is unavailable to another until it is used up or
+    /// given back, and a fresh clone never inherits readiness.
+    #[tokio::test]
+    async fn shared_bound_limits_in_flight_requests_across_clones() {
+        use std::future::poll_fn;
+        use tower::Service as _;
+
+        let mut a =
+            Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap()).shared(1);
+        let mut b = a.clone();
+
+        poll_fn(|cx| a.poll_ready(cx)).await.unwrap();
+        // Idempotent: a second poll_ready does not take a second permit.
+        poll_fn(|cx| a.poll_ready(cx)).await.unwrap();
+        assert!(
+            poll_fn(|cx| Poll::Ready(b.poll_ready(cx).is_pending())).await,
+            "the only permit is held by `a`"
+        );
+
+        // A clone of a ready handle starts without readiness of its own...
+        let mut c = a.clone();
+        assert!(poll_fn(|cx| Poll::Ready(c.poll_ready(cx).is_pending())).await);
+        // ...and dropping the ready handle returns the permit.
+        drop(a);
+        poll_fn(|cx| b.poll_ready(cx)).await.unwrap();
+
+        // Using the readiness up (here on a request that fails to connect)
+        // returns it too.
+        let request = Request::builder()
+            .uri("http://127.0.0.1:1/")
+            .body(crate::client::full_body(bytes::Bytes::new()))
+            .unwrap();
+        assert!(b.call(request).await.is_err());
+        poll_fn(|cx| c.poll_ready(cx)).await.unwrap();
+    }
+
+    #[test]
+    fn shared_debug_reports_connection_state_and_capacity() {
+        let shared =
+            Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap()).shared(3);
+        assert_eq!(
+            format!("{shared:?}"),
+            "SharedHttp2Connection { connected: false, available_permits: 3, .. }"
+        );
+    }
+
+    fn empty_request() -> Request<ClientBody> {
+        Request::builder()
+            .uri("http://test.invalid/")
+            .body(crate::client::full_body(bytes::Bytes::new()))
+            .unwrap()
+    }
+
+    /// A burst of requests against a shared connection that cannot connect
+    /// dials once: the requests queued behind the attempt share its failure
+    /// instead of each dialling in turn. A request made after the burst
+    /// dials again. (Paused time: the connector's delay elapses only once
+    /// every request in the burst is parked, however slow the test host.)
+    #[tokio::test(start_paused = true)]
+    async fn shared_burst_during_outage_dials_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dials = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&dials);
+        let refuse = tower::service_fn(move |_uri: Uri| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            async move {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                Err::<hyper_util::rt::TokioIo<tokio::io::DuplexStream>, _>(std::io::Error::other(
+                    "dial refused",
+                ))
+            }
+        });
+        let shared = Http2Connection::builder()
+            .no_establishment_timeout()
+            .lazy_with_connector(refuse, "http://test.invalid".parse().unwrap())
+            .shared(64);
+
+        let burst = futures::future::join_all(
+            (0..16).map(|_| ClientTransport::send(&shared, empty_request())),
+        )
+        .await;
+        assert_eq!(
+            dials.load(Ordering::SeqCst),
+            1,
+            "one dial for the whole burst"
+        );
+        for result in &burst {
+            let err = result.as_ref().unwrap_err();
+            assert_eq!(err.code, crate::error::ErrorCode::Unavailable);
+            assert!(
+                err.message.as_deref().unwrap().contains("dial refused"),
+                "every request in the burst reports the shared failure: {err:?}"
+            );
+        }
+
+        let _ = ClientTransport::send(&shared, empty_request()).await;
+        assert_eq!(
+            dials.load(Ordering::SeqCst),
+            2,
+            "a later request dials afresh"
+        );
+    }
+
+    /// A request abandoned mid-handshake (its deadline passed) neither kills
+    /// the attempt nor leaves it half-finished for the next request to
+    /// resume: the attempt runs to its own conclusion, requests arriving
+    /// meanwhile wait on it rather than dialling again, and a request made
+    /// after it has failed dials afresh instead of inheriting its
+    /// establishment timeout.
+    #[tokio::test(start_paused = true)]
+    async fn shared_connect_attempt_outlives_the_request_that_started_it() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dials = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&dials);
+        let stall = tower::service_fn(move |_uri: Uri| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            async move {
+                std::future::pending::<()>().await;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(tokio::io::duplex(1).0))
+            }
+        });
+        const ESTABLISHMENT: Duration = Duration::from_secs(3);
+        let shared = Http2Connection::builder()
+            .establishment_timeout(ESTABLISHMENT)
+            .lazy_with_connector(stall, "http://test.invalid".parse().unwrap())
+            .shared(4);
+        let send_within = |limit: Duration| {
+            tokio::time::timeout(limit, ClientTransport::send(&shared, empty_request()))
+        };
+
+        // Give up on the first request well inside the establishment timeout.
+        assert!(send_within(ESTABLISHMENT / 10).await.is_err());
+        assert_eq!(dials.load(Ordering::SeqCst), 1);
+
+        // A second request while that attempt is still running joins it.
+        assert!(send_within(ESTABLISHMENT / 10).await.is_err());
+        assert_eq!(
+            dials.load(Ordering::SeqCst),
+            1,
+            "no second dial mid-attempt"
+        );
+
+        // Once the attempt has timed out on its own, the next request dials
+        // afresh, and stalls afresh rather than failing at once with the
+        // previous attempt's timeout.
+        tokio::time::sleep(ESTABLISHMENT).await;
+        assert!(
+            send_within(ESTABLISHMENT / 10).await.is_err(),
+            "a fresh attempt, still stalled"
+        );
+        assert_eq!(dials.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn shared_call_without_poll_ready_is_an_error_not_a_panic() {
+        use tower::Service as _;
+        let mut shared =
+            Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap()).shared(4);
+        let request = Request::builder()
+            .uri("http://127.0.0.1:1/")
+            .body(crate::client::full_body(bytes::Bytes::new()))
+            .unwrap();
+        let err = shared.call(request).await.unwrap_err();
+        assert!(err.to_string().contains("before poll_ready"), "{err}");
+    }
+
+    #[test]
+    #[should_panic(expected = "bound must be positive")]
+    fn shared_rejects_a_zero_bound() {
+        let _ = Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap()).shared(0);
     }
 
     #[test]

--- a/connectrpc/src/client/http2.rs
+++ b/connectrpc/src/client/http2.rs
@@ -968,18 +968,22 @@ impl tower::Service<Request<ClientBody>> for Http2Connection {
 // state machine is !Clone by design (each instance tracks one connection),
 // while generated clients need `T: ClientTransport`, which is `Clone` and
 // sends through `&self`. `SharedHttp2Connection` bridges the two without a
-// queue or worker task of its own: hyper's h2 `SendRequest` is already a
-// cloneable handle that passes each request to the connection task over a
-// channel, so every request clones the current handle and sends on it
-// directly. A request that finds no live handle (never connected, or the
-// connection dropped), or has its request handed back unsent, takes the
-// reconnect state machine's lock, has it driven to a new connection, and
-// publishes the new handle for everyone else.
+// worker task: hyper's h2 `SendRequest` is already a cloneable handle that
+// passes each request to the connection task over a channel, so every request
+// clones the current handle and sends on it directly. A request that finds no
+// live handle (never connected, or the connection dropped), or has its request
+// handed back unsent, takes the reconnect state machine's lock, has it driven
+// to a new connection on a task of its own, and publishes the new handle for
+// everyone else. A semaphore bounds how many requests may wait for that at
+// once; it is the `bound` of `Http2Connection::shared` and the only queue the
+// handle keeps.
 
 type H2SendRequest = hyper::client::conn::http2::SendRequest<ClientBody>;
 
 /// State shared by every clone of a [`SharedHttp2Connection`].
 struct SharedState {
+    /// The endpoint, for `Debug`.
+    uri: Uri,
     /// The live connection's request handle; cloned per request. `None`
     /// before the first connect and while a replacement is being
     /// established. A handle whose connection has gone away reports
@@ -1008,6 +1012,15 @@ impl SharedState {
             .as_ref()
             .filter(|s| !s.is_closed())
             .cloned()
+    }
+
+    /// Whether there is a request handle onto an open connection.
+    fn is_connected(&self) -> bool {
+        self.sender
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .is_some_and(|s| !s.is_closed())
     }
 
     fn set_sender(&self, sender: Option<H2SendRequest>) {
@@ -1068,12 +1081,14 @@ impl SharedState {
             let mut last_failure = owner.last_failure();
             let result = match result {
                 Ok(sender) => {
+                    tracing::debug!(uri = %owner.uri, "shared h2 connection established");
                     *last_failure = None;
                     owner.set_sender(Some(sender.clone()));
                     Ok(sender)
                 }
                 Err(e) => {
                     let failure = h2_transport_error(e, "h2 connect failed");
+                    tracing::debug!(uri = %owner.uri, error = %failure, "shared h2 connect failed");
                     *last_failure = Some(failure.clone());
                     Err(failure)
                 }
@@ -1084,6 +1099,10 @@ impl SharedState {
         });
         match attempt.await {
             Ok(result) => result,
+            // The runtime is shutting down; nothing was established.
+            Err(e) if e.is_cancelled() => Err(ConnectError::unavailable(
+                "h2 connect failed: connect task cancelled",
+            )),
             Err(e) => Err(ConnectError::internal(format!(
                 "h2 connect task failed: {e}"
             ))),
@@ -1091,7 +1110,8 @@ impl SharedState {
     }
 
     /// Send `req` on the shared connection, connecting first if needed, and
-    /// await the response head.
+    /// await the response head. `queued` is the caller's queue slot, given
+    /// back as soon as the request has been handed to a connection.
     ///
     /// A handle can pass the `is_closed()` check and still lose the race with
     /// a connection that is going away. hyper hands the request back unsent in
@@ -1100,31 +1120,52 @@ impl SharedState {
     async fn send(
         shared: &Arc<Self>,
         mut req: Request<ClientBody>,
+        queued: tokio::sync::OwnedSemaphorePermit,
     ) -> Result<Response<hyper::body::Incoming>, BoxError> {
         /// Resends of a request hyper handed back unsent. The window is the
         /// gap between a connection starting to close and its handle
         /// reporting `is_closed()`, so one is nearly always enough.
-        const RESENDS: usize = 2;
+        const MAX_RESENDS: usize = 2;
+        use std::sync::atomic::Ordering;
 
         let mut sender = match shared.live_sender() {
             Some(sender) => sender,
             None => Self::reconnect(shared).await?,
         };
-        for _ in 0..RESENDS {
-            match sender.try_send_request(req).await {
+        let mut queued = Some(queued);
+        let mut resends = 0;
+        loop {
+            let generation = shared.attempts.load(Ordering::Acquire);
+            let response = sender.try_send_request(req);
+            // hyper took the request (or refused it) synchronously: from here
+            // it occupies an h2 stream, or the transport's queue for one, and
+            // no longer a slot in the queue for the connection.
+            drop(queued.take());
+            match response.await {
                 Ok(response) => return Ok(response),
+                // hyper hands a request back only if the connection went away
+                // before taking it off its queue, so its body is untouched and
+                // it can be sent again as new.
                 Err(mut unsent) => match unsent.take_message() {
-                    Some(returned) => {
+                    Some(returned) if resends < MAX_RESENDS => {
+                        resends += 1;
                         req = returned;
-                        // Do not let the fast path hand the same handle back.
-                        shared.set_sender(None);
+                        tracing::debug!(
+                            uri = %shared.uri,
+                            attempt = resends,
+                            "shared h2 connection closed before taking the request; resending"
+                        );
+                        // Retire the handle that failed, unless a reconnect has
+                        // already replaced it meanwhile.
+                        if shared.attempts.load(Ordering::Acquire) == generation {
+                            shared.set_sender(None);
+                        }
                         sender = Self::reconnect(shared).await?;
                     }
-                    None => return Err(unsent.into_error().into()),
+                    Some(_) | None => return Err(unsent.into_error().into()),
                 },
             }
         }
-        Ok(sender.send_request(req).await?)
     }
 }
 
@@ -1141,27 +1182,42 @@ fn h2_transport_error(err: BoxError, context: &str) -> ConnectError {
 /// A `Clone + ClientTransport` handle to a shared [`Http2Connection`].
 ///
 /// Created via [`Http2Connection::shared`]. Clones are cheap and all use the
-/// one underlying connection (and its reconnect state machine); requests from
-/// different clones are multiplexed as concurrent HTTP/2 streams. At most
-/// `bound` requests may be waiting for their response headers at once;
-/// beyond that,
-/// [`poll_ready`](tower::Service::poll_ready) and
-/// [`send`](ClientTransport::send) wait for one to finish, so unlike
-/// [`HttpClient`](super::HttpClient) readiness reflects real capacity.
+/// one underlying connection and its reconnect state machine; requests from
+/// different clones are multiplexed as concurrent HTTP/2 streams.
+///
+/// As a [`tower::Service`] it keeps [`Http2Connection`]'s readiness contract:
+/// [`poll_ready`](tower::Service::poll_ready) is pending while the connection
+/// is being (re-)established and ready once it is up, and a failed attempt is
+/// reported as ready with the connect error returned by the following
+/// [`call`](tower::Service::call), after which the next `poll_ready` tries
+/// again. A balancer therefore keeps the endpoint and steers by pending load
+/// while it is down, rather than discarding it for good.
 pub struct SharedHttp2Connection {
     shared: Arc<SharedState>,
-    in_flight: tokio_util::sync::PollSemaphore,
-    /// Taken in `poll_ready`, consumed by the following `call`. Never cloned:
-    /// a clone starts without readiness of its own.
+    /// Slots for requests waiting to be handed to the connection; `bound` of
+    /// them. See [`Http2Connection::shared`].
+    queue: tokio_util::sync::PollSemaphore,
+    /// Taken in `poll_ready`, consumed by the following `call`.
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    /// The connection attempt `poll_ready` is waiting on, having found no
+    /// live connection.
+    connecting: Option<sync_wrapper::SyncFuture<BoxFuture<'static, Result<(), ConnectError>>>>,
+    /// The failure of that attempt, returned by the next `call` (see the
+    /// readiness contract on the type).
+    deferred_error: Option<ConnectError>,
 }
 
+/// A clone shares the connection but not this handle's readiness: it must
+/// get its own `poll_ready` before `call`, as `tower::ServiceExt::oneshot`
+/// and the [`ClientTransport`] impl do.
 impl Clone for SharedHttp2Connection {
     fn clone(&self) -> Self {
         Self {
             shared: Arc::clone(&self.shared),
-            in_flight: self.in_flight.clone(),
+            queue: self.queue.clone(),
             permit: None,
+            connecting: None,
+            deferred_error: None,
         }
     }
 }
@@ -1169,8 +1225,8 @@ impl Clone for SharedHttp2Connection {
 impl std::fmt::Debug for SharedHttp2Connection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SharedHttp2Connection")
-            .field("connected", &self.shared.live_sender().is_some())
-            .field("available_permits", &self.in_flight.available_permits())
+            .field("uri", &self.shared.uri)
+            .field("connected", &self.shared.is_connected())
             .finish_non_exhaustive()
     }
 }
@@ -1179,18 +1235,23 @@ impl Http2Connection {
     /// Turn this connection into a `Clone + ClientTransport` handle that any
     /// number of clients and tasks can share.
     ///
-    /// `bound` caps how many requests may be in flight (sent and still
-    /// waiting for response headers) at once; further requests wait in
-    /// `poll_ready` / `send` until one completes. A stream whose headers have
-    /// arrived no longer counts, so the number of open streams is limited
-    /// only by the peer's `max_concurrent_streams`, beyond which the
-    /// transport queues new streams itself. For a single-connection gRPC
-    /// client, 1024 is a reasonable default. Values above tokio's semaphore
-    /// limit are clamped to it, which is unbounded in practice.
+    /// Requests are multiplexed onto the one connection as HTTP/2 streams, so
+    /// their concurrency is limited only by the peer's
+    /// `max_concurrent_streams`, past which the transport queues new streams
+    /// itself (in hyper's own, unbounded, queue). `bound` limits something
+    /// narrower: how many requests may be waiting, at once, to be handed to the
+    /// connection. A request holds one of the `bound` slots from `poll_ready`
+    /// (or the start of [`send`](ClientTransport::send)) until hyper has taken
+    /// it, which is immediate while the connection is up and lasts for the
+    /// (re-)establishment while it is not; further callers wait for a free
+    /// slot, in arrival order. A tower handle that has been polled ready and
+    /// not yet called holds its slot too. For a single-connection gRPC client,
+    /// 1024 is a reasonable default. Values above
+    /// `tokio::sync::Semaphore::MAX_PERMITS` are clamped to it.
     ///
-    /// Creating the handle needs no runtime; (re)connecting happens on a
-    /// spawned Tokio task when a request finds no live connection, so
-    /// requests must be made from within one (as with every transport here).
+    /// Connecting happens on a spawned Tokio task the first time a request
+    /// (or `poll_ready`) finds no live connection, so the handle must be used
+    /// from within a Tokio runtime, as with every transport here.
     ///
     /// # Panics
     ///
@@ -1205,30 +1266,19 @@ impl Http2Connection {
         };
         SharedHttp2Connection {
             shared: Arc::new(SharedState {
+                uri: self.inner.uri.clone(),
                 sender: std::sync::RwLock::new(sender),
                 conn: Arc::new(tokio::sync::Mutex::new(self)),
                 attempts: std::sync::atomic::AtomicU64::new(0),
                 last_failure: std::sync::Mutex::new(None),
             }),
-            in_flight: tokio_util::sync::PollSemaphore::new(Arc::new(tokio::sync::Semaphore::new(
+            queue: tokio_util::sync::PollSemaphore::new(Arc::new(tokio::sync::Semaphore::new(
                 bound,
             ))),
             permit: None,
+            connecting: None,
+            deferred_error: None,
         }
-    }
-}
-
-impl SharedHttp2Connection {
-    /// Send `req` holding `permit`, which is released when this future
-    /// finishes or is dropped.
-    async fn start(
-        shared: Arc<SharedState>,
-        permit: tokio::sync::OwnedSemaphorePermit,
-        req: Request<ClientBody>,
-    ) -> Result<Response<hyper::body::Incoming>, BoxError> {
-        let result = SharedState::send(&shared, req).await;
-        drop(permit);
-        result
     }
 }
 
@@ -1239,22 +1289,53 @@ impl tower::Service<Request<ClientBody>> for SharedHttp2Connection {
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         if self.permit.is_none() {
-            match futures::ready!(self.in_flight.poll_acquire(cx)) {
+            match futures::ready!(self.queue.poll_acquire(cx)) {
                 Some(permit) => self.permit = Some(permit),
                 // The semaphore is never closed.
-                None => return Poll::Ready(Err("h2 send failed: semaphore closed".into())),
+                None => {
+                    return Poll::Ready(Err(ConnectError::internal(
+                        "SharedHttp2Connection queue closed",
+                    )
+                    .into()));
+                }
             }
         }
-        Poll::Ready(Ok(()))
+        loop {
+            if let Some(connecting) = self.connecting.as_mut() {
+                let result = futures::ready!(Pin::new(connecting).poll(cx));
+                self.connecting = None;
+                if let Err(e) = result {
+                    // Ready, with the failure reported by `call`: an `Err` here
+                    // would tell the caller to discard the service for good.
+                    self.deferred_error = Some(e);
+                }
+                return Poll::Ready(Ok(()));
+            }
+            if self.deferred_error.is_some() || self.shared.is_connected() {
+                return Poll::Ready(Ok(()));
+            }
+            let shared = Arc::clone(&self.shared);
+            self.connecting = Some(sync_wrapper::SyncFuture::new(Box::pin(async move {
+                SharedState::reconnect(&shared).await.map(drop)
+            })));
+        }
     }
 
     fn call(&mut self, req: Request<ClientBody>) -> Self::Future {
         let Some(permit) = self.permit.take() else {
             return Box::pin(async {
-                Err("SharedHttp2Connection::call before poll_ready returned Ready".into())
+                Err(ConnectError::internal(
+                    "SharedHttp2Connection::call before poll_ready returned Ready",
+                )
+                .into())
             });
         };
-        Box::pin(Self::start(Arc::clone(&self.shared), permit, req))
+        if let Some(e) = self.deferred_error.take() {
+            drop(permit);
+            return Box::pin(async move { Err(e.into()) });
+        }
+        let shared = Arc::clone(&self.shared);
+        Box::pin(async move { SharedState::send(&shared, req, permit).await })
     }
 }
 
@@ -1267,14 +1348,14 @@ impl ClientTransport for SharedHttp2Connection {
         request: Request<ClientBody>,
     ) -> BoxFuture<'static, Result<Response<Self::ResponseBody>, Self::Error>> {
         let shared = Arc::clone(&self.shared);
-        let semaphore = self.in_flight.clone_inner();
+        let queue = self.queue.clone_inner();
         Box::pin(async move {
             // The semaphore is never closed, so this only waits.
-            let permit = semaphore
+            let permit = queue
                 .acquire_owned()
                 .await
-                .map_err(|e| ConnectError::unavailable_from_transport("h2 send failed", e))?;
-            Self::start(shared, permit, request)
+                .map_err(|_| ConnectError::internal("SharedHttp2Connection queue closed"))?;
+            SharedState::send(&shared, request, permit)
                 .await
                 .map_err(|e| h2_transport_error(e, "h2 send failed"))
         })
@@ -1788,6 +1869,13 @@ mod tests {
         server.abort();
     }
 
+    fn empty_request() -> Request<ClientBody> {
+        Request::builder()
+            .uri("http://test.invalid/")
+            .body(crate::client::full_body(bytes::Bytes::new()))
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn shared_send_after_deferred_connect_failure_preserves_source() {
         // A lazy connection defers its first connect failure (see
@@ -1797,13 +1885,7 @@ mod tests {
         let conn = Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap());
         let shared = conn.shared(1);
 
-        let request = Request::builder()
-            .method(http::Method::POST)
-            .uri("http://127.0.0.1:1/")
-            .body(crate::client::full_body(bytes::Bytes::new()))
-            .unwrap();
-
-        let err = ClientTransport::send(&shared, request)
+        let err = ClientTransport::send(&shared, empty_request())
             .await
             .expect_err("send over a connection that can never connect must fail");
         assert_eq!(err.code, crate::error::ErrorCode::Unavailable, "{err:?}");
@@ -1833,11 +1915,9 @@ mod tests {
         );
         let shared =
             Http2Connection::lazy_tls("http://127.0.0.1:1".parse().unwrap(), tls).shared(1);
-        let request = Request::builder()
-            .uri("http://127.0.0.1:1/")
-            .body(crate::client::full_body(bytes::Bytes::new()))
-            .unwrap();
-        let err = ClientTransport::send(&shared, request).await.unwrap_err();
+        let err = ClientTransport::send(&shared, empty_request())
+            .await
+            .unwrap_err();
         assert_eq!(
             err.code,
             crate::error::ErrorCode::InvalidArgument,
@@ -1845,58 +1925,164 @@ mod tests {
         );
     }
 
-    /// `bound` is a real in-flight limit shared by every clone: readiness
-    /// taken by one clone is unavailable to another until it is used up or
-    /// given back, and a fresh clone never inherits readiness.
+    /// `poll_ready` on a shared handle drives the connect itself and keeps
+    /// `Http2Connection`'s contract for a failed one: ready, with the failure
+    /// returned by the next `call`, and a fresh dial on the next `poll_ready`
+    /// (an `Err` from `poll_ready` would have a balancer discard the endpoint
+    /// for good).
     #[tokio::test]
-    async fn shared_bound_limits_in_flight_requests_across_clones() {
+    async fn shared_poll_ready_defers_connect_failure_to_call_and_redials() {
         use std::future::poll_fn;
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use tower::Service as _;
 
-        let mut a =
-            Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap()).shared(1);
+        let dials = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&dials);
+        let refuse = tower::service_fn(move |_uri: Uri| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            async {
+                Err::<hyper_util::rt::TokioIo<tokio::io::DuplexStream>, _>(std::io::Error::other(
+                    "dial refused",
+                ))
+            }
+        });
+        let mut shared = Http2Connection::builder()
+            .lazy_with_connector(refuse, "http://test.invalid".parse().unwrap())
+            .shared(4);
+
+        for expected_dials in [1, 2] {
+            poll_fn(|cx| shared.poll_ready(cx))
+                .await
+                .expect("a failed connect still reports ready");
+            assert_eq!(dials.load(Ordering::SeqCst), expected_dials);
+            let err = shared.call(empty_request()).await.unwrap_err();
+            let err = err.downcast_ref::<ConnectError>().expect("a ConnectError");
+            assert_eq!(err.code, crate::error::ErrorCode::Unavailable, "{err:?}");
+            assert!(
+                err.message.as_deref().unwrap().contains("dial refused"),
+                "{err:?}"
+            );
+            assert_eq!(
+                dials.load(Ordering::SeqCst),
+                expected_dials,
+                "call does not dial"
+            );
+            assert_eq!(shared.queue.available_permits(), 4, "the slot is returned");
+        }
+    }
+
+    /// `bound` counts requests waiting for the connection to be established:
+    /// each `poll_ready` parked on the connect holds a slot, a clone never
+    /// inherits one, a handle that gives up returns its slot, and a caller
+    /// past the bound waits for a slot rather than for the connect.
+    #[tokio::test]
+    async fn shared_bound_limits_requests_queued_for_a_connection() {
+        use tower::Service as _;
+
+        let stall = tower::service_fn(|_uri: Uri| async {
+            std::future::pending::<()>().await;
+            Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(tokio::io::duplex(1).0))
+        });
+        let mut a = Http2Connection::builder()
+            .no_establishment_timeout()
+            .lazy_with_connector(stall, "http://test.invalid".parse().unwrap())
+            .shared(2);
         let mut b = a.clone();
-
-        poll_fn(|cx| a.poll_ready(cx)).await.unwrap();
-        // Idempotent: a second poll_ready does not take a second permit.
-        poll_fn(|cx| a.poll_ready(cx)).await.unwrap();
-        assert!(
-            poll_fn(|cx| Poll::Ready(b.poll_ready(cx).is_pending())).await,
-            "the only permit is held by `a`"
-        );
-
-        // A clone of a ready handle starts without readiness of its own...
         let mut c = a.clone();
-        assert!(poll_fn(|cx| Poll::Ready(c.poll_ready(cx).is_pending())).await);
-        // ...and dropping the ready handle returns the permit.
-        drop(a);
-        poll_fn(|cx| b.poll_ready(cx)).await.unwrap();
+        let is_pending = |handle: &mut SharedHttp2Connection| {
+            let polled = handle.poll_ready(&mut Context::from_waker(std::task::Waker::noop()));
+            polled.is_pending()
+        };
 
-        // Using the readiness up (here on a request that fails to connect)
-        // returns it too.
-        let request = Request::builder()
-            .uri("http://127.0.0.1:1/")
-            .body(crate::client::full_body(bytes::Bytes::new()))
-            .unwrap();
-        assert!(b.call(request).await.is_err());
-        poll_fn(|cx| c.poll_ready(cx)).await.unwrap();
+        assert!(is_pending(&mut a), "a drives the connect");
+        assert!(is_pending(&mut a), "and asking again takes no second slot");
+        assert_eq!(a.queue.available_permits(), 1);
+        assert!(is_pending(&mut b), "b queues behind the same connect");
+        assert_eq!(a.queue.available_permits(), 0);
+        assert!(is_pending(&mut c), "c waits for a slot");
+        assert!(c.permit.is_none() && c.connecting.is_none());
+
+        // b gives up; its slot goes straight to c, which joins the connect.
+        drop(b);
+        assert!(is_pending(&mut c));
+        assert!(c.permit.is_some() && c.connecting.is_some());
+        assert_eq!(a.queue.available_permits(), 0);
+    }
+
+    /// `bound` does not cap concurrent streams: with a bound of 1, two
+    /// requests are open on the server at the same time (the server answers
+    /// neither until it has both, so a cap of one in-flight request would
+    /// deadlock here and trip the timeout).
+    #[cfg(feature = "server")]
+    #[tokio::test]
+    async fn shared_bound_does_not_cap_concurrent_streams() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let both_arrived = Arc::new(tokio::sync::Barrier::new(2));
+        let server = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let both_arrived = Arc::clone(&both_arrived);
+                tokio::spawn(async move {
+                    let service =
+                        hyper::service::service_fn(move |_req: Request<hyper::body::Incoming>| {
+                            let both_arrived = Arc::clone(&both_arrived);
+                            async move {
+                                both_arrived.wait().await;
+                                Ok::<_, std::convert::Infallible>(Response::new(
+                                    http_body_util::Full::new(bytes::Bytes::from_static(b"ok")),
+                                ))
+                            }
+                        });
+                    let _ = hyper::server::conn::http2::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection(hyper_util::rt::TokioIo::new(stream), service)
+                    .await;
+                });
+            }
+        });
+
+        let uri: Uri = format!("http://{addr}").parse().unwrap();
+        let shared = Http2Connection::lazy_plaintext(uri.clone()).shared(1);
+        let request = || {
+            Request::builder()
+                .uri(uri.clone())
+                .body(crate::client::full_body(bytes::Bytes::new()))
+                .unwrap()
+        };
+        let (first, second) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(
+                ClientTransport::send(&shared, request()),
+                ClientTransport::send(&shared, request())
+            )
+        })
+        .await
+        .expect("two concurrent streams over a bound of 1");
+        assert_eq!(first.unwrap().status(), http::StatusCode::OK);
+        assert_eq!(second.unwrap().status(), http::StatusCode::OK);
+
+        // The same over the tower interface, one handle per request.
+        use tower::ServiceExt as _;
+        let (first, second) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(
+                shared.clone().oneshot(request()),
+                shared.clone().oneshot(request())
+            )
+        })
+        .await
+        .expect("two concurrent streams over a bound of 1, via tower");
+        assert_eq!(first.unwrap().status(), http::StatusCode::OK);
+        assert_eq!(second.unwrap().status(), http::StatusCode::OK);
+        server.abort();
     }
 
     #[test]
-    fn shared_debug_reports_connection_state_and_capacity() {
+    fn shared_debug_reports_endpoint_and_connection_state() {
         let shared =
             Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap()).shared(3);
-        assert_eq!(
-            format!("{shared:?}"),
-            "SharedHttp2Connection { connected: false, available_permits: 3, .. }"
-        );
-    }
-
-    fn empty_request() -> Request<ClientBody> {
-        Request::builder()
-            .uri("http://test.invalid/")
-            .body(crate::client::full_body(bytes::Bytes::new()))
-            .unwrap()
+        let debug = format!("{shared:?}");
+        assert!(debug.contains("uri: http://127.0.0.1:1/"), "{debug}");
+        assert!(debug.contains("connected: false"), "{debug}");
     }
 
     /// A burst of requests against a shared connection that cannot connect
@@ -2006,11 +2192,7 @@ mod tests {
         use tower::Service as _;
         let mut shared =
             Http2Connection::lazy_plaintext("http://127.0.0.1:1".parse().unwrap()).shared(4);
-        let request = Request::builder()
-            .uri("http://127.0.0.1:1/")
-            .body(crate::client::full_body(bytes::Bytes::new()))
-            .unwrap();
-        let err = shared.call(request).await.unwrap_err();
+        let err = shared.call(empty_request()).await.unwrap_err();
         assert!(err.to_string().contains("before poll_ready"), "{err}");
     }
 

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! | Transport | Protocol | Use when |
 //! |---|---|---|
-//! | [`SharedHttp2Connection`] | HTTP/2 only | **Default for gRPC.** One multiplexed connection with reconnect and an in-flight bound; the underlying [`Http2Connection`] has honest `poll_ready` and composes with `tower::balance`. |
+//! | [`SharedHttp2Connection`] | HTTP/2 only | **Default for gRPC.** One multiplexed connection with automatic reconnect; honest `poll_ready`, composes with `tower::balance`. |
 //! | [`HttpClient`] | HTTP/1.1 + HTTP/2 (ALPN) | Connect protocol over h/1.1, or you genuinely don't know which protocol the server speaks. |
 //!
 //! # For gRPC: `SharedHttp2Connection`
@@ -47,9 +47,11 @@
 //! // for dynamic load-aware routing. See the http2 module docs.
 //! ```
 //!
-//! Because `Http2Connection::poll_ready` honestly reports connection state
-//! (connecting / closed / ready), `tower::balance` can route around
-//! failed connections and p2c can make useful decisions.
+//! Because `poll_ready` on both `Http2Connection` and its shared handle
+//! reflects connection state (pending while connecting; a failed connect is
+//! reported by the next call instead of hanging, and retried on the next
+//! `poll_ready`), `tower::balance` keeps steering by load around a connection
+//! that is down and p2c can make useful decisions.
 //!
 //! # For Connect over HTTP/1.1: `HttpClient`
 //!

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! | Transport | Protocol | Use when |
 //! |---|---|---|
-//! | [`SharedHttp2Connection`] | HTTP/2 only | **Default for gRPC.** Honest `poll_ready`, composes with `tower::balance`. |
+//! | [`SharedHttp2Connection`] | HTTP/2 only | **Default for gRPC.** One multiplexed connection with reconnect and an in-flight bound; the underlying [`Http2Connection`] has honest `poll_ready` and composes with `tower::balance`. |
 //! | [`HttpClient`] | HTTP/1.1 + HTTP/2 (ALPN) | Connect protocol over h/1.1, or you genuinely don't know which protocol the server speaks. |
 //!
 //! # For gRPC: `SharedHttp2Connection`

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -1143,11 +1143,200 @@ mod tests {
         );
     }
 
+    /// An echo server on its own runtime and thread, so that stopping it
+    /// tears down its accepted connections too (aborting an `axum::serve`
+    /// task on the test runtime would leave them open).
+    struct KillableServer {
+        stop: Option<std::sync::mpsc::Sender<()>>,
+        thread: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl KillableServer {
+        fn start(listener: std::net::TcpListener) -> Self {
+            let (stop, stopped) = std::sync::mpsc::channel::<()>();
+            listener.set_nonblocking(true).unwrap();
+            let thread = std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                let listener = {
+                    let _entered = rt.enter();
+                    TcpListener::from_std(listener).unwrap()
+                };
+                rt.spawn(async move {
+                    let service = ConnectRpcService::new(EchoServiceServer::new(TestEchoService));
+                    let app = axum::Router::new().fallback_service(service);
+                    axum::serve(listener, app).await.unwrap();
+                });
+                rt.block_on(async move {
+                    let _ = tokio::task::spawn_blocking(move || stopped.recv()).await;
+                });
+                // Dropping the runtime drops the accept loop and every
+                // connection task, closing their sockets.
+                rt.shutdown_background();
+            });
+            Self {
+                stop: Some(stop),
+                thread: Some(thread),
+            }
+        }
+
+        fn shutdown(&mut self) {
+            if let Some(stop) = self.stop.take() {
+                let _ = stop.send(());
+            }
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+
+    impl Drop for KillableServer {
+        fn drop(&mut self) {
+            self.shutdown();
+        }
+    }
+
+    /// A `SharedHttp2Connection` survives its server going away: requests
+    /// fail while it is down, and once it is back the same handle (and every
+    /// clone of it) reconnects on a subsequent request.
+    #[tokio::test]
+    async fn shared_http2_connection_reconnects_after_server_restart() {
+        use connectrpc::Protocol;
+        use connectrpc::client::Http2Connection;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = KillableServer::start(listener);
+
+        let uri: http::Uri = format!("http://{addr}").parse().unwrap();
+        let conn = Http2Connection::connect_plaintext(uri.clone())
+            .await
+            .unwrap()
+            .shared(16);
+        let config = ClientConfig::new(uri).with_protocol(Protocol::Grpc);
+        let client = EchoServiceClient::new(conn.clone(), config.clone());
+        async fn echo(
+            client: &EchoServiceClient<connectrpc::client::SharedHttp2Connection>,
+            n: i32,
+        ) -> Result<i32, connectrpc::ConnectError> {
+            let resp = client
+                .echo(EchoRequest {
+                    sequence: n,
+                    data: format!("restart-{n}"),
+                    ..Default::default()
+                })
+                .await?;
+            Ok(resp.view().sequence)
+        }
+
+        assert_eq!(echo(&client, 1).await.unwrap(), 1);
+
+        drop(server);
+        let err = echo(&client, 2)
+            .await
+            .expect_err("no server: the request must fail");
+        assert_eq!(err.code, connectrpc::ErrorCode::Unavailable, "{err:?}");
+
+        // Back on the same port (std sets SO_REUSEADDR, and nothing else in
+        // the test binds in between). The next request re-establishes the
+        // connection; allow a few attempts in case the listener is not yet
+        // accepting when the first one is made.
+        let _server = KillableServer::start(std::net::TcpListener::bind(addr).unwrap());
+        let mut reconnected = false;
+        for attempt in 3..8 {
+            if let Ok(sequence) = echo(&client, attempt).await {
+                assert_eq!(sequence, attempt);
+                reconnected = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(reconnected, "shared handle never reconnected");
+
+        // A clone made before the outage uses the new connection too.
+        let other = EchoServiceClient::new(conn, config);
+        assert_eq!(echo(&other, 9).await.unwrap(), 9);
+    }
+
+    /// A server that recycles connections (`with_max_connection_age`) sends
+    /// a graceful GOAWAY: no new streams on this connection, open streams may
+    /// finish. When one arrives while a stream is still open, the very next
+    /// request on the shared handle must go out on a fresh connection rather
+    /// than fail unsent against the retired one (issue #285), and the open
+    /// stream must be unharmed.
+    #[tokio::test]
+    async fn shared_http2_connection_survives_graceful_goaway_with_open_stream() {
+        use connectrpc::Protocol;
+        use connectrpc::client::Http2Connection;
+
+        const MAX_AGE: Duration = Duration::from_millis(300);
+        let bound = connectrpc::server::Server::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .with_max_connection_age(MAX_AGE)
+            .with_max_connection_age_grace(Duration::from_secs(30));
+        let addr = bound.local_addr().unwrap();
+        let _server = tokio::spawn(async move {
+            let service = ConnectRpcService::new(EchoServiceServer::new(TestEchoService));
+            bound.serve_with_service(service).await.unwrap();
+        });
+
+        let uri: http::Uri = format!("http://{addr}").parse().unwrap();
+        let conn = Http2Connection::connect_plaintext(uri.clone())
+            .await
+            .unwrap()
+            .shared(16);
+        let client =
+            EchoServiceClient::new(conn, ClientConfig::new(uri).with_protocol(Protocol::Grpc));
+        let ping = |n: i32| {
+            let client = client.clone();
+            async move {
+                client
+                    .echo(EchoRequest {
+                        sequence: n,
+                        ..Default::default()
+                    })
+                    .await
+                    .map(|r| r.view().sequence)
+            }
+        };
+
+        // A server stream that outlives the connection's max age: many
+        // messages, MSG_DELAY apart, of which only the first is read now.
+        let mut held = client
+            .server_stream(EchoRequest {
+                sequence: 1_000,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(held.message().await.unwrap().unwrap().view().sequence, 0);
+        assert_eq!(ping(1).await.unwrap(), 1);
+
+        // Past max_connection_age (which carries +-10% jitter): the GOAWAY
+        // has arrived and the held stream keeps the old connection open.
+        tokio::time::sleep(MAX_AGE * 2).await;
+        for n in 2..5 {
+            assert_eq!(
+                ping(n).await.map_err(|e| format!("{e:?}")),
+                Ok(n),
+                "request #{n} after GOAWAY"
+            );
+        }
+        assert_eq!(
+            held.message().await.unwrap().unwrap().view().sequence,
+            1,
+            "the open stream continues on the retired connection"
+        );
+    }
+
     /// End-to-end test of `Http2Connection` / `SharedHttp2Connection`.
     ///
     /// Uses the raw h2 transport (no legacy pool) against the monomorphic
-    /// server. Verifies connect + reconnect-wrapper + buffer + ClientTransport
-    /// wiring works for a real unary RPC.
+    /// server. Verifies connect + reconnect-wrapper + ClientTransport wiring
+    /// works for a real unary RPC.
     #[tokio::test]
     async fn http2_connection_transport() {
         use connectrpc::Protocol;
@@ -1190,7 +1379,7 @@ mod tests {
             .unwrap();
         assert_eq!(resp.view().data, "h2-lazy");
 
-        // Concurrent requests on the shared handle — exercises the Buffer.
+        // Concurrent requests on the shared handle — multiplexed as h2 streams.
         let mut handles = Vec::new();
         for i in 0..16 {
             let c = shared.clone();


### PR DESCRIPTION
`SharedHttp2Connection` queued every request to a `tower::buffer` worker task. In the small-unary gRPC benchmark at c=1 the shared handle is measurably slower per call than `HttpClient` against the same server, and the gap closes when the client runtime has a single worker thread, which points at the cross-task wakeup rather than CPU work (bare-metal before/after numbers in a comment below). The worker also established readiness ahead of the next request, which is the mechanism behind #285: after a graceful GOAWAY with a stream still open, the next request was handed to the already-retired connection and failed unsent.

hyper's h2 `SendRequest` is itself a cloneable handle onto the connection task, so the shared handle now keeps the live `SendRequest` beside the reconnect state machine. Each request clones the handle and sends on it directly; only a request that finds no open connection locks the state machine, has a new connection established on a spawned task, and publishes the new handle. Requests queued behind an attempt share its outcome instead of dialling in turn, a request abandoned mid-handshake leaves the attempt to finish on its own task rather than half-done for the next request to inherit, and a request that hyper hands back unsent because it raced a closing connection is resent on a fresh handle, at most twice.

`Http2Connection::shared(bound)` keeps its signature and `bound` keeps its role: it was the worker's queue depth and is now the number of requests that may wait for the connection to be (re-)established at once, held as a semaphore slot that is released the moment the request is handed to hyper, so it never caps concurrent streams. As a `tower::Service` the handle keeps `Http2Connection`'s readiness contract: `poll_ready` drives re-establishment itself and reports a failed attempt as ready with the error returned by the next `call`, so it stays usable under `tower::balance`. `Clone` is now manual because a clone shares the connection but not the readiness a handle took in `poll_ready`.

Fixes #285.
