### PR TITLE
encode: view bodies through `Vec<u8>`; de-frame in place; gzip buffer sizing

### DIFF
--- a/.changes/unreleased/Changed-20260911-190000.yaml
+++ b/.changes/unreleased/Changed-20260911-190000.yaml
@@ -1,0 +1,11 @@
+kind: Changed
+body: |-
+    **Cheaper encode and framing buffers.** View-encoded response bodies are
+    written through a `Vec<u8>` instead of a `BytesMut` (the isolated encode
+    step is 3-4x faster on string/varint-heavy messages); gRPC unary and
+    server-streaming requests on the server, and the Connect client-streaming
+    response on the client, are de-framed in place with the new
+    `Envelope::decode_bytes_with_limit` instead of being copied into a
+    `BytesMut` first; and gzip compression no longer grows its pre-sized output
+    buffer before writing. Additive; no wire change.
+time: 2026-09-11T19:00:00.000000000+00:00

--- a/benches/rpc/Cargo.toml
+++ b/benches/rpc/Cargo.toml
@@ -76,5 +76,9 @@ harness = false
 name = "view_rope_encode"
 harness = false
 
+[[bench]]
+name = "encode_frame"
+harness = false
+
 [lints]
 workspace = true

--- a/benches/rpc/benches/encode_frame.rs
+++ b/benches/rpc/benches/encode_frame.rs
@@ -5,9 +5,9 @@
 //!   `connectrpc::__codegen::encode_view_body` — the path every generated
 //!   `impl Encodable<M> for MView` takes, which sizes its own buffer.
 //! - `deframe/*`: one gRPC request envelope (as `collect().to_bytes()` hands
-//!   it to a handler) -> payload `Bytes`, via `Envelope::decode_with_limit`
-//!   on a `BytesMut` copy of the body (what the gRPC unary / server-streaming
-//!   paths used to do) vs on the `Bytes` itself.
+//!   it to a handler) -> payload `Bytes`: `Envelope::decode_with_limit` on a
+//!   `BytesMut` copy of the body (what the gRPC unary / server-streaming paths
+//!   used to do) vs `Envelope::decode_bytes_with_limit` on the `Bytes` itself.
 //!
 //! Shapes: ~350 B mixed message, ~4 KB and ~270 KB of string/varint-heavy
 //! log records, and ~256 KB in four large strings (memcpy-bound control).
@@ -94,7 +94,7 @@ macro_rules! bench_shape {
         g.bench_function("bytes_in_place", |b| {
             b.iter(|| {
                 let mut buf = body.clone();
-                black_box(Envelope::decode_with_limit(&mut buf, usize::MAX).unwrap())
+                black_box(Envelope::decode_bytes_with_limit(&mut buf, usize::MAX).unwrap())
             })
         });
         g.finish();

--- a/benches/rpc/benches/encode_frame.rs
+++ b/benches/rpc/benches/encode_frame.rs
@@ -1,0 +1,130 @@
+//! Encode and de-frame cost, isolated from HTTP.
+//!
+//! - `view_encode/*`: a decoded view (`ViewEncode`) -> `Bytes`, three ways:
+//!   buffa's `encode_to_bytes`, `Bytes::from(encode_to_vec())`, and
+//!   `connectrpc::__codegen::encode_view_body` — the path every generated
+//!   `impl Encodable<M> for MView` takes, which sizes its own buffer.
+//! - `deframe/*`: one gRPC request envelope (as `collect().to_bytes()` hands
+//!   it to a handler) -> payload `Bytes`, via `Envelope::decode_with_limit`
+//!   on a `BytesMut` copy of the body (what the gRPC unary / server-streaming
+//!   paths used to do) vs on the `Bytes` itself.
+//!
+//! Shapes: ~350 B mixed message, ~4 KB and ~270 KB of string/varint-heavy
+//! log records, and ~256 KB in four large strings (memcpy-bound control).
+//!
+//! ```text
+//! cargo bench -p rpc-bench --bench encode_frame
+//! ```
+
+use std::hint::black_box;
+
+use buffa::view::MessageView;
+use buffa::{Message, ViewEncode};
+use bytes::{BufMut, Bytes, BytesMut};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+
+use connectrpc::CodecFormat;
+use connectrpc::envelope::{Envelope, HEADER_SIZE, flags};
+use rpc_bench::proto::bench::v1::__buffa::view::FewLargeStringsView;
+use rpc_bench::proto::bench::v1::FewLargeStrings;
+use rpc_bench::{
+    BenchResponse, BenchResponseView, LogRequest, LogRequestView, log_request, small_payload,
+};
+
+/// `LogRequest` with enough records to reach roughly `target` encoded bytes.
+fn log_request_of_size(target: usize) -> LogRequest {
+    let per = log_request(1).encoded_len() as usize;
+    log_request(target.div_ceil(per).max(1))
+}
+
+fn few_large_strings(each: usize) -> FewLargeStrings {
+    let body = "x".repeat(each);
+    FewLargeStrings {
+        body_a: body.clone(),
+        body_b: body.clone(),
+        body_c: body.clone(),
+        body_d: body,
+        ts: 1,
+        seq: 2,
+        ..Default::default()
+    }
+}
+
+/// One gRPC data envelope: 5-byte header + payload.
+fn framed(payload: &[u8]) -> Bytes {
+    let mut buf = BytesMut::with_capacity(HEADER_SIZE + payload.len());
+    buf.put_u8(flags::DATA);
+    buf.put_u32(payload.len() as u32);
+    buf.put_slice(payload);
+    buf.freeze()
+}
+
+macro_rules! bench_shape {
+    ($c:expr, $name:expr, $msg:expr, $view_ty:ty) => {{
+        let wire = Bytes::from($msg.encode_to_vec());
+        let view = <$view_ty>::decode_view(&wire).expect("decode view");
+        let len = wire.len() as u64;
+
+        let mut g = $c.benchmark_group(format!("view_encode/{}", $name));
+        g.throughput(Throughput::Bytes(len));
+        g.bench_function("buffa_view_encode_to_bytes", |b| {
+            b.iter(|| black_box(ViewEncode::encode_to_bytes(&view)))
+        });
+        g.bench_function("buffa_view_vec_into_bytes", |b| {
+            b.iter(|| black_box(Bytes::from(ViewEncode::encode_to_vec(&view))))
+        });
+        g.bench_function("connectrpc_encode_view_body", |b| {
+            b.iter(|| {
+                black_box(
+                    connectrpc::__codegen::encode_view_body(&view, CodecFormat::Proto).unwrap(),
+                )
+            })
+        });
+        g.finish();
+
+        let body = framed(&wire);
+        let mut g = $c.benchmark_group(format!("deframe/{}", $name));
+        g.throughput(Throughput::Bytes(len));
+        g.bench_function("bytesmut_copy", |b| {
+            b.iter(|| {
+                let mut buf = BytesMut::from(&body[..]);
+                black_box(Envelope::decode_with_limit(&mut buf, usize::MAX).unwrap())
+            })
+        });
+        g.bench_function("bytes_in_place", |b| {
+            b.iter(|| {
+                let mut buf = body.clone();
+                black_box(Envelope::decode_with_limit(&mut buf, usize::MAX).unwrap())
+            })
+        });
+        g.finish();
+    }};
+}
+
+fn bench_encode_frame(c: &mut Criterion) {
+    bench_shape!(
+        c,
+        "small_300B",
+        BenchResponse {
+            payload: small_payload().into(),
+            ..Default::default()
+        },
+        BenchResponseView
+    );
+    bench_shape!(c, "logs_4KB", log_request_of_size(4 * 1024), LogRequestView);
+    bench_shape!(
+        c,
+        "logs_256KB",
+        log_request_of_size(256 * 1024),
+        LogRequestView
+    );
+    bench_shape!(
+        c,
+        "blob_256KB",
+        few_large_strings(64 * 1024),
+        FewLargeStringsView
+    );
+}
+
+criterion_group!(benches, bench_encode_frame);
+criterion_main!(benches);

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -4503,13 +4503,13 @@ fn scan_connect_client_stream_envelopes(
     encoding: Option<&str>,
     max_msg_size: usize,
 ) -> Result<(Bytes, http::HeaderMap), ConnectError> {
-    let mut buf = BytesMut::from(body.as_ref());
+    let mut buf = body;
     let mut message: Option<Bytes> = None;
     let mut trailers = http::HeaderMap::new();
     let mut saw_end_stream = false;
 
     while !buf.is_empty() {
-        let envelope = match Envelope::decode_with_limit(&mut buf, max_msg_size)? {
+        let envelope = match Envelope::decode_bytes_with_limit(&mut buf, max_msg_size)? {
             Some(env) => env,
             None => break,
         };

--- a/connectrpc/src/compression.rs
+++ b/connectrpc/src/compression.rs
@@ -585,7 +585,10 @@ impl GzipProvider {
         compressor: &mut flate2::Compress,
         data: &[u8],
     ) -> Result<Bytes, ConnectError> {
-        let mut output = Vec::with_capacity(data.len() + 32);
+        // Header + trailer + deflate's worst case (stored blocks add a few
+        // bytes per block), so even incompressible input finishes without
+        // growing the buffer.
+        let mut output = Vec::with_capacity(data.len() + (data.len() >> 8) + 64);
 
         // Gzip header (RFC 1952): fixed 10 bytes, no optional fields
         output.extend_from_slice(&[
@@ -601,7 +604,12 @@ impl GzipProvider {
         let start_in = compressor.total_in();
         loop {
             let consumed = (compressor.total_in() - start_in) as usize;
-            output.reserve(output.capacity().max(4096));
+            // `compress_vec` writes into spare capacity only; grow when there
+            // is none left rather than on every pass, so the pre-sized buffer
+            // is not doubled before the first byte is written.
+            if output.len() == output.capacity() {
+                output.reserve(output.capacity().max(4096));
+            }
             let status = compressor
                 .compress_vec(
                     &data[consumed..],

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -152,12 +152,39 @@ impl Envelope {
         buf: &mut BytesMut,
         max_size: usize,
     ) -> Result<Option<Self>, ConnectError> {
-        if buf.len() < HEADER_SIZE {
+        Self::decode_contiguous(buf, max_size)
+    }
+
+    /// [`decode_with_limit`](Self::decode_with_limit) for a body already held
+    /// as immutable [`Bytes`] (e.g. from `Collected::to_bytes`): on success the
+    /// envelope is consumed from `buf` and its payload is a zero-copy slice of
+    /// it; if more data is needed `buf` is left untouched.
+    ///
+    /// # Errors
+    ///
+    /// [`ResourceExhausted`](crate::ErrorCode::ResourceExhausted) if the
+    /// declared message size exceeds `max_size`.
+    pub fn decode_bytes_with_limit(
+        buf: &mut Bytes,
+        max_size: usize,
+    ) -> Result<Option<Self>, ConnectError> {
+        Self::decode_contiguous(buf, max_size)
+    }
+
+    /// Shared body for the contiguous buffers above (`chunk()` is the whole
+    /// unread region; `copy_to_bytes` splits without copying on both).
+    fn decode_contiguous<B: Buf>(
+        buf: &mut B,
+        max_size: usize,
+    ) -> Result<Option<Self>, ConnectError> {
+        let head = buf.chunk();
+        debug_assert_eq!(head.len(), buf.remaining(), "contiguous buffer");
+        if head.len() < HEADER_SIZE {
             return Ok(None);
         }
 
-        let flags = buf[0];
-        let length = u32::from_be_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+        let flags = head[0];
+        let length = u32::from_be_bytes([head[1], head[2], head[3], head[4]]) as usize;
 
         // Check size limit before waiting for more data
         if length > max_size {
@@ -171,12 +198,12 @@ impl Envelope {
         // in a debug build. Via `decode` (max_size = usize::MAX) the size check
         // above does not bound `length`, so saturate here. A saturated sum is
         // never <= buf.len(), so an over-large frame waits for more data.
-        if buf.len() < HEADER_SIZE.saturating_add(length) {
+        if head.len() < HEADER_SIZE.saturating_add(length) {
             return Ok(None);
         }
 
         buf.advance(HEADER_SIZE);
-        let data = buf.split_to(length).freeze();
+        let data = buf.copy_to_bytes(length);
 
         Ok(Some(Self { flags, data }))
     }
@@ -682,6 +709,37 @@ mod tests {
                 "{name}: must reassemble to the contiguous envelope"
             );
         }
+    }
+
+    /// De-framing an immutable `Bytes` body hands the payload over as a
+    /// slice of the input rather than a copy, and advances past the envelope.
+    #[test]
+    fn decode_bytes_with_limit_is_zero_copy() {
+        let mut wire = BytesMut::new();
+        write_envelope(flags::COMPRESSED, b"payload", &mut wire).unwrap();
+        wire.put_slice(b"next");
+        let wire = wire.freeze();
+
+        let mut buf = wire.clone();
+        let envelope = Envelope::decode_bytes_with_limit(&mut buf, 64)
+            .unwrap()
+            .unwrap();
+        assert_eq!(envelope.flags, flags::COMPRESSED);
+        assert_eq!(envelope.data, "payload");
+        assert!(std::ptr::eq(
+            envelope.data.as_ptr(),
+            wire[HEADER_SIZE..].as_ptr()
+        ));
+        assert_eq!(buf, "next");
+
+        let mut short = wire.slice(..HEADER_SIZE + 3);
+        assert!(
+            Envelope::decode_bytes_with_limit(&mut short, 64)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(short.len(), HEADER_SIZE + 3);
+        assert!(Envelope::decode_bytes_with_limit(&mut wire.clone(), 6).is_err());
     }
 
     #[test]

--- a/connectrpc/src/response.rs
+++ b/connectrpc/src/response.rs
@@ -743,9 +743,14 @@ pub fn encode_view_body<'a, V: ViewEncode<'a>>(
         CodecFormat::Proto => {
             let mut cache = buffa::SizeCache::new();
             let size = checked_response_size(view.compute_size(&mut cache))?;
-            let mut buf = BytesMut::with_capacity(size);
+            // `Vec<u8>`, not `BytesMut`: `<BytesMut as BufMut>::put_slice` is
+            // not inlined, so each tag/varint byte through it is an out-of-line
+            // call. `Bytes::from(Vec)` is zero-copy, and allocation-free when
+            // `len == capacity`.
+            let mut buf = Vec::with_capacity(size);
             view.write_to(&mut cache, &mut buf);
-            Ok(buf.freeze())
+            debug_assert_eq!(buf.len(), size);
+            Ok(Bytes::from(buf))
         }
         CodecFormat::Json => Err(ConnectError::unimplemented(
             "view-body responses do not support the JSON codec; return the owned message type for JSON-serving handlers",
@@ -875,9 +880,10 @@ pub fn encode_view_body_with_min_segment<'a, V: ViewEncode<'a>>(
             let size = checked_response_size(view.compute_size(&mut cache))?;
 
             if !worth_segmenting(size, backing.len(), min_segment) {
-                let mut buf = BytesMut::with_capacity(size);
+                let mut buf = Vec::with_capacity(size);
                 view.write_to(&mut cache, &mut buf);
-                return Ok(EncodedBody::Contiguous(buf.freeze()));
+                debug_assert_eq!(buf.len(), size);
+                return Ok(EncodedBody::Contiguous(Bytes::from(buf)));
             }
 
             // Known cost: a rope's tail starts empty and grows by doubling,

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -2274,8 +2274,8 @@ where
         let err = ConnectError::unimplemented("request body is empty: expected a message");
         return grpc_unary_error(&err);
     } else {
-        let mut buf = bytes::BytesMut::from(&post_body[..]);
-        let envelope = match Envelope::decode_with_limit(&mut buf, limits.max_message_size) {
+        let mut buf = post_body;
+        let envelope = match Envelope::decode_bytes_with_limit(&mut buf, limits.max_message_size) {
             Ok(Some(env)) => env,
             Ok(None) => {
                 let err = ConnectError::invalid_argument("incomplete request envelope");
@@ -2578,8 +2578,8 @@ where
         let err = ConnectError::unimplemented("server streaming request requires a message");
         return streaming_error_response(&err, protocol, codec_format);
     } else {
-        let mut buf = bytes::BytesMut::from(&post_body[..]);
-        let envelope = match Envelope::decode_with_limit(&mut buf, limits.max_message_size) {
+        let mut buf = post_body;
+        let envelope = match Envelope::decode_bytes_with_limit(&mut buf, limits.max_message_size) {
             Ok(Some(env)) => env,
             Ok(None) => {
                 let err = ConnectError::invalid_argument("incomplete request envelope");


### PR DESCRIPTION
Three small buffer-management fixes on the request/response path, plus a bench that isolates them from HTTP. Additive API (one new `Envelope` fn); no wire change. Reviewed with the repo's `rust-code-reviewer` and `rust-api-ergonomics-reviewer` agents; their Medium findings (keep `decode*` signatures concrete, changelog accuracy) are applied.

## What and why

- **`encode_view_body` / `encode_view_body_with_min_segment` write through a `Vec<u8>`, not a `BytesMut`.** These size their own buffer and encode the view into it (the path every generated `impl Encodable<M> for MView` takes). `bytes` does not inline `<BytesMut as BufMut>::put_slice`, so every tag and varint byte written through a `BytesMut` is an out-of-line call; a pre-sized `Vec<u8>` + `Bytes::from` is zero-copy, allocation-free at `len == capacity`, and 3–4× faster. Owned-message paths (`Encodable for M`, `PreEncoded`, client request encoding) call buffa's `encode_to_bytes`, which buffa ≥ 0.9.3 already routes through a `Vec` (anthropics/buffa#437), so they're left alone — verified below. Upstream `bytes` fix: tokio-rs/bytes#850.
- **New `Envelope::decode_bytes_with_limit(&mut Bytes, max)`** — `decode_with_limit` for a body already held as `Bytes`; the payload is split off by reference count (`Buf::copy_to_bytes` is zero-copy on `Bytes`) rather than the body first being copied into a `BytesMut`. The three places that did that copy just to de-frame — the gRPC unary and server-streaming handlers on the server, and the Connect client-streaming response scan on the client — use it: one allocation and one body-sized memcpy less per message. `decode` / `decode_with_limit` keep their `&mut BytesMut` signatures and now share a private body with the new function.
- **gzip `compress_inner` no longer doubles its pre-sized output buffer** before the first write; it grows only when spare capacity is exhausted (3 allocations / ~3× input bytes → 2 / ~1× per compressed response).
- **`benches/rpc/benches/encode_frame.rs`**: `view_encode/*` (view → `Bytes` via buffa's two entry points and `encode_view_body`) and `deframe/*` (`decode_with_limit` on a `BytesMut` copy vs `decode_bytes_with_limit` on the `Bytes`), over a 346 B, 4.4 KB and 271 KB log-record message and a 256 KB four-string blob.

## Numbers

criterion medians, one pinned core (Xeon 8488C), `main` → this branch:

| bench | main | this branch |
|---|---|---|
| `view_encode/small_300B/connectrpc_encode_view_body` | 628 ns | 166 ns |
| `view_encode/logs_4KB/connectrpc_encode_view_body` | 4.56 µs | 1.21 µs |
| `view_encode/logs_256KB/connectrpc_encode_view_body` | 264 µs | 75.4 µs |
| `view_encode/blob_256KB/connectrpc_encode_view_body` (memcpy-bound) | 5.33 µs | 5.59 µs |
| `deframe/small_300B` copy → in place | 50 ns | 25 ns |
| `deframe/logs_4KB` copy → in place | 103 ns | 25 ns |
| `deframe/logs_256KB` copy → in place | 5.42 µs | 25 ns |
| gzip, 256 KB text (allocs / bytes allocated, one-off count) | 3 / 792 KB | 2 / 265 KB |

End-to-end (`rpc_bench`, loopback, ~70 µs floor): unary −1…−8 %, gRPC server-streaming −6 %, other arms within noise — these are per-message constant costs, visible as CPU more than latency.

Why the owned paths are not touched: on `main` with only the buffa dependency swapped (0.9.2 → 0.9.2 + anthropics/buffa#437), `Encodable::encode` goes 647 → 184 ns, 4.87 → 1.38 µs, 282 → 86 µs (= the `Vec` reference), while `encode_view_body` stays at 563 ns / 4.16 µs / 237 µs — the buffa bump fixes everything except the sites changed here.

## Testing

`cargo test --workspace` (937 passed), `cargo test -p connectrpc --no-default-features` (514), `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo fmt --check`; conformance server and client suites pass. New unit test that `decode_bytes_with_limit` aliases its input, leaves incomplete input untouched, and rejects over-limit frames.

## Follow-ups (not here)

- Client request framing without the copy (fused `Vec` when uncompressed, or header + payload as two body frames ≥ 16 KiB): saves one alloc + memcpy per request but makes HTTP/1.1 request bodies chunked; wants its own discussion.
- zstd output overhang: `compress` returns a `Vec` with `cap = compress_bound(N)`; a tiny result pins an N-sized buffer until sent.
